### PR TITLE
Allow the short syntax in knative endpoints

### DIFF
--- a/pkg/cmd/modeline.go
+++ b/pkg/cmd/modeline.go
@@ -1,15 +1,32 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (
 	"context"
 	"fmt"
 	"path"
+	"path/filepath"
 
 	"github.com/apache/camel-k/pkg/util/modeline"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"path/filepath"
 )
 
 const (

--- a/pkg/cmd/modeline_test.go
+++ b/pkg/cmd/modeline_test.go
@@ -4,7 +4,6 @@ contributor license agreements.  See the NOTICE file distributed with
 this work for additional information regarding copyright ownership.
 The ASF licenses this file to You under the Apache License, Version 2.0
 (the "License"); you may not use this file except in compliance with
-
 the License.  You may obtain a copy of the License at
 
    http://www.apache.org/licenses/LICENSE-2.0
@@ -20,12 +19,12 @@ package cmd
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 )
 
 func TestModelineRunSimple(t *testing.T) {

--- a/pkg/trait/knative_test.go
+++ b/pkg/trait/knative_test.go
@@ -74,6 +74,8 @@ func TestKnativeEnvConfigurationFromTrait(t *testing.T) {
 							"channel-sinks":    "channel-sink-1",
 							"endpoint-sources": "endpoint-source-1",
 							"endpoint-sinks":   "endpoint-sink-1,endpoint-sink-2",
+							"event-sources":    "knative:event",
+							"event-sinks":      "knative:event",
 						},
 					},
 				},
@@ -141,6 +143,12 @@ func TestKnativeEnvConfigurationFromTrait(t *testing.T) {
 	eSink2 := ne.FindService("endpoint-sink-2", knativeapi.CamelEndpointKindSink, knativeapi.CamelServiceTypeEndpoint, "serving.knative.dev/v1", "Service")
 	assert.NotNil(t, eSink2)
 	assert.Equal(t, "endpoint-sink-2.host", eSink2.Host)
+
+	eEventSource := ne.FindService("default", knativeapi.CamelEndpointKindSource, knativeapi.CamelServiceTypeEvent, "eventing.knative.dev/v1alpha1", "Broker")
+	assert.NotNil(t, eEventSource)
+	eEventSink := ne.FindService("default", knativeapi.CamelEndpointKindSink, knativeapi.CamelServiceTypeEvent, "eventing.knative.dev/v1alpha1", "Broker")
+	assert.NotNil(t, eEventSink)
+	assert.Equal(t, "broker-default.host", eEventSink.Host)
 }
 
 func TestKnativeEnvConfigurationFromSource(t *testing.T) {

--- a/pkg/util/knative/uri.go
+++ b/pkg/util/knative/uri.go
@@ -26,7 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var uriRegexp = regexp.MustCompile(`^knative:[/]*(channel|endpoint|event)/([A-Za-z0-9.-]+)(?:[/?].*|$)`)
+var uriRegexp = regexp.MustCompile(`^knative:[/]*(channel|endpoint|event)(?:$|/([A-Za-z0-9.-]+)(?:[/?].*|$))`)
 var plainNameRegexp = regexp.MustCompile(`^[A-Za-z0-9.-]+$`)
 
 const (


### PR DESCRIPTION
<!-- Description -->

Like `knative:event` and then setting the details in headers.

Related to apache/camel-k-runtime#326

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Dynamic event types can be used when targeting the knative broker
```
