### PR TITLE
build handlers: split buld step in two phases: submit and run

### DIFF
--- a/pkg/apis/camel/v1alpha1/integration_types.go
+++ b/pkg/apis/camel/v1alpha1/integration_types.go
@@ -131,8 +131,10 @@ const (
 	IntegrationPhaseWaitingForPlatform IntegrationPhase = "Waiting For Platform"
 	// IntegrationPhaseBuildingContext --
 	IntegrationPhaseBuildingContext IntegrationPhase = "Building Context"
-	// IntegrationPhaseBuildingImage --
-	IntegrationPhaseBuildingImage IntegrationPhase = "Building Image"
+	// IntegrationPhaseBuildImageSubmitted --
+	IntegrationPhaseBuildImageSubmitted IntegrationPhase = "Build Image Submitted"
+	// IntegrationPhaseBuildImageRunning --
+	IntegrationPhaseBuildImageRunning IntegrationPhase = "Build Image Running"
 	// IntegrationPhaseDeploying --
 	IntegrationPhaseDeploying IntegrationPhase = "Deploying"
 	// IntegrationPhaseRunning --

--- a/pkg/apis/camel/v1alpha1/integrationcontext_types.go
+++ b/pkg/apis/camel/v1alpha1/integrationcontext_types.go
@@ -64,8 +64,10 @@ const (
 	// IntegrationContextTypeExternal --
 	IntegrationContextTypeExternal = "external"
 
-	// IntegrationContextPhaseBuilding --
-	IntegrationContextPhaseBuilding IntegrationContextPhase = "Building"
+	// IntegrationContextPhaseBuildSubmitted --
+	IntegrationContextPhaseBuildSubmitted IntegrationContextPhase = "Build Submitted"
+	// IntegrationContextPhaseBuildRunning --
+	IntegrationContextPhaseBuildRunning IntegrationContextPhase = "Build Running"
 	// IntegrationContextPhaseReady --
 	IntegrationContextPhaseReady IntegrationContextPhase = "Ready"
 	// IntegrationContextPhaseError --

--- a/pkg/builder/builder_types.go
+++ b/pkg/builder/builder_types.go
@@ -47,7 +47,7 @@ const (
 // Builder --
 type Builder interface {
 	IsBuilding(object v1.ObjectMeta) bool
-	Submit(request Request, handler func(Result))
+	Submit(request Request, handler func(*Result))
 	Close()
 }
 
@@ -102,6 +102,7 @@ type Resource struct {
 
 // Request --
 type Request struct {
+	C            context.Context
 	Meta         v1.ObjectMeta
 	Platform     v1alpha1.IntegrationPlatformSpec
 	Dependencies []string
@@ -190,4 +191,7 @@ const (
 
 	// StatusError --
 	StatusError
+
+	// StatusInterrupted --
+	StatusInterrupted
 )

--- a/pkg/controller/integrationcontext/initialize.go
+++ b/pkg/controller/integrationcontext/initialize.go
@@ -60,7 +60,7 @@ func (action *initializeAction) Handle(ctx context.Context, ictx *v1alpha1.Integ
 
 	if target.Spec.Image == "" {
 		// by default the context should be build
-		target.Status.Phase = v1alpha1.IntegrationContextPhaseBuilding
+		target.Status.Phase = v1alpha1.IntegrationContextPhaseBuildSubmitted
 	} else {
 		// but in case it has been created from an image, mark the
 		// context as ready

--- a/pkg/controller/integrationcontext/integrationcontext_controller.go
+++ b/pkg/controller/integrationcontext/integrationcontext_controller.go
@@ -88,7 +88,7 @@ func (r *ReconcileIntegrationContext) Reconcile(request reconcile.Request) (reco
 
 	integrationContextActionPool := []Action{
 		NewInitializeAction(),
-		NewBuildAction(ctx),
+		NewBuildAction(),
 		NewErrorRecoveryAction(),
 		NewMonitorAction(),
 	}

--- a/pkg/controller/integrationcontext/monitor.go
+++ b/pkg/controller/integrationcontext/monitor.go
@@ -52,7 +52,7 @@ func (action *monitorAction) Handle(ctx context.Context, ictx *v1alpha1.Integrat
 
 		target := ictx.DeepCopy()
 		target.Status.Digest = hash
-		target.Status.Phase = v1alpha1.IntegrationContextPhaseBuilding
+		target.Status.Phase = v1alpha1.IntegrationContextPhaseBuildSubmitted
 
 		logrus.Info("Context ", target.Name, " transitioning to state ", target.Status.Phase)
 

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -49,11 +49,11 @@ func (t *builderTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if e.IntegrationContextInPhase(v1alpha1.IntegrationContextPhaseBuilding) {
+	if e.IntegrationContextInPhase(v1alpha1.IntegrationContextPhaseBuildSubmitted) {
 		return true, nil
 	}
 
-	if e.InPhase(v1alpha1.IntegrationContextPhaseReady, v1alpha1.IntegrationPhaseBuildingImage) {
+	if e.InPhase(v1alpha1.IntegrationContextPhaseReady, v1alpha1.IntegrationPhaseBuildImageSubmitted) {
 		return true, nil
 	}
 
@@ -61,7 +61,7 @@ func (t *builderTrait) Configure(e *Environment) (bool, error) {
 }
 
 func (t *builderTrait) Apply(e *Environment) error {
-	if e.IntegrationContextInPhase(v1alpha1.IntegrationContextPhaseBuilding) {
+	if e.IntegrationContextInPhase(v1alpha1.IntegrationContextPhaseBuildSubmitted) {
 		if platform.SupportsS2iPublishStrategy(e.Platform) {
 			e.Steps = s2i.DefaultSteps
 			if e.DetermineProfile() == v1alpha1.TraitProfileKnative {
@@ -73,7 +73,7 @@ func (t *builderTrait) Apply(e *Environment) error {
 		}
 	}
 
-	if e.InPhase(v1alpha1.IntegrationContextPhaseReady, v1alpha1.IntegrationPhaseBuildingImage) {
+	if e.InPhase(v1alpha1.IntegrationContextPhaseReady, v1alpha1.IntegrationPhaseBuildImageSubmitted) {
 		if platform.SupportsS2iPublishStrategy(e.Platform) {
 			e.Steps = []builder.Step{
 				builder.NewStep("packager", builder.ApplicationPackagePhase, builder.StandardPackager),

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -127,7 +127,7 @@ func createBuilderTestEnv(cluster v1alpha1.IntegrationPlatformCluster, strategy 
 		},
 		Context: &v1alpha1.IntegrationContext{
 			Status: v1alpha1.IntegrationContextStatus{
-				Phase: v1alpha1.IntegrationContextPhaseBuilding,
+				Phase: v1alpha1.IntegrationContextPhaseBuildSubmitted,
 			},
 		},
 		Platform: &v1alpha1.IntegrationPlatform{

--- a/pkg/trait/deployment.go
+++ b/pkg/trait/deployment.go
@@ -76,7 +76,7 @@ func (t *deploymentTrait) Configure(e *Environment) (bool, error) {
 func (t *deploymentTrait) Apply(e *Environment) error {
 	if t.ContainerImage && e.InPhase(v1alpha1.IntegrationContextPhaseReady, v1alpha1.IntegrationPhaseBuildingContext) {
 		// trigger container image build
-		e.Integration.Status.Phase = v1alpha1.IntegrationPhaseBuildingImage
+		e.Integration.Status.Phase = v1alpha1.IntegrationPhaseBuildImageSubmitted
 	}
 
 	if !t.ContainerImage && e.InPhase(v1alpha1.IntegrationContextPhaseReady, v1alpha1.IntegrationPhaseBuildingContext) {

--- a/pkg/trait/springboot.go
+++ b/pkg/trait/springboot.go
@@ -46,7 +46,7 @@ func (t *springBootTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if e.IntegrationContextInPhase(v1alpha1.IntegrationContextPhaseBuilding) {
+	if e.IntegrationContextInPhase(v1alpha1.IntegrationContextPhaseBuildSubmitted) {
 		return true, nil
 	}
 	if e.InPhase(v1alpha1.IntegrationContextPhaseReady, v1alpha1.IntegrationPhaseDeploying) {
@@ -113,7 +113,7 @@ func (t *springBootTrait) Apply(e *Environment) error {
 	// Integration Context
 	//
 
-	if e.IntegrationContextInPhase(v1alpha1.IntegrationContextPhaseBuilding) {
+	if e.IntegrationContextInPhase(v1alpha1.IntegrationContextPhaseBuildSubmitted) {
 		// add custom initialization logic
 		e.Steps = append(e.Steps, builder.NewStep("initialize/spring-boot", builder.InitPhase, springboot.Initialize))
 		e.Steps = append(e.Steps, builder.NewStep("build/compute-boot-dependencies", builder.ProjectBuildPhase+1, springboot.ComputeDependencies))


### PR DESCRIPTION
- split build phase in submit and run to have a better understanding of what happen
- add support to cancel an in progress build
- add consistence check when the build process ends and a resource is about to be updated
