### PR TITLE
fix #1382: enable prometheus roles when installing from olm and helm

### DIFF
--- a/deploy/olm-catalog/camel-k/1.0.0-snapshot/camel-k.v1.0.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/camel-k/1.0.0-snapshot/camel-k.v1.0.0-snapshot.clusterserviceversion.yaml
@@ -409,6 +409,19 @@ spec:
           - clusterroles
           verbs:
           - bind
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: camel-k-operator
     strategy: deployment
   installModes:

--- a/deploy/operator-role-olm.yaml
+++ b/deploy/operator-role-olm.yaml
@@ -221,3 +221,16 @@ rules:
   - bind
   resourceNames:
   - system:image-builder
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/helm/camel-k/templates/operator-role.yaml
+++ b/helm/camel-k/templates/operator-role.yaml
@@ -214,3 +214,24 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+  resourceNames:
+  - system:image-builder
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
<!-- Description -->

Fix #1382 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
The Camel K operator can now manage Prometheus servicemonitors without requiring additional permissions
```
