### PR TITLE
Simplify install and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Apache Camel K (a.k.a. Kamel) is a lightweight integration framework built from 
 
 ## Getting Started
 
-You can run Camel K integrations on a Kubernetes or Openshift cluster, so you can choose to create a development cluster or use a cloud instance
-for Camel K.
+Camel K allows to run integrations on a Kubernetes or Openshift cluster. If you don't have a cloud instance of Kubernetes or Openshift, you can create a development cluster following the instructions below.
 
 ### Creating a Development Cluster
 There are various options for creating a development cluster:
@@ -34,8 +33,9 @@ Minikube and Kubernetes are not yet supported (but support is coming soon).
 ### Setting Up the Cluster
 
 To start using Camel K you need the **"kamel"** binary, that can be used to both configure the cluster and run integrations.
+Look into the [release page](https://github.com/apache/camel-k/releases) for latest version of the `kamel` tool.
 
-There's currently no release channel for the "kamel" binary, so you need to **build it from source!** Refer to the [contributing guide](#contributing)
+If you wanto to contribute, you can also **build it from source!** Refer to the [contributing guide](#contributing)
 for information on how to do it.
 
 Once you have the "kamel" binary, log into your cluster using the "oc" or "kubectl" tool and execute the following command to install Camel K:
@@ -178,8 +178,8 @@ make test-integration
 ### Running
 
 If you want to install everything you have in your source code and see it running on Kubernetes, you need to run the following command:
-- `make install-minishift`: to build the project and run it on Minishift, the default namespace for this is `myproject`
-- you can specify a different namespace with `make install-minishift project=myawesomeproject`
+- Run `make install-minishift` (or just `make install`): to build the project and install it in the current namespace on Minishift
+- You can specify a different namespace with `make install-minishift project=myawesomeproject`
 
 This command assumes you have an already running Minishift instance.
 
@@ -194,7 +194,6 @@ To add additional dependencies to your routes:
 ```
 ./kamel run -d camel:dns runtime/examples/dns.js
 ```
-
 
 ### Debugging and Running from IDE
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -52,6 +52,7 @@ images-build:
 images-push:
 	./build/images_push.sh
 
+install: install-minishift
 install-minishift:
 	./build/install_minishift.sh
 

--- a/cmd/kamel/kamel.go
+++ b/cmd/kamel/kamel.go
@@ -36,7 +36,7 @@ func main() {
 
 func exitOnError(err error) {
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println("Error:", err)
 		os.Exit(1)
 	}
 }

--- a/deploy/operator-deployment.yaml
+++ b/deploy/operator-deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     app: "camel-k"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: camel-k-operator

--- a/deploy/resources.go
+++ b/deploy/resources.go
@@ -102,6 +102,8 @@ metadata:
     app: "camel-k"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: camel-k-operator

--- a/pkg/client/cmd/install.go
+++ b/pkg/client/cmd/install.go
@@ -24,7 +24,8 @@ import (
 
 	"github.com/apache/camel-k/pkg/install"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/pkg/errors"
 )
 
 // NewCmdInstall --
@@ -52,11 +53,9 @@ type installCmdOptions struct {
 
 func (o *installCmdOptions) install(cmd *cobra.Command, args []string) error {
 	err := install.SetupClusterwideResources()
-	if err != nil && errors.IsForbidden(err) {
-		// TODO explain that this is a one time operation and add a flag to do cluster-level operations only when logged as admin
+	if err != nil && k8serrors.IsForbidden(err) {
 		fmt.Println("Current user is not authorized to create cluster-wide objects like custom resource definitions or cluster roles: ", err)
-		fmt.Println("Please login as cluster-admin and execute \"kamel install --cluster-setup\" to install those resources (one-time operation).")
-		return nil // TODO better error handling: if here we return err the help page is shown
+		return errors.New("please login as cluster-admin and execute \"kamel install --cluster-setup\" to install cluster-wide resources (one-time operation)")
 	}
 
 	if o.clusterSetupOnly {


### PR DESCRIPTION
I've changed the install script to fail on error, do a simplified installation if cluster resources are installed and install on the current namespace by default.

@oscerd can you have a look?