### PR TITLE
fix(OpenAPI): Use catalog runtime version to generate OpenAPI project

### DIFF
--- a/pkg/trait/rest-dsl.go
+++ b/pkg/trait/rest-dsl.go
@@ -225,7 +225,7 @@ func (t *restDslTrait) generateMavenProject(e *Environment) (maven.Project, erro
 			{
 				GroupID:    "org.apache.camel.k",
 				ArtifactID: "camel-k-maven-plugin",
-				Version:    e.RuntimeVersion,
+				Version:    e.CamelCatalog.RuntimeVersion,
 				Executions: []maven.Execution{
 					{
 						Phase: "generate-resources",


### PR DESCRIPTION
Fixes #1056.

**Release Note**
```release-note
fix(OpenAPI): Use catalog runtime version to generate OpenAPI project
```
