### PR TITLE
fix(kamel log): Use integration name for looking up containers

### DIFF
--- a/pkg/util/log/util.go
+++ b/pkg/util/log/util.go
@@ -30,7 +30,7 @@ import (
 
 // Print prints integrations logs to the stdout
 func Print(ctx context.Context, client kubernetes.Interface, integration *v1alpha1.Integration) error {
-	scraper := NewSelectorScraper(client, integration.Namespace, "camel.apache.org/integration="+integration.Name)
+	scraper := NewSelectorScraper(client, integration.Namespace, integration.Name,"camel.apache.org/integration="+integration.Name)
 	reader := scraper.Start(ctx)
 
 	if _, err := io.Copy(os.Stdout, ioutil.NopCloser(reader)); err != nil {

--- a/test/log_scrape_integration_test.go
+++ b/test/log_scrape_integration_test.go
@@ -39,7 +39,7 @@ func TestPodLogScrape(t *testing.T) {
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
 	defer cancel()
-	scraper := log.NewPodScraper(testClient, pod.Namespace, pod.Name)
+	scraper := log.NewPodScraper(testClient, pod.Namespace, pod.Name, "scraped")
 	in := scraper.Start(ctx)
 
 	res := make(chan bool)
@@ -74,7 +74,7 @@ func TestSelectorLogScrape(t *testing.T) {
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
 	defer cancel()
-	scraper := log.NewSelectorScraper(testClient, deployment.Namespace, "scrape=me")
+	scraper := log.NewSelectorScraper(testClient, deployment.Namespace, "main", "scrape=me")
 	in := scraper.Start(ctx)
 
 	res := make(chan string)


### PR DESCRIPTION
Use integration name for looking up containers as a fallback if no
container could be found.

If no container could be identified even with the integration name,
use the first container for the log, assuming its the "main" container.

Fixes #347