### PR TITLE
chore(test): allow to change some defaults for testing

### DIFF
--- a/e2e/test_support.go
+++ b/e2e/test_support.go
@@ -77,6 +77,16 @@ func init() {
 
 	// Defaults for testing
 	gomega.SetDefaultEventuallyTimeout(60 * time.Second)
+
+	imageName := os.Getenv("CAMEL_K_TEST_IMAGE_NAME")
+	if imageName != "" {
+		testImageName = imageName
+	}
+	imageVersion := os.Getenv("CAMEL_K_TEST_IMAGE_VERSION")
+	if imageVersion != "" {
+		testImageVersion = imageVersion
+	}
+
 }
 
 func newTestClient() (client.Client, error) {


### PR DESCRIPTION
<!-- Description -->

This allow to customize image and version for tests that don't use `kamel` (other cases are covered by PR #1133).

@lburgazzoli this is enough for current tests, do you think we should do something better with that defaults?


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
