### PR TITLE
fix #972: strip local host data from build

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -29,9 +29,6 @@ GO_PATH := $(shell go env GOPATH)
 LINT_GOGC := 10
 LINT_DEADLINE := 5m
 
-# For signing binary artifacts
-GPG_PASS := $(GPG_PASS)
-
 # Used to push pre-relase artifacts
 STAGING_IMAGE_NAME := docker.io/camelk/camel-k
 
@@ -181,7 +178,7 @@ git-tag:
 	./script/git_tag.sh $(VERSION) $(RELEASE_GIT_REMOTE)
 
 cross-compile:
-	./script/cross_compile.sh $(VERSION) $(GPG_PASS)
+	./script/cross_compile.sh $(VERSION) '$(GOFLAGS)'
 
 package-examples:
 	./script/package_examples.sh $(VERSION)

--- a/script/cross_compile.sh
+++ b/script/cross_compile.sh
@@ -22,13 +22,13 @@ rm -rf ${builddir}
 
 basename=camel-k-client
 
-if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
-    echo "usage: $0 version [pgp_pass]"
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 version build_flags"
     exit 1
 fi
 
 version=$1
-gpg_pass=$2
+build_flags=$2
 
 cross_compile () {
 	local label=$1
@@ -41,10 +41,10 @@ cross_compile () {
 	fi
 
 	targetdir=${builddir}/${label}
-	go build -o ${targetdir}/kamel${extension} ./cmd/kamel/...
+	eval go build "$build_flags" -o ${targetdir}/kamel${extension} ./cmd/kamel/...
 
-	if [ -n "$gpg_pass" ]; then
-	    gpg --output ${targetdir}/kamel${extension}.asc --armor --detach-sig --passphrase ${gpg_pass} ${targetdir}/kamel${extension}
+	if [ -n "$GPG_PASS" ]; then
+	    gpg --output ${targetdir}/kamel${extension}.asc --armor --detach-sig --passphrase ${GPG_PASS} ${targetdir}/kamel${extension}
 	fi
 
     pushd . && cd ${targetdir} && sha512sum -b kamel${extension} > kamel${extension}.sha512 && popd


### PR DESCRIPTION
<!-- Description -->

Problem was that go flags were not forwarded to cross-compile.

I prefer not requiring everybody to upgrade to go 1.13 for using the new flag. Will open an issue for next milestone.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
