### PR TITLE
Check whether KAMEL_BIN file exists

### DIFF
--- a/e2e/test_support.go
+++ b/e2e/test_support.go
@@ -92,6 +92,9 @@ func kamel(args ...string) *cobra.Command {
 
 	kamelBin := os.Getenv("KAMEL_BIN")
 	if kamelBin != "" {
+		if _, e := os.Stat(kamelBin); e != nil && os.IsNotExist(e) {
+			panic(e)
+		}
 		fmt.Printf("Using external kamel binary on path %s\n", kamelBin)
 		c = &cobra.Command{
 			DisableFlagParsing: true,


### PR DESCRIPTION
Allow additional parameters for `kamel` binary during integration-test phase.

Tests can be parameterized in the following way:
`KAMEL_install="--local-repository /local/repo --maven-repository http://mynexus-proxy" go test -timeout 30m -v ./e2e/... -tags=integration`
