### PR TITLE
[ADD] Add rest test

### DIFF
--- a/e2e/files/RestConsumer.java
+++ b/e2e/files/RestConsumer.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class RestConsumer extends RouteBuilder {
+  @Override
+  public void configure() throws Exception {
+    restConfiguration().port(8080);
+    rest("/customers")
+    .get("/{name}").to("direct:start");
+
+    from("direct:start").log("get ${header.name}").setBody(simple("${header.name} Doe"));
+  }
+}

--- a/e2e/files/RestProducer.groovy
+++ b/e2e/files/RestProducer.groovy
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+from('timer:tick').to('http:{{serviceName}}/customers/{{name}}')
+    .log('${body}')

--- a/e2e/rest_test.go
+++ b/e2e/rest_test.go
@@ -1,0 +1,86 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "knative"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"bytes"
+
+	"github.com/apache/camel-k/pkg/util/openshift"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestRunREST(t *testing.T) {
+	withNewTestNamespace(t, func(ns string) {
+		var profile string
+		ocp, err := openshift.IsOpenShift(testClient)
+		assert.Nil(t, err)
+		if ocp {
+			profile = "OpenShift"
+		} else {
+			profile = "Kubernetes"
+		}
+
+		Expect(kamel("install", "-n", ns, "--trait-profile", profile).Execute()).Should(BeNil())
+		Expect(kamel("run", "-n", ns, "files/RestConsumer.java", "-d", "camel:undertow").Execute()).Should(BeNil())
+		Eventually(integrationPodPhase(ns, "rest-consumer"), testTimeoutMedium).Should(Equal(v1.PodRunning))
+
+		t.Run("Service works", func(t *testing.T) {
+			name := "John"
+			service := service(ns, "rest-consumer")
+			Eventually(service, testTimeoutShort).ShouldNot(BeNil())
+			Expect(kamel("run", "-n", ns, "files/RestProducer.groovy", "-p", "serviceName=rest-consumer", "-p", "name="+name).Execute()).Should(BeNil())
+			Eventually(integrationPodPhase(ns, "rest-producer"), testTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(integrationLogs(ns, "rest-consumer"), testTimeoutShort).Should(ContainSubstring(fmt.Sprintf("get %s", name)))
+			Eventually(integrationLogs(ns, "rest-producer"), testTimeoutShort).Should(ContainSubstring(fmt.Sprintf("%s Doe", name)))
+		})
+
+		if ocp {
+			t.Run("Route works", func(t *testing.T) {
+				name := "Peter"
+				route := route(ns, "rest-consumer")
+				Eventually(route, testTimeoutShort).ShouldNot(BeNil())
+				response := httpReqest(t, fmt.Sprintf("http://%s/customers/%s", route().Spec.Host, name))
+				assert.Equal(t, fmt.Sprintf("%s Doe", name), response)
+				Eventually(integrationLogs(ns, "rest-consumer"), testTimeoutShort).Should(ContainSubstring(fmt.Sprintf("get %s", name)))
+
+			})
+		}
+
+		// Cleanup
+		Expect(kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+	})
+}
+
+func httpReqest(t *testing.T, url string) string {
+	response, err := http.Get(url)
+	defer response.Body.Close()
+	assert.Nil(t, err)
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(response.Body)
+	return buf.String()
+}

--- a/e2e/test_support.go
+++ b/e2e/test_support.go
@@ -45,6 +45,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/onsi/gomega"
 	projectv1 "github.com/openshift/api/project/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
@@ -77,6 +78,7 @@ var testImageVersion = defaults.Version
 func init() {
 	// Register some resources used in e2e tests only
 	client.FastMapperAllowedAPIGroups["project.openshift.io"] = true
+	client.FastMapperAllowedAPIGroups["route.openshift.io"] = true
 	client.FastMapperAllowedAPIGroups["eventing.knative.dev"] = true
 	client.FastMapperAllowedAPIGroups["messaging.knative.dev"] = true
 
@@ -276,6 +278,40 @@ func configMap(ns string, name string) func() *corev1.ConfigMap {
 			panic(err)
 		}
 		return &cm
+	}
+}
+
+func service(ns string, name string) func() *corev1.Service {
+	return func() *corev1.Service {
+		svc := corev1.Service{}
+		key := k8sclient.ObjectKey{
+			Namespace: ns,
+			Name:      name,
+		}
+		err := testClient.Get(testContext, key, &svc)
+		if err != nil && k8serrors.IsNotFound(err) {
+			return nil
+		} else if err != nil {
+			panic(err)
+		}
+		return &svc
+	}
+}
+
+func route(ns string, name string) func() *routev1.Route {
+	return func() *routev1.Route {
+		route := routev1.Route{}
+		key := k8sclient.ObjectKey{
+			Namespace: ns,
+			Name:      name,
+		}
+		err := testClient.Get(testContext, key, &route)
+		if err != nil && k8serrors.IsNotFound(err) {
+			return nil
+		} else if err != nil {
+			panic(err)
+		}
+		return &route
 	}
 }
 


### PR DESCRIPTION
Add test for REST service. This test covers:
- REST DSL route
- dependency trait (see `"run", "-n", ns, "files/RestConsumer.java", "-d", "camel:undertow`
- custom properties (`"run", "-n", ns, "files/RestProducer.groovy", "-p", "serviceIp="+service().Spec.ClusterIP, "-p", "name="+name`)
- service trait
- route trait