### PR TITLE
Add label to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ You can check the status of all integrations by executing the following command:
 kamel get
 ```
 
+### Uninstalling Camel K
+
+If requires to uninstall Camel K from the OpenShift or Kubernetes, it's nessesary to run following command using "oc" or "kubectl" tool:
+
+```
+delete all,pvc,configmap,rolebindings,clusterrolebindings,secrets,sa,roles,clusterroles,crd -l 'app=camel-k'
+```
+
 ## Building
 
 In order to build the project follow these steps:

--- a/deploy/operator-service.yaml
+++ b/deploy/operator-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: camel-k-operator
+    app: "camel-k"
+  name: camel-k-operator
+spec:
+  ports:
+    - name: metrics
+      port: 60000
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    name: camel-k-operator
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/deploy/resources.go
+++ b/deploy/resources.go
@@ -86,7 +86,6 @@ spec:
     metadata:
       labels:
         name: camel-k-operator
-        app: "camel-k"
     spec:
       serviceAccountName: camel-k-operator
       containers:
@@ -310,6 +309,29 @@ metadata:
   name: camel-k-operator
   labels:
     app: "camel-k"
+
+`
+	Resources["operator-service.yaml"] =
+		`
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: camel-k-operator
+    app: "camel-k"
+  name: camel-k-operator
+spec:
+  ports:
+    - name: metrics
+      port: 60000
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    name: camel-k-operator
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
 
 `
 	Resources["operator.yaml"] =

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -31,6 +31,7 @@ func Operator(namespace string) error {
 		"operator-role-openshift.yaml", // TODO distinguish between Openshift and Kubernetes
 		"operator-role-binding.yaml",
 		"operator-deployment.yaml",
+		"operator-service.yaml",
 	)
 }
 


### PR DESCRIPTION
Missing to add label to service. This requires to separate service creation in single file operator-service.yaml.