### PR TITLE
Fix #221: use registry name instead of IP in Knative on Openshift

### DIFF
--- a/pkg/apis/camel/v1alpha1/types.go
+++ b/pkg/apis/camel/v1alpha1/types.go
@@ -200,10 +200,19 @@ type IntegrationContextSpec struct {
 
 // IntegrationContextStatus --
 type IntegrationContextStatus struct {
-	Phase     IntegrationContextPhase `json:"phase,omitempty"`
-	Image     string                  `json:"image,omitempty"`
-	Digest    string                  `json:"digest,omitempty"`
-	Artifacts []Artifact              `json:"artifacts,omitempty"`
+	Phase       IntegrationContextPhase `json:"phase,omitempty"`
+	Image       string                  `json:"image,omitempty"`
+	PublicImage string                  `json:"publicImage,omitempty"`
+	Digest      string                  `json:"digest,omitempty"`
+	Artifacts   []Artifact              `json:"artifacts,omitempty"`
+}
+
+// ImageForIntegration returns the image to use when using it for running an integration
+func (c IntegrationContext) ImageForIntegration() string {
+	if c.Status.PublicImage != "" {
+		return c.Status.PublicImage
+	}
+	return c.Status.Image
 }
 
 // IntegrationContextPhase --

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -191,6 +191,7 @@ func (b *defaultBuilder) submit(request Request) {
 
 	r.Status = StatusCompleted
 	r.Image = c.Image
+	r.PublicImage = c.PublicImage
 	r.Error = c.Error
 	r.Task.CompletedAt = time.Now()
 
@@ -205,9 +206,10 @@ func (b *defaultBuilder) submit(request Request) {
 	b.request.Store(request.Meta.Name, r)
 
 	b.log.Infof("request to build context %s executed in %f seconds", request.Meta.Name, r.Task.Elapsed().Seconds())
-	b.log.Infof("dependencies       : %s", request.Dependencies)
-	b.log.Infof("artifacts          : %s", ArtifactIDs(c.Artifacts))
-	b.log.Infof("artifacts selected : %s", ArtifactIDs(c.SelectedArtifacts))
-	b.log.Infof("requested image    : %s", request.Image)
-	b.log.Infof("resolved image     : %s", c.Image)
+	b.log.Infof("dependencies          : %s", request.Dependencies)
+	b.log.Infof("artifacts             : %s", ArtifactIDs(c.Artifacts))
+	b.log.Infof("artifacts selected    : %s", ArtifactIDs(c.SelectedArtifacts))
+	b.log.Infof("requested image       : %s", request.Image)
+	b.log.Infof("resolved image        : %s", c.Image)
+	b.log.Infof("resolved public image : %s", c.PublicImage)
 }

--- a/pkg/builder/builder_types.go
+++ b/pkg/builder/builder_types.go
@@ -125,12 +125,13 @@ func (t Task) Elapsed() time.Duration {
 
 // Result represents the result of a build
 type Result struct {
-	Request   Request
-	Image     string
-	Error     error
-	Status    Status
-	Artifacts []v1alpha1.Artifact
-	Task      Task
+	Request     Request
+	Image       string
+	PublicImage string
+	Error       error
+	Status      Status
+	Artifacts   []v1alpha1.Artifact
+	Task        Task
 }
 
 // Context --
@@ -138,6 +139,7 @@ type Context struct {
 	C                 context.Context
 	Request           Request
 	Image             string
+	PublicImage       string
 	Error             error
 	Namespace         string
 	Project           maven.Project

--- a/pkg/builder/builder_types.go
+++ b/pkg/builder/builder_types.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	// IntiPhase --
-	IntiPhase int32 = 0
+	// InitPhase --
+	InitPhase int32 = 0
 	// ProjectGenerationPhase --
 	ProjectGenerationPhase int32 = 10
 	// ProjectBuildPhase --

--- a/pkg/stub/action/context/build.go
+++ b/pkg/stub/action/context/build.go
@@ -89,6 +89,7 @@ func (action *buildAction) Handle(context *v1alpha1.IntegrationContext) error {
 	case builder.StatusCompleted:
 		target := context.DeepCopy()
 		target.Status.Image = res.Image
+		target.Status.PublicImage = res.PublicImage
 		target.Status.Phase = v1alpha1.IntegrationContextPhaseReady
 		target.Status.Artifacts = make([]v1alpha1.Artifact, 0, len(res.Artifacts))
 

--- a/pkg/stub/action/integration/build_context.go
+++ b/pkg/stub/action/integration/build_context.go
@@ -78,7 +78,7 @@ func (action *buildContextAction) Handle(integration *v1alpha1.Integration) erro
 
 		if ctx.Status.Phase == v1alpha1.IntegrationContextPhaseError {
 			target := integration.DeepCopy()
-			target.Status.Image = ctx.Status.Image
+			target.Status.Image = ctx.ImageForIntegration()
 			target.Spec.Context = ctx.Name
 			target.Status.Phase = v1alpha1.IntegrationPhaseError
 
@@ -94,7 +94,7 @@ func (action *buildContextAction) Handle(integration *v1alpha1.Integration) erro
 
 		if ctx.Status.Phase == v1alpha1.IntegrationContextPhaseReady {
 			target := integration.DeepCopy()
-			target.Status.Image = ctx.Status.Image
+			target.Status.Image = ctx.ImageForIntegration()
 			target.Spec.Context = ctx.Name
 
 			dgst, err := digest.ComputeForIntegration(target)

--- a/pkg/stub/action/integration/build_image.go
+++ b/pkg/stub/action/integration/build_image.go
@@ -122,7 +122,11 @@ func (action *buildImageAction) Handle(integration *v1alpha1.Integration) error 
 	case builder.StatusCompleted:
 		target := integration.DeepCopy()
 		target.Status.Phase = v1alpha1.IntegrationPhaseDeploying
-		target.Status.Image = res.Image
+		if res.PublicImage != "" {
+			target.Status.Image = res.PublicImage
+		} else {
+			target.Status.Image = res.Image
+		}
 
 		dgst, err := digest.ComputeForIntegration(integration)
 		if err != nil {

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -96,7 +96,7 @@ func (t *builderTrait) Apply(e *Environment) error {
 }
 
 func (t *builderTrait) ReplaceHost(ctx *builder.Context) error {
-	ctx.Image = getImageWithOpenShiftHost(ctx.Image)
+	ctx.PublicImage = getImageWithOpenShiftHost(ctx.Image)
 	return nil
 }
 

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -141,3 +141,13 @@ func createBuilderTestEnv(cluster v1alpha1.IntegrationPlatformCluster, strategy 
 		Resources:      kubernetes.NewCollection(),
 	}
 }
+
+func TestIPReplacement(t *testing.T) {
+	assert.Equal(t, "docker-registry.default.svc:5000/myproject/camel-k:1234", getImageWithOpenShiftHost("172.30.1.1:5000/myproject/camel-k:1234"))
+	assert.Equal(t, "docker-registry.default.svc/myproject/camel-k:1234", getImageWithOpenShiftHost("172.30.1.1/myproject/camel-k:1234"))
+	assert.Equal(t, "docker-registry.default.svc/myproject/camel-k:1234", getImageWithOpenShiftHost("10.0.0.1/myproject/camel-k:1234"))
+	assert.Equal(t, "docker-registry.default.svc/camel-k", getImageWithOpenShiftHost("10.0.0.1/camel-k"))
+	assert.Equal(t, "10.0.2.3.4/camel-k", getImageWithOpenShiftHost("10.0.2.3.4/camel-k"))
+	assert.Equal(t, "gcr.io/camel-k/camel-k:latest", getImageWithOpenShiftHost("gcr.io/camel-k/camel-k:latest"))
+	assert.Equal(t, "docker.io/camel-k:latest", getImageWithOpenShiftHost("docker.io/camel-k:latest"))
+}

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -169,6 +169,8 @@ func (t *knativeTrait) getServiceFor(e *Environment) *serving.Service {
 	}
 
 	annotations := make(map[string]string)
+	// Resolve registry host names when used
+	annotations["alpha.image.policy.openshift.io/resolve-names"] = "*"
 	if t.MinScale != nil {
 		annotations[knativeMinScaleAnnotation] = strconv.Itoa(*t.MinScale)
 	}

--- a/pkg/trait/springboot.go
+++ b/pkg/trait/springboot.go
@@ -107,7 +107,7 @@ func (t *springBootTrait) Apply(e *Environment) error {
 
 	if e.Context != nil && e.Context.Status.Phase == v1alpha1.IntegrationContextPhaseBuilding {
 		// add custom initialization logic
-		e.Steps = append(e.Steps, builder.NewStep("initialize/spring-boot", builder.IntiPhase, springboot.Initialize))
+		e.Steps = append(e.Steps, builder.NewStep("initialize/spring-boot", builder.InitPhase, springboot.Initialize))
 		e.Steps = append(e.Steps, builder.NewStep("build/compute-boot-dependencies", builder.ProjectBuildPhase+1, springboot.ComputeDependencies))
 
 		// replace project generator


### PR DESCRIPTION
This is to avoid having to whitelist the registry ip address in Knative on Openshift.