### PR TITLE
fix: Rename kamel get 'context' column to 'kit'

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -75,7 +75,7 @@ func (o *getCmdOptions) run(_ *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
-	fmt.Fprintln(w, "NAME\tPHASE\tCONTEXT")
+	fmt.Fprintln(w, "NAME\tPHASE\tKIT")
 	for _, integration := range integrationList.Items {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", integration.Name, string(integration.Status.Phase), integration.Status.Kit)
 	}


### PR DESCRIPTION
<!-- Description -->






<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

**Release Note**
```release-note
Updated 'CONTEXT' column header in 'kamel get' output to 'KIT'
```
