### PR TITLE
Fixed array index out of boun that would kill camel-k operator in case of a malformed --dependency

### DIFF
--- a/pkg/util/maven/maven.go
+++ b/pkg/util/maven/maven.go
@@ -20,6 +20,8 @@ package maven
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"os/exec"
 	"regexp"
@@ -99,6 +101,12 @@ func ParseGAV(gav string) (Dependency, error) {
 	dep := Dependency{}
 	rex := regexp.MustCompile("([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?(:([^: ]+))?")
 	res := rex.FindStringSubmatch(gav)
+
+	fmt.Println(res, len(res))
+
+	if res == nil || len(res) < 9 {
+		return Dependency{}, errors.New("GAV must match <groupId>:<artifactId>[:<packagingType>[:<classifier>]]:(<version>|'?')")
+	}
 
 	dep.GroupID = res[1]
 	dep.ArtifactID = res[2]

--- a/pkg/util/maven/maven_test.go
+++ b/pkg/util/maven/maven_test.go
@@ -182,6 +182,21 @@ func TestParseGAVWithClassifierAndType(t *testing.T) {
 	assert.Equal(t, dep.Classifier, "test")
 }
 
+func TestParseGAVMvnNoVersion(t *testing.T) {
+	dep, err := ParseGAV("mvn:org.apache.camel/camel-core")
+
+	assert.Nil(t, err)
+	assert.Equal(t, dep.GroupID, "mvn")
+	assert.Equal(t, dep.ArtifactID, "org.apache.camel/camel-core")
+}
+
+func TestParseGAVErrorNoColumn(t *testing.T) {
+	dep, err := ParseGAV("org.apache.camel.k.camel-k-runtime-noop-0.2.1-SNAPSHOT.jar")
+
+	assert.EqualError(t, err, "GAV must match <groupId>:<artifactId>[:<packagingType>[:<classifier>]]:(<version>|'?')")
+	assert.Equal(t, Dependency{}, dep)
+}
+
 func TestNewRepository(t *testing.T) {
 	r := NewRepository("http://nexus/public")
 	assert.Equal(t, "", r.ID)


### PR DESCRIPTION
Passing a malformed --dependency like `myJarName.jar` to `kamel run` resulted in an "array index out of bound" and consequently a failure of the operator.