### PR TITLE
fix(camel): Report runtime version from Camel catalog into integration and kit statuses

### DIFF
--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -72,12 +72,12 @@ func (t *camelTrait) Apply(e *Environment) error {
 
 	if e.Integration != nil {
 		e.Integration.Status.CamelVersion = e.CamelCatalog.Version
-		e.Integration.Status.RuntimeVersion = rv
+		e.Integration.Status.RuntimeVersion = e.CamelCatalog.RuntimeVersion
 		e.Integration.Status.RuntimeProvider = e.CamelCatalog.RuntimeProvider
 	}
 	if e.IntegrationKit != nil {
 		e.IntegrationKit.Status.CamelVersion = e.CamelCatalog.Version
-		e.IntegrationKit.Status.RuntimeVersion = rv
+		e.IntegrationKit.Status.RuntimeVersion = e.CamelCatalog.RuntimeVersion
 		e.IntegrationKit.Status.RuntimeProvider = e.CamelCatalog.RuntimeProvider
 	}
 

--- a/pkg/trait/camel_test.go
+++ b/pkg/trait/camel_test.go
@@ -79,7 +79,8 @@ func createNominalCamelTest() (*camelTrait, *Environment) {
 	environment := &Environment{
 		CamelCatalog: &camel.RuntimeCatalog{
 			CamelCatalogSpec: v1alpha1.CamelCatalogSpec{
-				Version: "1.23.0",
+				Version:        "1.23.0",
+				RuntimeVersion: "0.0.1",
 			},
 		},
 		Catalog: NewEnvironmentTestCatalog(),


### PR DESCRIPTION
I think it's more correct to report the runtime version from the matching catalog, so that it is fully prescriptive.

**Release Note**
```release-note
Report runtime version from Camel catalog into integration and kit statuses
```
