### PR TITLE
Upgrade to camel-k-runtime 0.3.2

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -1,7 +1,7 @@
 VERSIONFILE := pkg/util/defaults/defaults.go
 VERSION := 0.3.3-SNAPSHOT
-RUNTIME_VERSION := 0.3.1
-CAMEL_VERSION := 2.23.1
+RUNTIME_VERSION := 0.3.2
+CAMEL_VERSION := 2.23.2
 CAMEL_VERSION_CONSTRAINT := ~2.23.x
 BASE_IMAGE := fabric8/s2i-java:3.0-java8
 LOCAL_REPOSITORY := /tmp/artifacts/m2


### PR DESCRIPTION
Is there more to do than this?

Also at one point we should default to use Camel 3.x as the default.