### PR TITLE
Orphan generated XML DSL from OpenAPI JSON after deleting integration

### DIFF
--- a/pkg/trait/owner.go
+++ b/pkg/trait/owner.go
@@ -54,7 +54,7 @@ func (t *ownerTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	return e.IntegrationInPhase(v1alpha1.IntegrationPhaseDeploying), nil
+	return e.IntegrationInPhase(v1alpha1.IntegrationPhaseInitialization, v1alpha1.IntegrationPhaseDeploying), nil
 }
 
 func (t *ownerTrait) Apply(e *Environment) error {

--- a/pkg/trait/trait_catalog.go
+++ b/pkg/trait/trait_catalog.go
@@ -207,7 +207,8 @@ func (c *Catalog) apply(environment *Environment) error {
 		}
 
 		if enabled {
-			c.L.Infof("Apply trait: %s", trait.ID())
+
+			c.L.Infof("Apply trait: %s, phase: %s", trait.ID(), environment.Phase())
 
 			err = trait.Apply(environment)
 			if err != nil {

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -178,6 +178,18 @@ func (e *Environment) InPhase(c v1alpha1.IntegrationKitPhase, i v1alpha1.Integra
 	return e.IntegrationKitInPhase(c) && e.IntegrationInPhase(i)
 }
 
+// Phase for Integration or IntegrationKit
+func (e *Environment) Phase() string {
+	if e.Integration != nil {
+		if e.Integration.Status.Phase != "" {
+			return string(e.Integration.Status.Phase)
+		} else if e.IntegrationKit.Status.Phase != "" {
+			return string(e.IntegrationKit.Status.Phase)
+		}
+	}
+	return string(v1alpha1.IntegrationPhaseNone)
+}
+
 // DetermineProfile determines the TraitProfile of the environment.
 // First looking at the Integration.Spec for a Profile,
 // next looking at the IntegrationKit.Spec


### PR DESCRIPTION
The problem has been fixed, but looks like we need a little bit rethink traits lifecycle with Configure and Apply. For example, we are creating entities, i.e. ConfigMaps on separate Phases, but and traits but configure specific things in ComputeConfigMaps or in separate trait, that cause potential problems like this. @nicolaferraro , @lburgazzoli , @oscerd , @astefanutti what do you think about this?