### PR TITLE
feat: Enable integration scale sub-resource

### DIFF
--- a/deploy/crd-integration.yaml
+++ b/deploy/crd-integration.yaml
@@ -40,9 +40,13 @@ spec:
   additionalPrinterColumns:
     - name: Phase
       type: string
-      description: The Integration phase
+      description: The integration phase
       JSONPath: .status.phase
     - name: Kit
       type: string
-      description: The IntegrationKit to use
+      description: The integration kit
       JSONPath: .status.kit
+    - name: Replicas
+      type: integer
+      description: The number of pods
+      JSONPath: .status.replicas

--- a/deploy/crd-integration.yaml
+++ b/deploy/crd-integration.yaml
@@ -27,6 +27,9 @@ spec:
   version: v1alpha1
   subresources:
     status: {}
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
   names:
     kind: Integration
     listKind: IntegrationList

--- a/pkg/apis/camel/v1alpha1/integration_types.go
+++ b/pkg/apis/camel/v1alpha1/integration_types.go
@@ -53,6 +53,7 @@ type IntegrationStatus struct {
 	Configuration    []ConfigurationSpec    `json:"configuration,omitempty"`
 	Conditions       []IntegrationCondition `json:"conditions,omitempty"`
 	Version          string                 `json:"version,omitempty"`
+	Replicas         *int32                 `json:"replicas,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/camel/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/camel/v1alpha1/zz_generated.deepcopy.go
@@ -942,6 +942,11 @@ func (in *IntegrationStatus) DeepCopyInto(out *IntegrationStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -142,7 +142,7 @@ func (t *knativeServiceTrait) Apply(e *Environment) error {
 	e.Resources.Add(ksvc)
 
 	e.Integration.Status.SetCondition(
-		v1alpha1.IntegrationConditionDeploymentAvailable,
+		v1alpha1.IntegrationConditionKnativeServiceAvailable,
 		corev1.ConditionTrue,
 		v1alpha1.IntegrationConditionKnativeServiceAvailableReason,
 		ksvc.Name,


### PR DESCRIPTION
Fixes #353.

This enables using `kubectl scale it` and exposes the `replicas` status field to integration so that tooling can rely on it.

**Release Notes:**
```release-notes
Enable integration scale sub-resource
```
