### PR TITLE
chore(maven): Run Maven in batch mode to reduce log noise

### DIFF
--- a/pkg/util/maven/maven.go
+++ b/pkg/util/maven/maven.go
@@ -75,6 +75,8 @@ func Run(buildDir string, args ...string) error {
 		mvnCmd = c
 	}
 
+	args = append(args, "--batch-mode")
+
 	cmd := exec.Command(mvnCmd, args...)
 	cmd.Dir = buildDir
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Should help to reduce the amount of noise output in the camel-k-operator logs.