### PR TITLE
Change builder to sync style API and remove in-memory working queue

### DIFF
--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -28,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/builder"
 	"github.com/apache/camel-k/pkg/builder/util"
 	"github.com/apache/camel-k/pkg/client"
-	"github.com/apache/camel-k/pkg/platform"
 	"github.com/apache/camel-k/pkg/util/cancellable"
 	"github.com/apache/camel-k/pkg/util/defaults"
 	logger "github.com/apache/camel-k/pkg/util/log"
@@ -64,7 +64,6 @@ func main() {
 		c.Get(ctx, types.NamespacedName{Namespace: build.Namespace, Name: build.Name}, build),
 	)
 
-	builder := platform.GetPlatformBuilder(c)
 	req, err := util.NewRequestForBuild(ctx, c, build)
 	exitOnError(err)
 
@@ -74,7 +73,7 @@ func main() {
 		util.UpdateBuildStatus(ctx, target, c, log),
 	)
 
-	result := builder.Build(*req)
+	result := builder.New(c).Build(*req)
 
 	exitOnError(
 		util.UpdateBuildFromResult(req.C, build, result, c, log),

--- a/pkg/apis/camel/v1alpha1/build_types.go
+++ b/pkg/apis/camel/v1alpha1/build_types.go
@@ -58,7 +58,7 @@ const (
 	BuildPhaseFailed BuildPhase = "Failed"
 	// BuildPhaseInterrupted --
 	BuildPhaseInterrupted = "Interrupted"
-	// IntegrationContextPhaseError --
+	// BuildPhaseError --
 	BuildPhaseError BuildPhase = "Error"
 )
 

--- a/pkg/builder/builder_steps_test.go
+++ b/pkg/builder/builder_steps_test.go
@@ -19,7 +19,6 @@ package builder
 
 import (
 	"errors"
-	"sync"
 	"testing"
 
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
@@ -313,10 +312,7 @@ func TestFailure(t *testing.T) {
 	catalog, err := test.DefaultCatalog()
 	assert.Nil(t, err)
 
-	b := NewLocalBuilder(nil, "ns")
-
-	var wg sync.WaitGroup
-	wg.Add(1)
+	b := New(nil)
 
 	r := Request{
 		C:              cancellable.NewContext(),
@@ -337,26 +333,10 @@ func TestFailure(t *testing.T) {
 		},
 	}
 
-	var res *Result
+	result := b.Build(r)
 
-	b.Submit(r, func(result *Result) {
-		switch result.Status {
-		case v1alpha1.BuildPhaseFailed:
-			res = result
-			wg.Done()
-		case v1alpha1.BuildPhaseSucceeded:
-			res = result
-			wg.Done()
-		case v1alpha1.BuildPhaseInterrupted:
-			res = result
-			wg.Done()
-		}
-	})
-
-	wg.Wait()
-
-	assert.NotNil(t, res)
-	assert.Equal(t, v1alpha1.BuildPhaseFailed, res.Status)
+	assert.NotNil(t, result)
+	assert.Equal(t, v1alpha1.BuildPhaseFailed, result.Status)
 }
 
 func TestListPublishedImages(t *testing.T) {

--- a/pkg/builder/builder_types.go
+++ b/pkg/builder/builder_types.go
@@ -49,7 +49,7 @@ const (
 // Builder --
 type Builder interface {
 	IsBuilding(object metav1.ObjectMeta) bool
-	Submit(request Request, handlers ...func(*Result))
+	Build(request Request) Result
 	Close()
 }
 

--- a/pkg/builder/builder_types.go
+++ b/pkg/builder/builder_types.go
@@ -48,9 +48,7 @@ const (
 
 // Builder --
 type Builder interface {
-	IsBuilding(object metav1.ObjectMeta) bool
 	Build(request Request) Result
-	Close()
 }
 
 // Step --

--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -123,7 +123,7 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 
 	buildActionPool := []Action{
 		NewInitializeAction(),
-		NewScheduleRoutineAction(),
+		NewScheduleRoutineAction(r.client),
 		NewSchedulePodAction(),
 		NewMonitorAction(),
 		NewErrorRecoveryAction(),

--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -27,29 +27,29 @@ import (
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 )
 
-// NewMonitorAction creates a new monitor action
-func NewMonitorAction() Action {
-	return &monitorAction{}
+// NewMonitorPodAction creates a new monitor action for scheduled pod
+func NewMonitorPodAction() Action {
+	return &monitorPodAction{}
 }
 
-type monitorAction struct {
+type monitorPodAction struct {
 	baseAction
 }
 
 // Name returns a common name of the action
-func (action *monitorAction) Name() string {
-	return "monitor"
+func (action *monitorPodAction) Name() string {
+	return "monitor-pod"
 }
 
 // CanHandle tells whether this action can handle the build
-func (action *monitorAction) CanHandle(build *v1alpha1.Build) bool {
+func (action *monitorPodAction) CanHandle(build *v1alpha1.Build) bool {
 	return (build.Status.Phase == v1alpha1.BuildPhasePending ||
 		build.Status.Phase == v1alpha1.BuildPhaseRunning) &&
 		build.Spec.Platform.Build.BuildStrategy == v1alpha1.IntegrationPlatformBuildStrategyPod
 }
 
 // Handle handles the builds
-func (action *monitorAction) Handle(ctx context.Context, build *v1alpha1.Build) error {
+func (action *monitorPodAction) Handle(ctx context.Context, build *v1alpha1.Build) error {
 	target := build.DeepCopy()
 
 	// Get the build pod

--- a/pkg/controller/build/monitor_routine.go
+++ b/pkg/controller/build/monitor_routine.go
@@ -1,0 +1,67 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"context"
+	"sync"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+)
+
+// NewMonitorRoutineAction creates a new monitor action for scheduled routine
+func NewMonitorRoutineAction(r *sync.Map) Action {
+	return &monitorRoutineAction{
+		routines: r,
+	}
+}
+
+type monitorRoutineAction struct {
+	baseAction
+	routines *sync.Map
+}
+
+// Name returns a common name of the action
+func (action *monitorRoutineAction) Name() string {
+	return "monitor-routine"
+}
+
+// CanHandle tells whether this action can handle the build
+func (action *monitorRoutineAction) CanHandle(build *v1alpha1.Build) bool {
+	return (build.Status.Phase == v1alpha1.BuildPhasePending ||
+		build.Status.Phase == v1alpha1.BuildPhaseRunning) &&
+		build.Spec.Platform.Build.BuildStrategy == v1alpha1.IntegrationPlatformBuildStrategyRoutine
+}
+
+// Handle handles the builds
+func (action *monitorRoutineAction) Handle(ctx context.Context, build *v1alpha1.Build) error {
+	target := build.DeepCopy()
+
+	// Check the build routine
+	if _, ok := action.routines.Load(build.Name); !ok {
+		// and reschedule the build if it's missing. This can happen when the operator
+		// stops abruptly and restarts.
+		target.Status.Phase = v1alpha1.BuildPhaseScheduling
+
+		action.L.Info("Build state transition", "phase", target.Status.Phase)
+
+		return action.client.Status().Update(ctx, target)
+	}
+
+	return nil
+}

--- a/pkg/controller/build/schedule_pod.go
+++ b/pkg/controller/build/schedule_pod.go
@@ -74,6 +74,7 @@ func (action *schedulePodAction) Handle(ctx context.Context, build *v1alpha1.Bui
 	for _, b := range builds.Items {
 		if b.Status.Phase == v1alpha1.BuildPhasePending || b.Status.Phase == v1alpha1.BuildPhaseRunning {
 			hasScheduledBuild = true
+			break
 		}
 	}
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -21,10 +21,27 @@ import (
 	"context"
 	"errors"
 
-	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
-	"github.com/apache/camel-k/pkg/client"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/builder"
+	"github.com/apache/camel-k/pkg/client"
 )
+
+// gBuilder is the current builder
+// Note: it cannot be changed at runtime, needs a operator restart
+var gBuilder builder.Builder
+
+// GetPlatformBuilder --
+func GetPlatformBuilder(c client.Client) builder.Builder {
+	if gBuilder != nil {
+		return gBuilder
+	}
+
+	gBuilder = builder.New(c)
+
+	return gBuilder
+}
 
 // GetCurrentPlatform returns the currently installed platform
 func GetCurrentPlatform(ctx context.Context, c client.Client, namespace string) (*v1alpha1.IntegrationPlatform, error) {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -24,24 +24,8 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
-	"github.com/apache/camel-k/pkg/builder"
 	"github.com/apache/camel-k/pkg/client"
 )
-
-// gBuilder is the current builder
-// Note: it cannot be changed at runtime, needs a operator restart
-var gBuilder builder.Builder
-
-// GetPlatformBuilder --
-func GetPlatformBuilder(c client.Client) builder.Builder {
-	if gBuilder != nil {
-		return gBuilder
-	}
-
-	gBuilder = builder.New(c)
-
-	return gBuilder
-}
 
 // GetCurrentPlatform returns the currently installed platform
 func GetCurrentPlatform(ctx context.Context, c client.Client, namespace string) (*v1alpha1.IntegrationPlatform, error) {


### PR DESCRIPTION
Since the build working state is persisted in the cluster with the Build CR, there is no need for an in-memory working queue. Besides, as the builder is reused in pod build strategy synchronous flow,
the API is changed to sync style for ease of use.