### PR TITLE
Kaniko cache warmer and platform multi-tenancy improvements

### DIFF
--- a/pkg/builder/kaniko/publisher.go
+++ b/pkg/builder/kaniko/publisher.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/apache/camel-k/pkg/builder"
-	"github.com/apache/camel-k/pkg/platform"
 	"github.com/apache/camel-k/pkg/util/defaults"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/apache/camel-k/pkg/util/tar"
@@ -187,25 +186,14 @@ func publisher(ctx *builder.Context) error {
 		},
 	}
 
-	var labelKey string
-	var labelValue string
-	if ctx.Namespace == platform.GetOperatorNamespace() {
-		// Check if the operator is running in the same namespace
-		labelKey = "camel.apache.org/component"
-		labelValue = "operator"
-	} else {
-		labelKey = "camel.apache.org/build"
-		labelValue = ctx.Build.Meta.Name
-	}
-
-	// Co-locate with builder pod for sharing the volume
+	// Co-locate with the build pod for sharing the volume
 	pod.Spec.Affinity = &corev1.Affinity{
 		PodAffinity: &corev1.PodAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							labelKey: labelValue,
+							"camel.apache.org/build": ctx.Build.Meta.Name,
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -58,7 +58,7 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&impl.skipOperatorSetup, "skip-operator-setup", false, "Do not install the operator in the namespace (in case there's a global one)")
 	cmd.Flags().BoolVar(&impl.skipClusterSetup, "skip-cluster-setup", false, "Skip the cluster-setup phase")
 	cmd.Flags().BoolVar(&impl.exampleSetup, "example", false, "Install example integration")
-	cmd.Flags().BoolVar(&impl.global, "global", false, "Configure the operator to watch all namespaces")
+	cmd.Flags().BoolVar(&impl.global, "global", false, "Configure the operator to watch all namespaces. No integration platform is created.")
 
 	cmd.Flags().StringVarP(&impl.outputFormat, "output", "o", "", "Output format. One of: json|yaml")
 	cmd.Flags().StringVar(&impl.registry.Organization, "organization", "", "A organization on the Docker registry that can be used to publish images")
@@ -249,9 +249,13 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 
 		platform.Spec.Resources.Kits = o.kits
 
-		err = install.RuntimeObjectOrCollect(o.Context, c, namespace, collection, platform)
-		if err != nil {
-			return err
+		// Do not create an integration platform in global mode as platforms are expected
+		// to be created in other namespaces
+		if !o.global {
+			err = install.RuntimeObjectOrCollect(o.Context, c, namespace, collection, platform)
+			if err != nil {
+				return err
+			}
 		}
 
 		if o.exampleSetup {

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -269,7 +269,11 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 				}
 			}
 
-			fmt.Println("Camel K installed in namespace", namespace)
+			if o.global {
+				fmt.Println("Camel K installed in namespace", namespace, "(global mode)")
+			} else {
+				fmt.Println("Camel K installed in namespace", namespace)
+			}
 		}
 	}
 

--- a/pkg/controller/integrationplatform/initialize.go
+++ b/pkg/controller/integrationplatform/initialize.go
@@ -135,15 +135,13 @@ func (action *initializeAction) Handle(ctx context.Context, platform *v1alpha1.I
 			return nil, err
 		}
 
-		// Check if the operator is running in the same namespace before starting the cache warmer
-		if platform.Namespace == platformutil.GetOperatorNamespace() && platform.Spec.Build.IsKanikoCacheEnabled() {
+		if platform.Spec.Build.IsKanikoCacheEnabled() {
 			// Create the Kaniko warmer pod that caches the base image into the Camel K builder volume
 			action.L.Info("Create Kaniko cache warmer pod")
 			err = createKanikoCacheWarmerPod(ctx, action.client, platform)
 			if err != nil {
 				return nil, err
 			}
-
 			platform.Status.Phase = v1alpha1.IntegrationPlatformPhaseWarming
 		} else {
 			// Skip the warmer pod creation

--- a/pkg/controller/integrationplatform/kaniko_cache.go
+++ b/pkg/controller/integrationplatform/kaniko_cache.go
@@ -48,6 +48,9 @@ func createKanikoCacheWarmerPod(ctx context.Context, client client.Client, platf
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: platform.Namespace,
 			Name:      platform.Name + "-cache",
+			Labels: map[string]string{
+				"camel.apache.org/component": "kaniko-warmer",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -89,23 +92,6 @@ func createKanikoCacheWarmerPod(ctx context.Context, client client.Client, platf
 					VolumeSource: corev1.VolumeSource{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 							ClaimName: platform.Spec.Build.PersistentVolumeClaim,
-						},
-					},
-				},
-			},
-			// Co-locate with the builder pod for sharing the host path volume as the current
-			// persistent volume claim uses the default storage class which is likely relying
-			// on the host path provisioner.
-			Affinity: &corev1.Affinity{
-				PodAffinity: &corev1.PodAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"camel.apache.org/component": "operator",
-								},
-							},
-							TopologyKey: "kubernetes.io/hostname",
 						},
 					},
 				},


### PR DESCRIPTION
Fixes #984.

This should also correct Kaniko cache warmer multi-tenancy per namespace.

**Release Note**
```release-note
Do not install default integration platform when `--global` option is set
Fix Kaniko cache warmer multi-tenancy per namespace
```
