### PR TITLE
Aggregate multiple occurences of the same run command CLI option into…

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -471,7 +471,17 @@ func (*runCmdOptions) configureTrait(integration *v1alpha1.Integration, config s
 		}
 	}
 
-	spec.Configuration[prop] = val
+	if len(spec.Configuration[prop]) > 0 {
+		// Aggregate multiple occurences of the same option into a comma-separated string,
+		// attempting to follow POSIX conventions.
+		// This enables to execute:
+		// $ kamel run -t <trait>.<property>=<value_1> ... -t <trait>.<property>=<value_N>
+		// Or:
+		// $ kamel run --trait <trait>.<property>=<value_1>,...,<value_N>
+		spec.Configuration[prop] = spec.Configuration[prop] + "," + val
+	} else {
+		spec.Configuration[prop] = val
+	}
 	integration.Spec.Traits[traitID] = spec
 	return nil
 }


### PR DESCRIPTION
… a comma-separated string configuration

It attempts to follow POSIX conventions, so that it's possible to execute:

    $ kamel run -t <trait>.<property>=<value_1> ... -t <trait>.<property>=<value_N>

Or:

    $ kamel run --trait <trait>.<property>=<value_1>,...,<value_N>