### PR TITLE
feat: Set env var with Kamel

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,7 @@ integration "sample" created
 integration "sample" in phase Waiting For Platform
 ```
 
-NOTE: It will take some time for your integration to get started for the first time. This is because the camel-k operator has to pull and cache the camel-k builder images into the cluster’s registry. 
+NOTE: It will take some time for your integration to get started for the first time. This is because the camel-k operator has to pull and cache the camel-k builder images into the cluster’s registry.
 
 You can follow this process by watching the pods in the namespace where the operator is running:
 
@@ -206,6 +206,14 @@ It's possible to mount persistent volumes into integration containers by using t
 
 ```
 kamel run examples/Sample.java -v myPvcName:/some/path
+```
+
+==== Configure Environment Variables
+
+It's possible to configure environment variables for integration containers by using the `-e` or `--env` flag:
+
+```
+kamel run examples/Sample.java -e MY_ENV_VAR=some-value
 ```
 
 === Running Integrations in "Dev" Mode for Fast Feedback

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -88,6 +88,7 @@ func newCmdRun(rootCmdOptions *RootCmdOptions) *cobra.Command {
 	cmd.Flags().StringSliceVar(&options.OpenAPIs, "open-api", nil, "Add an OpenAPI v2 spec")
 	cmd.Flags().StringVar(&options.DeletionPolicy, "deletion-policy", "owner", "Policy used to cleanup child resources, default owner")
 	cmd.Flags().StringSliceVarP(&options.Volumes, "volume", "v", nil, "Mount a volume into the integration container. E.g \"-v pvcname:/container/path\"")
+	cmd.Flags().StringSliceVarP(&options.EnvVars, "env", "e", nil, "Set an environment variable in the integration container. E.g \"-e MY_VAR=my-value\"")
 
 	// completion support
 	configureKnownCompletions(&cmd)
@@ -118,6 +119,7 @@ type runCmdOptions struct {
 	Traits             []string
 	LoggingLevels      []string
 	Volumes            []string
+	EnvVars            []string
 }
 
 func (o *runCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
@@ -377,9 +379,11 @@ func (o *runCmdOptions) updateIntegrationCode(c client.Client, sources []string)
 	for _, item := range o.Secrets {
 		integration.Spec.AddConfiguration("secret", item)
 	}
-
 	for _, item := range o.Volumes {
 		integration.Spec.AddConfiguration("volume", item)
+	}
+	for _, item := range o.EnvVars {
+		integration.Spec.AddConfiguration("env", item)
 	}
 
 	for _, traitConf := range o.Traits {


### PR DESCRIPTION
fixes #606

In terms of the potential for users to break things with this feature, I think we've ended up with an ok compromise.

Since the configuration of environment variables from traits etc, comes after those provided from 'kamel run', it results in those values taking precedence over the user provided ones. I think that's acceptable in the majority of cases.

E.g. If someone did `kamel run simple.js -e JAVA_MAIN_CLASS=some.invalid.Thing`, then `JAVA_MAIN_CLASS` would get ignored and restored to the camel-k default.
