### PR TITLE
chore(magic): auto-add dependency on camel-jackson when using plain .…

### DIFF
--- a/pkg/metadata/metadata_dependencies_test.go
+++ b/pkg/metadata/metadata_dependencies_test.go
@@ -162,6 +162,27 @@ func TestJacksonDependency(t *testing.T) {
 	assert.ElementsMatch(t, []string{"camel:http", "camel:jackson", "camel:log"}, meta.Dependencies.List())
 }
 
+func TestJacksonImplicitDependency(t *testing.T) {
+	code := v1alpha1.SourceSpec{
+		DataSpec: v1alpha1.DataSpec{
+			Name: "Request.groovy",
+			Content: `
+			    from("http:test")
+					.unmarshal().json()
+					.to("log:end")
+		    `,
+		},
+		Language: v1alpha1.LanguageGroovy,
+	}
+
+	catalog, err := camel.DefaultCatalog()
+	assert.Nil(t, err)
+
+	meta := Extract(catalog, code)
+
+	assert.ElementsMatch(t, []string{"camel:http", "camel:jackson", "camel:log"}, meta.Dependencies.List())
+}
+
 func TestLanguageDependencies(t *testing.T) {
 	code := v1alpha1.SourceSpec{
 		DataSpec: v1alpha1.DataSpec{

--- a/pkg/util/source/inspector.go
+++ b/pkg/util/source/inspector.go
@@ -43,6 +43,7 @@ var (
 	}{
 		main: map[string]string{
 			`.*JsonLibrary\.Jackson.*`:                         "camel:jackson",
+			`.*\.json().*`:                                     "camel:jackson",
 			`.*\.hystrix().*`:                                  "camel:hystrix",
 			`.*restConfiguration().*`:                          "camel:rest",
 			`.*rest(("[a-zA-Z0-9-/]+")*).*`:                    "camel:rest",

--- a/pkg/util/source/inspector.go
+++ b/pkg/util/source/inspector.go
@@ -43,10 +43,10 @@ var (
 	}{
 		main: map[string]string{
 			`.*JsonLibrary\.Jackson.*`:                         "camel:jackson",
-			`.*\.json().*`:                                     "camel:jackson",
-			`.*\.hystrix().*`:                                  "camel:hystrix",
-			`.*restConfiguration().*`:                          "camel:rest",
-			`.*rest(("[a-zA-Z0-9-/]+")*).*`:                    "camel:rest",
+			`.*\.json\(\).*`:                                   "camel:jackson",
+			`.*\.hystrix\(\).*`:                                "camel:hystrix",
+			`.*restConfiguration\(\).*`:                        "camel:rest",
+			`.*rest\(("[a-zA-Z0-9-/]+")*\).*`:                  "camel:rest",
 			`^\s*rest\s*{.*`:                                   "camel:rest",
 			`.*\.groovy\s*\(.*\).*`:                            "camel:groovy",
 			`.*\.?(jsonpath|jsonpathWriteAsString)\s*\(.*\).*`: "camel:jsonpath",
@@ -58,10 +58,10 @@ var (
 			`.*\.xtokenize\s*\(.*\).*`:                         "camel:jaxp",
 		},
 		quarkus: map[string]string{
-			`.*restConfiguration().*`:       "camel-quarkus:rest",
-			`.*rest(("[a-zA-Z0-9-/]+")*).*`: "camel-quarkus:rest",
-			`^\s*rest\s*{.*`:                "camel-quarkus:rest",
-			`.*\.?simple\s*\(.*\).*`:        "camel-quarkus:bean",
+			`.*restConfiguration\(\).*`:       "camel-quarkus:rest",
+			`.*rest\(("[a-zA-Z0-9-/]+")*\).*`: "camel-quarkus:rest",
+			`^\s*rest\s*{.*`:                  "camel-quarkus:rest",
+			`.*\.?simple\s*\(.*\).*`:          "camel-quarkus:bean",
 		},
 	}
 )


### PR DESCRIPTION
…json()

<!-- Description -->

Now that jackson is the default on Camel 3.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
