### PR TITLE
Add labels trait to transfer integration labels onto owned resources

### DIFF
--- a/docs/traits.adoc
+++ b/docs/traits.adoc
@@ -196,6 +196,21 @@ The following is a list of common traits that can be configured by the end users
 
 !===
 
+| labels
+| All
+| Transfers labels on the integration onto the owned resources being created.
+  +
+  +
+  It's enabled by default.
+
+[cols="m,"]
+!===
+
+! labels.target-labels
+! The labels to be transfered (A comma-separared list of label keys)
+
+!===
+
 | prometheus
 | Kubernetes, OpenShift
 | Exposes the integration with a `Service` and a `ServiceMonitor` resources so that the Prometheus endpoint can be scraped.

--- a/pkg/trait/catalog.go
+++ b/pkg/trait/catalog.go
@@ -40,6 +40,7 @@ type Catalog struct {
 	tRoute          Trait
 	tIngress        Trait
 	tJolokia        Trait
+	tLabels         Trait
 	tPrometheus     Trait
 	tOwner          Trait
 	tImages         Trait
@@ -65,6 +66,7 @@ func NewCatalog(ctx context.Context, c client.Client) *Catalog {
 		tRoute:          newRouteTrait(),
 		tIngress:        newIngressTrait(),
 		tJolokia:        newJolokiaTrait(),
+		tLabels:         newLabelsTrait(),
 		tPrometheus:     newPrometheusTrait(),
 		tOwner:          newOwnerTrait(),
 		tImages:         newImagesTrait(),
@@ -98,6 +100,7 @@ func (c *Catalog) allTraits() []Trait {
 		c.tRoute,
 		c.tIngress,
 		c.tJolokia,
+		c.tLabels,
 		c.tPrometheus,
 		c.tOwner,
 		c.tImages,
@@ -129,6 +132,7 @@ func (c *Catalog) traitsFor(environment *Environment) []Trait {
 			c.tService,
 			c.tRoute,
 			c.tOwner,
+			c.tLabels,
 		}
 	case v1alpha1.TraitProfileKubernetes:
 		return []Trait{
@@ -146,6 +150,7 @@ func (c *Catalog) traitsFor(environment *Environment) []Trait {
 			c.tService,
 			c.tIngress,
 			c.tOwner,
+			c.tLabels,
 		}
 	case v1alpha1.TraitProfileKnative:
 		return []Trait{
@@ -162,6 +167,7 @@ func (c *Catalog) traitsFor(environment *Environment) []Trait {
 			c.tKnativeService,
 			c.tIstio,
 			c.tOwner,
+			c.tLabels,
 		}
 	}
 

--- a/pkg/trait/labels.go
+++ b/pkg/trait/labels.go
@@ -1,0 +1,68 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trait
+
+import (
+	"strings"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// labelsTrait transfers labels on the integration onto the owned resources being created
+type labelsTrait struct {
+	BaseTrait `property:",squash"`
+
+	TargetLabels string `property:"target-labels"`
+}
+
+func newLabelsTrait() *labelsTrait {
+	return &labelsTrait{
+		BaseTrait: newBaseTrait("labels"),
+	}
+}
+
+func (t *labelsTrait) Configure(e *Environment) (bool, error) {
+	if t.Enabled != nil && !*t.Enabled {
+		return false, nil
+	}
+
+	return e.IntegrationInPhase(v1alpha1.IntegrationPhaseDeploying), nil
+}
+
+func (t *labelsTrait) Apply(e *Environment) error {
+	targetLabels := map[string]string{}
+	for _, k := range strings.Split(t.TargetLabels, ",") {
+		if v, ok := e.Integration.Labels[k]; ok {
+			targetLabels[k] = v
+		}
+	}
+	if len(targetLabels) == 0 {
+		return nil
+	}
+	e.Resources.VisitMetaObject(func(res metav1.Object) {
+		labels := res.GetLabels()
+		for k, v := range targetLabels {
+			if _, ok := labels[k]; !ok {
+				labels[k] = v
+			}
+		}
+		res.SetLabels(labels)
+	})
+	return nil
+}


### PR DESCRIPTION
Fixes #263

I wonder whether it should be merged with the `owner` trait as it relates to the ownership concept?