### PR TITLE
Enhance kubeconfig loading

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -151,11 +151,15 @@ func initialize(kubeconfig string) {
 }
 
 func getDefaultKubeConfigFile() (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
+	home := os.Getenv("HOME")
+	if home == "" {
+		usr, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		home = usr.HomeDir
 	}
-	return filepath.Join(usr.HomeDir, ".kube", "config"), nil
+	return filepath.Join(home, ".kube", "config"), nil
 }
 
 // GetCurrentNamespace --


### PR DESCRIPTION
Enable using `HOME` environment variable to load kubernetes config.

Previous code was causing issues when running client in docker container wit random userId.

See
```
panic: user: unknown userid 1102770000

goroutine 1 [running]:
github.com/apache/camel-k/pkg/client.initialize(0x0, 0x0)
	/home/jenkins/workspace/fuse-camel-k-install/pkg/client/client.go:147 +0x123
github.com/apache/camel-k/pkg/client.NewOutOfClusterClient(0x0, 0x0, 0x1ad7100, 0x15, 0xc00012c58b, 0x3)
	/home/jenkins/workspace/fuse-camel-k-install/pkg/client/client.go:74 +0x35
github.com/apache/camel-k/e2e.newTestClient(...)
	/home/jenkins/workspace/fuse-camel-k-install/e2e/test_support.go:82
github.com/apache/camel-k/e2e.init.1()
	/home/jenkins/workspace/fuse-camel-k-install/e2e/test_support.go:72 +0xfd
FAIL	github.com/apache/camel-k/e2e	0.268s
FAIL
```