### PR TITLE
chore(dev): Require Go version 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,13 @@ language: go
 dist: xenial
 
 go:
-  - 1.12.x
+  - 1.13.x
 
 install:
   - go mod tidy
 
 env:
   global:
-    - GO111MODULE="on"
     - OPENSHIFT_VERSION=3.10.0
     - OPENSHIFT_COMMIT=dd10d17
     - MAVEN_OPTS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn

--- a/docs/modules/ROOT/pages/developers.adoc
+++ b/docs/modules/ROOT/pages/developers.adoc
@@ -12,7 +12,7 @@ to manage the lifecycle of those custom resources.
 
 In order to build the project, you need to comply with the following requirements:
 
-* **Go version 1.12+**: needed to compile and test the project. Refer to the https://golang.org/[Go website] for the installation.
+* **Go version 1.13+**: needed to compile and test the project. Refer to the https://golang.org/[Go website] for the installation.
 * **Operator SDK v0.9.0+**: used to build the operator and the Docker images. Instructions in the https://github.com/operator-framework/operator-sdk[Operator SDK website] (binary downloads available in the release page).
 * **GNU Make**: used to define composite build actions. This should be already installed or available as package if you have a good OS (https://www.gnu.org/software/make/).
 
@@ -51,8 +51,6 @@ This is a high-level overview of the project structure:
 
 [[building]]
 == Building
-
-Since Camel K uses Go modules, you need to invoke the Go commands with the environment variable `GO111MODULE=on`, in case you've checked out the repository inside of the `$GOPATH/src` tree.
 
 To build the whole project you now need to run:
 

--- a/go.mod
+++ b/go.mod
@@ -55,3 +55,5 @@ replace (
 // down. The github mirror should be used instead.
 // Locking to a specific version (from 'go mod graph'):
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/gomega v1.5.0
-	github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8+incompatible
+	github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8
 	github.com/operator-framework/operator-sdk v0.11.0
 	github.com/pkg/errors v0.8.1
 	github.com/radovskyb/watcher v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -363,7 +363,7 @@ github.com/operator-framework/operator-marketplace v0.0.0-20190216021216-57300a3
 github.com/operator-framework/operator-registry v1.0.1/go.mod h1:1xEdZjjUg2hPEd52LG3YQ0jtwiwEGdm98S1TH5P4RAA=
 github.com/operator-framework/operator-registry v1.0.4/go.mod h1:hve6YwcjM2nGVlscLtNsp9sIIBkNZo6jlJgzWw7vP9s=
 github.com/operator-framework/operator-registry v1.1.1/go.mod h1:7D4WEwL+EKti5npUh4/u64DQhawCBRugp8Ql20duUb4=
-github.com/operator-framework/operator-sdk v0.11.0 h1:If0MefBJjPGYAW6Os6azpTMoaFtsSlXRlQctF23/ORs=
+github.com/operator-framework/operator-sdk v0.11.0 h1:tQumPT2UjD6uhggfAerRbPt+rWOPKC80DmgKUEqeGYo=
 github.com/operator-framework/operator-sdk v0.11.0/go.mod h1:Oo+O2br5qR6XSLWY/GgIvTvpsEKtzeWp+I3rHF0WIq8=
 github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,7 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=

--- a/go.sum
+++ b/go.sum
@@ -348,8 +348,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
-github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8+incompatible h1:guk+2xu6eydBeXbREMFGv1sP17NhJeSiKEHRk/pXSsA=
-github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8 h1:TgTRbDa0hkrDT+HVJMSYizUFjfEr5dPP6vFZNg4bCWw=
+github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=

--- a/script/Makefile
+++ b/script/Makefile
@@ -133,15 +133,7 @@ build-compile-integration-tests:
 	go test -c -tags="integration knative" ./e2e/*.go
 
 clean:
-	# go clean fails if modules support are turned on as it tries to
-	# resolve modules, if module support is turned off, it does not
-	# care about modules and simply deletes bits.
-	#
-	# For more info:
-	#
-	#   https://github.com/golang/go/commit/9238a8ffe12b6eb44aab12de1b861c0f045da8b7
-	#
-	GO111MODULE=off go clean
+	go clean
 	rm -f camel-k
 	rm -f kamel
 	rm -f *.test

--- a/script/Makefile
+++ b/script/Makefile
@@ -26,7 +26,6 @@ LOCAL_REPOSITORY := /tmp/artifacts/m2
 IMAGE_NAME := docker.io/apache/camel-k
 RELEASE_GIT_REMOTE := upstream
 GIT_COMMIT := $(shell git rev-list -1 HEAD)
-GO_PATH := $(shell go env GOPATH)
 LINT_GOGC := 10
 LINT_DEADLINE := 5m
 
@@ -38,7 +37,7 @@ STAGING_IMAGE_NAME := docker.io/camelk/camel-k
 PACKAGE_ARTIFACTS_STRATEGY := copy
 
 GOLDFLAGS += -X github.com/apache/camel-k/pkg/cmd/operator.GitCommit=$(GIT_COMMIT)
-GOFLAGS = -ldflags "$(GOLDFLAGS)" -gcflags=-trimpath=$(GO_PATH) -asmflags=-trimpath=$(GO_PATH)
+GOFLAGS = -ldflags "$(GOLDFLAGS)" -trimpath
 
 define LICENSE_HEADER
 Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
Fixes #981.

**Release Note**
```release-note
chore(dev): Require Go version 1.13
```
