### PR TITLE
Fix #1089: defer knative detection to when integration runs

### DIFF
--- a/e2e/knative_platform_test.go
+++ b/e2e/knative_platform_test.go
@@ -1,0 +1,78 @@
+// +build knative
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/util/knative"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestKnativePlatformTest(t *testing.T) {
+	withNewTestNamespace(t, func(ns string) {
+		if !knative.IsEnabledInNamespace(testContext, testClient, ns) {
+			t.Error("Knative not installed in the cluster")
+			t.FailNow()
+		}
+
+		Expect(kamel("install", "-n", ns).Execute()).Should(BeNil())
+		Eventually(platformPhase(ns), 5*time.Minute).Should(Equal(v1alpha1.IntegrationPlatformPhaseReady))
+		Eventually(platformProfile(ns), 1*time.Minute).Should(Equal(v1alpha1.TraitProfile("")))
+		cluster := platform(ns)().Status.Cluster
+
+		t.Run("run yaml on cluster profile", func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(kamel("run", "-n", ns, "files/yaml.yaml", "--profile", string(cluster)).Execute()).Should(BeNil())
+			Eventually(integrationPodPhase(ns, "yaml"), 5*time.Minute).Should(Equal(v1.PodRunning))
+			Eventually(integrationLogs(ns, "yaml"), 1*time.Minute).Should(ContainSubstring("Magicstring!"))
+			Eventually(integrationProfile(ns, "yaml"), 1*time.Minute).Should(Equal(v1alpha1.TraitProfile(string(cluster))))
+			// Change something in the integration to produce a redeploy
+			Expect(updateIntegration(ns, "yaml", func(it *v1alpha1.Integration) {
+				it.Spec.Profile = v1alpha1.TraitProfile("")
+				it.Spec.Sources[0].Content = strings.ReplaceAll(it.Spec.Sources[0].Content, "string!", "string!!!")
+			})).To(BeNil())
+			// Spec profile should be reset by "kamel run"
+			Eventually(integrationSpecProfile(ns, "yaml")).Should(Equal(v1alpha1.TraitProfile("")))
+			// When integration is running again ...
+			Eventually(integrationPhase(ns, "yaml")).Should(Equal(v1alpha1.IntegrationPhaseRunning))
+			Eventually(integrationLogs(ns, "yaml"), 1*time.Minute).Should(ContainSubstring("Magicstring!!!"))
+			// It should keep the old profile saved in status
+			Eventually(integrationProfile(ns, "yaml"), 5*time.Minute).Should(Equal(v1alpha1.TraitProfile(string(cluster))))
+
+			Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+		})
+
+		t.Run("run yaml on automatic profile", func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(kamel("run", "-n", ns, "files/yaml.yaml").Execute()).Should(BeNil())
+			Eventually(integrationPodPhase(ns, "yaml"), 5*time.Minute).Should(Equal(v1.PodRunning))
+			Eventually(integrationProfile(ns, "yaml"), 1*time.Minute).Should(Equal(v1alpha1.TraitProfileKnative))
+			Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+		})
+
+	})
+}

--- a/e2e/platformless_run_test.go
+++ b/e2e/platformless_run_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"github.com/apache/camel-k/pkg/util/openshift"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
@@ -53,6 +54,7 @@ func TestPlatformlessRun(t *testing.T) {
 
 		// Platform should be recreated
 		Eventually(platform(ns)).ShouldNot(BeNil())
+		Eventually(platformProfile(ns)).Should(Equal(v1alpha1.TraitProfile("")))
 		Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
 	})
 }

--- a/e2e/test_support.go
+++ b/e2e/test_support.go
@@ -246,6 +246,36 @@ func integrationVersion(ns string, name string) func() string {
 	}
 }
 
+func integrationProfile(ns string, name string) func() v1alpha1.TraitProfile {
+	return func() v1alpha1.TraitProfile {
+		it := integration(ns, name)()
+		if it == nil {
+			return ""
+		}
+		return it.Status.Profile
+	}
+}
+
+func integrationPhase(ns string, name string) func() v1alpha1.IntegrationPhase {
+	return func() v1alpha1.IntegrationPhase {
+		it := integration(ns, name)()
+		if it == nil {
+			return ""
+		}
+		return it.Status.Phase
+	}
+}
+
+func integrationSpecProfile(ns string, name string) func() v1alpha1.TraitProfile {
+	return func() v1alpha1.TraitProfile {
+		it := integration(ns, name)()
+		if it == nil {
+			return ""
+		}
+		return it.Spec.Profile
+	}
+}
+
 func setIntegrationVersion(ns string, name string, version string) error {
 	it := integration(ns, name)()
 	if it == nil {
@@ -253,6 +283,15 @@ func setIntegrationVersion(ns string, name string, version string) error {
 	}
 	it.Status.Version = version
 	return testClient.Status().Update(testContext, it)
+}
+
+func updateIntegration(ns string, name string, upd func(it *v1alpha1.Integration)) error {
+	it := integration(ns, name)()
+	if it == nil {
+		return fmt.Errorf("no integration named %s found", name)
+	}
+	upd(it)
+	return testClient.Update(testContext, it)
 }
 
 func kits(ns string) func() []v1alpha1.IntegrationKit {
@@ -399,6 +438,26 @@ func platformVersion(ns string) func() string {
 			return ""
 		}
 		return p.Status.Version
+	}
+}
+
+func platformPhase(ns string) func() v1alpha1.IntegrationPlatformPhase {
+	return func() v1alpha1.IntegrationPlatformPhase {
+		p := platform(ns)()
+		if p == nil {
+			return ""
+		}
+		return p.Status.Phase
+	}
+}
+
+func platformProfile(ns string) func() v1alpha1.TraitProfile {
+	return func() v1alpha1.TraitProfile {
+		p := platform(ns)()
+		if p == nil {
+			return ""
+		}
+		return p.Status.Profile
 	}
 }
 

--- a/pkg/apis/camel/v1alpha1/integration_types.go
+++ b/pkg/apis/camel/v1alpha1/integration_types.go
@@ -44,6 +44,7 @@ type IntegrationStatus struct {
 	Digest           string                 `json:"digest,omitempty"`
 	Image            string                 `json:"image,omitempty"`
 	Dependencies     []string               `json:"dependencies,omitempty"`
+	Profile          TraitProfile           `json:"profile,omitempty"`
 	Kit              string                 `json:"kit,omitempty"`
 	Platform         string                 `json:"platform,omitempty"`
 	GeneratedSources []SourceSpec           `json:"generatedSources,omitempty"`

--- a/pkg/apis/camel/v1alpha1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1alpha1/integrationplatform_types.go
@@ -75,9 +75,9 @@ type IntegrationPlatformCluster string
 
 const (
 	// IntegrationPlatformClusterOpenShift is used when targeting a OpenShift cluster
-	IntegrationPlatformClusterOpenShift = "OpenShift"
+	IntegrationPlatformClusterOpenShift IntegrationPlatformCluster = "OpenShift"
 	// IntegrationPlatformClusterKubernetes is used when targeting a Kubernetes cluster
-	IntegrationPlatformClusterKubernetes = "Kubernetes"
+	IntegrationPlatformClusterKubernetes IntegrationPlatformCluster = "Kubernetes"
 )
 
 // AllIntegrationPlatformClusters --
@@ -88,11 +88,11 @@ type TraitProfile string
 
 const (
 	// TraitProfileOpenShift is used by default on OpenShift clusters
-	TraitProfileOpenShift = "OpenShift"
+	TraitProfileOpenShift TraitProfile = "OpenShift"
 	// TraitProfileKubernetes is used by default on Kubernetes clusters
-	TraitProfileKubernetes = "Kubernetes"
+	TraitProfileKubernetes TraitProfile = "Kubernetes"
 	// TraitProfileKnative is used by default on OpenShift/Kubernetes clusters powered by Knative
-	TraitProfileKnative = "Knative"
+	TraitProfileKnative TraitProfile = "Knative"
 	// DefaultTraitProfile is the trait profile used as default when no other profile is set
 	DefaultTraitProfile = TraitProfileKubernetes
 )

--- a/pkg/controller/integration/initialize.go
+++ b/pkg/controller/integration/initialize.go
@@ -21,8 +21,11 @@ import (
 	"context"
 
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/client"
+	"github.com/apache/camel-k/pkg/platform"
 	"github.com/apache/camel-k/pkg/trait"
 	"github.com/apache/camel-k/pkg/util/defaults"
+	"github.com/apache/camel-k/pkg/util/knative"
 )
 
 // NewInitializeAction creates a new initialize action
@@ -50,11 +53,36 @@ func (action *initializeAction) Handle(ctx context.Context, integration *v1alpha
 		return nil, err
 	}
 
+	pl, err := platform.GetCurrentPlatform(ctx, action.client, integration.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	kit := v1alpha1.NewIntegrationKit(integration.Namespace, integration.Spec.Kit)
 
 	integration.Status.Phase = v1alpha1.IntegrationPhaseBuildingKit
 	integration.SetIntegrationKit(&kit)
+	integration.Status.Profile = determineBestProfile(ctx, action.client, integration, pl)
 	integration.Status.Version = defaults.Version
 
 	return integration, nil
+}
+
+// DetermineBestProfile tries to detect the best trait profile for the integration
+func determineBestProfile(ctx context.Context, c client.Client, integration *v1alpha1.Integration, p *v1alpha1.IntegrationPlatform) v1alpha1.TraitProfile {
+	if integration.Spec.Profile != "" {
+		return integration.Spec.Profile
+	}
+	if integration.Status.Profile != "" {
+		// Integration already has a profile
+		return integration.Status.Profile
+	}
+	if p.Status.Profile != "" {
+		// Use platform profile if set
+		return p.Status.Profile
+	}
+	if knative.IsEnabledInNamespace(ctx, c, p.Namespace) {
+		return v1alpha1.TraitProfileKnative
+	}
+	return platform.GetProfile(p)
 }

--- a/pkg/controller/integration/monitor.go
+++ b/pkg/controller/integration/monitor.go
@@ -57,6 +57,9 @@ func (action *monitorAction) Handle(ctx context.Context, integration *v1alpha1.I
 
 		integration.Status.Digest = hash
 		integration.Status.Phase = v1alpha1.IntegrationPhaseInitialization
+		if integration.Spec.Profile != v1alpha1.TraitProfile("") {
+			integration.Status.Profile = integration.Spec.Profile
+		}
 		integration.Status.Version = defaults.Version
 
 		return integration, nil

--- a/pkg/platform/defaults.go
+++ b/pkg/platform/defaults.go
@@ -93,9 +93,6 @@ func ConfigureDefaults(ctx context.Context, c client.Client, p *v1alpha1.Integra
 }
 
 func setPlatformDefaults(ctx context.Context, c client.Client, p *v1alpha1.IntegrationPlatform, verbose bool) error {
-	if p.Status.Profile == "" {
-		p.Status.Profile = DetermineBestProfile(ctx, c, p)
-	}
 	if p.Status.Build.CamelVersion == "" {
 		p.Status.Build.CamelVersion = defaults.DefaultCamelVersion
 	}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -21,8 +21,6 @@ import (
 	"context"
 
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
-	"github.com/apache/camel-k/pkg/client"
-	"github.com/apache/camel-k/pkg/util/knative"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,17 +94,6 @@ func ListPlatforms(ctx context.Context, c k8sclient.Reader, namespace string) (*
 // IsActive determines if the given platform is being used
 func IsActive(p *v1alpha1.IntegrationPlatform) bool {
 	return p.Status.Phase != "" && p.Status.Phase != v1alpha1.IntegrationPlatformPhaseDuplicate
-}
-
-// DetermineBestProfile tries to detect the best trait profile for the platform
-func DetermineBestProfile(ctx context.Context, c client.Client, p *v1alpha1.IntegrationPlatform) v1alpha1.TraitProfile {
-	if p.Status.Profile != "" {
-		return p.Status.Profile
-	}
-	if knative.IsEnabledInNamespace(ctx, c, p.Namespace) {
-		return v1alpha1.TraitProfileKnative
-	}
-	return GetProfile(p)
 }
 
 // GetProfile returns the current profile of the platform (if present) or returns the default one for the cluster

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -209,8 +209,13 @@ func (e *Environment) InPhase(c v1alpha1.IntegrationKitPhase, i v1alpha1.Integra
 // next looking at the IntegrationKit.Spec
 // and lastly the Platform Profile
 func (e *Environment) DetermineProfile() v1alpha1.TraitProfile {
-	if e.Integration != nil && e.Integration.Spec.Profile != "" {
-		return e.Integration.Spec.Profile
+	if e.Integration != nil {
+		if e.Integration.Status.Profile != "" {
+			return e.Integration.Status.Profile
+		}
+		if e.Integration.Spec.Profile != "" {
+			return e.Integration.Spec.Profile
+		}
 	}
 
 	if e.IntegrationKit != nil && e.IntegrationKit.Spec.Profile != "" {

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -40,6 +40,10 @@ func ComputeForIntegration(integration *v1alpha1.Integration) (string, error) {
 	if _, err := hash.Write([]byte(integration.Spec.Kit)); err != nil {
 		return "", err
 	}
+	// Profile is relevant
+	if _, err := hash.Write([]byte(integration.Spec.Profile)); err != nil {
+		return "", err
+	}
 
 	// Integration code
 	for _, s := range integration.Spec.Sources {


### PR DESCRIPTION
<!-- Description -->

Profile has no default in the platform. Detection has been postponed to when the integration runs.

Integrations that have been run initially with a specific profile, don't change it unless they are completely recreated (not just edited).


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Knative profile detection has been deferred to when the integration runs, in order to allow Camel K and Knative to be installed in any order
```
