### PR TITLE
fix: Validate maven artifacts

### DIFF
--- a/pkg/util/maven/maven_project.go
+++ b/pkg/util/maven/maven_project.go
@@ -166,10 +166,12 @@ func NewRepository(repo string) Repository {
 	r := Repository{
 		URL: repo,
 		Releases: RepositoryPolicy{
-			Enabled: true,
+			Enabled:        true,
+			ChecksumPolicy: "fail",
 		},
 		Snapshots: RepositoryPolicy{
-			Enabled: false,
+			Enabled:        false,
+			ChecksumPolicy: "fail",
 		},
 	}
 
@@ -184,6 +186,9 @@ func NewRepository(repo string) Repository {
 				r.Releases.Enabled = false
 			case strings.HasPrefix(attribute, "id="):
 				r.ID = attribute[3:]
+			case strings.HasPrefix(attribute, "checksumpolicy="):
+				r.Snapshots.ChecksumPolicy = attribute[15:]
+				r.Releases.ChecksumPolicy = attribute[15:]
 			}
 		}
 	}

--- a/pkg/util/maven/maven_project_test.go
+++ b/pkg/util/maven/maven_project_test.go
@@ -187,6 +187,8 @@ func TestNewRepository(t *testing.T) {
 	assert.Equal(t, "http://nexus/public", r.URL)
 	assert.True(t, r.Releases.Enabled)
 	assert.False(t, r.Snapshots.Enabled)
+	assert.Equal(t, "fail", r.Releases.ChecksumPolicy)
+	assert.Equal(t, "fail", r.Snapshots.ChecksumPolicy)
 }
 
 func TestNewRepositoryWithSnapshots(t *testing.T) {
@@ -195,6 +197,8 @@ func TestNewRepositoryWithSnapshots(t *testing.T) {
 	assert.Equal(t, "http://nexus/public", r.URL)
 	assert.True(t, r.Releases.Enabled)
 	assert.True(t, r.Snapshots.Enabled)
+	assert.Equal(t, "fail", r.Releases.ChecksumPolicy)
+	assert.Equal(t, "fail", r.Snapshots.ChecksumPolicy)
 }
 
 func TestNewRepositoryWithSnapshotsAndID(t *testing.T) {
@@ -203,6 +207,8 @@ func TestNewRepositoryWithSnapshotsAndID(t *testing.T) {
 	assert.Equal(t, "http://nexus/public", r.URL)
 	assert.True(t, r.Releases.Enabled)
 	assert.True(t, r.Snapshots.Enabled)
+	assert.Equal(t, "fail", r.Releases.ChecksumPolicy)
+	assert.Equal(t, "fail", r.Snapshots.ChecksumPolicy)
 }
 
 func TestNewRepositoryWithID(t *testing.T) {
@@ -211,4 +217,16 @@ func TestNewRepositoryWithID(t *testing.T) {
 	assert.Equal(t, "http://nexus/public", r.URL)
 	assert.True(t, r.Releases.Enabled)
 	assert.False(t, r.Snapshots.Enabled)
+	assert.Equal(t, "fail", r.Releases.ChecksumPolicy)
+	assert.Equal(t, "fail", r.Snapshots.ChecksumPolicy)
+}
+
+func TestNewRepositoryWithChecksumPolicy(t *testing.T) {
+	r := NewRepository("http://nexus/public@checksumpolicy=warn")
+	assert.Equal(t, "", r.ID)
+	assert.Equal(t, "http://nexus/public", r.URL)
+	assert.True(t, r.Releases.Enabled)
+	assert.False(t, r.Snapshots.Enabled)
+	assert.Equal(t, "warn", r.Releases.ChecksumPolicy)
+	assert.Equal(t, "warn", r.Snapshots.ChecksumPolicy)
 }

--- a/pkg/util/maven/maven_settings_test.go
+++ b/pkg/util/maven/maven_settings_test.go
@@ -40,10 +40,12 @@ const expectedSettings = `<?xml version="1.0" encoding="UTF-8"?>
           <url>https://repo.maven.apache.org/maven2</url>
           <snapshots>
             <enabled>false</enabled>
+            <checksumPolicy>warn</checksumPolicy>
           </snapshots>
           <releases>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
           </releases>
         </repository>
       </repositories>
@@ -66,11 +68,13 @@ func TestSettingsGeneration(t *testing.T) {
 					ID:  "central",
 					URL: "https://repo.maven.apache.org/maven2",
 					Snapshots: RepositoryPolicy{
-						Enabled: false,
+						Enabled:        false,
+						ChecksumPolicy: "warn",
 					},
 					Releases: RepositoryPolicy{
-						Enabled:      true,
-						UpdatePolicy: "never",
+						Enabled:        true,
+						UpdatePolicy:   "never",
+						ChecksumPolicy: "fail",
 					},
 				},
 			},

--- a/pkg/util/maven/maven_types.go
+++ b/pkg/util/maven/maven_types.go
@@ -34,8 +34,9 @@ type Repository struct {
 
 // RepositoryPolicy --
 type RepositoryPolicy struct {
-	Enabled      bool   `xml:"enabled"`
-	UpdatePolicy string `xml:"updatePolicy,omitempty"`
+	Enabled        bool   `xml:"enabled"`
+	UpdatePolicy   string `xml:"updatePolicy,omitempty"`
+	ChecksumPolicy string `xml:"checksumPolicy,omitempty"`
 }
 
 // Build --


### PR DESCRIPTION
fixes #742

@lburgazzoli we talked a little about this. I made the Maven repository `checksumPolicy` configurable when doing `kamel install`. By default the `checksumPolicy` is 'fail'.

E.g: 

```
kamel install --maven-repository http://foobar.com/repo/@checksumpolicy=warn
```

I also tweaked things slightly so that there is always repository config set up for Maven central in order to enforce the `checksumPolicy` for it. Users can override this if they want to.  