### PR TITLE
chore(build): fix package_artifact.sh script call

### DIFF
--- a/script/package_maven_artifacts.sh
+++ b/script/package_maven_artifacts.sh
@@ -36,6 +36,7 @@ if [ "$strategy" = "copy" ]; then
         -DoutputDirectory=$PWD/build/_maven_output \
         -Druntime.version=$version \
         -Dstaging.repo=$staging_repo \
+        -Dalpn.jdk8.version="8.1.13.v20181017" \
         dependency:copy-dependencies
 elif [ "$strategy" = "download" ]; then
     ./mvnw \
@@ -45,6 +46,7 @@ elif [ "$strategy" = "download" ]; then
         -Dmaven.repo.local=$PWD/build/_maven_output \
         -Druntime.version=$version \
         -Dstaging.repo=$staging_repo \
+        -Dalpn.jdk8.version="8.1.13.v20181017" \
         install
 else
     echo "unknown strategy: $strategy"


### PR DESCRIPTION
Was getting:

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.1.1:copy-dependencies (default-cli) on project camel-k-runtime-builder: Some problems were encountered while processing the POMs:
[ERROR] [ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-surefire-plugin].dependencies.dependency.version' for org.mortbay.jetty.alpn:alpn-boot:jar is missing. @ com.squareup.okhttp3:parent:3.12.6, /home/jpoth/.m2/repository/com/squareup/okhttp3/parent/3.12.6/parent-3.12.6.pom, line 337, column 28`

Which happens when you are using a Java 8 version not listed in okttp3 parent [pom.xml](https://repo1.maven.org/maven2/com/squareup/okhttp3/parent/3.12.6/parent-3.12.6.pom)