### PR TITLE
Switch to images-dev build on install-mini<plaform>

### DIFF
--- a/script/install_minikube.sh
+++ b/script/install_minikube.sh
@@ -20,7 +20,7 @@
 set -e
 
 eval $(minikube docker-env)
-make images
+make images-dev
 
 # Perform installation
 ./kamel install

--- a/script/install_minishift.sh
+++ b/script/install_minishift.sh
@@ -25,7 +25,7 @@ else
 fi
 
 eval $(minishift docker-env)
-make images
+make images-dev
 
 # Try setup with standard user
 ret=0


### PR DESCRIPTION
@nicolaferraro , @lburgazzoli , @oscerd what do you think to switch to images-dev build when install-mini<platform> or we can add an additional env variable for switching between images and images-dev builds or create a separate targets, i.e. install-mini<platform>-dev?