### PR TITLE
Add readme in examples subfolder

### DIFF
--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -1,0 +1,3 @@
+# Camel K Examples
+
+This folder contains examples of Camel K integrations defined in various languages.


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

I would like to point to the examples folder of this repo for the example project when creating a Camel K Che stack.
Currently Eclipse Che is opening the Camel K Tekton pipelines readme by default. This is not ideal.

Would it be possible to provide a readme at the root of the examples folder?
If yes, in this PR I proposed a very simple description, maybe you have some ideas on what to highlight more specifically?

**Release Note**
```release-note
NONE
```
