### PR TITLE
fix: point to the staging site from README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ Apache Camel K is a lightweight integration platform, born on Kubernetes, with s
 Camel K allows to run integrations directly on a Kubernetes or OpenShift cluster.
 To use it, you need to be connected to a cloud environment or to a local cluster created for development purposes.
 
-If you need help on how to create a local development environment based on *Minishift* or *Minikube*, you can follow the xref:docs/modules/ROOT/pages/installation/installation.adoc[local cluster setup guide].
+If you need help on how to create a local development environment based on *Minishift* or *Minikube*, you can follow the https://camel.apache.org/staging/camel-k/latest/installation/installation.html[local cluster setup guide].
 
 [[installation]]
 === Installation
@@ -22,17 +22,17 @@ If you need help on how to create a local development environment based on *Mini
 Make sure you apply specific configuration settings for your cluster before installing Camel K. Customized instructions are needed for
 the following cluster types:
 
-- xref:docs/modules/ROOT/pages/installation/minikube.adoc[Minikube]
-- xref:docs/modules/ROOT/pages/installation/minishift.adoc[Minishift]
-- xref:docs/modules/ROOT/pages/installation/gke.adoc[Google Kubernetes Engine (GKE)]
-- xref:docs/modules/ROOT/pages/installation/openshift.adoc[OpenShift]
+- https://camel.apache.org/staging/camel-k/latest/installation/minikube.html[Minikube]
+- https://camel.apache.org/staging/camel-k/latest/installation/minishift.html[Minishift]
+- https://camel.apache.org/staging/camel-k/latest/installation/gke.html[Google Kubernetes Engine (GKE)]
+- https://camel.apache.org/staging/camel-k/latest/installation/openshift.html[OpenShift]
 
 Other cluster types (such as OpenShift clusters) should not need prior configuration.
 
 To start using Camel K you need the **"kamel"** binary, that can be used to both configure the cluster and run integrations.
 Look into the https://github.com/apache/camel-k/releases[release page] for latest version of the `kamel` tool.
 
-If you want to contribute, you can also **build it from source!** Refer to the xref:docs/modules/ROOT/pages/developers.adoc[contributing guide]
+If you want to contribute, you can also **build it from source!** Refer to the https://camel.apache.org/staging/camel-k/latest/developers.html[contributing guide]
 for information on how to do it.
 
 Once you have the "kamel" binary, log into your cluster using the standard "oc" (OpenShift) or "kubectl" (Kubernetes) client tool and execute the following command to install Camel K:
@@ -332,7 +332,7 @@ Camel K supports multiple languages for writing integrations:
 | Kotlin			| Kotlin Script `.kts` files are supported (experimental).
 |=======================
 
-More information about supported languages is provided in the xref:docs/modules/ROOT/pages/languages/languages.adoc[languages guide].
+More information about supported languages is provided in the https://camel.apache.org/staging/camel-k/latest/languages/languages.html[languages guide].
 
 Integrations written in different languages are provided in the link:/examples[examples] directory.
 
@@ -358,7 +358,7 @@ kamel run examples/dns.js
 === Traits
 
 The details of how the integration is mapped into Kubernetes resources can be *customized using traits*.
-More information is provided in the xref:docs/modules/ROOT/pages/traits.adoc[traits section].
+More information is provided in the https://camel.apache.org/staging/camel-k/latest/traits.html[traits section].
 
 === Monitoring the Status
 
@@ -374,7 +374,7 @@ kamel get
 
 We love contributions and we want to make Camel K great!
 
-Contributing is easy, just take a look at our xref:docs/modules/ROOT/pages/traits.adoc[developer's guide].
+Contributing is easy, just take a look at our https://camel.apache.org/staging/camel-k/latest/developers.html[developer's guide].
 
 [[uninstalling]]
 == Uninstalling


### PR DESCRIPTION
Changes all `xref` links in the README.adoc to point to the staging site where the `docs/` content is rendered.

Be aware that there is no link between the `camel-website` build and the `camel-k` repository, that is to say changes to the `camel-k` git repository will not be reflected on the website until the website build is run[1]. There's an open issue to trigger the website build on changes to the documentation in the other repositories[2].

Fixes #827

[1] https://builds.apache.org/job/Camel.website/job/master/
[2] https://issues.apache.org/jira/browse/CAMEL-13753