### PR TITLE
Failed to resolve endpoint: twitter-search

### DIFF
--- a/pkg/metadata/metadata_dependencies_test.go
+++ b/pkg/metadata/metadata_dependencies_test.go
@@ -32,6 +32,8 @@ func TestDependenciesJavaSource(t *testing.T) {
 			    from("telegram:bots/cippa").to("log:stash");
 			    from("timer:tick").to("amqp:queue");
 			    from("ine:xistent").to("amqp:queue");
+				from("twitter-search:{{twitterKeywords}}"
+                    + "?delay={{twitterDelayMs}}");
 			`,
 		},
 		Language: v1alpha1.LanguageJavaSource,
@@ -39,24 +41,7 @@ func TestDependenciesJavaSource(t *testing.T) {
 
 	meta := Extract(code)
 	// assert all dependencies are found and sorted (removing duplicates)
-	assert.Equal(t, []string{"camel:amqp", "camel:core", "camel:telegram"}, meta.Dependencies)
-}
-
-func TestDependenciesJavaClass(t *testing.T) {
-	code := v1alpha1.SourceSpec{
-		DataSpec: v1alpha1.DataSpec{
-			Name: "Request.class",
-			Content: `
-			    from("telegram:bots/cippa").to("log:stash");
-			    from("timer:tick").to("amqp:queue");
-			    from("ine:xistent").to("amqp:queue");
-		    `,
-		},
-		Language: v1alpha1.LanguageJavaClass,
-	}
-
-	meta := Extract(code)
-	assert.Empty(t, meta.Dependencies)
+	assert.Equal(t, []string{"camel:amqp", "camel:core", "camel:telegram", "camel:twitter"}, meta.Dependencies)
 }
 
 func TestDependenciesJavaScript(t *testing.T) {
@@ -85,7 +70,9 @@ func TestDependenciesGroovy(t *testing.T) {
 			    from('telegram:bots/cippa').to("log:stash");
 			    from('timer:tick').to("amqp:queue");
 			    from("ine:xistent").to("amqp:queue");
-			    '"'
+				from('twitter-search:{{twitterKeywords}}'
+                    + '?delay={{twitterDelayMs}}');
+			    '"
 		    `,
 		},
 		Language: v1alpha1.LanguageGroovy,
@@ -93,7 +80,7 @@ func TestDependenciesGroovy(t *testing.T) {
 
 	meta := Extract(code)
 	// assert all dependencies are found and sorted (removing duplicates)
-	assert.Equal(t, []string{"camel:amqp", "camel:core", "camel:telegram"}, meta.Dependencies)
+	assert.Equal(t, []string{"camel:amqp", "camel:core", "camel:telegram", "camel:twitter"}, meta.Dependencies)
 }
 
 func TestDependencies(t *testing.T) {

--- a/pkg/util/source/inspector.go
+++ b/pkg/util/source/inspector.go
@@ -29,14 +29,14 @@ import (
 )
 
 var (
-	singleQuotedFrom = regexp.MustCompile(`from\s*\(\s*'([a-z0-9-]+:[^']+)'\s*\)`)
-	doubleQuotedFrom = regexp.MustCompile(`from\s*\(\s*"([a-z0-9-]+:[^"]+)"\s*\)`)
-	singleQuotedTo   = regexp.MustCompile(`\.to\s*\(\s*'([a-z0-9-]+:[^']+)'\s*\)`)
-	singleQuotedToD  = regexp.MustCompile(`\.toD\s*\(\s*'([a-z0-9-]+:[^']+)'\s*\)`)
-	singleQuotedToF  = regexp.MustCompile(`\.toF\s*\(\s*'([a-z0-9-]+:[^']+)'[^)]*\)`)
-	doubleQuotedTo   = regexp.MustCompile(`\.to\s*\(\s*"([a-z0-9-]+:[^"]+)"\s*\)`)
-	doubleQuotedToD  = regexp.MustCompile(`\.toD\s*\(\s*"([a-z0-9-]+:[^"]+)"\s*\)`)
-	doubleQuotedToF  = regexp.MustCompile(`\.toF\s*\(\s*"([a-z0-9-]+:[^"]+)"[^)]*\)`)
+	singleQuotedFrom = regexp.MustCompile(`from\s*\(\s*'([a-z0-9-]+:[^']+)'`)
+	doubleQuotedFrom = regexp.MustCompile(`from\s*\(\s*"([a-z0-9-]+:[^"]+)"`)
+	singleQuotedTo   = regexp.MustCompile(`\.to\s*\(\s*'([a-z0-9-]+:[^']+)'`)
+	singleQuotedToD  = regexp.MustCompile(`\.toD\s*\(\s*'([a-z0-9-]+:[^']+)'`)
+	singleQuotedToF  = regexp.MustCompile(`\.toF\s*\(\s*'([a-z0-9-]+:[^']+)'`)
+	doubleQuotedTo   = regexp.MustCompile(`\.to\s*\(\s*"([a-z0-9-]+:[^"]+)"`)
+	doubleQuotedToD  = regexp.MustCompile(`\.toD\s*\(\s*"([a-z0-9-]+:[^"]+)"`)
+	doubleQuotedToF  = regexp.MustCompile(`\.toF\s*\(\s*"([a-z0-9-]+:[^"]+)"`)
 
 	additionalDependencies = map[string]string{
 		".*JsonLibrary\\.Jackson.*": "camel:jackson",


### PR DESCRIPTION
fixes #370

This fixes this issue but there are still cases that are not 
properly covered so assuming we have a route like this:

```java
from("twitter-search:{{twitterKeywords}}?delay={{twitterDelayMs}}"
    + "&consumerKey={{twitterConsumerKey}}"
    + "&consumerSecret={{twitterConsumerSecret}}"
    + "&accessToken={{twitterAccessToken}}"
    + "&accessTokenSecret={{twitterAccessTokenSecret}}")
```

the operator will properly discovery the component but
the url will be truncated and will contains only:

    twitter-search:{{twitterKeywords}}?delay={{twitterDelayMs}}

