### PR TITLE
fix: do not add probes to knative services

### DIFF
--- a/pkg/trait/probes.go
+++ b/pkg/trait/probes.go
@@ -24,7 +24,6 @@ import (
 	"github.com/apache/camel-k/pkg/util"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	serving "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -80,11 +79,6 @@ func (t *probesTrait) Apply(e *Environment) error {
 
 			deployment.Spec.Template.Spec.Containers[0].LivenessProbe = t.newLivenessProbe()
 			deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = t.newReadinessProbe()
-		})
-
-		e.Resources.VisitKnativeService(func(service *serving.Service) {
-			service.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.LivenessProbe = t.newLivenessProbe()
-			service.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ReadinessProbe = t.newReadinessProbe()
 		})
 	}
 

--- a/pkg/trait/probes_test.go
+++ b/pkg/trait/probes_test.go
@@ -127,11 +127,6 @@ func TestProbesOnKnativeService(t *testing.T) {
 
 	err = tr.Apply(&e)
 	assert.Nil(t, err)
-	assert.Equal(t, "", target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.LivenessProbe.HTTPGet.Host)
-	assert.Equal(t, int32(9191), target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.LivenessProbe.HTTPGet.Port.IntVal)
-	assert.Equal(t, "/health", target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.LivenessProbe.HTTPGet.Path)
-	assert.Equal(t, "", target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ReadinessProbe.HTTPGet.Host)
-	assert.Equal(t, int32(9191), target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ReadinessProbe.HTTPGet.Port.IntVal)
-	assert.Equal(t, "/health", target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ReadinessProbe.HTTPGet.Path)
-	assert.Equal(t, int32(4321), target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ReadinessProbe.TimeoutSeconds)
+	assert.Nil(t, target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.LivenessProbe)
+	assert.Nil(t, target.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ReadinessProbe)
 }


### PR DESCRIPTION
Related to #528 