### PR TITLE
feat: Offer easier access to trait list

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -50,6 +50,11 @@ func NewKamelCommand(ctx context.Context) (*cobra.Command, error) {
 	var err error
 	cmd := kamelPreAddCommandInit(&options)
 	addKamelSubcommands(cmd, &options)
+
+	if err := addHelpSubCommands(cmd, &options); err != nil {
+		return cmd, err
+	}
+
 	err = kamelPostAddCommandInit(cmd)
 
 	return cmd, err
@@ -114,6 +119,26 @@ func addKamelSubcommands(cmd *cobra.Command, options *RootCmdOptions) {
 	cmd.AddCommand(cmdOnly(newCmdRebuild(options)))
 	cmd.AddCommand(newCmdOperator())
 	cmd.AddCommand(cmdOnly(newCmdBuilder(options)))
+}
+
+func addHelpSubCommands(cmd *cobra.Command, options *RootCmdOptions) error {
+	cmd.InitDefaultHelpCmd()
+
+	var helpCmd *cobra.Command
+	for _, c := range cmd.Commands() {
+		if c.Name() == "help" {
+			helpCmd = c
+			break
+		}
+	}
+
+	if helpCmd == nil {
+		return errors.New("could not find any configured help command")
+	}
+
+	helpCmd.AddCommand(cmdOnly(newTraitHelpCmd(options)))
+
+	return nil
 }
 
 func (command *RootCmdOptions) preRun(cmd *cobra.Command, _ []string) error {

--- a/pkg/cmd/trait_help_test.go
+++ b/pkg/cmd/trait_help_test.go
@@ -1,0 +1,37 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/apache/camel-k/pkg/util/test"
+)
+
+func TestHelpForNonExistentTrait(t *testing.T) {
+	options, rootCommand := kamelTestPreAddCommandInit()
+	traitHelpCommand, _ := newTraitHelpCmd(options)
+	rootCommand.AddCommand(traitHelpCommand)
+
+	kamelTestPostAddCommandInit(t, rootCommand)
+
+	_, err := test.ExecuteCommand(rootCommand, "trait", "foobar")
+	if err == nil {
+		t.Fatalf("Expected error result for invalid trait 'foobar'")
+	}
+}


### PR DESCRIPTION
fixes #1203

Added a new command to list traits and their various config options.

Describe all traits:

`kamel describe trait`

Describe the prometheus trait:

`kamel describe trait prometheus` 

I've hidden this from users based on the assumption that they can already get at this info via shell completion. Hence the output is in JSON, so that it's easy for tooling to parse / filter.

@bfitzpat Here's an example of the output. Hope that's along the lines of what you need.

```json
[
  {
    "name": "prometheus",
    "platform": false,
    "profiles": [
      "Kubernetes",
      "Knative",
      "OpenShift"
    ],
    "properties": [
      {
        "name": "enabled",
        "type": "bool",
        "default": false
      },
      {
        "name": "port",
        "type": "int"
      },
      {
        "name": "service-monitor",
        "type": "bool"
      },
      {
        "name": "service-monitor-labels",
        "type": "string"
      }
    ]
  }
]

```

**Release Note**
```release-note
NONE
```
