### PR TITLE
fix(SDK): Add relative symlink to kamel main package

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,0 +1,1 @@
+../kamel/main.go


### PR DESCRIPTION
This fixes requirement for Operator SDK commands like `operator-sdk generate k8s`.

**Release Note**
```release-note
NONE
```
