### PR TITLE
Fix #1356: remove namespace resources on uninstall and fix maven-sett…

### DIFF
--- a/e2e/uninstall_test.go
+++ b/e2e/uninstall_test.go
@@ -38,7 +38,7 @@ func TestBasicUninstall(t *testing.T) {
 		Eventually(role(ns)).Should(BeNil())
 		Eventually(rolebinding(ns)).Should(BeNil())
 		Eventually(configmap(ns, "camel-k-maven-settings")).Should(BeNil())
-		Eventually(serviceaccount(ns, "camel-k-maven-settings")).Should(BeNil())
+		Eventually(serviceaccount(ns, "camel-k-operator")).Should(BeNil())
 		Eventually(operatorPod(ns)).Should(BeNil())
 	})
 }


### PR DESCRIPTION
…ings override

<!-- Description -->

Fix #1356

I've also made sure we don't remove cluster-wide resources unless we explicitly say we want to. Otherwise people wanting to install the operator from their namespace can delete the global CRDs and so also all integrations running in the cluster.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Uninstall does no longer remove cluster-wide resources unless explicitly stated 
```
