### PR TITLE
Renamed RuntimeTrait in ContextCustomizer since the name clashed and …

### DIFF
--- a/runtime/camel-k-runtime-core/src/main/java/org/apache/camel/k/Constants.java
+++ b/runtime/camel-k-runtime-core/src/main/java/org/apache/camel/k/Constants.java
@@ -20,13 +20,14 @@ public final class Constants {
     public static final String ENV_CAMEL_K_ROUTES = "CAMEL_K_ROUTES";
     public static final String ENV_CAMEL_K_CONF = "CAMEL_K_CONF";
     public static final String ENV_CAMEL_K_CONF_D = "CAMEL_K_CONF_D";
-    public static final String ENV_CAMEL_K_TRAITS = "CAMEL_K_TRAITS";
+    public static final String ENV_CAMEL_K_CUSTOMIZERS = "CAMEL_K_CUSTOMIZERS";
     public static final String SCHEME_CLASSPATH = "classpath:";
     public static final String SCHEME_FILE = "file:";
     public static final String SCHEME_ENV = "env:";
     public static final String LOGGING_LEVEL_PREFIX = "logging.level.";
     public static final String ROUTES_LOADER_RESOURCE_PATH = "META-INF/services/org/apache/camel/k/loader/";
-    public static final String RUNTIME_TRAIT_RESOURCE_PATH = "META-INF/services/org/apache/camel/k/trait/";
+    public static final String CONTEXT_CUSTOMIZER_RESOURCE_PATH = "META-INF/services/org/apache/camel/k/customizer/";
+    public static final String PROPERTY_CAMEL_K_CUSTOMIZER = "camel.k.customizer";
 
     private Constants() {
     }

--- a/runtime/camel-k-runtime-core/src/main/java/org/apache/camel/k/ContextCustomizer.java
+++ b/runtime/camel-k-runtime-core/src/main/java/org/apache/camel/k/ContextCustomizer.java
@@ -14,25 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.k.jvm;
+package org.apache.camel.k;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.k.RuntimeTrait;
 
-public class TestTrait implements RuntimeTrait {
-    private boolean messageHistory = true;
-
-    public boolean isMessageHistory() {
-        return messageHistory;
-    }
-
-    public void setMessageHistory(boolean messageHistory) {
-        this.messageHistory = messageHistory;
-    }
-
-    @Override
-    public void apply(CamelContext camelContext) {
-        camelContext.setMessageHistory(messageHistory);
-        camelContext.setLoadTypeConverters(false);
-    }
+@FunctionalInterface
+public interface ContextCustomizer {
+    /**
+     * Perform CamelContext customization.
+     *
+     * @param camelContext the camel context to customize.
+     * @param registry the runtime registry.
+     */
+    void apply(CamelContext camelContext, RuntimeRegistry registry);
 }

--- a/runtime/camel-k-runtime-jvm/src/main/java/org/apache/camel/k/jvm/Application.java
+++ b/runtime/camel-k-runtime-jvm/src/main/java/org/apache/camel/k/jvm/Application.java
@@ -21,6 +21,7 @@ import javax.xml.bind.JAXBException;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.k.Constants;
+import org.apache.camel.k.RuntimeRegistry;
 import org.apache.camel.k.support.RuntimeSupport;
 import org.apache.camel.main.MainListenerSupport;
 import org.apache.camel.main.MainSupport;
@@ -68,7 +69,7 @@ public class Application {
         Runtime runtime = new Runtime();
         runtime.setProperties(ApplicationSupport.loadProperties());
         runtime.load(routes.split(",", -1));
-        runtime.addMainListener(new ComponentPropertiesBinder());
+        runtime.addMainListener(new ComponentPropertiesBinder(runtime.getRegistry()));
         runtime.addMainListener(new RoutesDumper());
         runtime.run();
     }
@@ -80,6 +81,12 @@ public class Application {
     // *******************************
 
     static class ComponentPropertiesBinder extends MainListenerSupport {
+
+        private RuntimeRegistry registry;
+
+        public ComponentPropertiesBinder(RuntimeRegistry registry){
+            this.registry = registry;
+        }
 
         @Override
         public void configure(CamelContext context) {
@@ -103,7 +110,7 @@ public class Application {
             // This is useful to configure services such as the ClusterService,
             // RouteController, etc
             //
-            RuntimeSupport.configureContext(context);
+            RuntimeSupport.configureContext(context, registry);
 
             //
             // Configure components upon creation

--- a/runtime/camel-k-runtime-jvm/src/test/java/org/apache/camel/k/jvm/TestCustomizer.java
+++ b/runtime/camel-k-runtime-jvm/src/test/java/org/apache/camel/k/jvm/TestCustomizer.java
@@ -14,14 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.camel.k;
+package org.apache.camel.k.jvm;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.k.ContextCustomizer;
+import org.apache.camel.k.RuntimeRegistry;
 
-@FunctionalInterface
-public interface RuntimeTrait {
-    /**
-     * Perform CamelContext customization.
-     */
-    void apply(CamelContext camelContext);
+public class TestCustomizer implements ContextCustomizer {
+    private boolean messageHistory = true;
+
+    public boolean isMessageHistory() {
+        return messageHistory;
+    }
+
+    public void setMessageHistory(boolean messageHistory) {
+        this.messageHistory = messageHistory;
+    }
+
+    @Override
+    public void apply(CamelContext camelContext, RuntimeRegistry registry) {
+        camelContext.setMessageHistory(messageHistory);
+        camelContext.setLoadTypeConverters(false);
+    }
 }

--- a/runtime/camel-k-runtime-jvm/src/test/resources/META-INF/services/org/apache/camel/k/customizer/test
+++ b/runtime/camel-k-runtime-jvm/src/test/resources/META-INF/services/org/apache/camel/k/customizer/test
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-class=org.apache.camel.k.jvm.TestTrait
+class=org.apache.camel.k.jvm.TestCustomizer

--- a/runtime/camel-k-runtime-spring-boot/src/main/java/org/apache/camel/k/spring/boot/Application.java
+++ b/runtime/camel-k-runtime-spring-boot/src/main/java/org/apache/camel/k/spring/boot/Application.java
@@ -99,7 +99,7 @@ public class Application {
                 // This is useful to configure services such as the ClusterService,
                 // RouteController, etc
                 //
-                RuntimeSupport.configureContext( context);
+                RuntimeSupport.configureContext(context, registry);
 
                 try {
                     for (String route : routes.split(",")) {


### PR DESCRIPTION
…created confusion.

Changed ContextCustomizer.apply(...) signature to pass a RuntimeRegistry in addition to CamelContext.