### PR TITLE
Add container ports to integration deployment

### DIFF
--- a/pkg/trait/catalog.go
+++ b/pkg/trait/catalog.go
@@ -192,6 +192,13 @@ func (c *Catalog) apply(environment *Environment) error {
 		}
 	}
 
+	for _, processor := range environment.PostProcessors {
+		err := processor(environment)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/trait/types.go
+++ b/pkg/trait/types.go
@@ -30,8 +30,8 @@ import (
 	"github.com/apache/camel-k/pkg/metadata"
 	"github.com/apache/camel-k/pkg/platform"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
-	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // Identifiable represent an identifiable type
@@ -99,6 +99,7 @@ type Environment struct {
 	Context        *v1alpha1.IntegrationContext
 	Integration    *v1alpha1.Integration
 	Resources      *kubernetes.Collection
+	PostProcessors []func(*Environment) error
 	Steps          []builder.Step
 	BuildDir       string
 	ExecutedTraits []Trait


### PR DESCRIPTION
This is useful for applications that discover containers depending on exposed ports metadata, e.g. tooling.

Note that this PR introduces the concept of `Environment` post-processors. This enables traits to influence the generated resources before they are applied. 