### PR TITLE
Add sync and dev mode

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -318,6 +318,14 @@
   revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
+  digest = "1:669828a2363f1ecad15fff9f008dd1d07d449fb25c9060998b15f83fec896458"
+  name = "github.com/radovskyb/watcher"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "6145e1439b9de93806925353403f91d2abbad8a5"
+  version = "v1.0.2"
+
+[[projects]]
   digest = "1:0975c74a2cd70df6c2ae353c6283a25ce759dda7e1e706e5c07458baf3faca22"
   name = "github.com/rs/xid"
   packages = ["."]
@@ -719,6 +727,7 @@
     "github.com/operator-framework/operator-sdk/pkg/util/k8sutil",
     "github.com/operator-framework/operator-sdk/version",
     "github.com/pkg/errors",
+    "github.com/radovskyb/watcher",
     "github.com/rs/xid",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/cmd/camel-k-operator/kamel_k_operator.go
+++ b/cmd/camel-k-operator/kamel_k_operator.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"context"
+	"math/rand"
 	"runtime"
 	"time"
 
@@ -45,6 +46,8 @@ func watch(resource string, kind string, namespace string, resyncPeriod time.Dur
 }
 
 func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
 	printVersion()
 
 	sdk.ExposeMetricsPort()

--- a/pkg/apis/camel/v1alpha1/types.go
+++ b/pkg/apis/camel/v1alpha1/types.go
@@ -127,8 +127,6 @@ const (
 
 	// IntegrationContextPhaseBuilding --
 	IntegrationContextPhaseBuilding IntegrationContextPhase = "Building"
-	// IntegrationContextPhaseDeploying --
-	IntegrationContextPhaseDeploying IntegrationContextPhase = "Deploying"
 	// IntegrationContextPhaseReady --
 	IntegrationContextPhaseReady IntegrationContextPhase = "Ready"
 	// IntegrationContextPhaseError --

--- a/pkg/apis/camel/v1alpha1/types_support.go
+++ b/pkg/apis/camel/v1alpha1/types_support.go
@@ -39,6 +39,16 @@ func (spec ConfigurationSpec) String() string {
 //
 // **********************************
 
+// NewIntegrationList --
+func NewIntegrationList() IntegrationList {
+	return IntegrationList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: SchemeGroupVersion.String(),
+			Kind:       IntegrationKind,
+		},
+	}
+}
+
 // NewIntegrationContext --
 func NewIntegrationContext(namespace string, name string) IntegrationContext {
 	return IntegrationContext{

--- a/pkg/stub/action/integration/build.go
+++ b/pkg/stub/action/integration/build.go
@@ -19,6 +19,7 @@ package action
 
 import (
 	"fmt"
+	"github.com/apache/camel-k/pkg/util/digest"
 
 	"github.com/rs/xid"
 
@@ -74,6 +75,7 @@ func (action *buildAction) Handle(integration *v1alpha1.Integration) error {
 			target.Status.Image = ctx.Status.Image
 			target.Spec.Context = ctx.Name
 			target.Status.Phase = v1alpha1.IntegrationPhaseDeploying
+			target.Status.Digest = digest.ComputeForIntegration(target)
 			return sdk.Update(target)
 		}
 

--- a/pkg/stub/action/integration/deploy.go
+++ b/pkg/stub/action/integration/deploy.go
@@ -151,6 +151,9 @@ func getDeploymentFor(ctx *v1alpha1.IntegrationContext, integration *v1alpha1.In
 	// has been changed
 	environment["CAMEL_K_DIGEST"] = integration.Status.Digest
 
+	// optimizations
+	environment["AB_JOLOKIA_OFF"] = "true"
+
 	labels := map[string]string{
 		"camel.apache.org/integration": integration.Name,
 	}

--- a/pkg/util/sync/file_test.go
+++ b/pkg/util/sync/file_test.go
@@ -1,0 +1,65 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestFile(t *testing.T) {
+	tempdir := os.TempDir()
+	fileName := path.Join(tempdir, "camel-k-test-"+strconv.FormatUint(rand.Uint64(), 10))
+	_, err := os.Create(fileName)
+	assert.Nil(t, err)
+	defer os.Remove(fileName)
+
+	ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(100*time.Second))
+	changes, err := File(ctx, fileName)
+	assert.Nil(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+	expectedNumChanges := 3
+	for i := 0; i < expectedNumChanges; i++ {
+		ioutil.WriteFile(fileName, []byte("data-"+strconv.Itoa(i)), 0777)
+		time.Sleep(350 * time.Millisecond)
+	}
+
+	numChanges := 0
+watch:
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-changes:
+			numChanges++
+			if (numChanges == expectedNumChanges) {
+				break watch
+			}
+		}
+	}
+
+	assert.Equal(t, expectedNumChanges, numChanges)
+}


### PR DESCRIPTION
This fixes #34, #90 and also #80 . So we've completed the "One second to deploy and redeploy" project.

With `kamel run Sample.java --dev`, you can edit your source file and see the integration logs always updated with your changes.