### PR TITLE
chore: add debug trait

### DIFF
--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -134,6 +134,7 @@ func createBuilderTestEnv(cluster v1alpha1.IntegrationPlatformCluster, strategy 
 				},
 			},
 		},
+		EnvVars:        make(map[string]string),
 		ExecutedTraits: make([]ID, 0),
 		Resources:      kubernetes.NewCollection(),
 	}

--- a/pkg/trait/catalog.go
+++ b/pkg/trait/catalog.go
@@ -24,12 +24,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
-	"github.com/apache/camel-k/pkg/platform"
 	"github.com/fatih/structs"
 )
 
 // Catalog collects all information about traits in one place
 type Catalog struct {
+	tDebug        Trait
 	tDependencies Trait
 	tDeployment   Trait
 	tKnative      Trait
@@ -44,6 +44,7 @@ type Catalog struct {
 // NewCatalog creates a new trait Catalog
 func NewCatalog() *Catalog {
 	return &Catalog{
+		tDebug:        newDebugTrait(),
 		tDependencies: newDependenciesTrait(),
 		tDeployment:   newDeploymentTrait(),
 		tKnative:      newKnativeTrait(),
@@ -58,6 +59,7 @@ func NewCatalog() *Catalog {
 
 func (c *Catalog) allTraits() []Trait {
 	return []Trait{
+		c.tDebug,
 		c.tDependencies,
 		c.tDeployment,
 		c.tKnative,
@@ -71,17 +73,12 @@ func (c *Catalog) allTraits() []Trait {
 }
 
 func (c *Catalog) traitsFor(environment *Environment) []Trait {
-	profile := platform.GetProfile(environment.Platform)
-	if environment.Context != nil && environment.Context.Spec.Profile != "" {
-		profile = environment.Context.Spec.Profile
-	}
-	if environment.Integration != nil && environment.Integration.Spec.Profile != "" {
-		profile = environment.Integration.Spec.Profile
-	}
+	profile := environment.DetermineProfile()
 
 	switch profile {
 	case v1alpha1.TraitProfileOpenShift:
 		return []Trait{
+			c.tDebug,
 			c.tDependencies,
 			c.tService,
 			c.tRoute,
@@ -92,6 +89,7 @@ func (c *Catalog) traitsFor(environment *Environment) []Trait {
 		}
 	case v1alpha1.TraitProfileKubernetes:
 		return []Trait{
+			c.tDebug,
 			c.tDependencies,
 			c.tService,
 			c.tIngress,
@@ -102,6 +100,7 @@ func (c *Catalog) traitsFor(environment *Environment) []Trait {
 		}
 	case v1alpha1.TraitProfileKnative:
 		return []Trait{
+			c.tDebug,
 			c.tDependencies,
 			c.tKnative,
 			c.tBuilder,

--- a/pkg/trait/debug.go
+++ b/pkg/trait/debug.go
@@ -1,0 +1,43 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trait
+
+import (
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+)
+
+type debugTrait struct {
+	BaseTrait `property:",squash"`
+}
+
+func newDebugTrait() *debugTrait {
+	return &debugTrait{
+		BaseTrait: newBaseTrait("debug"),
+	}
+}
+
+func (r *debugTrait) appliesTo(e *Environment) bool {
+	return e.Integration != nil && e.Integration.Status.Phase == v1alpha1.IntegrationPhaseDeploying
+}
+
+func (r *debugTrait) apply(e *Environment) error {
+	// this is all that's needed as long as the base image is `fabric8/s2i-java` look into builder/builder.go
+	e.EnvVars["JAVA_DEBUG"] = "true"
+
+	return nil
+}

--- a/pkg/trait/debug_test.go
+++ b/pkg/trait/debug_test.go
@@ -1,0 +1,49 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trait
+
+import (
+	"testing"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	env = &Environment{
+		Integration: &v1alpha1.Integration{
+			Status: v1alpha1.IntegrationStatus{
+				Phase: v1alpha1.IntegrationPhaseDeploying,
+			},
+		},
+		EnvVars: make(map[string]string)}
+
+	trait = newDebugTrait()
+)
+
+func TestApplicability(t *testing.T) {
+	assert.True(t, trait.appliesTo(env))
+
+	env.Integration.Status.Phase = v1alpha1.IntegrationPhaseRunning
+	assert.False(t, trait.appliesTo(env))
+}
+
+func TestApply(t *testing.T) {
+	assert.Nil(t, trait.apply(env))
+	assert.Equal(t, "true", env.EnvVars["JAVA_DEBUG"])
+}

--- a/pkg/trait/trait_test.go
+++ b/pkg/trait/trait_test.go
@@ -179,6 +179,7 @@ func createTestEnv(cluster v1alpha1.IntegrationPlatformCluster, dependencies ...
 				Cluster: cluster,
 			},
 		},
+		EnvVars:        make(map[string]string),
 		ExecutedTraits: make([]ID, 0),
 		Resources:      kubernetes.NewCollection(),
 	}

--- a/pkg/trait/types.go
+++ b/pkg/trait/types.go
@@ -20,6 +20,7 @@ package trait
 import (
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"github.com/apache/camel-k/pkg/builder"
+	"github.com/apache/camel-k/pkg/platform"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 )
 
@@ -111,4 +112,20 @@ func (e *Environment) IntegrationInPhase(phase v1alpha1.IntegrationPhase) bool {
 // IntegrationContextInPhase --
 func (e *Environment) IntegrationContextInPhase(phase v1alpha1.IntegrationContextPhase) bool {
 	return e.Context != nil && e.Context.Status.Phase == phase
+}
+
+// DeterimeProfile determines the TraitProfile of the environment.
+// First looking at the Integration.Spec for a Profile,
+// next looking at the Context.Spec
+// and lastly the Platform Profile
+func (e *Environment) DetermineProfile() v1alpha1.TraitProfile {
+	if e.Integration != nil && e.Integration.Spec.Profile != "" {
+		return e.Integration.Spec.Profile
+	}
+
+	if e.Context != nil && e.Context.Spec.Profile != "" {
+		return e.Context.Spec.Profile
+	}
+
+	return platform.GetProfile(e.Platform)
 }


### PR DESCRIPTION
This adds the `debug` trait, which can be activated via `--trait debug.enabled=true`.

Fixes #190