### PR TITLE
Jolokia and Prometheus traits fixes

### DIFF
--- a/pkg/trait/jolokia_test.go
+++ b/pkg/trait/jolokia_test.go
@@ -113,12 +113,13 @@ func TestApplyJolokiaTraitNominalShouldSucceed(t *testing.T) {
 
 	err := trait.Apply(environment)
 
+	container := environment.Resources.GetContainerByName(defaultContainerName)
+
 	assert.Nil(t, err)
-	test.EnvVarHasValue(t, environment.EnvVars, "AB_JOLOKIA_AUTH_OPENSHIFT", "false")
-	test.EnvVarHasValue(t, environment.EnvVars, "AB_JOLOKIA_OPTS", "port=8778")
+	test.EnvVarHasValue(t, container.Env, "AB_JOLOKIA_AUTH_OPENSHIFT", "false")
+	test.EnvVarHasValue(t, container.Env, "AB_JOLOKIA_OPTS", "port=8778")
 	assert.Len(t, environment.Integration.Status.Conditions, 1)
 
-	container := environment.Resources.GetContainerByName("integration")
 	assert.NotNil(t, container)
 	assert.Len(t, container.Ports, 1)
 	containerPort := container.Ports[0]
@@ -158,8 +159,10 @@ func TestApplyJolokiaTraitWithOptionShouldOverrideDefault(t *testing.T) {
 
 	err := trait.Apply(environment)
 
+	container := environment.Resources.GetContainerByName(defaultContainerName)
+
 	assert.Nil(t, err)
-	ev := envvar.Get(environment.EnvVars, "AB_JOLOKIA_OPTS")
+	ev := envvar.Get(container.Env, "AB_JOLOKIA_OPTS")
 	assert.NotNil(t, ev)
 	assert.Contains(t, ev.Value, "port=8778", "host=explicit-host", "discoveryEnabled=true", "protocol=http", "caCert=.cacert")
 	assert.Contains(t, ev.Value, "extendedClientCheck=false", "clientPrincipal=cn:any", "useSslClientAuthentication=false")
@@ -181,8 +184,10 @@ func TestApplyDisabledJolokiaTraitShouldNotSucceed(t *testing.T) {
 
 	err := trait.Apply(environment)
 
+	container := environment.Resources.GetContainerByName(defaultContainerName)
+
 	assert.Nil(t, err)
-	test.EnvVarHasValue(t, environment.EnvVars, "AB_JOLOKIA_OFF", "true")
+	test.EnvVarHasValue(t, container.Env, "AB_JOLOKIA_OFF", "true")
 }
 
 func TestSetDefaultJolokiaOptionShoudlNotOverrideOptionsMap(t *testing.T) {
@@ -283,7 +288,6 @@ func TestAddWrongTypeOptionToJolokiaOptionsDoesNothing(t *testing.T) {
 }
 
 func createNominalJolokiaTest() (*jolokiaTrait, *Environment) {
-
 	trait := newJolokiaTrait()
 	enabled := true
 	trait.Enabled = &enabled

--- a/pkg/trait/prometheus.go
+++ b/pkg/trait/prometheus.go
@@ -92,7 +92,7 @@ func (t *prometheusTrait) Apply(e *Environment) (err error) {
 	// Add the container port
 	containerPort := t.getContainerPort()
 	container.Ports = append(container.Ports, *containerPort)
-	condition.Message += fmt.Sprintf("%s(%s/%d)", container.Name, containerPort.Name, containerPort.ContainerPort)
+	condition.Message = fmt.Sprintf("%s(%s/%d)", container.Name, containerPort.Name, containerPort.ContainerPort)
 
 	// Retrieve the service or create a new one if the service trait is enabled
 	serviceEnabled := false
@@ -114,7 +114,7 @@ func (t *prometheusTrait) Apply(e *Environment) (err error) {
 	if serviceEnabled {
 		servicePort := t.getServicePort()
 		service.Spec.Ports = append(service.Spec.Ports, *servicePort)
-		condition.Message += fmt.Sprintf("%s(%s/%d) -> ", service.Name, servicePort.Name, servicePort.Port)
+		condition.Message = fmt.Sprintf("%s(%s/%d) -> ", service.Name, servicePort.Name, servicePort.Port) + condition.Message
 
 		// Add the ServiceMonitor resource
 		if t.ServiceMonitor {

--- a/pkg/trait/trait_catalog.go
+++ b/pkg/trait/trait_catalog.go
@@ -184,6 +184,8 @@ func (c *Catalog) traitsFor(environment *Environment) []Trait {
 			c.tAffinity,
 			c.tKnativeService,
 			c.tContainer,
+			c.tJolokia,
+			c.tPrometheus,
 			c.tClasspath,
 			c.tProbes,
 			c.tIstio,


### PR DESCRIPTION
It follows-up on #825 that precludes traits configuration based on environment variables after the container trait applies. That was leaving the Jolokia and Prometheus traits ineffective, hence inheriting the default behaviour from the Fabric8 based image that activates Jolokia and Prometheus.  

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

**Release Note**
```release-note
Fixed Jolokia and Prometheus traits configuration
```
