### PR TITLE
Fix #732: Adjusted CLI tagline to be in sync with updated (serverless superpowers) language.

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -26,9 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const kamelCommandLongDescription = `Apache Camel K is a lightweight integration framework
-built from Apache Camel that runs natively on Kubernetes and is
-specifically designed for serverless and microservice architectures.
+const kamelCommandLongDescription = `Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless 
+superpowers.
 `
 
 // RootCmdOptions --


### PR DESCRIPTION
Adjusted CLI tagline to be in sync with updated (serverless superpowers) language.