### PR TITLE
Fix gke permissions

### DIFF
--- a/pkg/apis/camel/v1alpha1/integrationplatform_types_support.go
+++ b/pkg/apis/camel/v1alpha1/integrationplatform_types_support.go
@@ -159,3 +159,12 @@ func (in *IntegrationPlatformStatus) RemoveCondition(condType IntegrationPlatfor
 
 	in.Conditions = newConditions
 }
+
+// IsKanikoCacheEnabled tells if the KanikoCache is enabled on the integration platform build spec
+func (b IntegrationPlatformBuildSpec) IsKanikoCacheEnabled() bool {
+	if b.KanikoBuildCache == nil {
+		// Cache is enabled unless explicitly disabled
+		return true
+	}
+	return *b.KanikoBuildCache
+}

--- a/pkg/builder/kaniko/publisher.go
+++ b/pkg/builder/kaniko/publisher.go
@@ -88,7 +88,7 @@ func publisher(ctx *builder.Context) error {
 		"--dockerfile=Dockerfile",
 		"--context=" + contextDir,
 		"--destination=" + image,
-		"--cache=" + strconv.FormatBool(*ctx.Build.Platform.Build.KanikoBuildCache),
+		"--cache=" + strconv.FormatBool(ctx.Build.Platform.Build.IsKanikoCacheEnabled()),
 		"--cache-dir=/workspace/cache",
 	}
 

--- a/pkg/controller/integrationplatform/initialize.go
+++ b/pkg/controller/integrationplatform/initialize.go
@@ -136,7 +136,7 @@ func (action *initializeAction) Handle(ctx context.Context, platform *v1alpha1.I
 		}
 
 		// Check if the operator is running in the same namespace before starting the cache warmer
-		if platform.Namespace == platformutil.GetOperatorNamespace() && *platform.Spec.Build.KanikoBuildCache {
+		if platform.Namespace == platformutil.GetOperatorNamespace() && platform.Spec.Build.IsKanikoCacheEnabled() {
 			// Create the Kaniko warmer pod that caches the base image into the Camel K builder volume
 			action.L.Info("Create Kaniko cache warmer pod")
 			err = createKanikoCacheWarmerPod(ctx, action.client, platform)

--- a/pkg/controller/integrationplatform/kaniko_cache.go
+++ b/pkg/controller/integrationplatform/kaniko_cache.go
@@ -72,11 +72,8 @@ func createKanikoCacheWarmerPod(ctx context.Context, client client.Client, platf
 					Name:            "create-kaniko-cache",
 					Image:           "busybox",
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command: []string{
-						"mkdir",
-						"-p",
-						"/workspace/cache",
-					},
+					Command:         []string{"/bin/sh", "-c"},
+					Args:            []string{"mkdir -p /workspace/cache && chmod -R a+rwx /workspace"},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "camel-k-builder",


### PR DESCRIPTION
<!-- Description -->
Fixes #915
Fixes #947

Kaniko builds are executed with multiple containers, some of which still need to run as root. This PR sets the permissions during init so that any UID has full access over the `/workspace` dir.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fixed issue which prevented creating builds on GKE
```
