### PR TITLE
 fix: Enable proxy server to be configured for Kaniko builds

### DIFF
--- a/pkg/apis/camel/v1alpha1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1alpha1/integrationplatform_types.go
@@ -104,6 +104,7 @@ type IntegrationPlatformBuildSpec struct {
 	Timeout               metav1.Duration                         `json:"timeout,omitempty"`
 	PersistentVolumeClaim string                                  `json:"persistentVolumeClaim,omitempty"`
 	Maven                 MavenSpec                               `json:"maven,omitempty"`
+	HTTPProxySecret       string                                  `json:"httpProxySecret,omitempty"`
 }
 
 // IntegrationPlatformRegistrySpec --

--- a/pkg/builder/kaniko/publisher.go
+++ b/pkg/builder/kaniko/publisher.go
@@ -111,6 +111,46 @@ func publisher(ctx *builder.Context) error {
 		args = baseArgs
 	}
 
+	if ctx.Build.Platform.Build.HTTPProxySecret != "" {
+		optional := true
+		envs = append(envs, corev1.EnvVar{
+			Name: "HTTP_PROXY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: ctx.Build.Platform.Build.HTTPProxySecret,
+					},
+					Key:      "HTTP_PROXY",
+					Optional: &optional,
+				},
+			},
+		})
+		envs = append(envs, corev1.EnvVar{
+			Name: "HTTPS_PROXY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: ctx.Build.Platform.Build.HTTPProxySecret,
+					},
+					Key:      "HTTPS_PROXY",
+					Optional: &optional,
+				},
+			},
+		})
+		envs = append(envs, corev1.EnvVar{
+			Name: "NO_PROXY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: ctx.Build.Platform.Build.HTTPProxySecret,
+					},
+					Key:      "NO_PROXY",
+					Optional: &optional,
+				},
+			},
+		})
+	}
+
 	pod := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -74,6 +74,8 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) *cobra.Command {
 	cmd.Flags().StringVar(&impl.buildStrategy, "build-strategy", "", "Set the build strategy")
 	cmd.Flags().StringVar(&impl.buildTimeout, "build-timeout", "", "Set how long the build process can last")
 	cmd.Flags().StringVar(&impl.traitProfile, "trait-profile", "", "The profile to use for traits")
+	cmd.Flags().StringVar(&impl.httpProxySecret, "http-proxy-secret", "", "Configure the source of the secret holding HTTP proxy server details "+
+		"(HTTP_PROXY|HTTPS_PROXY|NO_PROXY)")
 
 	// maven settings
 	cmd.Flags().StringVar(&impl.localRepository, "local-repository", "", "Location of the local maven repository")
@@ -114,6 +116,7 @@ type installCmdOptions struct {
 	kits              []string
 	registry          v1alpha1.IntegrationPlatformRegistrySpec
 	traitProfile      string
+	httpProxySecret   string
 }
 
 // nolint: gocyclo
@@ -226,6 +229,10 @@ func (o *installCmdOptions) install(_ *cobra.Command, _ []string) error {
 				return err
 			}
 			platform.Spec.Build.Maven.Settings = mavenSettings
+		}
+
+		if o.httpProxySecret != "" {
+			platform.Spec.Build.HTTPProxySecret = o.httpProxySecret
 		}
 
 		platform.Spec.Resources.Kits = o.kits

--- a/pkg/controller/integrationplatform/kaniko_cache.go
+++ b/pkg/controller/integrationplatform/kaniko_cache.go
@@ -83,7 +83,7 @@ func createKanikoCacheWarmerPod(ctx context.Context, client client.Client, platf
 					},
 				},
 			},
-			RestartPolicy: corev1.RestartPolicyNever,
+			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Volumes: []corev1.Volume{
 				{
 					Name: "camel-k-builder",


### PR DESCRIPTION
fixes #899

I also tacked on a small 'fix' for the Kaniko cache pod, because it's almost impossible to reliably install camel-k on Minikube without the cache pod crashing (for me at least).