### PR TITLE
Fix #1102: add run --property-file option

### DIFF
--- a/e2e/files/Prop.java
+++ b/e2e/files/Prop.java
@@ -17,7 +17,7 @@
 
 import org.apache.camel.builder.RouteBuilder;
 
-public class Java extends RouteBuilder {
+public class Prop extends RouteBuilder {
   @Override
   public void configure() throws Exception {
 	  from("timer:tick")

--- a/e2e/files/Prop.java
+++ b/e2e/files/Prop.java
@@ -21,8 +21,7 @@ public class Java extends RouteBuilder {
   @Override
   public void configure() throws Exception {
 	  from("timer:tick")
-	  .setHeader("m").constant("string!")
-	  .setBody().simple("Magic${header.m}")
+	  .setBody().simple("Magic{{myproperty}}")
       .log("${body}");
   }
 }

--- a/e2e/files/prop.properties
+++ b/e2e/files/prop.properties
@@ -1,0 +1,3 @@
+# This is injected into the integration
+
+myproperty=string!

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -45,6 +45,14 @@ func TestRunSimpleExamples(t *testing.T) {
 			Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
 		})
 
+		t.Run("run java with properties", func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(kamel("run", "-n", ns, "files/Prop.java", "--property-file", "files/prop.properties").Execute()).Should(BeNil())
+			Eventually(integrationPodPhase(ns, "prop"), 5*time.Minute).Should(Equal(v1.PodRunning))
+			Eventually(integrationLogs(ns, "prop"), 1*time.Minute).Should(ContainSubstring("Magicstring!"))
+			Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+		})
+
 		t.Run("run xml", func(t *testing.T) {
 			RegisterTestingT(t)
 			Expect(kamel("run", "-n", ns, "files/xml.xml").Execute()).Should(BeNil())
@@ -98,7 +106,7 @@ func TestRunSimpleExamples(t *testing.T) {
 			t.Run("init run "+string(lang), func(t *testing.T) {
 				RegisterTestingT(t)
 				dir := util.MakeTempDir(t)
-				itName := fmt.Sprintf("init%s", string(lang)) // e.g. initjava
+				itName := fmt.Sprintf("init%s", string(lang))          // e.g. initjava
 				fileName := fmt.Sprintf("%s.%s", itName, string(lang)) // e.g. initjava.java
 				file := path.Join(dir, fileName)
 				Expect(kamel("init", file).Execute()).Should(BeNil())

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -177,12 +177,14 @@ func (o *runCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
 	}
 
 	for _, fileName := range o.PropertyFiles {
+		if !strings.HasSuffix(fileName, ".properties") {
+			return fmt.Errorf("supported property files must have a .properties extension: %s", fileName)
+		}
+
 		if file, err := os.Stat(fileName); err != nil {
 			return errors.Wrapf(err, "unable to access property file %s", fileName)
 		} else if file.IsDir() {
 			return fmt.Errorf("property file %s is a directory", fileName)
-		} else if !strings.HasSuffix(fileName, ".properties") {
-			return fmt.Errorf("supported property files must have a .properties extension: %s", fileName)
 		}
 	}
 


### PR DESCRIPTION
<!-- Description -->

And extended dev mode to trigger redeployment on changes to property files and resources.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Property files can now be linked to the integration without manually creating an external configmap
```
