### PR TITLE
Fixed AddDependency in integration_type_support.go to handle default …

### DIFF
--- a/pkg/apis/camel/v1alpha1/integration_types_support.go
+++ b/pkg/apis/camel/v1alpha1/integration_types_support.go
@@ -84,12 +84,10 @@ func (is *IntegrationSpec) AddConfiguration(confType string, confValue string) {
 // AddDependency --
 func (is *IntegrationSpec) AddDependency(dependency string) {
 	switch {
-	case strings.HasPrefix(dependency, "mvn:"):
-		util.StringSliceUniqueAdd(&is.Dependencies, dependency)
-	case strings.HasPrefix(dependency, "file:"):
-		util.StringSliceUniqueAdd(&is.Dependencies, dependency)
 	case strings.HasPrefix(dependency, "camel-"):
 		util.StringSliceUniqueAdd(&is.Dependencies, "camel:"+strings.TrimPrefix(dependency, "camel-"))
+	default:
+		util.StringSliceUniqueAdd(&is.Dependencies, dependency)
 	}
 }
 

--- a/pkg/apis/camel/v1alpha1/integration_types_support_test.go
+++ b/pkg/apis/camel/v1alpha1/integration_types_support_test.go
@@ -41,3 +41,21 @@ func TestLanguageAlreadySet(t *testing.T) {
 	}
 	assert.Equal(t, LanguageJavaScript, code.InferLanguage())
 }
+
+func TestAddDependency(t *testing.T) {
+	integration := IntegrationSpec{}
+	integration.AddDependency("camel-ciaone")
+	assert.Equal(t, integration.Dependencies, []string{"camel:ciaone"})
+
+	integration = IntegrationSpec{}
+	integration.AddDependency("runtime:ciaone")
+	assert.Equal(t, integration.Dependencies, []string{"runtime:ciaone"})
+
+	integration = IntegrationSpec{}
+	integration.AddDependency("mvn:ciaone")
+	assert.Equal(t, integration.Dependencies, []string{"mvn:ciaone"})
+
+	integration = IntegrationSpec{}
+	integration.AddDependency("file:ciaone")
+	assert.Equal(t, integration.Dependencies, []string{"file:ciaone"})
+}


### PR DESCRIPTION
…case instead of discarding.

there was a problem handling `--runtime xxx` dependencies that got discarded:
```if o.Runtime != "" {
        integration.Spec.AddDependency("runtime:" + o.Runtime)
    }```
and
```func (is *IntegrationSpec) AddDependency(dependency string) {
    switch {
    case strings.HasPrefix(dependency, "mvn:"):
        util.StringSliceUniqueAdd(&is.Dependencies, dependency)
    case strings.HasPrefix(dependency, "file:"):
        util.StringSliceUniqueAdd(&is.Dependencies, dependency)
    case strings.HasPrefix(dependency, "camel-"):
        util.StringSliceUniqueAdd(&is.Dependencies, "camel:"+strings.TrimPrefix(dependency, "camel-"))
    }
}```
were not cooping that well together resulting in any `--runtime` option to be discarded.