### PR TITLE
BuildConfig's, ImageStream's and Pod's not labeled with camel-k and can't delete with -l 'app=camel-k'

### DIFF
--- a/deploy/operator-deployment.yaml
+++ b/deploy/operator-deployment.yaml
@@ -34,6 +34,7 @@ spec:
       labels:
         name: camel-k-operator
         camel.apache.org/component: operator
+        app: "camel-k"
     spec:
       serviceAccountName: camel-k-operator
       containers:

--- a/deploy/resources.go
+++ b/deploy/resources.go
@@ -2757,6 +2757,7 @@ spec:
       labels:
         name: camel-k-operator
         camel.apache.org/component: operator
+        app: "camel-k"
     spec:
       serviceAccountName: camel-k-operator
       containers:

--- a/pkg/builder/kaniko/publisher.go
+++ b/pkg/builder/kaniko/publisher.go
@@ -119,6 +119,9 @@ func publisher(ctx *builder.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ctx.Namespace,
 			Name:      "camel-k-" + ctx.Build.Meta.Name,
+			Labels: map[string]string{
+				"app": "camel-k",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/pkg/builder/s2i/publisher.go
+++ b/pkg/builder/s2i/publisher.go
@@ -51,6 +51,9 @@ func publisher(ctx *builder.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "camel-k-" + ctx.Build.Meta.Name,
 			Namespace: ctx.Namespace,
+			Labels: map[string]string{
+				"app": "camel-k",
+			},
 		},
 		Spec: buildv1.BuildConfigSpec{
 			CommonSpec: buildv1.CommonSpec{
@@ -93,6 +96,9 @@ func publisher(ctx *builder.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "camel-k-" + ctx.Build.Meta.Name,
 			Namespace: ctx.Namespace,
+			Labels: map[string]string{
+				"app": "camel-k",
+			},
 		},
 		Spec: imagev1.ImageStreamSpec{
 			LookupPolicy: imagev1.ImageLookupPolicy{


### PR DESCRIPTION
Fixes #840