### PR TITLE
#1465 remove crd and clusterrole on uninstall

### DIFF
--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -107,7 +107,7 @@ func (o *uninstallCmdOptions) uninstall(cmd *cobra.Command, _ []string) error {
 	}
 
 	uninstallViaOLM := false
-	if o.OlmEnabled || o.UninstallAll {
+	if o.OlmEnabled {
 		var err error
 		if uninstallViaOLM, err = olm.IsAPIAvailable(o.Context, c, o.Namespace); err != nil {
 			return errors.Wrap(err, "error while checking OLM availability. Run with '--olm=false' to skip this check")

--- a/pkg/cmd/uninstall_test.go
+++ b/pkg/cmd/uninstall_test.go
@@ -64,3 +64,18 @@ func TestUninstallSkipFlags(t *testing.T) {
 	assert.True(t, uninstallCmdOptions.SkipClusterRoles)
 	assert.True(t, uninstallCmdOptions.SkipIntegrationPlatform)
 }
+
+func TestUninstallAllFlag(t *testing.T) {
+	options, cmd := kamelTestPreAddCommandInit()
+
+	uninstallCmdOptions := addTestUninstallCmd(options, cmd)
+
+	kamelTestPostAddCommandInit(t, cmd)
+
+	_, err := test.ExecuteCommand(cmd, "uninstall", "--all")
+	assert.Nil(t, err)
+	assert.True(t, uninstallCmdOptions.SkipCrd)
+	assert.True(t, uninstallCmdOptions.SkipClusterRoles)
+	assert.True(t, uninstallCmdOptions.OlmEnabled)
+	assert.False(t, uninstallCmdOptions.SkipIntegrationPlatform)
+}

--- a/pkg/cmd/uninstall_test.go
+++ b/pkg/cmd/uninstall_test.go
@@ -76,6 +76,5 @@ func TestUninstallAllFlag(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, uninstallCmdOptions.SkipCrd)
 	assert.True(t, uninstallCmdOptions.SkipClusterRoles)
-	assert.True(t, uninstallCmdOptions.OlmEnabled)
 	assert.False(t, uninstallCmdOptions.SkipIntegrationPlatform)
 }


### PR DESCRIPTION
Fix for #1465. It enables the removal of _**CRD**_ and _**ClusterRole**_ upon _kamel uninstall_.