### PR TITLE
fix #1230: make some commands to work offline

### DIFF
--- a/e2e/offline_commands_test.go
+++ b/e2e/offline_commands_test.go
@@ -1,3 +1,7 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
 /*
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -15,26 +19,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package e2e
 
 import (
-	"fmt"
+	"testing"
 
-	"github.com/apache/camel-k/pkg/util/defaults"
-
-	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
-func newCmdVersion() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Display client version",
-		Long:  `Display Camel K client version.`,
-		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println("Camel K Client " + defaults.Version)
-		},
-		Annotations: map[string]string{
-			offlineCommandLabel: "true",
-		},
-	}
+func TestKamelVersionWorksOffline(t *testing.T) {
+	assert.Nil(t, kamel("version", "--config", "non-existent-kubeconfig-file").Execute())
+}
+
+func TestKamelHelpTraitWorksOffline(t *testing.T) {
+	assert.Nil(t, kamel("help", "trait", "--all", "--config", "non-existent-kubeconfig-file").Execute())
+}
+
+func TestKamelCompletionWorksOffline(t *testing.T) {
+	assert.Nil(t, kamel("completion", "bash", "--config", "non-existent-kubeconfig-file").Execute())
+	assert.Nil(t, kamel("completion", "zsh", "--config", "non-existent-kubeconfig-file").Execute())
 }

--- a/pkg/cmd/completion_bash.go
+++ b/pkg/cmd/completion_bash.go
@@ -188,6 +188,9 @@ func newCmdCompletionBash(root *cobra.Command) *cobra.Command {
 				fmt.Print(err.Error())
 			}
 		},
+		Annotations: map[string]string{
+			offlineCommandLabel: "true",
+		},
 	}
 }
 

--- a/pkg/cmd/completion_zsh.go
+++ b/pkg/cmd/completion_zsh.go
@@ -54,6 +54,9 @@ func newCmdCompletionZsh(root *cobra.Command) *cobra.Command {
 				fmt.Print(err.Error())
 			}
 		},
+		Annotations: map[string]string{
+			offlineCommandLabel: "true",
+		},
 	}
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -143,7 +143,7 @@ func addHelpSubCommands(cmd *cobra.Command, options *RootCmdOptions) error {
 }
 
 func (command *RootCmdOptions) preRun(cmd *cobra.Command, _ []string) error {
-	if command.Namespace == "" {
+	if command.Namespace == "" && !isOfflineCommand(cmd) {
 		var current string
 		client, err := command.GetCmdClient()
 		if err != nil {

--- a/pkg/cmd/trait_help.go
+++ b/pkg/cmd/trait_help.go
@@ -52,6 +52,9 @@ func newTraitHelpCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *traitHelp
 			}
 			return options.run(args)
 		},
+		Annotations: map[string]string{
+			offlineCommandLabel: "true",
+		},
 	}
 
 	cmd.Flags().Bool("all", false, "Include all traits")

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -38,6 +38,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	offlineCommandLabel = "camel.apache.org/cmd.offline"
+)
+
 // DeleteIntegration --
 func DeleteIntegration(ctx context.Context, c client.Client, name string, namespace string) error {
 	integration := v1.Integration{
@@ -217,4 +221,8 @@ func stringToSliceHookFunc(comma rune) mapstructure.DecodeHookFunc {
 
 func cmdOnly(cmd *cobra.Command, options interface{}) *cobra.Command {
 	return cmd
+}
+
+func isOfflineCommand(cmd *cobra.Command) bool {
+	return cmd.Annotations[offlineCommandLabel] == "true"
 }


### PR DESCRIPTION
<!-- Description -->

fix #1230


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Some commands like `kamel version` threw an error if executed without connection to a cluster
```
