### PR TITLE
chore: regenerated resources.go

### DIFF
--- a/deploy/resources.go
+++ b/deploy/resources.go
@@ -2798,6 +2798,29 @@ artifacts:
     version: 2.23.1
 
 `
+	Resources["cr-example.yaml"] =
+		`
+apiVersion: camel.apache.org/v1alpha1
+kind: Integration
+metadata:
+  name: example
+spec:
+  source:
+    content: |-
+      // This is Camel K Groovy example route
+
+      rnd = new Random()
+
+      from('timer:groovy?period=1s')
+          .routeId('groovy')
+          .setBody()
+              .constant('Hello Camel K!')
+          .process {
+              it.in.headers['RandomValue'] = rnd.nextInt()
+          }
+          .to('log:info?showHeaders=true')
+    name: routes.groovy
+`
 	Resources["crd-integration-context.yaml"] =
 		`
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -2887,29 +2910,6 @@ spec:
       description: The IntegrationContext to use
       JSONPath: .status.context
 
-`
-	Resources["cr-example.yaml"] =
-		`
-apiVersion: camel.apache.org/v1alpha1
-kind: Integration
-metadata:
-  name: example
-spec:
-  source:
-    content: |-
-      // This is Camel K Groovy example route
-
-      rnd = new Random()
-
-      from('timer:groovy?period=1s')
-          .routeId('groovy')
-          .setBody()
-              .constant('Hello Camel K!')
-          .process {
-              it.in.headers['RandomValue'] = rnd.nextInt()
-          }
-          .to('log:info?showHeaders=true')
-    name: routes.groovy
 `
 	Resources["operator-deployment-kubernetes.yaml"] =
 		`

--- a/script/embed_resources.sh
+++ b/script/embed_resources.sh
@@ -38,7 +38,7 @@ func init() {
 
 EOM
 
-for f in $(ls $destdir | grep ".yaml" | grep -v -e "^operator.yaml$"); do
+for f in $(ls $destdir | grep ".yaml" | grep -v -e "^operator.yaml$" | sort); do
 	printf "\tResources[\"$f\"] =\n\t\t\`\n" >> $destfile
 	cat $destdir/$f >> $destfile
 	printf "\n\`\n" >> $destfile


### PR DESCRIPTION
Not sure whether this is white-space diff only. But if so, the generation should
be fixed to yield the same format on every platform.