### PR TITLE
Fix #1286: overwrite resources when --force option is passed to kamel…

### DIFF
--- a/e2e/tekton_test.go
+++ b/e2e/tekton_test.go
@@ -36,7 +36,7 @@ func TestTektonLikeBehavior(t *testing.T) {
 		Expect(createOperatorRoleBinding(ns)).Should(BeNil())
 
 		Eventually(operatorPod(ns)).Should(BeNil())
-		Expect(createKamelPod(ns, "tekton-task", "install", "--skip-cluster-setup")).Should(BeNil())
+		Expect(createKamelPod(ns, "tekton-task", "install", "--skip-cluster-setup", "--force")).Should(BeNil())
 
 		Eventually(operatorPod(ns)).ShouldNot(BeNil())
 	})

--- a/e2e/test_support.go
+++ b/e2e/test_support.go
@@ -681,7 +681,7 @@ func serviceaccount(ns, name string) func() *corev1.ServiceAccount {
 */
 
 func createOperatorServiceAccount(ns string) error {
-	return install.Resource(testContext, testClient, ns, install.IdentityResourceCustomizer, "operator-service-account.yaml")
+	return install.Resource(testContext, testClient, ns, true, install.IdentityResourceCustomizer, "operator-service-account.yaml")
 }
 
 func createOperatorRole(ns string) (err error) {
@@ -690,13 +690,13 @@ func createOperatorRole(ns string) (err error) {
 		panic(err)
 	}
 	if oc {
-		return install.Resource(testContext, testClient, ns, install.IdentityResourceCustomizer, "operator-role-openshift.yaml")
+		return install.Resource(testContext, testClient, ns, true, install.IdentityResourceCustomizer, "operator-role-openshift.yaml")
 	}
-	return install.Resource(testContext, testClient, ns, install.IdentityResourceCustomizer, "operator-role-kubernetes.yaml")
+	return install.Resource(testContext, testClient, ns, true, install.IdentityResourceCustomizer, "operator-role-kubernetes.yaml")
 }
 
 func createOperatorRoleBinding(ns string) error {
-	return install.Resource(testContext, testClient, ns, install.IdentityResourceCustomizer, "operator-role-binding.yaml")
+	return install.Resource(testContext, testClient, ns, true, install.IdentityResourceCustomizer, "operator-role-binding.yaml")
 }
 
 func createKamelPod(ns string, name string, command ...string) error {

--- a/pkg/controller/integrationplatform/create.go
+++ b/pkg/controller/integrationplatform/create.go
@@ -49,7 +49,7 @@ func (action *createAction) Handle(ctx context.Context, platform *v1.Integration
 	for _, k := range deploy.Resources("/") {
 		if strings.HasPrefix(k, "camel-catalog-") {
 			action.L.Infof("Installing camel catalog: %s", k)
-			err := install.Resources(ctx, action.client, platform.Namespace, install.IdentityResourceCustomizer, k)
+			err := install.Resources(ctx, action.client, platform.Namespace, true, install.IdentityResourceCustomizer, k)
 			if err != nil {
 				return nil, err
 			}
@@ -73,7 +73,7 @@ func (action *createAction) Handle(ctx context.Context, platform *v1.Integration
 
 		if len(res) > 0 {
 			action.L.Info("Installing custom platform resources")
-			err := install.Resources(ctx, action.client, platform.Namespace, install.IdentityResourceCustomizer, res...)
+			err := install.Resources(ctx, action.client, platform.Namespace, true, install.IdentityResourceCustomizer, res...)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/install/builder.go
+++ b/pkg/install/builder.go
@@ -43,7 +43,7 @@ func BuilderServiceAccountRoles(ctx context.Context, c client.Client, namespace 
 }
 
 func installBuilderServiceAccountRolesOpenshift(ctx context.Context, c client.Client, namespace string) error {
-	return ResourcesOrCollect(ctx, c, namespace, nil, IdentityResourceCustomizer,
+	return ResourcesOrCollect(ctx, c, namespace, nil, true, IdentityResourceCustomizer,
 		"builder-service-account.yaml",
 		"builder-role-openshift.yaml",
 		"builder-role-binding.yaml",
@@ -51,7 +51,7 @@ func installBuilderServiceAccountRolesOpenshift(ctx context.Context, c client.Cl
 }
 
 func installBuilderServiceAccountRolesKubernetes(ctx context.Context, c client.Client, namespace string) error {
-	return ResourcesOrCollect(ctx, c, namespace, nil, IdentityResourceCustomizer,
+	return ResourcesOrCollect(ctx, c, namespace, nil, true, IdentityResourceCustomizer,
 		"builder-service-account.yaml",
 		"builder-role-kubernetes.yaml",
 		"builder-role-binding.yaml",

--- a/pkg/install/common.go
+++ b/pkg/install/common.go
@@ -47,7 +47,8 @@ func Resources(ctx context.Context, c client.Client, namespace string, force boo
 }
 
 // ResourcesOrCollect --
-func ResourcesOrCollect(ctx context.Context, c client.Client, namespace string, collection *kubernetes.Collection, force bool, customizer ResourceCustomizer, names ...string) error {
+func ResourcesOrCollect(ctx context.Context, c client.Client, namespace string, collection *kubernetes.Collection,
+	force bool, customizer ResourceCustomizer, names ...string) error {
 	for _, name := range names {
 		if err := ResourceOrCollect(ctx, c, namespace, collection, force, customizer, name); err != nil {
 			return err
@@ -62,7 +63,8 @@ func Resource(ctx context.Context, c client.Client, namespace string, force bool
 }
 
 // ResourceOrCollect --
-func ResourceOrCollect(ctx context.Context, c client.Client, namespace string, collection *kubernetes.Collection, force bool, customizer ResourceCustomizer, name string) error {
+func ResourceOrCollect(ctx context.Context, c client.Client, namespace string, collection *kubernetes.Collection,
+	force bool, customizer ResourceCustomizer, name string) error {
 	obj, err := kubernetes.LoadResourceFromYaml(c.GetScheme(), deploy.ResourceAsString(name))
 	if err != nil {
 		return err

--- a/pkg/install/secret.go
+++ b/pkg/install/secret.go
@@ -30,7 +30,7 @@ import (
 const registrySecretName = "camel-k-registry-secret"
 
 // RegistrySecretOrCollect generates a secret from auth settings and creates it on the cluster (or appends it to the collection)
-func RegistrySecretOrCollect(ctx context.Context, c client.Client, namespace string, auth registry.Auth, collection *kubernetes.Collection) (string, error) {
+func RegistrySecretOrCollect(ctx context.Context, c client.Client, namespace string, auth registry.Auth, collection *kubernetes.Collection, force bool) (string, error) {
 	secretData, err := auth.GenerateDockerConfig()
 	if err != nil {
 		return "", err
@@ -51,7 +51,7 @@ func RegistrySecretOrCollect(ctx context.Context, c client.Client, namespace str
 		},
 	}
 
-	if err := RuntimeObjectOrCollect(ctx, c, namespace, collection, &registrySecret); err != nil {
+	if err := RuntimeObjectOrCollect(ctx, c, namespace, collection, force, &registrySecret); err != nil {
 		return "", err
 	}
 	return registrySecretName, nil


### PR DESCRIPTION
… install

<!-- Description -->

Fix #1286

I've limited the --force flag to non-cluster resources in normal install for now.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
