### PR TITLE
fix bug due to state change during trait evaluation

### DIFF
--- a/pkg/trait/deployment.go
+++ b/pkg/trait/deployment.go
@@ -76,11 +76,17 @@ func (t *deploymentTrait) Apply(e *Environment) error {
 		e.IntegrationInPhase(v1alpha1.IntegrationPhaseBuildingContext, v1alpha1.IntegrationPhaseResolvingContext) {
 
 		if t.deployer.ContainerImage {
-			// trigger container image build
-			e.Integration.Status.Phase = v1alpha1.IntegrationPhaseBuildImageSubmitted
+			e.PostProcessors = append(e.PostProcessors, func(environment *Environment) error {
+				// trigger container image build
+				e.Integration.Status.Phase = v1alpha1.IntegrationPhaseBuildImageSubmitted
+				return nil
+			})
 		} else {
-			// trigger integration deploy
-			e.Integration.Status.Phase = v1alpha1.IntegrationPhaseDeploying
+			e.PostProcessors = append(e.PostProcessors, func(environment *Environment) error {
+				// trigger integration deploy
+				e.Integration.Status.Phase = v1alpha1.IntegrationPhaseDeploying
+				return nil
+			})
 		}
 
 		return nil


### PR DESCRIPTION
After the deployment trait, other traits like the knative-service trait are immediately executed, because they find the right integration state (`Deploying`). But they are not supposed to run until next full trait iteration.

Without this, the operator crashes because the classpath trait has not run before the knative-service trait.