### PR TITLE
fix: Add option to disable Kaniko cache warming

### DIFF
--- a/pkg/apis/camel/v1alpha1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1alpha1/integrationplatform_types.go
@@ -105,7 +105,7 @@ type IntegrationPlatformBuildSpec struct {
 	PersistentVolumeClaim string                                  `json:"persistentVolumeClaim,omitempty"`
 	Maven                 MavenSpec                               `json:"maven,omitempty"`
 	HTTPProxySecret       string                                  `json:"httpProxySecret,omitempty"`
-	KanikoBuildCache      bool                                    `json:"kanikoBuildCache,omitempty"`
+	KanikoBuildCache      *bool                                   `json:"kanikoBuildCache,omitempty"`
 }
 
 // IntegrationPlatformRegistrySpec --

--- a/pkg/apis/camel/v1alpha1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1alpha1/integrationplatform_types.go
@@ -105,6 +105,7 @@ type IntegrationPlatformBuildSpec struct {
 	PersistentVolumeClaim string                                  `json:"persistentVolumeClaim,omitempty"`
 	Maven                 MavenSpec                               `json:"maven,omitempty"`
 	HTTPProxySecret       string                                  `json:"httpProxySecret,omitempty"`
+	KanikoBuildCache      bool                                    `json:"kanikoBuildCache,omitempty"`
 }
 
 // IntegrationPlatformRegistrySpec --

--- a/pkg/builder/kaniko/publisher.go
+++ b/pkg/builder/kaniko/publisher.go
@@ -80,7 +80,7 @@ func publisher(ctx *builder.Context) error {
 		"--dockerfile=Dockerfile",
 		"--context=" + contextDir,
 		"--destination=" + image,
-		"--cache=" + strconv.FormatBool(ctx.Build.Platform.Build.KanikoBuildCache),
+		"--cache=" + strconv.FormatBool(*ctx.Build.Platform.Build.KanikoBuildCache),
 		"--cache-dir=/workspace/cache",
 	}
 

--- a/pkg/builder/kaniko/publisher.go
+++ b/pkg/builder/kaniko/publisher.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/apache/camel-k/pkg/builder"
@@ -79,7 +80,7 @@ func publisher(ctx *builder.Context) error {
 		"--dockerfile=Dockerfile",
 		"--context=" + contextDir,
 		"--destination=" + image,
-		"--cache",
+		"--cache=" + strconv.FormatBool(ctx.Build.Platform.Build.KanikoBuildCache),
 		"--cache-dir=/workspace/cache",
 	}
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -239,10 +239,12 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 
 		kanikoBuildCacheFlag := cobraCmd.Flags().Lookup("kaniko-build-cache")
 
+		defaultKanikoBuildCache := true
+
 		if kanikoBuildCacheFlag.Changed {
-			platform.Spec.Build.KanikoBuildCache = o.kanikoBuildCache
+			platform.Spec.Build.KanikoBuildCache = &o.kanikoBuildCache
 		} else {
-			platform.Spec.Build.KanikoBuildCache = true
+			platform.Spec.Build.KanikoBuildCache = &defaultKanikoBuildCache
 		}
 
 		platform.Spec.Resources.Kits = o.kits

--- a/pkg/controller/integrationplatform/initialize.go
+++ b/pkg/controller/integrationplatform/initialize.go
@@ -136,8 +136,15 @@ func (action *initializeAction) Handle(ctx context.Context, platform *v1alpha1.I
 			return nil, err
 		}
 
+		defaultKanikoBuildCache := true
+		// Check if the KanikoBuildCache has been initialized
+		if platform.Spec.Build.KanikoBuildCache == nil {
+			//if not initialized then default it to true
+			platform.Spec.Build.KanikoBuildCache = &defaultKanikoBuildCache
+		}
+
 		// Check if the operator is running in the same namespace before starting the cache warmer
-		if platform.Namespace == platformutil.GetOperatorNamespace() && platform.Spec.Build.KanikoBuildCache {
+		if platform.Namespace == platformutil.GetOperatorNamespace() && *platform.Spec.Build.KanikoBuildCache {
 			// Create the Kaniko warmer pod that caches the base image into the Camel K builder volume
 			action.L.Info("Create Kaniko cache warmer pod")
 			err = createKanikoCacheWarmerPod(ctx, action.client, platform)

--- a/pkg/controller/integrationplatform/initialize.go
+++ b/pkg/controller/integrationplatform/initialize.go
@@ -137,7 +137,7 @@ func (action *initializeAction) Handle(ctx context.Context, platform *v1alpha1.I
 		}
 
 		// Check if the operator is running in the same namespace before starting the cache warmer
-		if platform.Namespace == platformutil.GetOperatorNamespace() {
+		if platform.Namespace == platformutil.GetOperatorNamespace() && platform.Spec.Build.KanikoBuildCache {
 			// Create the Kaniko warmer pod that caches the base image into the Camel K builder volume
 			action.L.Info("Create Kaniko cache warmer pod")
 			err = createKanikoCacheWarmerPod(ctx, action.client, platform)


### PR DESCRIPTION
Fixes: #907 

This option will enable user to enable or disable the cache for building the images.