### PR TITLE
fix for issue #1138

### DIFF
--- a/cmd/kamel/main.go
+++ b/cmd/kamel/main.go
@@ -28,8 +28,8 @@ import (
 	_ "github.com/apache/camel-k/pkg/builder/s2i"
 	"github.com/apache/camel-k/pkg/cmd"
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func main() {

--- a/cmd/kamel/main.go
+++ b/cmd/kamel/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/camel-k/pkg/cmd"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 )
 
 func main() {


### PR DESCRIPTION
<!-- Description -->
Camel-K client install fails cluster setup for azure kubernetes service (aks) without the azure RBAC client support.
Error: No Auth Provider found for name "azure"`
By adding client-go import for azure pkg will allows AKS users to use camel-k client CLI to install camel operators to AKS cluster.
Fixes :#1138 

**Release Note**
```
fix issue #1138 
```
