### PR TITLE
fix #662: mark kit traits to avoid rebuilding when not necessary

### DIFF
--- a/pkg/controller/integration/build_kit.go
+++ b/pkg/controller/integration/build_kit.go
@@ -117,7 +117,7 @@ func (action *buildKitAction) Handle(ctx context.Context, integration *v1alpha1.
 	platformKit.Spec = v1alpha1.IntegrationKitSpec{
 		Dependencies: integration.Status.Dependencies,
 		Repositories: integration.Spec.Repositories,
-		Traits:       integration.Spec.Traits,
+		Traits:       action.filterKitTraits(ctx, integration.Spec.Traits),
 	}
 
 	if err := action.client.Create(ctx, &platformKit); err != nil {
@@ -129,4 +129,21 @@ func (action *buildKitAction) Handle(ctx context.Context, integration *v1alpha1.
 	integration.SetIntegrationKit(&platformKit)
 
 	return integration, nil
+}
+
+func (action *buildKitAction) filterKitTraits(ctx context.Context, in map[string]v1alpha1.TraitSpec) map[string]v1alpha1.TraitSpec {
+	if len(in) == 0 {
+		return in
+	}
+	catalog := trait.NewCatalog(ctx, action.client)
+	out := make(map[string]v1alpha1.TraitSpec)
+	for name, conf := range in {
+		t := catalog.GetTrait(name)
+		if t != nil && !t.InfluencesKit() {
+			// We don't store the trait configuration if the trait cannot influence the kit behavior
+			continue
+		}
+		out[name] = conf
+	}
+	return out
 }

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -53,3 +53,8 @@ func (t *builderTrait) Apply(e *Environment) error {
 
 	return nil
 }
+
+// InfluencesKit overrides base class method
+func (t *builderTrait) InfluencesKit() bool {
+	return true
+}

--- a/pkg/trait/trait_test.go
+++ b/pkg/trait/trait_test.go
@@ -361,6 +361,19 @@ func TestConfigureVolumesAndMounts(t *testing.T) {
 	assert.Equal(t, "/foo/bar", m.MountPath)
 }
 
+func TestOnlySomeKitsInfluenceBuild(t *testing.T) {
+	c := NewTraitTestCatalog()
+	buildTraits := []string{"builder"}
+
+	for _, trait := range c.allTraits() {
+		if trait.InfluencesKit() {
+			assert.Contains(t, buildTraits, string(trait.ID()))
+		} else {
+			assert.NotContains(t, buildTraits, trait.ID())
+		}
+	}
+}
+
 func findVolume(vols []corev1.Volume, condition func(corev1.Volume) bool) *corev1.Volume {
 	for _, v := range vols {
 		v := v

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -66,6 +66,9 @@ type Trait interface {
 
 	// Apply executes a customization of the Environment
 	Apply(environment *Environment) error
+
+	// InfluencesKit determines if the trait has any influence on Integration Kits
+	InfluencesKit() bool
 }
 
 /* Base trait */
@@ -99,6 +102,11 @@ func (trait *BaseTrait) InjectClient(c client.Client) {
 // InjectContext allows to inject a context into the trait
 func (trait *BaseTrait) InjectContext(ctx context.Context) {
 	trait.ctx = ctx
+}
+
+// InfluencesKit determines if the trait has any influence on Integration Kits
+func (trait *BaseTrait) InfluencesKit() bool {
+	return false
 }
 
 /* Environment */


### PR DESCRIPTION
<!-- Description -->

I was working on this @lburgazzoli, to mark traits that can influence builds so that we don't copy all the trait config from integrations to kits if not necessary...

But the only trait that seems to influence the build has no config.. what am I missing? Why we copy trait config into the (platform) kits?


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
