### PR TITLE
Add a wait option to kamel run

### DIFF
--- a/cmd/kamel/kamel.go
+++ b/cmd/kamel/kamel.go
@@ -22,10 +22,12 @@ import (
 	"github.com/apache/camel-k/pkg/client/cmd"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"os"
+	"context"
 )
 
 func main() {
-	rootCmd, err := cmd.NewKamelCommand()
+	ctx := context.Background()
+	rootCmd, err := cmd.NewKamelCommand(ctx)
 	exitOnError(err)
 
 	err = rootCmd.Execute()

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: camel-k-operator
           image: docker.io/apache/camel-k:0.0.1-SNAPSHOT
+          ports:
+          - containerPort: 60000
+            name: metrics
           command:
           - camel-k-operator
           imagePullPolicy: Always
@@ -23,3 +26,5 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "camel-k-operator"

--- a/pkg/client/cmd/root.go
+++ b/pkg/client/cmd/root.go
@@ -23,15 +23,19 @@ import (
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"context"
 )
 
 type RootCmdOptions struct {
+	Context    context.Context
 	KubeConfig string
 	Namespace  string
 }
 
-func NewKamelCommand() (*cobra.Command, error) {
-	options := RootCmdOptions{}
+func NewKamelCommand(ctx context.Context) (*cobra.Command, error) {
+	options := RootCmdOptions{
+		Context: ctx,
+	}
 	var cmd = cobra.Command{
 		Use:   "kamel",
 		Short: "Kamel is a awesome client tool for running Apache Camel integrations natively on Kubernetes",

--- a/pkg/util/watch/watch.go
+++ b/pkg/util/watch/watch.go
@@ -1,0 +1,82 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"context"
+	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/sirupsen/logrus"
+)
+
+// Watches a integration resource and send it through a channel when its status changes
+func WatchStateChanges(ctx context.Context, integration *v1alpha1.Integration) (<-chan *v1alpha1.Integration, error) {
+	resourceClient, _, err := k8sclient.GetResourceClient(integration.APIVersion, integration.Kind, integration.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	watcher, err := resourceClient.Watch(metav1.ListOptions{
+		FieldSelector: "metadata.name=" + integration.Name,
+	})
+	if err != nil {
+		return nil, err
+	}
+	events := watcher.ResultChan()
+
+	out := make(chan *v1alpha1.Integration)
+	var lastObservedState *v1alpha1.IntegrationPhase
+
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case e, ok := <-events:
+				if !ok {
+					return
+				}
+
+				if e.Object != nil {
+					if runtimeUnstructured, ok := e.Object.(runtime.Unstructured); ok {
+						unstr := unstructured.Unstructured{
+							Object: runtimeUnstructured.UnstructuredContent(),
+						}
+						icopy := integration.DeepCopy()
+						err := k8sutil.UnstructuredIntoRuntimeObject(&unstr, icopy)
+						if err != nil {
+							logrus.Error("Unexpected error detected when watching resource", err)
+							return // closes the channel
+						}
+
+						if lastObservedState == nil || *lastObservedState != icopy.Status.Phase {
+							lastObservedState = &icopy.Status.Phase
+							out <- icopy
+						}
+					}
+				}
+			}
+		}
+	}()
+
+	return out, nil
+}


### PR DESCRIPTION
It's part of #33.
Now `kamel run Sample.java -w` will tell you the state of the integration and unlock the command when finished.