### PR TITLE
chore: Display Kaniko version in prelude log

### DIFF
--- a/pkg/builder/kaniko/publisher.go
+++ b/pkg/builder/kaniko/publisher.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/apache/camel-k/pkg/builder"
 	"github.com/apache/camel-k/pkg/platform"
+	"github.com/apache/camel-k/pkg/util/defaults"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/apache/camel-k/pkg/util/tar"
 
@@ -175,7 +176,7 @@ func publisher(ctx *builder.Context) error {
 			Containers: []corev1.Container{
 				{
 					Name:         "kaniko",
-					Image:        "gcr.io/kaniko-project/executor:v0.9.0",
+					Image:        fmt.Sprintf("gcr.io/kaniko-project/executor:v%s", defaults.KanikoVersion),
 					Args:         args,
 					Env:          envs,
 					VolumeMounts: volumeMounts,

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -45,7 +45,8 @@ var GitCommit string
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("Operator SDK Version: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("Kaniko Version: %v", defaults.KanikoVersion))
 	log.Info(fmt.Sprintf("Camel K Operator Version: %v", defaults.Version))
 	log.Info(fmt.Sprintf("Camel K Git Commit: %v", GitCommit))
 }

--- a/pkg/controller/integrationplatform/kaniko_cache.go
+++ b/pkg/controller/integrationplatform/kaniko_cache.go
@@ -19,6 +19,7 @@ package integrationplatform
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +28,7 @@ import (
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"github.com/apache/camel-k/pkg/builder/kaniko"
 	"github.com/apache/camel-k/pkg/client"
+	"github.com/apache/camel-k/pkg/util/defaults"
 
 	"github.com/pkg/errors"
 )
@@ -51,7 +53,7 @@ func createKanikoCacheWarmerPod(ctx context.Context, client client.Client, platf
 			Containers: []corev1.Container{
 				{
 					Name:  "warm-kaniko-cache",
-					Image: "gcr.io/kaniko-project/warmer:v0.9.0",
+					Image: fmt.Sprintf("gcr.io/kaniko-project/warmer:v%s", defaults.KanikoVersion),
 					Args: []string{
 						"--cache-dir=/workspace/cache",
 						"--image=" + platform.Spec.Build.BaseImage,

--- a/pkg/util/defaults/defaults.go
+++ b/pkg/util/defaults/defaults.go
@@ -30,6 +30,9 @@ const (
 	// RuntimeVersion --
 	RuntimeVersion = "1.0.0"
 
+	// KanikoVersion --
+	KanikoVersion = "0.9.0"
+
 	// BaseImage --
 	BaseImage = "fabric8/s2i-java:3.0-java8"
 

--- a/script/Makefile
+++ b/script/Makefile
@@ -19,6 +19,7 @@ LAST_RELEASED_VERSION := 1.0.0-M1
 RUNTIME_VERSION := 1.0.0
 CAMEL_VERSION := 3.0.0-M4
 CAMEL_VERSION_CONSTRAINT := >=3.0.0-M4
+KANIKO_VERSION := 0.9.0
 BASE_IMAGE := fabric8/s2i-java:3.0-java8
 LOCAL_REPOSITORY := /tmp/artifacts/m2
 IMAGE_NAME := docker.io/apache/camel-k
@@ -83,6 +84,9 @@ codegen:
 	@echo "" >> $(VERSIONFILE)
 	@echo "  // RuntimeVersion -- " >> $(VERSIONFILE)
 	@echo "  RuntimeVersion = \"$(RUNTIME_VERSION)\"" >> $(VERSIONFILE)
+	@echo "" >> $(VERSIONFILE)
+	@echo "  // KanikoVersion -- " >> $(VERSIONFILE)
+	@echo "  KanikoVersion = \"$(KANIKO_VERSION)\"" >> $(VERSIONFILE)
 	@echo "" >> $(VERSIONFILE)
 	@echo "  // BaseImage -- " >> $(VERSIONFILE)
 	@echo "  BaseImage = \"$(BASE_IMAGE)\"" >> $(VERSIONFILE)


### PR DESCRIPTION
I've tried upgrading Kaniko to version 0.12.0 but builds seem a lot slower. I'll try to investigate further ASAP. In the meantime, I'm dumping what I have :) 