### PR TITLE
fix(OLM): Remove integration context leftovers from OLM bundles

### DIFF
--- a/deploy/olm-catalog/camel-k/1.0.0-M1/camel-k.v1.0.0-M1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/camel-k/1.0.0-M1/camel-k.v1.0.0-M1.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
       },
       {
         "apiVersion": "camel.apache.org/v1alpha1",
-        "kind": "IntegrationContext",
+        "kind": "IntegrationKit",
         "metadata": {
           "name": "example"
         }
@@ -76,10 +76,10 @@ spec:
       kind: Integration
       name: integrations.camel.apache.org
       version: v1alpha1
-    - description: A Camel K integration context
-      displayName: Integration Context
-      kind: IntegrationContext
-      name: integrationcontexts.camel.apache.org
+    - description: A Camel K integration kit
+      displayName: Integration Kit
+      kind: IntegrationKit
+      name: integrationkits.camel.apache.org
       version: v1alpha1
     - description: A Camel K integration platform
       displayName: Integration Platform

--- a/deploy/olm-catalog/camel-k/1.0.0-M1/crd-integration-kit.yaml
+++ b/deploy/olm-catalog/camel-k/1.0.0-M1/crd-integration-kit.yaml
@@ -18,7 +18,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrationcontexts.camel.apache.org
+  name: integrationkits.camel.apache.org
   labels:
     app: "camel-k"
 spec:
@@ -28,22 +28,22 @@ spec:
   subresources:
     status: {}
   names:
-    kind: IntegrationContext
-    listKind: IntegrationContextList
-    plural: integrationcontexts
-    singular: integrationcontext
+    kind: IntegrationKit
+    listKind: IntegrationKitList
+    plural: integrationkits
+    singular: integrationkit
     shortNames:
-    - ictx
+    - ik
   additionalPrinterColumns:
     - name: Phase
       type: string
-      description: The IntegrationContext phase
+      description: The IntegrationKit phase
       JSONPath: .status.phase
     - name: Type
       type: string
-      description: The IntegrationContext type
-      JSONPath: .metadata.labels.camel\.apache\.org\/context\.type
+      description: The IntegrationKit type
+      JSONPath: .metadata.labels.camel\.apache\.org\/kit\.type
     - name: Image
       type: string
-      description: The IntegrationContext image
+      description: The IntegrationKit image
       JSONPath: .status.image

--- a/deploy/olm-catalog/camel-k/1.0.0-M2-SNAPSHOT/camel-k.v1.0.0-M2-SNAPSHOT.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/camel-k/1.0.0-M2-SNAPSHOT/camel-k.v1.0.0-M2-SNAPSHOT.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
       },
       {
         "apiVersion": "camel.apache.org/v1alpha1",
-        "kind": "IntegrationContext",
+        "kind": "IntegrationKit",
         "metadata": {
           "name": "example"
         }
@@ -76,10 +76,10 @@ spec:
       kind: Integration
       name: integrations.camel.apache.org
       version: v1alpha1
-    - description: A Camel K integration context
-      displayName: Integration Context
-      kind: IntegrationContext
-      name: integrationcontexts.camel.apache.org
+    - description: A Camel K integration kit
+      displayName: Integration Kit
+      kind: IntegrationKit
+      name: integrationkits.camel.apache.org
       version: v1alpha1
     - description: A Camel K integration platform
       displayName: Integration Platform


### PR DESCRIPTION
Since #726 and 1.0.0-M1, integration context CRD has been renamed to integration kit.