### PR TITLE
Related to #1190: add more logs when patch fails

### DIFF
--- a/e2e/init_test.go
+++ b/e2e/init_test.go
@@ -1,0 +1,63 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/apache/camel-k/e2e/util"
+	camelv1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestRunInitGeneratedExamples(t *testing.T) {
+	withNewTestNamespace(t, func(ns string) {
+		Expect(kamel("install", "-n", ns).Execute()).Should(BeNil())
+
+		for _, lang := range camelv1.Languages {
+			t.Run("init run "+string(lang), func(t *testing.T) {
+				RegisterTestingT(t)
+				dir := util.MakeTempDir(t)
+				itName := fmt.Sprintf("init%s", string(lang))          // e.g. initjava
+				fileName := fmt.Sprintf("%s.%s", itName, string(lang)) // e.g. initjava.java
+				file := path.Join(dir, fileName)
+				Expect(kamel("init", file).Execute()).Should(BeNil())
+				Expect(kamel("run", "-n", ns, file).Execute()).Should(BeNil())
+				Eventually(integrationPodPhase(ns, itName), 5*time.Minute).Should(Equal(v1.PodRunning))
+				Eventually(integrationLogs(ns, itName), 1*time.Minute).Should(ContainSubstring(languageInitExpectedString(lang)))
+				Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+			})
+		}
+	})
+}
+
+func languageInitExpectedString(lang camelv1.Language) string {
+	langDesc := string(lang)
+	if lang == camelv1.LanguageKotlin {
+		langDesc = "kotlin"
+	}
+	return fmt.Sprintf(" Hello Camel K from %s", langDesc)
+}

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -22,13 +22,9 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
-	"path"
 	"testing"
 	"time"
 
-	"github.com/apache/camel-k/e2e/util"
-	camelv1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )
@@ -102,27 +98,5 @@ func TestRunSimpleExamples(t *testing.T) {
 			Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
 		})
 
-		for _, lang := range camelv1.Languages {
-			t.Run("init run "+string(lang), func(t *testing.T) {
-				RegisterTestingT(t)
-				dir := util.MakeTempDir(t)
-				itName := fmt.Sprintf("init%s", string(lang))          // e.g. initjava
-				fileName := fmt.Sprintf("%s.%s", itName, string(lang)) // e.g. initjava.java
-				file := path.Join(dir, fileName)
-				Expect(kamel("init", file).Execute()).Should(BeNil())
-				Expect(kamel("run", "-n", ns, file).Execute()).Should(BeNil())
-				Eventually(integrationPodPhase(ns, itName), 5*time.Minute).Should(Equal(v1.PodRunning))
-				Eventually(integrationLogs(ns, itName), 1*time.Minute).Should(ContainSubstring(languageInitExpectedString(lang)))
-				Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
-			})
-		}
 	})
-}
-
-func languageInitExpectedString(lang camelv1.Language) string {
-	langDesc := string(lang)
-	if lang == camelv1.LanguageKotlin {
-		langDesc = "kotlin"
-	}
-	return fmt.Sprintf(" Hello Camel K from %s", langDesc)
 }

--- a/pkg/cmd/builder/builder.go
+++ b/pkg/cmd/builder/builder.go
@@ -88,10 +88,14 @@ func Run(namespace string, buildName string, taskName string) {
 	// Patch the build status with the result
 	p, err := patch.PositiveMergePatch(build, target)
 	exitOnError(err, "cannot create merge patch")
-	exitOnError(
-		c.Status().Patch(ctx, target, controller.ConstantPatch(types.MergePatchType, p)),
-		fmt.Sprintf("\n--- patch ---\n%s\n-------------\n", string(p)),
-	)
+	if len(p) > 0 {
+		exitOnError(
+			c.Status().Patch(ctx, target, controller.ConstantPatch(types.MergePatchType, p)),
+			fmt.Sprintf("\n--- patch ---\n%s\n-------------\n", string(p)),
+		)
+	} else {
+		log.Info("Patch not applied (no difference)")
+	}
 	build.Status = target.Status
 
 	switch build.Status.Phase {


### PR DESCRIPTION
<!-- Description -->


Fix #1190

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
