### PR TITLE
-Add Camel-K CSV and Package for OLM integration and deployment of op…

### DIFF
--- a/deploy/bundle/camel-k.package.yaml
+++ b/deploy/bundle/camel-k.package.yaml
@@ -1,0 +1,4 @@
+packageName: camel-k
+channels:
+- name: alpha
+  currentCSV: camel-k-operator.v0.2.0

--- a/deploy/bundle/camel-k.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/bundle/camel-k.v0.2.0.clusterserviceversion.yaml
@@ -1,0 +1,266 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: camel-k-operator.v0.2.0
+  namespace: placeholder
+  annotations:
+    categories: "Integration & Delivery"
+    certified: "false" 
+    containerImage: docker.io/apache/camel-k:0.2.0
+    description: |-
+      Apache Camel K (a.k.a. Kamel) is a lightweight integration framework built from Apache Camel that runs natively on Kubernetes and is specifically designed for serverless and microservice architectures.
+    alm-examples: |-
+      [{
+        "apiVersion": "camel.apache.org/v1alpha1",
+        "kind": "Integration",
+        "metadata": {
+          "name": "example"
+        },
+        "spec": {
+          "source": {
+            "content": "// Add example Java code to create Integration",
+            "name": "Example.java"
+          }
+        }
+      }]
+spec:
+  displayName: Camel-K Operator
+  description: |
+    Apache Camel K
+    ==============
+
+    Camel K (a.k.a Kamel) is a lightweight integration framework built from Apache Camel that runs natively on Kubernetes and is specifically designed for serverless and microservice architectures.
+    
+    ## Installation
+
+    To start using Camel K, install the operator and then create the following IntegrationPlatform:
+    ```
+    apiVersion: camel.apache.org/v1alpha1
+    kind: IntegrationPlatform
+    metadata:
+      name: camel-k
+      labels:
+        app: "camel-k"
+    spec:
+      build:
+        camelVersion: "2.23.1"
+        baseImage: "fabric8/s2i-java:3.0-java8"
+        localRepository: "/tmp/artifacts/m2"
+    ```
+    ## Running an Integration
+    
+    After the initial setup, you can run a Camel integration on the cluster by creating an example Integration:
+    ```
+    apiVersion: camel.apache.org/v1alpha1
+    kind: Integration
+    metadata:
+      name: example
+    spec:
+      sources:
+      - content: "import org.apache.camel.builder.RouteBuilder;\n\npublic class Example
+          extends RouteBuilder {\n  @Override\n  public void configure() throws Exception
+          {\n\t  from(\"timer:tick\")\n    .setBody(constant(\"-\\n             r\\n             o\\n
+          \            c\\nHello World!\\n             s\\n             !\\n\"))\n\t\t.to(\"log:info?skipBodyLineSeparator=false\");\n
+          \ }\n}\n"
+        name: Example.java
+    ```
+  keywords: ['apache', 'kamel', 'kubernetes', 'serverless', 'microservices']
+  version: 0.2.0
+  maintainers:
+  - name: The Apache Software Foundation
+    email: users@camel.apache.org
+  provider:
+    name: The Apache Software Foundation
+  labels:
+    name: camel-k-operator
+  selector:
+    matchLabels:
+      name: camel-k-operator
+  links:
+  - name: Camel K Operator Source Code
+    url: https://github.com/apache/camel-k
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: camel-k-operator
+        rules:
+        - apiGroups:
+          - camel.apache.org
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          attributeRestrictions: null
+          resources:
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - "build.openshift.io"
+          resources:
+          - buildconfigs
+          - buildconfigs/webhooks
+          - builds
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - "image.openshift.io"
+          resources:
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams
+          - imagestreams/secrets
+          - imagestreamtags
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          attributeRestrictions: null
+          resources:
+          - buildconfigs/instantiate
+          - buildconfigs/instantiatebinary
+          - builds/clone
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - "route.openshift.io"
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+      deployments:
+      - name: camel-k-operator
+        spec:
+          replicas: 1
+          strategy:
+            type: Recreate
+          selector:
+            matchLabels:
+              name: camel-k-operator
+          template:
+            metadata:
+              labels:
+                name: camel-k-operator
+                camel.apache.org/component: operator
+            spec:
+              serviceAccountName: camel-k-operator
+              containers:
+                - name: camel-k-operator
+                  image: docker.io/apache/camel-k:0.2.0
+                  ports:
+                  - containerPort: 60000
+                    name: metrics
+                  command:
+                  - camel-k
+                  imagePullPolicy: IfNotPresent
+                  env:
+                    - name: WATCH_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.annotations['olm.targetNamespaces']
+                    - name: OPERATOR_NAME
+                      value: "camel-k"
+  customresourcedefinitions:
+    owned:
+    - name: integrations.camel.apache.org
+      version: v1alpha1
+      kind: Integration
+      displayName: Integration CRD
+      description: Integration CRD for Camel-K
+    - name: integrationplatforms.camel.apache.org
+      version: v1alpha1
+      kind: IntegrationPlatform
+      displayName: Integration Platforms CRD
+      description: Integration Platforms CRD for Camel-K
+    - name: integrationcontexts.camel.apache.org
+      version: v1alpha1
+      kind: IntegrationContext     
+      displayName: Integration Context CRD
+      description: Integration Context CRD for Camel-K


### PR DESCRIPTION
…erator through OperatorHub

- This pull requests introduces a CSV and Package which can be bundled together and used by the [Operator Lifecycle Manager(OLM)](https://github.com/operator-framework/operator-lifecycle-manager) to install, manage, and upgrade the Camel-K Operator in a cluster.

- The Camel-K operator versions available to all Kubernetes clusters using OLM can be updated by submitting a pull request to the [Community Operators GitHub repo](https://github.com/operator-framework/community-operators) that includes the latest CSVs, CRDs, and Packages.

- The CSV was created based on the [documentation provided by OLM](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md) and the [documentation](https://github.com/operator-framework/community-operators/blob/master/docs/marketplace-required-csv-annotations.md) provided by [OperatorHub](https://github.com/operator-framework/operator-marketplace).

- It was confirmed that the behavior of the operator deployed by the steps outlined in the Camel-K README reached a running state in a Kubernetes 1.11.0 cluster with OLM installed, and that the operator watched the creation of the cr.example.yaml CR provided in the deploy directory. It was then confirmed that the operator deployed with the CSV matched this behavior in the same environment.

- The CSV had to be verified against the [scorecard functionality recently introduced](https://github.com/operator-framework/operator-sdk/pull/758) to the [Operator-sdk](https://github.com/operator-framework/operator-sdk), to ensure that it conforms to the format expected by the OLM. However, the sdk currently does not support scoring operators that have multiple CRDs. A [feature request](https://github.com/operator-framework/operator-sdk/issues/984) has been made against the operator-sdk repository to allow testing operators that have multiple CRDs. The CSV in this pull request has been manually verified instead. All future changes to the CSV should be tested against the scorecard, when the feature becomes available.

OLM integration can be improved by future code changes to the Operator:
- Addressing the operator-sdk scorecard tests that might fail, once the Operator can be scored with the scorecard.
- Adding additional information to the Camel-K CSV based on the [CSV documentation provided by OLM](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md)
- Adding additional information to the Camel-K CSV based on the [CSV documentation provided by OperatorHub](https://github.com/operator-framework/community-operators/blob/master/docs/marketplace-required-csv-annotations.md)

- Adding [StatusDescriptors and SpecDescriptors](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#your-custom-resource-definitions) to the CRDs
- Adding additional CR examples to `metadata.annotations.alm-examples`