### PR TITLE
tekton parameters with parentheses instead of curly brackets

### DIFF
--- a/docs/modules/ROOT/assets/attachments/tekton/camel-k-pipeline-task-definition.yaml
+++ b/docs/modules/ROOT/assets/attachments/tekton/camel-k-pipeline-task-definition.yaml
@@ -63,7 +63,7 @@ spec:
       args:
         - "run"
         - "--wait"
-        - "${inputs.params.file}"
+        - "$(inputs.params.file)"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline

--- a/docs/modules/ROOT/pages/tutorials/tekton/tekton.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tekton/tekton.adoc
@@ -38,7 +38,6 @@ spec:
         - "$(inputs.params.file)" //<2>
 ----
 
-TIP: Tekton Pipelines 0.6+ support also the $() syntax for variable substitution
 
 <1> The base image for the step is `apache/camel-k:1.0.0-M2`
 <2> It executes command `kamel run --wait ${inputs.params.file}`, with file to run received as parameter

--- a/docs/modules/ROOT/pages/tutorials/tekton/tekton.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tekton/tekton.adoc
@@ -35,7 +35,7 @@ spec:
       args:
         - "run"
         - "--wait"
-        - "${inputs.params.file}" //<2>
+        - "$(inputs.params.file)" //<2>
 ----
 
 TIP: Tekton Pipelines 0.6+ support also the $() syntax for variable substitution


### PR DESCRIPTION
I've tested this tutorial using OpenShift v4.2 and the Pipelines Operator v0.8.2.
It fails as is, it appears parameters with curly brackets do not work.
Using parentheses it works.

Mind this is the documentation page, which also makes reference to the source file:
 - camel-k-pipeline-task-definition.yaml
I don't know where that file is located, but also would need to be updated to replace '{ }' with '( )'.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

Mind this is the documentation page, which also makes reference to the source file:
 - camel-k-pipeline-task-definition.yaml
I don't know where that file is located, but also would need to be updated to replace '{ }' with '( )'.


**Release Note**
```release-note

```
