### PR TITLE
Update 3scale.go

### DIFF
--- a/addons/threescale/3scale.go
+++ b/addons/threescale/3scale.go
@@ -41,7 +41,7 @@ type threeScaleTrait struct {
 	Path string `property:"path"`
 	// The port where the service is exposed (default `80`)
 	Port int `property:"port"`
-	// The path where the Open-API specification is published (default `/api-doc`)
+	// The path where the Open-API specification is published (default `/openapi.json`)
 	DescriptionPath *string `property:"description-path"`
 }
 
@@ -64,7 +64,7 @@ const (
 	// ThreeScaleDescriptionPathAnnotation --
 	ThreeScaleDescriptionPathAnnotation = "discovery.3scale.net/description-path"
 	// ThreeScaleDescriptionPathDefaultValue --
-	ThreeScaleDescriptionPathDefaultValue = "/api-doc"
+	ThreeScaleDescriptionPathDefaultValue = "/openapi.json"
 
 	// ThreeScaleDiscoveryLabel --
 	ThreeScaleDiscoveryLabel = "discovery.3scale.net"

--- a/addons/threescale/3scale_test.go
+++ b/addons/threescale/3scale_test.go
@@ -59,7 +59,7 @@ func TestThreeScaleInjection(t *testing.T) {
 	assert.Equal(t, "http", svc.Annotations["discovery.3scale.net/scheme"])
 	assert.Equal(t, "/", svc.Annotations["discovery.3scale.net/path"])
 	assert.Equal(t, "80", svc.Annotations["discovery.3scale.net/port"])
-	assert.Equal(t, "/api-doc", svc.Annotations["discovery.3scale.net/description-path"])
+	assert.Equal(t, "/openapi.json", svc.Annotations["discovery.3scale.net/description-path"])
 }
 
 func TestThreeScaleInjectionNoAPIPath(t *testing.T) {

--- a/deploy/traits.yaml
+++ b/deploy/traits.yaml
@@ -706,3 +706,32 @@ traits:
   - name: auto
     type: bool
     description: To automatically detect from the code if a Service needs to be created.
+- name: 3scale
+  platform: false
+  profiles:
+  - Kubernetes
+  - Knative
+  - OpenShift
+  description: The 3scale trait can be used to automatically create annotations that
+    allow3scale to discover the generated service and make it available for API management.The
+    3scale trait is disabled by default.
+  properties:
+  - name: enabled
+    type: bool
+    description: Can be used to enable or disable a trait. All traits share this common
+      property.
+  - name: auto
+    type: bool
+    description: Enables automatic configuration of the trait.
+  - name: scheme
+    type: string
+    description: The scheme to use to contact the service (default `http`)
+  - name: path
+    type: string
+    description: The path where the API is published (default `/`)
+  - name: port
+    type: int
+    description: The port where the service is exposed (default `80`)
+  - name: description-path
+    type: string
+    description: The path where the Open-API specification is published (default `/openapi.json`)


### PR DESCRIPTION
Fixes #1428

Changed references of "/api-doc" to "/openapi.json"

I tried performing `make generate-doc` too but it changed a lot of files and created updates that I was unsure of. Hence I discarded those changes.

Kindly take a look and let me know if this looks fine. 
Please let me know what else needs to be done if this is not enough.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
