### PR TITLE
chore(release): automatic generation of release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- Description -->
+
+
+
+
+
+
+<!-- Enter your extended release note in the below block. If the PR requires
+additional action from users switching to the new release, include the string
+"action required". If no release note is required, write "NONE". -->
+
+**Release Note**
+```release-note
+NONE
+```

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # Released Packages
 *.tar.gz
 
+# Release Notes
+/release-notes.md
+
 # Unuseful file
 /deploy/operator.yaml
 

--- a/script/Makefile
+++ b/script/Makefile
@@ -15,6 +15,7 @@
 
 VERSIONFILE := pkg/util/defaults/defaults.go
 VERSION := 1.0.0-M2-SNAPSHOT
+LAST_RELEASED_VERSION := 1.0.0-M1
 RUNTIME_VERSION := 1.0.0
 CAMEL_VERSION := 3.0.0-M4
 CAMEL_VERSION_CONSTRAINT := >=3.0.0-M4
@@ -205,4 +206,7 @@ install-minishift:
 install-minikube:
 	./script/install_minikube.sh
 
-.PHONY: build build-operator build-kamel build-resources build-builder build-olm unsnapshot-olm dep codegen images images-dec images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag
+release-notes:
+	./script/gen_release_notes.sh $(LAST_RELEASED_VERSION) $(VERSION)
+
+.PHONY: build build-operator build-kamel build-resources build-builder build-olm unsnapshot-olm dep codegen images images-dec images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes

--- a/script/gen_release_notes.sh
+++ b/script/gen_release_notes.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 last-tag new-tag"
+    exit 1
+fi
+
+location=$(dirname $0)
+last_tag=$1
+new_tag=$2
+
+echo "Generating release notes for version $new_tag starting from tag $last_tag"
+
+start_sha=$(git rev-list -n 1 $last_tag)
+if [ "$start_sha" == "" ]; then
+	echo "cannot determine initial SHA from tag $last_tag"
+	exit 1
+fi
+echo "Using start SHA $start_sha from tag $last_tag"
+
+set +e
+end_sha=$(git rev-list -n 1 $new_tag 2>&1)
+if [ $? -ne 0 ]; then
+	end_sha=$(git rev-parse upstream/master)
+    if [ "$end_sha" == "" ]; then
+    	echo "cannot determine current SHA from git"
+    	exit 1
+    fi
+    echo "Using end SHA $end_sha from upstream/master"
+else
+	echo "Using end SHA $end_sha from tag $new_tag"
+fi
+set -e
+
+set +e
+which release-notes > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "No \"release-notes\" command found. Please follow these steps to install it:"
+  echo "  1) git clone git@github.com:nicolaferraro/release.git"
+  echo "  2) cd release && go install ./cmd/release-notes/"
+  echo ""
+  exit 1
+fi
+set -e
+
+cli_version=$(release-notes --version)
+if [ "$cli_version" != "nicolaferraro" ]; then
+  echo "You must install a specific fork from nicolaferraro of the \"release-notes\" command"
+  exit 1
+fi
+
+release-notes --start-sha $start_sha --end-sha $end_sha --github-repo camel-k --github-org apache --release-version $new_tag --output $location/../release-notes.md --requiredAuthor ""


### PR DESCRIPTION
This adds a "release note" section on the template of each PR that allows the author of the PR to provide a message that will be added in the release notes section of each Camel K release.

Extraction of notes is based on a fork of the [k8s.io/release](https://github.com/kubernetes/release) project available at https://github.com/nicolaferraro/release.

Details on how to install it are provided when running `make release-notes`.