### PR TITLE
kamel run --wait should return non-zero exit code in case of failure

### DIFF
--- a/cmd/kamel/main.go
+++ b/cmd/kamel/main.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"os"
 	"time"
@@ -49,8 +48,6 @@ func main() {
 
 func exitOnError(err error) {
 	if err != nil {
-		fmt.Println("Error:", err)
-
 		os.Exit(1)
 	}
 }

--- a/pkg/cmd/describe_integration.go
+++ b/pkg/cmd/describe_integration.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -66,7 +67,7 @@ type describeIntegrationCommandOptions struct {
 
 func (command *describeIntegrationCommandOptions) validate(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("accepts at least 1 arg, received %d", len(args))
+		return errors.New("describe expects an integration name argument")
 	}
 	return nil
 }

--- a/pkg/cmd/describe_kit.go
+++ b/pkg/cmd/describe_kit.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -59,7 +60,7 @@ type describeKitCommandOptions struct {
 
 func (command *describeKitCommandOptions) validate(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("accepts at least 1 arg, received %d", len(args))
+		return errors.New("describe expects a kit name argument")
 	}
 	return nil
 }

--- a/pkg/cmd/describe_platform.go
+++ b/pkg/cmd/describe_platform.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -59,7 +60,7 @@ type describePlatformCommandOptions struct {
 
 func (command *describePlatformCommandOptions) validate(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("accepts at least 1 arg, received %d", len(args))
+		return errors.New("describe expects a platform name argument")
 	}
 	return nil
 }

--- a/pkg/cmd/log.go
+++ b/pkg/cmd/log.go
@@ -18,7 +18,7 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
+	"errors"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	k8slog "github.com/apache/camel-k/pkg/util/kubernetes/log"
@@ -53,7 +53,7 @@ type logCmdOptions struct {
 
 func (o *logCmdOptions) validate(_ *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 arg, received %d", len(args))
+		return errors.New("log expects an integration name argument")
 	}
 
 	return nil

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -63,6 +63,7 @@ func kamelPreAddCommandInit(options *RootCmdOptions) *cobra.Command {
 		Use:                    "kamel",
 		Short:                  "Kamel is a awesome client tool for running Apache Camel integrations natively on Kubernetes",
 		Long:                   kamelCommandLongDescription,
+		SilenceUsage:           true,
 	}
 
 	cmd.PersistentFlags().StringVar(&options.KubeConfig, "config", os.Getenv("KUBECONFIG"), "Path to the config file to use for CLI requests")

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -120,7 +120,7 @@ type runCmdOptions struct {
 
 func (o *runCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return errors.New("accepts at least 1 arg, received 0")
+		return errors.New("run expects at least 1 argument, received 0")
 	}
 	if len(args) > 1 && o.IntegrationName == "" {
 		return errors.New("integration name is mandatory when using multiple sources")
@@ -207,8 +207,11 @@ func (o *runCmdOptions) run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			if integrationPhase == nil || *integrationPhase == v1.IntegrationPhaseRunning || *integrationPhase == v1.IntegrationPhaseError {
+			if *integrationPhase == v1.IntegrationPhaseRunning {
+				fmt.Println("Running")
 				break
+			} else if integrationPhase == nil || *integrationPhase == v1.IntegrationPhaseError {
+				return fmt.Errorf("integration \"%s\" deployment failed", integration.Name)
 			}
 
 			// The integration watch timed out so recreate it using the latest integration resource version
@@ -254,7 +257,6 @@ func (o *runCmdOptions) waitForIntegrationReady(integration *v1.Integration) (*v
 			}
 
 			if i.Status.Phase == v1.IntegrationPhaseError {
-				fmt.Println("integration deployment failed")
 				return false
 			}
 		}


### PR DESCRIPTION
fixes #1170

Note: I enabled `SilenceUsage` on the Cobra config because it looks a bit weird when a command fails to print the `kamel` usage blurb. You can still get usage via the `help` switch or if invalid args / commands were given.

**Release Note**
```release-note
NONE
```
