### PR TITLE
Making kamel CLI 90% faster on remote clusters

### DIFF
--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -54,7 +54,7 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 	printVersion()
 
-	c, err := client.NewClient()
+	c, err := client.NewClient(false)
 	exitOnError(err)
 
 	ctx := cancellable.NewContext()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,10 +23,10 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"github.com/apache/camel-k/pkg/apis"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/client/fastmapper.go
+++ b/pkg/client/fastmapper.go
@@ -40,9 +40,10 @@ func newFastDiscoveryRESTMapperWithFilter(config *rest.Config, filter func(*meta
 	wg := wait.Group{}
 	totalCount := 0
 	pickedCount := 0
-	var grs []*restmapper.APIGroupResources
+	grs := make([]*restmapper.APIGroupResources, 0)
 	for _, group := range groups.Groups {
-		pick := filter(&group)
+		pinnedGroup := group
+		pick := filter(&pinnedGroup)
 		logrus.Debugf("Group: %s %v", group.Name, pick)
 		totalCount++
 		if !pick {

--- a/pkg/client/fastmapper.go
+++ b/pkg/client/fastmapper.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// allowedAPIGroups contains a set of API groups that are allowed when using the fastmapper.
+// Those must correspond to all groups used by the "kamel" binary tool when running out-of-cluster.
+var allowedAPIGroups = map[string]bool{
+	"":                          true, // core APIs
+	"apiextensions.k8s.io":      true,
+	"apps":                      true,
+	"camel.apache.org":          true,
+	"rbac.authorization.k8s.io": true,
+}
+
+func newFastDiscoveryRESTMapper(config *rest.Config) meta.RESTMapper {
+	return meta.NewLazyRESTMapperLoader(func() (meta.RESTMapper, error) {
+		return newFastDiscoveryRESTMapperWithFilter(config, func(g *metav1.APIGroup) bool {
+			return allowedAPIGroups[g.Name]
+		})
+	})
+}
+
+func newFastDiscoveryRESTMapperWithFilter(config *rest.Config, filter func(*metav1.APIGroup) bool) (meta.RESTMapper, error) {
+	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
+	groups, err := dc.ServerGroups()
+	if err != nil {
+		return nil, err
+	}
+	wg := wait.Group{}
+	totalCount := 0
+	pickedCount := 0
+	var grs []*restmapper.APIGroupResources
+	for _, group := range groups.Groups {
+		pick := filter(&group)
+		logrus.Debugf("Group: %s %v", group.Name, pick)
+		totalCount++
+		if !pick {
+			continue
+		}
+		pickedCount++
+		gr := &restmapper.APIGroupResources{
+			Group:              group,
+			VersionedResources: make(map[string][]metav1.APIResource),
+		}
+		grs = append(grs, gr)
+		wg.Start(func() { discoverGroupResources(dc, gr) })
+	}
+	wg.Wait()
+	logrus.Debugf("Picked %d/%d", pickedCount, totalCount)
+	return restmapper.NewDiscoveryRESTMapper(grs), nil
+}
+
+func discoverGroupResources(dc discovery.DiscoveryInterface, gr *restmapper.APIGroupResources) {
+	for _, version := range gr.Group.Versions {
+		resources, err := dc.ServerResourcesForGroupVersion(version.GroupVersion)
+		if err != nil {
+			logrus.Fatal(err, version.GroupVersion)
+		}
+		gr.VersionedResources[version.Version] = resources.APIResources
+	}
+}

--- a/pkg/client/fastmapper.go
+++ b/pkg/client/fastmapper.go
@@ -18,6 +18,7 @@ var allowedAPIGroups = map[string]bool{
 	"apiextensions.k8s.io":      true,
 	"apps":                      true,
 	"camel.apache.org":          true,
+	"project.openshift.io":      true, // used in e2e tests
 	"rbac.authorization.k8s.io": true,
 }
 

--- a/pkg/client/fastmapper.go
+++ b/pkg/client/fastmapper.go
@@ -21,6 +21,8 @@ var allowedAPIGroups = map[string]bool{
 	"rbac.authorization.k8s.io": true,
 }
 
+// newFastDiscoveryRESTMapper comes from https://github.com/kubernetes-sigs/controller-runtime/pull/592.
+// We may leverage the controller-runtime bits in the future, if that gets merged upstream.
 func newFastDiscoveryRESTMapper(config *rest.Config) meta.RESTMapper {
 	return meta.NewLazyRESTMapperLoader(func() (meta.RESTMapper, error) {
 		return newFastDiscoveryRESTMapperWithFilter(config, func(g *metav1.APIGroup) bool {


### PR DESCRIPTION
Fix #792

Latest released version:
```
[nferraro@localhost camel-k]$ time kamel-1.0.0-M1 run examples/routes.groovy
integration "routes" created

real    0m16.353s
user    0m0.794s
sys     0m0.068s
```

With this change:
```
[nferraro@localhost camel-k]$ time kamel run examples/routes.groovy
integration "routes" created

real    0m1.898s
user    0m0.508s
sys     0m0.036s
```

I.e. from **16 seconds** to just ~ **2 seconds**.

This is fast because it does not initialize all kubernetes custom resources available in the cluster (~50 on a standard OpenShift installation) but focuses on the 5 resource groups that our CLI needs.

Only drawback is that we should remember to sync the set of allowed API groups (you get a unknown-resource error in case you use a new group from the CLI client).