### PR TITLE
fix: Add .exe file extension to Windows kamel binary

### DIFF
--- a/script/cross_compile.sh
+++ b/script/cross_compile.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 location=$(dirname $0)
-builddir=$(realpath $location/../xtmp)
+builddir=$(realpath ${location}/../xtmp)
 
-rm -rf $builddir
+rm -rf ${builddir}
 
 basename=camel-k-client
 
@@ -15,22 +15,27 @@ fi
 version=$1
 
 cross_compile () {
-	label=$1
+	local label=$1
+	local extension=""
 	export GOOS=$2
 	export GOARCH=$3
 
-	targetdir=$builddir/$label
-	go build -o $targetdir/kamel ./cmd/kamel/...
+	if [ "${GOOS}" == "windows" ]; then
+		extension=".exe"
+	fi
 
-	cp $location/../LICENSE $targetdir/
-	cp $location/../NOTICE $targetdir/
+	targetdir=${builddir}/${label}
+	go build -o ${targetdir}/kamel${extension} ./cmd/kamel/...
 
-	pushd . && cd $targetdir && tar -zcvf ../../$label.tar.gz . && popd
+	cp ${location}/../LICENSE ${targetdir}/
+	cp ${location}/../NOTICE ${targetdir}/
+
+	pushd . && cd ${targetdir} && tar -zcvf ../../${label}.tar.gz . && popd
 }
 
-cross_compile $basename-$version-linux-64bit linux amd64
-cross_compile $basename-$version-mac-64bit darwin amd64
-cross_compile $basename-$version-windows-64bit windows amd64
+cross_compile ${basename}-${version}-linux-64bit linux amd64
+cross_compile ${basename}-${version}-mac-64bit darwin amd64
+cross_compile ${basename}-${version}-windows-64bit windows amd64
 
 
-rm -rf $builddir
+rm -rf ${builddir}


### PR DESCRIPTION
Relates to #619.

Note: Since `cross_compile.sh` uses bash shell builtins `pushd` & `popd`, I changed the script shebang line to `/bin/bash` as `/bin/sh` could be symlinked to any shell (dash in the case of my system).