### PR TITLE
The --maven-repository shortcut does not configure plugin repositories

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -229,6 +229,7 @@ func (o *installCmdOptions) install(_ *cobra.Command, _ []string) error {
 						ActiveByDefault: true,
 					},
 					Repositories: repositories,
+					PluginRepositories: repositories,
 				},
 			}
 


### PR DESCRIPTION
Fixes #746