### PR TITLE
Fix #1237: check specific knative serving versions to determine if it…

### DIFF
--- a/pkg/util/knative/apis.go
+++ b/pkg/util/knative/apis.go
@@ -108,6 +108,19 @@ var (
 			Resource: "brokers",
 		},
 	}
+
+	// RequiredKinds are Knative kinds used by Camel K for materializing integrations.
+	// They must be present on the cluster
+	RequiredKinds = []GroupVersionKindResource{
+		{
+			GroupVersionKind: schema.GroupVersionKind{
+				Kind:    "Service",
+				Group:   "serving.knative.dev",
+				Version: "v1",
+			},
+			Resource: "services",
+		},
+	}
 )
 
 // GroupVersionKindResource --

--- a/pkg/util/knative/enabled.go
+++ b/pkg/util/knative/enabled.go
@@ -39,7 +39,7 @@ func IsEnabledInNamespace(ctx context.Context, c client.Client, namespace string
 		log.Infof("could not create dynamic client to check knative installation in namespace %s, got error: %v", namespace, err)
 		return false
 	}
-	for _, kgv := range KnownEndpointKinds {
+	for _, kgv := range RequiredKinds {
 		_, err = dyn.Resource(schema.GroupVersionResource{
 			Group:    kgv.Group,
 			Version:  kgv.Version,
@@ -60,7 +60,7 @@ func IsEnabledInNamespace(ctx context.Context, c client.Client, namespace string
 // This method should not be called from the operator, as it might require permissions that are not available.
 func IsInstalled(ctx context.Context, c kubernetes.Interface) (bool, error) {
 	// check some Knative APIs
-	for _, api := range getKnativeGroupVersions() {
+	for _, api := range getRequiredKnativeGroupVersions() {
 		if installed, err := isInstalled(c, api); err != nil {
 			return false, err
 		} else if installed {
@@ -80,10 +80,10 @@ func isInstalled(c kubernetes.Interface, api schema.GroupVersion) (bool, error) 
 	return true, nil
 }
 
-func getKnativeGroupVersions() []schema.GroupVersion {
+func getRequiredKnativeGroupVersions() []schema.GroupVersion {
 	apis := make(map[schema.GroupVersion]bool)
 	res := make([]schema.GroupVersion, 0)
-	for _, gvk := range KnownEndpointKinds {
+	for _, gvk := range RequiredKinds {
 		if !apis[gvk.GroupVersion()] {
 			apis[gvk.GroupVersion()] = true
 			res = append(res, gvk.GroupVersion())


### PR DESCRIPTION
…'s installed

<!-- Description -->

Fix #1237


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
