### PR TITLE
fix #985: add correct clusterroles for knative in global mode

### DIFF
--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -122,7 +122,7 @@ func OperatorOrCollect(ctx context.Context, c client.Client, cfg OperatorConfigu
 		return err
 	}
 	if isKnative {
-		return installKnative(ctx, c, cfg.Namespace, collection)
+		return installKnative(ctx, c, cfg.Namespace, customizer, collection)
 	}
 	return nil
 }
@@ -145,8 +145,8 @@ func installKubernetes(ctx context.Context, c client.Client, namespace string, c
 	)
 }
 
-func installKnative(ctx context.Context, c client.Client, namespace string, collection *kubernetes.Collection) error {
-	return ResourcesOrCollect(ctx, c, namespace, collection, IdentityResourceCustomizer,
+func installKnative(ctx context.Context, c client.Client, namespace string, customizer ResourceCustomizer, collection *kubernetes.Collection) error {
+	return ResourcesOrCollect(ctx, c, namespace, collection, customizer,
 		"operator-role-knative.yaml",
 		"operator-role-binding-knative.yaml",
 	)


### PR DESCRIPTION
<!-- Description -->
Fix #985



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Knative permissions are now correctly configured when the operator is in global mode
```
