### PR TITLE
Jolokia trait improvements

### DIFF
--- a/pkg/trait/jolokia.go
+++ b/pkg/trait/jolokia.go
@@ -90,7 +90,7 @@ func (t *jolokiaTrait) Configure(e *Environment) (bool, error) {
 	// Configure HTTPS by default for OpenShift
 	if e.DetermineProfile() == v1.TraitProfileOpenShift {
 		setDefaultJolokiaOption(options, &t.Protocol, "protocol", "https")
-		setDefaultJolokiaOption(options, &t.CaCert, "caCert", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+		setDefaultJolokiaOption(options, &t.CaCert, "caCert", "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt")
 		setDefaultJolokiaOption(options, &t.ExtendedClientCheck, "extendedClientCheck", true)
 		setDefaultJolokiaOption(options, &t.ClientPrincipal, "clientPrincipal", "cn=system:master-proxy")
 		setDefaultJolokiaOption(options, &t.UseSslClientAuthentication, "useSslClientAuthentication", true)

--- a/pkg/trait/jolokia_test.go
+++ b/pkg/trait/jolokia_test.go
@@ -77,9 +77,8 @@ func TestConfigureJolokiaTraitForOpenShiftProfileShouldSetDefaultHttpsJolokiaOpt
 	assert.Nil(t, err)
 	assert.True(t, configured)
 	assert.Equal(t, *trait.Protocol, "https")
-	assert.Equal(t, *trait.CaCert, "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	assert.Equal(t, *trait.CaCert, "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt")
 	assert.Equal(t, *trait.ExtendedClientCheck, true)
-	assert.Equal(t, *trait.ClientPrincipal, "cn=system:master-proxy")
 	assert.Equal(t, *trait.UseSslClientAuthentication, true)
 }
 


### PR DESCRIPTION
**Release Note**
```release-note
feat(jolokia): Support auto-configuration for OpenShift 4
feat(jolokia): Automatically adds the camel-management dependency
```

This enables using [Hawtio Online](https://github.com/hawtio/hawtio-online) OOTB on OpenShift 4 with the latest Fabric8 base image:

<img width="1277" alt="Screenshot 2020-01-13 at 14 28 31" src="https://user-images.githubusercontent.com/366207/72259791-9af03980-3611-11ea-92e7-7ee457402161.png">
