### PR TITLE
chore(cli): Hide builder and operator commands

### DIFF
--- a/pkg/cmd/builder.go
+++ b/pkg/cmd/builder.go
@@ -27,10 +27,11 @@ func newCmdBuilder(rootCmdOptions *RootCmdOptions) *cobra.Command {
 		RootCmdOptions: rootCmdOptions,
 	}
 	cmd := cobra.Command{
-		Use:   "builder",
-		Short: "Run the Camel K builder",
-		Long:  `Run the Camel K builder`,
-		Run:   impl.run,
+		Use:    "builder",
+		Short:  "Run the Camel K builder",
+		Long:   `Run the Camel K builder`,
+		Hidden: true,
+		Run:    impl.run,
 	}
 
 	cmd.Flags().StringVar(&impl.BuildName, "build-name", "", "The name of the build resource")

--- a/pkg/cmd/operator.go
+++ b/pkg/cmd/operator.go
@@ -27,10 +27,11 @@ func newCmdOperator(rootCmdOptions *RootCmdOptions) *cobra.Command {
 		RootCmdOptions: rootCmdOptions,
 	}
 	cmd := cobra.Command{
-		Use:   "operator",
-		Short: "Run the Camel K operator",
-		Long:  `Run the Camel K operator`,
-		Run:   impl.run,
+		Use:    "operator",
+		Short:  "Run the Camel K operator",
+		Long:   `Run the Camel K operator`,
+		Hidden: true,
+		Run:    impl.run,
 	}
 
 	return &cmd


### PR DESCRIPTION
Follows up #966. The `builder` and `operator` commands are better hidden as they are not intended to be used as part of the public CLI.