### PR TITLE
Fix #1393: create standard role at operator startup in OLM

### DIFF
--- a/deploy/olm-catalog/camel-k/1.0.0-snapshot/camel-k.v1.0.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/camel-k/1.0.0-snapshot/camel-k.v1.0.0-snapshot.clusterserviceversion.yaml
@@ -169,6 +169,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - camel.apache.org
+          resources:
+          - '*'
+          verbs:
+          - '*'
         serviceAccountName: camel-k-operator
       deployments:
       - name: camel-k-operator
@@ -401,14 +407,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resourceNames:
-          - system:image-builder
-          resources:
-          - clusterroles
-          verbs:
-          - bind
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/deploy/operator-role-olm-cluster.yaml
+++ b/deploy/operator-role-olm-cluster.yaml
@@ -35,3 +35,9 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -147,12 +147,9 @@ func Run() {
 	}
 
 	// Try to register the OpenShift CLI Download link if possible
-	installCtx, installCancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	installCtx, installCancel := context.WithTimeout(context.TODO(), 1*time.Minute)
 	defer installCancel()
-	if err := install.OpenShiftConsoleDownloadLink(installCtx, c); err != nil {
-		log.Info("Cannot install OpenShift CLI download link: skipping.")
-		log.V(8).Info("Error while installing OpenShift CLI download link", "error", err)
-	}
+	install.OperatorStartupOptionalTools(installCtx, c, log)
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {

--- a/pkg/install/optional.go
+++ b/pkg/install/optional.go
@@ -1,0 +1,29 @@
+package install
+
+import (
+	"context"
+	"github.com/apache/camel-k/pkg/client"
+	"github.com/go-logr/logr"
+)
+
+// OperatorStartupOptionalTools tries to install optional tools at operator startup and warns if something goes wrong
+func OperatorStartupOptionalTools(ctx context.Context, c client.Client, log logr.Logger) {
+
+	// Try to register the OpenShift CLI Download link if possible
+	if err := OpenShiftConsoleDownloadLink(ctx, c); err != nil {
+		log.Info("Cannot install OpenShift CLI download link: skipping.")
+		log.V(8).Info("Error while installing OpenShift CLI download link", "error", err)
+	}
+
+	// Try to register the cluster role for standard admin and edit users
+	if clusterRoleInstalled, err := IsClusterRoleInstalled(ctx, c); err != nil {
+		log.Info("Cannot detect user cluster role: skipping.")
+		log.V(8).Info("Error while getting user cluster role", "error", err)
+	} else if !clusterRoleInstalled {
+		if err := installClusterRole(ctx, c, nil); err != nil {
+			log.Info("Cannot install user cluster role: skipping.")
+			log.V(8).Info("Error while installing user cluster role", "error", err)
+		}
+	}
+
+}


### PR DESCRIPTION
<!-- Description -->

Fix #1393


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
