### PR TITLE
feat: Add kamel describe command

### DIFF
--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -1,0 +1,123 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type flusher interface {
+	flush()
+}
+
+type indentedWriter struct {
+	out io.Writer
+}
+
+func newIndentedWriter(out io.Writer) *indentedWriter {
+	return &indentedWriter{out: out}
+}
+
+func (iw *indentedWriter) write(indentLevel int, format string, i ...interface{}) {
+	indent := "  "
+	prefix := ""
+	for i := 0; i < indentLevel; i++ {
+		prefix += indent
+	}
+	fmt.Fprintf(iw.out, prefix+format, i...)
+}
+
+func (iw *indentedWriter) writeLine(i ...interface{}) {
+	fmt.Fprintln(iw.out, i...)
+}
+
+func (iw *indentedWriter) Flush() {
+	if f, ok := iw.out.(flusher); ok {
+		f.flush()
+	}
+}
+
+func describeObjectMeta(w *indentedWriter, om metav1.ObjectMeta) {
+	w.write(0, "Name:\t%s\n", om.Name)
+	w.write(0, "Namespace:\t%s\n", om.Namespace)
+
+	if len(om.GetLabels()) > 0 {
+		w.write(0, "Labels:")
+		for k, v := range om.Labels {
+			w.write(0, "\t%s=%s\n", k, strings.TrimSpace(v))
+		}
+	}
+
+	if len(om.GetAnnotations()) > 0 {
+		w.write(0, "Annotations:")
+		for k, v := range om.Annotations {
+			w.write(0, "\t%s=%s\n", k, strings.TrimSpace(v))
+		}
+	}
+
+	w.write(0, "Creation Timestamp:\t%s\n", om.CreationTimestamp.Format(time.RFC1123Z))
+}
+
+func describeTraits(w *indentedWriter, traits map[string]v1alpha1.TraitSpec) {
+	if len(traits) > 0 {
+		w.write(0, "Traits:\n")
+
+		for trait := range traits {
+			w.write(1, "%s:\n", strings.Title(trait))
+			w.write(2, "Configuration:\n")
+			for k, v := range traits[trait].Configuration {
+				w.write(3, "%s:\t%s\n", strings.Title(k), v)
+			}
+		}
+	}
+}
+
+func indentedString(f func(io.Writer)) string {
+	out := new(tabwriter.Writer)
+	buf := &bytes.Buffer{}
+	out.Init(buf, 0, 8, 2, ' ', 0)
+
+	f(out)
+
+	out.Flush()
+	str := string(buf.String())
+	return str
+}
+
+func newCmdDescribe(rootCmdOptions *RootCmdOptions) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "describe",
+		Short: "Describe a resource",
+		Long:  `Describe a Camel K resource.`,
+	}
+
+	cmd.AddCommand(newDescribeContextCmd(rootCmdOptions))
+	cmd.AddCommand(newDescribeIntegrationCmd(rootCmdOptions))
+	cmd.AddCommand(newDescribePlatformCmd(rootCmdOptions))
+
+	return &cmd
+}

--- a/pkg/cmd/describe_context.go
+++ b/pkg/cmd/describe_context.go
@@ -1,0 +1,127 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/spf13/cobra"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newDescribeContextCmd(rootCmdOptions *RootCmdOptions) *cobra.Command {
+
+	impl := &describeContextCommand{
+		rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		Use:   "context",
+		Short: "Describe an Integration Context",
+		Long:  `Describe an Integration Context.`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := impl.validate(args); err != nil {
+				return err
+			}
+			if err := impl.run(args); err != nil {
+				fmt.Println(err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	return &cmd
+}
+
+type describeContextCommand struct {
+	*RootCmdOptions
+}
+
+func (command *describeContextCommand) validate(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("accepts at least 1 arg, received %d", len(args))
+	}
+	return nil
+}
+
+func (command *describeContextCommand) run(args []string) error {
+	c, err := command.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := v1alpha1.NewIntegrationContext(command.Namespace, args[0])
+	key := k8sclient.ObjectKey{
+		Namespace: command.Namespace,
+		Name:      args[0],
+	}
+
+	if err := c.Get(command.Context, key, &ctx); err == nil {
+		fmt.Print(command.describeIntegrationContext(ctx))
+	} else {
+		fmt.Printf("IntegrationContext '%s' does not exist.\n", args[0])
+	}
+
+	return nil
+}
+
+func (command *describeContextCommand) describeIntegrationContext(i v1alpha1.IntegrationContext) string {
+	return indentedString(func(out io.Writer) {
+		w := newIndentedWriter(out)
+
+		describeObjectMeta(w, i.ObjectMeta)
+
+		w.write(0, "Phase:\t%s\n", i.Status.Phase)
+		w.write(0, "Camel Version:\t%s\n", i.Status.CamelVersion)
+		w.write(0, "Image:\t%s\n", i.Status.Image)
+
+		if len(i.Status.Artifacts) > 0 {
+			w.write(0, "Artifacts:\t\n")
+			for _, artifact := range i.Status.Artifacts {
+				w.write(1, "%s\n", artifact.ID)
+			}
+		}
+
+		if len(i.Spec.Configuration) > 0 {
+			w.write(0, "Configuration:\n")
+			for _, config := range i.Spec.Configuration {
+				w.write(1, "Type:\t%s\n", config.Type)
+				w.write(1, "Value:\t%s\n", config.Value)
+			}
+		}
+
+		if len(i.Spec.Dependencies) > 0 {
+			w.write(0, "Dependencies:\t\n")
+			for _, dependency := range i.Spec.Dependencies {
+				w.write(1, "%s\n", dependency)
+			}
+		}
+
+		if len(i.Spec.Repositories) > 0 {
+			w.write(0, "Repositories:\n")
+			for _, repository := range i.Spec.Repositories {
+				w.write(1, "%s\n", repository)
+			}
+		}
+
+		describeTraits(w, i.Spec.Traits)
+	})
+}

--- a/pkg/cmd/describe_integration.go
+++ b/pkg/cmd/describe_integration.go
@@ -1,0 +1,141 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/spf13/cobra"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newDescribeIntegrationCmd(rootCmdOptions *RootCmdOptions) *cobra.Command {
+
+	impl := &describeIntegrationCommand{
+		rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		Use:   "integration",
+		Short: "Describe an Integration",
+		Long:  `Describe an Integration.`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := impl.validate(args); err != nil {
+				return err
+			}
+			if err := impl.run(args); err != nil {
+				fmt.Println(err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	return &cmd
+}
+
+type describeIntegrationCommand struct {
+	*RootCmdOptions
+}
+
+func (command *describeIntegrationCommand) validate(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("accepts at least 1 arg, received %d", len(args))
+	}
+	return nil
+}
+
+func (command *describeIntegrationCommand) run(args []string) error {
+	c, err := command.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := v1alpha1.NewIntegration(command.Namespace, args[0])
+	key := k8sclient.ObjectKey{
+		Namespace: command.Namespace,
+		Name:      args[0],
+	}
+
+	if err := c.Get(command.Context, key, &ctx); err == nil {
+		fmt.Print(command.describeIntegration(ctx))
+	} else {
+		fmt.Printf("Integration '%s' does not exist.\n", args[0])
+	}
+
+	return nil
+}
+
+func (command *describeIntegrationCommand) describeIntegration(i v1alpha1.Integration) string {
+	return indentedString(func(out io.Writer) {
+		w := newIndentedWriter(out)
+
+		describeObjectMeta(w, i.ObjectMeta)
+
+		w.write(0, "Phase:\t%s\n", i.Status.Phase)
+		w.write(0, "Camel Version:\t%s\n", i.Status.CamelVersion)
+		w.write(0, "Context:\t%s\n", i.Status.Context)
+		w.write(0, "Image:\t%s\n", i.Status.Image)
+
+		if len(i.Spec.Configuration) > 0 {
+			w.write(0, "Configuration:\n")
+			for _, config := range i.Spec.Configuration {
+				w.write(1, "Type:\t%s\n", config.Type)
+				w.write(1, "Value:\t%s\n", config.Value)
+			}
+		}
+
+		if len(i.Status.Dependencies) > 0 {
+			w.write(0, "Dependencies:\n")
+			for _, dependency := range i.Status.Dependencies {
+				w.write(1, "%s\n", dependency)
+			}
+		}
+
+		if len(i.Spec.Repositories) > 0 {
+			w.write(0, "Repositories:\n")
+			for _, repository := range i.Spec.Repositories {
+				w.write(1, "%s\n", repository)
+			}
+		}
+
+		if len(i.Spec.Resources) > 0 {
+			w.write(0, "Resources:\n")
+			for _, resource := range i.Spec.Resources {
+				w.write(1, "Content:\n")
+				w.write(2, "%s\n", strings.TrimSpace(resource.Content))
+				w.write(1, "Name:\t%s\n", resource.Name)
+				w.write(1, "Type:\t%s\n", resource.Type)
+			}
+		}
+
+		if len(i.Sources()) > 0 {
+			w.write(0, "Sources:\n")
+			for _, s := range i.Sources() {
+				w.write(1, "Name:\t%s\n", s.Name)
+				w.write(1, "Content:\n")
+				w.write(2, "%s\n", strings.TrimSpace(s.Content))
+			}
+		}
+
+		describeTraits(w, i.Spec.Traits)
+	})
+}

--- a/pkg/cmd/describe_platform.go
+++ b/pkg/cmd/describe_platform.go
@@ -1,0 +1,104 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/spf13/cobra"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newDescribePlatformCmd(rootCmdOptions *RootCmdOptions) *cobra.Command {
+
+	impl := &describePlatformCommand{
+		rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		Use:   "platform",
+		Short: "Describe an Integration Platform",
+		Long:  `Describe an Integration Platform.`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := impl.validate(args); err != nil {
+				return err
+			}
+			if err := impl.run(args); err != nil {
+				fmt.Println(err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	return &cmd
+}
+
+type describePlatformCommand struct {
+	*RootCmdOptions
+}
+
+func (command *describePlatformCommand) validate(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("accepts at least 1 arg, received %d", len(args))
+	}
+	return nil
+}
+
+func (command *describePlatformCommand) run(args []string) error {
+	c, err := command.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := v1alpha1.NewIntegrationPlatform(command.Namespace, args[0])
+	key := k8sclient.ObjectKey{
+		Namespace: command.Namespace,
+		Name:      args[0],
+	}
+
+	if err := c.Get(command.Context, key, &ctx); err == nil {
+		fmt.Print(command.describeIntegrationPlatform(ctx))
+	} else {
+		fmt.Printf("IntegrationPlatform '%s' does not exist.\n", args[0])
+	}
+
+	return nil
+}
+
+func (command *describePlatformCommand) describeIntegrationPlatform(i v1alpha1.IntegrationPlatform) string {
+	return indentedString(func(out io.Writer) {
+		w := newIndentedWriter(out)
+		describeObjectMeta(w, i.ObjectMeta)
+		w.write(0, "Phase:\t%s\n", i.Status.Phase)
+		w.write(0, "Base Image:\t%s\n", i.Spec.Build.BaseImage)
+		w.write(0, "Camel Version:\t%s\n", i.Spec.Build.CamelVersion)
+		w.write(0, "Local Repository:\t%s\n", i.Spec.Build.LocalRepository)
+		w.write(0, "Publish Strategy:\t%s\n", i.Spec.Build.PublishStrategy)
+
+		if len(i.Spec.Resources.Contexts) > 0 {
+			w.write(0, "Resources:\n")
+			w.write(1, "Contexts:\n")
+			for _, context := range i.Spec.Resources.Contexts {
+				w.write(2, "%s\n", context)
+			}
+		}
+	})
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -63,6 +63,7 @@ func NewKamelCommand(ctx context.Context) (*cobra.Command, error) {
 	cmd.AddCommand(newCmdLog(&options))
 	cmd.AddCommand(newCmdContext(&options))
 	cmd.AddCommand(newCmdReset(&options))
+	cmd.AddCommand(newCmdDescribe(&options))
 
 	return &cmd, nil
 }


### PR DESCRIPTION
As per #398...

I wasn't totally sure exactly what should be included in the output for the various camel-k resources. The output looks a little like `kubectl describe`, but I took an opinionated view and excluded content that I thought folks would not find relevant.

Here's a little example of it in action:

![output](https://user-images.githubusercontent.com/4721408/56652597-a6669380-6683-11e9-9427-847c9f817aa2.gif)

Thoughts?