### PR TITLE
Get JAVA_HOME path from system property for Kotlin loader

### DIFF
--- a/runtime/kotlin/src/main/kotlin/org/apache/camel/k/kotlin/KotlinRoutesLoader.kt
+++ b/runtime/kotlin/src/main/kotlin/org/apache/camel/k/kotlin/KotlinRoutesLoader.kt
@@ -50,7 +50,7 @@ class KotlinRoutesLoader : RoutesLoader {
                 val compiler = JvmScriptCompiler()
                 val evaluator = BasicJvmScriptEvaluator()
                 val host = BasicJvmScriptingHost(compiler = compiler, evaluator = evaluator)
-                val javaHome = System.getenv("KOTLIN_JDK_HOME") ?: "/usr/lib/jvm/java"
+                val javaHome = System.getenv("KOTLIN_JDK_HOME") ?: System.getProperty("java.home")
 
                 LOGGER.info("JAVA_HOME is set to {}", javaHome)
 


### PR DESCRIPTION
I unable to build `camel-k-runtime-kotlin` maven project on MAC or Windows OS. The reason is the default value of javaHome is hardcoded in Kotlin's route builder and this path could not work on all systems. 