### PR TITLE
Fix knative sources

### DIFF
--- a/pkg/controller/integration/initialize.go
+++ b/pkg/controller/integration/initialize.go
@@ -21,11 +21,8 @@ import (
 	"context"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/client"
-	"github.com/apache/camel-k/pkg/platform"
 	"github.com/apache/camel-k/pkg/trait"
 	"github.com/apache/camel-k/pkg/util/defaults"
-	"github.com/apache/camel-k/pkg/util/knative"
 )
 
 // NewInitializeAction creates a new initialize action
@@ -53,36 +50,11 @@ func (action *initializeAction) Handle(ctx context.Context, integration *v1.Inte
 		return nil, err
 	}
 
-	pl, err := platform.GetCurrentPlatform(ctx, action.client, integration.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
 	kit := v1.NewIntegrationKit(integration.Namespace, integration.Spec.Kit)
 
 	integration.Status.Phase = v1.IntegrationPhaseBuildingKit
 	integration.SetIntegrationKit(&kit)
-	integration.Status.Profile = determineBestProfile(ctx, action.client, integration, pl)
 	integration.Status.Version = defaults.Version
 
 	return integration, nil
-}
-
-// DetermineBestProfile tries to detect the best trait profile for the integration
-func determineBestProfile(ctx context.Context, c client.Client, integration *v1.Integration, p *v1.IntegrationPlatform) v1.TraitProfile {
-	if integration.Spec.Profile != "" {
-		return integration.Spec.Profile
-	}
-	if integration.Status.Profile != "" {
-		// Integration already has a profile
-		return integration.Status.Profile
-	}
-	if p.Status.Profile != "" {
-		// Use platform profile if set
-		return p.Status.Profile
-	}
-	if knative.IsEnabledInNamespace(ctx, c, p.Namespace) {
-		return v1.TraitProfileKnative
-	}
-	return platform.GetProfile(p)
 }

--- a/pkg/controller/integration/platform_setup.go
+++ b/pkg/controller/integration/platform_setup.go
@@ -20,6 +20,11 @@ package integration
 import (
 	"context"
 
+	"github.com/apache/camel-k/pkg/client"
+	"github.com/apache/camel-k/pkg/platform"
+	"github.com/apache/camel-k/pkg/util/knative"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/trait"
 )
@@ -50,5 +55,31 @@ func (action *platformSetupAction) Handle(ctx context.Context, integration *v1.I
 		return nil, err
 	}
 
+	pl, err := platform.GetCurrentPlatform(ctx, action.client, integration.Namespace)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, err
+	} else if pl != nil {
+		integration.Status.Profile = determineBestProfile(ctx, action.client, integration, pl)
+	}
+
 	return integration, nil
+}
+
+// DetermineBestProfile tries to detect the best trait profile for the integration
+func determineBestProfile(ctx context.Context, c client.Client, integration *v1.Integration, p *v1.IntegrationPlatform) v1.TraitProfile {
+	if integration.Spec.Profile != "" {
+		return integration.Spec.Profile
+	}
+	if integration.Status.Profile != "" {
+		// Integration already has a profile
+		return integration.Status.Profile
+	}
+	if p.Status.Profile != "" {
+		// Use platform profile if set
+		return p.Status.Profile
+	}
+	if knative.IsEnabledInNamespace(ctx, c, integration.Namespace) {
+		return v1.TraitProfileKnative
+	}
+	return platform.GetProfile(p)
 }

--- a/pkg/install/optional.go
+++ b/pkg/install/optional.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+
 	"github.com/apache/camel-k/pkg/client"
 	"github.com/go-logr/logr"
 )

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/apache/camel-k/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controller "sigs.k8s.io/controller-runtime/pkg/client"
@@ -735,4 +736,16 @@ func (e *Environment) getIntegrationContainer() *corev1.Container {
 	}
 
 	return e.Resources.GetContainerByName(containerName)
+}
+
+func (e *Environment) getAllInterceptors() []string {
+	res := make([]string, 0)
+	util.StringSliceUniqueConcat(&res, e.Interceptors)
+
+	if e.Integration != nil {
+		for _, s := range e.Integration.Sources() {
+			util.StringSliceUniqueConcat(&res, s.Interceptors)
+		}
+	}
+	return res
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -88,6 +88,16 @@ func StringSliceUniqueAdd(slice *[]string, item string) bool {
 	return true
 }
 
+// StringSliceUniqueConcat append all the items of the "items" slice if they are not already present in the slice
+func StringSliceUniqueConcat(slice *[]string, items []string) bool {
+	for _, item := range items {
+		if !StringSliceUniqueAdd(slice, item) {
+			return false
+		}
+	}
+	return true
+}
+
 // EncodeXML --
 func EncodeXML(content interface{}) ([]byte, error) {
 	w := &bytes.Buffer{}


### PR DESCRIPTION
<!-- Description -->

Fix #1419

@lburgazzoli this adds the required libs and capabilities whenever the `knative-source` interceptor is used. I don't think we should add a capability to avoid naming the libs directly, or do we?

It also add a compatibiity hack to transform the old loader to an interceptor in order for next release to work with all currently released versions of Knative (I'll fix it in Knative 0.15).

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
