### PR TITLE
chore(contributing.adoc): Add explanation to add KOTLIN_JDK_HOME for building on MacOs

### DIFF
--- a/contributing.adoc
+++ b/contributing.adoc
@@ -72,6 +72,16 @@ make dep
 
 The `make dep` command runs `dep ensure -v` under the hood, so make sure that `dep` is properly installed.
 
+For now, you have to set environment variable `KOTLIN_JDK_HOME` pointing to your JDK (not JRE) home directory.
+Also ensure, that you are using a Java version 8.
+
+For Mac you can just do a
+
+[source, bash]
+----
+export KOTLIN_JDK_HOME=$(/usr/libexec/java_home -v 1.8)
+----
+
 To build the whole project you now need to run:
 
 ```


### PR DESCRIPTION
As this seems to be a temporary workaround, just let document it.
Otherwise it would have made sense to adapt the Makefile to set it
automatically.

Fixes #297.