### PR TITLE
chore(ux): show the same basic info with oc and kamel

### DIFF
--- a/deploy/crd-integration-context.yaml
+++ b/deploy/crd-integration-context.yaml
@@ -20,3 +20,11 @@ spec:
       type: string
       description: The IntegrationContext phase
       JSONPath: .status.phase
+    - name: Type
+      type: string
+      description: The IntegrationContext type
+      JSONPath: .metadata.labels.camel\.apache\.org\/context\.type
+    - name: Image
+      type: string
+      description: The IntegrationContext image
+      JSONPath: .status.image

--- a/deploy/crd-integration.yaml
+++ b/deploy/crd-integration.yaml
@@ -20,3 +20,7 @@ spec:
       type: string
       description: The Integration phase
       JSONPath: .status.phase
+    - name: Context
+      type: string
+      description: The IntegrationContext to use
+      JSONPath: .status.context

--- a/deploy/resources.go
+++ b/deploy/resources.go
@@ -2216,6 +2216,14 @@ spec:
       type: string
       description: The IntegrationContext phase
       JSONPath: .status.phase
+    - name: Type
+      type: string
+      description: The IntegrationContext type
+      JSONPath: .metadata.labels.camel\.apache\.org\/context\.type
+    - name: Image
+      type: string
+      description: The IntegrationContext image
+      JSONPath: .status.image
 
 `
 	Resources["crd-integration-platform.yaml"] =
@@ -2268,6 +2276,10 @@ spec:
       type: string
       description: The Integration phase
       JSONPath: .status.phase
+    - name: Context
+      type: string
+      description: The IntegrationContext to use
+      JSONPath: .status.context
 
 `
 	Resources["cr-example.yaml"] =

--- a/pkg/cmd/context_get.go
+++ b/pkg/cmd/context_get.go
@@ -77,14 +77,14 @@ func (command *contextGetCommand) run() error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
-	fmt.Fprintln(w, "NAME\tTYPE\tSTATUS")
+	fmt.Fprintln(w, "NAME\tPHASE\tTYPE\tIMAGE")
 	for _, ctx := range ctxList.Items {
 		t := ctx.Labels["camel.apache.org/context.type"]
 		u := command.user && t == "user"
 		p := command.platform && t == v1alpha1.IntegrationContextTypePlatform
 
 		if u || p {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", ctx.Name, t, string(ctx.Status.Phase))
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", ctx.Name, string(ctx.Status.Phase), t, ctx.Status.Image)
 		}
 	}
 	w.Flush()

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -68,9 +68,9 @@ func (o *getCmdOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
-	fmt.Fprintln(w, "NAME\tCONTEXT\tSTATUS")
+	fmt.Fprintln(w, "NAME\tPHASE\tCONTEXT")
 	for _, integration := range integrationList.Items {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", integration.Name, integration.Status.Context, string(integration.Status.Phase))
+		fmt.Fprintf(w, "%s\t%s\t%s\n", integration.Name, string(integration.Status.Phase), integration.Status.Context)
 	}
 	w.Flush()
 


### PR DESCRIPTION
This PR aims to harmonize the basic information shown using **oc** and **kamel**

* **integration context info**:

```
$ oc get ictx
NAME          PHASE     TYPE       IMAGE
groovy        Ready     platform   172.30.1.1:5000/camel-k/camel-k-groovy:379349
jvm           Ready     platform   172.30.1.1:5000/camel-k/camel-k-jvm:379347
kotlin        Ready     platform   172.30.1.1:5000/camel-k/camel-k-kotlin:379352
spring-boot   Ready     platform   172.30.1.1:5000/camel-k/camel-k-spring-boot:379448

$ kamel context get
NAME		PHASE	TYPE		IMAGE
groovy		Ready	platform	172.30.1.1:5000/camel-k/camel-k-groovy:379349
jvm		Ready	platform	172.30.1.1:5000/camel-k/camel-k-jvm:379347
kotlin		Ready	platform	172.30.1.1:5000/camel-k/camel-k-kotlin:379352
spring-boot	Ready	platform	172.30.1.1:5000/camel-k/camel-k-spring-boot:379448
```

* **integration info**

```
$ oc get it
NAME      PHASE     CONTEXT
hello     Running   jvm

$ kamel get
NAME	PHASE	CONTEXT
hello	Running	jvm
```
