### PR TITLE
Add release commands and bump to 0.0.2-SNAPSHOT

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -17,6 +17,9 @@ release: prepare-release build images-build images-push test-integration cross-c
 prepare-release:
 	./build/prepare_release.sh
 
+new-version:
+	./build/next_snapshot.sh
+
 cross-compile:
 	./build/cross_compile.sh
 
@@ -57,4 +60,4 @@ check-integration:
 
 
 
-.PHONY: build build-operator build-kamel build-embed-resources build-runtime dep codegen images images-build images-push test check test-integration check-integration clean release prepare-release cross-compile
+.PHONY: build build-operator build-kamel build-embed-resources build-runtime dep codegen images images-build images-push test check test-integration check-integration clean release prepare-release cross-compile new-version git-tag

--- a/build/Makefile
+++ b/build/Makefile
@@ -17,7 +17,9 @@ release: prepare-release build images-build images-push test-integration cross-c
 prepare-release:
 	./build/prepare_release.sh
 
-new-version:
+new-version: increment-snapshot build images-build images-push
+
+increment-snapshot:
 	./build/next_snapshot.sh
 
 cross-compile:
@@ -60,4 +62,4 @@ check-integration:
 
 
 
-.PHONY: build build-operator build-kamel build-embed-resources build-runtime dep codegen images images-build images-push test check test-integration check-integration clean release prepare-release cross-compile new-version git-tag
+.PHONY: build build-operator build-kamel build-embed-resources build-runtime dep codegen images images-build images-push test check test-integration check-integration clean release prepare-release cross-compile new-version git-tag increment-snapshot

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,5 +1,3 @@
-VERSION := $(shell ./build/get_version.sh)
-
 build: build-runtime build-operator build-kamel test
 
 build-operator: build-embed-resources
@@ -41,10 +39,10 @@ codegen:
 images: images-build
 
 images-build:
-	./build/package_maven_artifacts.sh && operator-sdk build docker.io/apache/camel-k:$(VERSION)
+	./build/images_build.sh
 
 images-push:
-	docker push docker.io/apache/camel-k:$(VERSION)
+	./build/images_push.sh
 
 test: check
 check:

--- a/build/Makefile
+++ b/build/Makefile
@@ -12,13 +12,16 @@ build-embed-resources:
 build-runtime:
 	mvn clean install -f ./runtime/pom.xml
 
-release: prepare-release build images-build images-push test-integration cross-compile
+release: prepare-release build images-build images-push test-integration cross-compile git-tag
 
 prepare-release:
 	./build/prepare_release.sh
 
 cross-compile:
 	./build/cross_compile.sh
+
+git-tag:
+	./build/git_tag.sh
 
 dep:
 	dep ensure -v

--- a/build/git_tag.sh
+++ b/build/git_tag.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+location=$(dirname $0)
+version=$($location/get_version.sh)
+
+git branch -D staging-$version || true
+git checkout -b staging-$version
+git add * || true
+git commit -m "Release $version"
+git tag --force $version staging-$version
+git push --force upstream $version
+
+echo "Tag $version pushed upstream"

--- a/build/images_build.sh
+++ b/build/images_build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+location=$(dirname $0)
+version=$($location/get_version.sh)
+
+$location/package_maven_artifacts.sh && operator-sdk build docker.io/apache/camel-k:$version

--- a/build/images_push.sh
+++ b/build/images_push.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+location=$(dirname $0)
+version=$($location/get_version.sh)
+
+docker push docker.io/apache/camel-k:$version

--- a/build/next_snapshot.sh
+++ b/build/next_snapshot.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+location=$(dirname $0)
+global_version_file=$location/../version/version.go
+
+version=$($location/get_version.sh)
+version_num=$(echo $version | sed -E "s/([0-9.]*)-SNAPSHOT/\1/g")
+next_version_num=$(echo $version_num | awk 'BEGIN { FS = "." } ; {print $1"."$2"."++$3}')
+next_version="$next_version_num-SNAPSHOT"
+
+echo "Increasing version to $next_version"
+
+$location/set_version.sh $next_version

--- a/build/prepare_release.sh
+++ b/build/prepare_release.sh
@@ -3,17 +3,10 @@
 set -e
 
 location=$(dirname $0)
-global_version_file=$location/../version/version.go
 
-# Set the new global version by removing "-SNAPSHOT"
-sed -i "s/-SNAPSHOT//g" $global_version_file
-find $location/../deploy -type f -exec sed -i "s/-SNAPSHOT//g" {} \;
-
-# Get the new version
 version=$($location/get_version.sh)
+version_num=$(echo $version | sed -E "s/([0-9.]*)-SNAPSHOT/\1/g")
 
-# Updating the Java modules
-mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$version -f $location/../runtime
+$location/set_version.sh $version_num
 
-echo "Camel K prepared for releasing version: $version"
-
+echo "Camel K prepared for releasing version: $version_num"

--- a/build/prepare_release.sh
+++ b/build/prepare_release.sh
@@ -7,6 +7,7 @@ global_version_file=$location/../version/version.go
 
 # Set the new global version by removing "-SNAPSHOT"
 sed -i "s/-SNAPSHOT//g" $global_version_file
+find $location/../deploy -type f -exec sed -i "s/-SNAPSHOT//g" {} \;
 
 # Get the new version
 version=$($location/get_version.sh)

--- a/build/set_version.sh
+++ b/build/set_version.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+location=$(dirname $0)
+new_version=$1
+
+global_version_file=$location/../version/version.go
+version=$($location/get_version.sh)
+
+# Set the new global version
+sed -i "s/$version/$new_version/g" $global_version_file
+find $location/../deploy -type f -exec sed -i "s/$version/$new_version/g" {} \;
+
+# Updating the Java modules
+mvn versions:set -DgenerateBackupPoms=false -DnewVersion=$new_version -f $location/../runtime
+
+echo "Camel K version set to: $new_version"
+

--- a/deploy/operator-deployment.yaml
+++ b/deploy/operator-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: camel-k-operator
       containers:
         - name: camel-k-operator
-          image: docker.io/apache/camel-k:0.0.1-SNAPSHOT
+          image: docker.io/apache/camel-k:0.0.2-SNAPSHOT
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/resources.go
+++ b/deploy/resources.go
@@ -113,7 +113,7 @@ spec:
       serviceAccountName: camel-k-operator
       containers:
         - name: camel-k-operator
-          image: docker.io/apache/camel-k:0.0.1-SNAPSHOT
+          image: docker.io/apache/camel-k:0.0.2-SNAPSHOT
           ports:
           - containerPort: 60000
             name: metrics

--- a/runtime/jvm/pom.xml
+++ b/runtime/jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.camel.k</groupId>
         <artifactId>camel-k-runtime-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.apache.camel.k</groupId>
     <artifactId>camel-k-runtime-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/version/version.go
+++ b/version/version.go
@@ -20,5 +20,5 @@ package version
 
 var (
 	// Global Camel K Version
-	Version = "0.0.1-SNAPSHOT"
+	Version = "0.0.2-SNAPSHOT"
 )


### PR DESCRIPTION
Fixes #59.
This basically adds a `make release` command that does everything except uploading the binary artifacts for different platforms to github (but they are generated).
I've added also a `make new-version` that bumps the snapshot and publishes its image on docker hub.