### PR TITLE
resources: add options to configure mount path and key

### DIFF
--- a/pkg/apis/camel/v1alpha1/integration_types.go
+++ b/pkg/apis/camel/v1alpha1/integration_types.go
@@ -59,6 +59,7 @@ type DataSpec struct {
 	Name        string `json:"name,omitempty"`
 	Content     string `json:"content,omitempty"`
 	ContentRef  string `json:"contentRef,omitempty"`
+	ContentKey  string `json:"contentKey,omitempty"`
 	Compression bool   `json:"compression,omitempty"`
 }
 
@@ -68,7 +69,8 @@ type ResourceType string
 // ResourceSpec --
 type ResourceSpec struct {
 	DataSpec
-	Type ResourceType `json:"type,omitempty"`
+	Type      ResourceType `json:"type,omitempty"`
+	MountPath string       `json:"mountPath,omitempty"`
 }
 
 const (

--- a/pkg/controller/integration/build_image.go
+++ b/pkg/controller/integration/build_image.go
@@ -235,9 +235,15 @@ func (action *buildImageAction) inlineResources(ctx context.Context, integration
 	}
 
 	for _, data := range resources {
+		t := path.Join("resources", data.Name)
+
+		if data.MountPath != "" {
+			t = path.Join(data.MountPath, data.Name)
+		}
+
 		r.Resources = append(r.Resources, builder.Resource{
 			Content: []byte(data.Content),
-			Target:  path.Join("resources", data.Name),
+			Target:  t,
 		})
 	}
 


### PR DESCRIPTION

This allows to configure where a resource should be mounted and in case the resource references a config map, the key of the entry (default value `content `).
 
```yaml
apiVersion: camel.apache.org/v1alpha1
kind: Integration
metadata:
  name: hello
spec:
  resources:
  - contentRef: nexus3
    contentKey: nexus3-persistent-template.yaml
    mountPath: /etc/camel/resources/n3
    name: nexus.yaml
    type: data
  sources:
  - content: |
      <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xmlns="http://camel.apache.org/schema/spring"
              xsi:schemaLocation="
                  http://camel.apache.org/schema/spring
                  http://camel.apache.org/schema/spring/camel-spring.xsd">

          <route id="hello">
              <from uri="timer:hello?period=3s"/>
              <setBody>
                  <constant>Hello World!!!</constant>
              </setBody>
              <to uri="log:info"/>
          </route>

      </routes>
    name: hello.xml

```

**NOTE** in case the trait `deployer.container-image` is set to `true` the `mountPath` is relative to the `/deployment` folder