### PR TITLE
fix(GC): Skip 503 errors when scanning for resources to be GCed

### DIFF
--- a/pkg/util/kubernetes/util.go
+++ b/pkg/util/kubernetes/util.go
@@ -259,7 +259,8 @@ func LookUpResources(ctx context.Context, client client.Client, namespace string
 		if err := client.List(ctx, &options, &list); err != nil {
 			if k8serrors.IsNotFound(err) ||
 				k8serrors.IsForbidden(err) ||
-				k8serrors.IsMethodNotSupported(err) {
+				k8serrors.IsMethodNotSupported(err) ||
+				k8serrors.IsServiceUnavailable(err) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
Speculatively fixes #832.