### PR TITLE
Add log4j-slf4j-impl as runtime dependency in default project build

### DIFF
--- a/pkg/builder/builder_steps.go
+++ b/pkg/builder/builder_steps.go
@@ -87,6 +87,14 @@ func GenerateProject(ctx *Context) error {
 		}
 	}
 
+	// Add Log4j 2 SLF4J binding as default logging impl
+	ctx.Project.AddDependency(maven.Dependency{
+		GroupID:    "org.apache.logging.log4j",
+		ArtifactID: "log4j-slf4j-impl",
+		Version:    "2.11.2",
+		Scope:      "runtime",
+	})
+
 	return nil
 }
 

--- a/pkg/builder/builder_steps_test.go
+++ b/pkg/builder/builder_steps_test.go
@@ -124,7 +124,7 @@ func TestGenerateJvmProject(t *testing.T) {
 	assert.Equal(t, "pom", ctx.Project.DependencyManagement.Dependencies[0].Type)
 	assert.Equal(t, "import", ctx.Project.DependencyManagement.Dependencies[0].Scope)
 
-	assert.Equal(t, 3, len(ctx.Project.Dependencies))
+	assert.Equal(t, 4, len(ctx.Project.Dependencies))
 	assert.Contains(t, ctx.Project.Dependencies, maven.Dependency{
 		GroupID:    "org.apache.camel.k",
 		ArtifactID: "camel-k-runtime-jvm",
@@ -138,6 +138,12 @@ func TestGenerateJvmProject(t *testing.T) {
 	assert.Contains(t, ctx.Project.Dependencies, maven.Dependency{
 		GroupID:    "org.apache.camel.k",
 		ArtifactID: "camel-k-adapter-camel-2",
+	})
+	assert.Contains(t, ctx.Project.Dependencies, maven.Dependency{
+		GroupID:    "org.apache.logging.log4j",
+		ArtifactID: "log4j-slf4j-impl",
+		Version:    "2.11.2",
+		Scope:      "runtime",
 	})
 }
 
@@ -173,7 +179,7 @@ func TestGenerateGroovyProject(t *testing.T) {
 	assert.Equal(t, "pom", ctx.Project.DependencyManagement.Dependencies[0].Type)
 	assert.Equal(t, "import", ctx.Project.DependencyManagement.Dependencies[0].Scope)
 
-	assert.Equal(t, 5, len(ctx.Project.Dependencies))
+	assert.Equal(t, 6, len(ctx.Project.Dependencies))
 
 	assert.Contains(t, ctx.Project.Dependencies, maven.Dependency{
 		GroupID:    "org.apache.camel.k",
@@ -198,6 +204,12 @@ func TestGenerateGroovyProject(t *testing.T) {
 	assert.Contains(t, ctx.Project.Dependencies, maven.Dependency{
 		GroupID:    "org.apache.camel",
 		ArtifactID: "camel-groovy",
+	})
+	assert.Contains(t, ctx.Project.Dependencies, maven.Dependency{
+		GroupID:    "org.apache.logging.log4j",
+		ArtifactID: "log4j-slf4j-impl",
+		Version:    "2.11.2",
+		Scope:      "runtime",
 	})
 }
 


### PR DESCRIPTION
This prepares support for other runtime, like Quarkus, that bring their own logging backend.

This requires apache/camel-k-runtime#37.