### PR TITLE
Add nightly releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: release
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cache modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Prerequisites
+      run: |
+        export OPERATOR_SDK_VERSION=v0.15.2
+        curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.15.2/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk
+        chmod a+x operator-sdk
+        sudo mv operator-sdk /usr/local/bin
+
+    - name: Global Env
+      env:
+        TEST_DOCKER_HUB_USERNAME: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
+        TEST_DOCKER_HUB_PASSWORD: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
+      run: |
+        VERSION=nightly-$(date +%Y%m%d%H%M)
+        echo "Using VERSION=$VERSION"
+        echo "::set-env name=VERSION::$VERSION"
+
+        IMAGE_NAME=docker.io/${TEST_DOCKER_HUB_USERNAME:-testcamelk}/camel-k
+        echo "Using IMAGE_NAME=$IMAGE_NAME"
+        echo "::set-env name=IMAGE_NAME::$IMAGE_NAME"
+
+        docker login -u $TEST_DOCKER_HUB_USERNAME -p $TEST_DOCKER_HUB_PASSWORD
+
+    - name: Codegen
+      run: |
+        make VERSION=$VERSION IMAGE_NAME=$IMAGE_NAME codegen set-version build-resources
+
+    - name: Tag version
+      uses: anothrNick/github-tag-action@1.17.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CUSTOM_TAG: ${{ env.VERSION }}
+    - name: Build
+      run: |
+        make VERSION=$VERSION IMAGE_NAME=$IMAGE_NAME release-nightly
+
+    - name: Check
+      run: ls -l
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.VERSION }}
+        release_name: Release ${{ env.VERSION }}
+        body: |
+          Apache Camel K nightly build for testing (unstable).
+
+        draft: false
+        prerelease: true
+    - name: Upload Client Linux
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./camel-k-client-${{ env.VERSION }}-linux-64bit.tar.gz
+        asset_name: camel-k-client-${{ env.VERSION }}-linux-64bit.tar.gz
+        asset_content_type: application/tar+gzip
+    - name: Upload Client Mac
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./camel-k-client-${{ env.VERSION }}-mac-64bit.tar.gz
+        asset_name: camel-k-client-${{ env.VERSION }}-mac-64bit.tar.gz
+        asset_content_type: application/tar+gzip
+    - name: Upload Client Windows
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./camel-k-client-${{ env.VERSION }}-windows-64bit.tar.gz
+        asset_name: camel-k-client-${{ env.VERSION }}-windows-64bit.tar.gz
+        asset_content_type: application/tar+gzip
+    - name: Upload Examples
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./camel-k-examples-${{ env.VERSION }}.tar.gz
+        asset_name: camel-k-examples-${{ env.VERSION }}.tar.gz
+        asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         TEST_DOCKER_HUB_USERNAME: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
         TEST_DOCKER_HUB_PASSWORD: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
       run: |
-        VERSION=nightly-$(date +%Y%m%d%H%M)
+        VERSION=$(make get-version | sed s/-SNAPSHOT/-nightly.$(date +%Y%m%d%H%M)/)
         echo "Using VERSION=$VERSION"
         echo "::set-env name=VERSION::$VERSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@
 name: release
 
 on:
-  push:
-    branches:
-      - master
+  schedule:
+  - cron:  '0 0 * * *'
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
         echo "Using IMAGE_NAME=$IMAGE_NAME"
         echo "::set-env name=IMAGE_NAME::$IMAGE_NAME"
 
+        MAVEN_REPOSITORY=$(make get-staging-repo)
+        echo "Using MAVEN_REPOSITORY=$MAVEN_REPOSITORY"
+        echo "::set-env name=MAVEN_REPOSITORY::$MAVEN_REPOSITORY"
+
         docker login -u $TEST_DOCKER_HUB_USERNAME -p $TEST_DOCKER_HUB_PASSWORD
 
     - name: Codegen
@@ -86,6 +90,12 @@ jobs:
         release_name: Release ${{ env.VERSION }}
         body: |
           Apache Camel K nightly build for testing (unstable).
+
+          To test it, download the client for your OS and run:
+
+          ```
+          kamel install --olm=false --maven-repository=${{ env.MAVEN_REPOSITORY }}
+          ```
 
         draft: false
         prerelease: true

--- a/script/Makefile
+++ b/script/Makefile
@@ -241,4 +241,7 @@ release-notes:
 get-staging-repo:
 	@echo $(or ${STAGING_RUNTIME_REPO},https://repository.apache.org/content/repositories/snapshots@id=apache-snapshots@snapshots)
 
-.PHONY: build build-kamel build-resources build-olm unsnapshot-olm dep codegen images images-dev images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes check-licenses generate-deepcopy generate-client generate-doc build-resources release-helm release-staging release-nightly get-staging-repo
+get-version:
+	@echo $(VERSION)
+
+.PHONY: build build-kamel build-resources build-olm unsnapshot-olm dep codegen images images-dev images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes check-licenses generate-deepcopy generate-client generate-doc build-resources release-helm release-staging release-nightly get-staging-repo get-version

--- a/script/Makefile
+++ b/script/Makefile
@@ -225,6 +225,8 @@ release: clean codegen set-version build-resources check-licenses unsnapshot-olm
 
 release-staging: clean codegen set-version build-resources check-licenses unsnapshot-olm build images images-push-staging cross-compile package-examples git-tag
 
+release-nightly: clean codegen set-version build-resources build images images-push cross-compile package-examples
+
 release-helm:
 	./script/release_helm.sh
 
@@ -236,4 +238,4 @@ install-minikube:
 release-notes:
 	./script/gen_release_notes.sh $(LAST_RELEASED_VERSION) $(VERSION)
 
-.PHONY: build build-kamel build-resources build-olm unsnapshot-olm dep codegen images images-dev images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes check-licenses generate-deepcopy generate-client generate-doc build-resources release-helm
+.PHONY: build build-kamel build-resources build-olm unsnapshot-olm dep codegen images images-dev images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes check-licenses generate-deepcopy generate-client generate-doc build-resources release-helm release-staging release-nightly

--- a/script/Makefile
+++ b/script/Makefile
@@ -30,7 +30,7 @@ LINT_DEADLINE := 10m
 # Used to push pre-release artifacts
 STAGING_IMAGE_NAME := docker.io/camelk/camel-k
 
-STAGING_RUNTIME_REPO := https://repository.apache.org/content/repositories/orgapachecamel-1189
+STAGING_RUNTIME_REPO :=
 
 # When packaging artifacts into the docker image, you can "copy" them from local maven
 # or "download" them from Apache Snapshots and Maven Central
@@ -238,4 +238,7 @@ install-minikube:
 release-notes:
 	./script/gen_release_notes.sh $(LAST_RELEASED_VERSION) $(VERSION)
 
-.PHONY: build build-kamel build-resources build-olm unsnapshot-olm dep codegen images images-dev images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes check-licenses generate-deepcopy generate-client generate-doc build-resources release-helm release-staging release-nightly
+get-staging-repo:
+	@echo $(or ${STAGING_RUNTIME_REPO},https://repository.apache.org/content/repositories/snapshots@id=apache-snapshots@snapshots)
+
+.PHONY: build build-kamel build-resources build-olm unsnapshot-olm dep codegen images images-dev images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes check-licenses generate-deepcopy generate-client generate-doc build-resources release-helm release-staging release-nightly get-staging-repo

--- a/script/package_examples.sh
+++ b/script/package_examples.sh
@@ -25,4 +25,6 @@ fi
 
 version=$1
 
-pushd $rootdir/examples && tar --exclude=".*" -zcvf ../camel-k-examples-$version.tar.gz * && popd
+cd $rootdir/examples
+
+tar --exclude=".*" -zcvf ../camel-k-examples-$version.tar.gz *

--- a/script/set_version.sh
+++ b/script/set_version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
<!-- Description -->

Fix #1365 

This adds automatic nightly builds.
We need a way to remove old builds and just keep one, but for now we can delete them manually.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Nighly build releases will be available from the release page from now on
```
