### PR TITLE
support for jitpack dependencies

### DIFF
--- a/pkg/util/jitpack/jitpack.go
+++ b/pkg/util/jitpack/jitpack.go
@@ -1,0 +1,67 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jitpack
+
+import (
+	"strings"
+
+	"github.com/apache/camel-k/pkg/util/maven"
+)
+
+const RepoURL = "https://jitpack.io"
+const LatestVersion = "master-SNAPSHOT"
+
+func ToDependency(dependencyID string) *maven.Dependency {
+	gav := ""
+
+	switch {
+	case strings.HasPrefix(dependencyID, "github:"):
+		gav = strings.TrimPrefix(dependencyID, "github:")
+		gav = "com.github." + gav
+	case strings.HasPrefix(dependencyID, "gitlab:"):
+		gav = strings.TrimPrefix(dependencyID, "gitlab:")
+		gav = "com.gitlab." + gav
+	case strings.HasPrefix(dependencyID, "bitbucket:"):
+		gav = strings.TrimPrefix(dependencyID, "bitbucket:")
+		gav = "org.bitbucket." + gav
+	case strings.HasPrefix(dependencyID, "gitee:"):
+		gav = strings.TrimPrefix(dependencyID, "gitee:")
+		gav = "com.gitee." + gav
+	case strings.HasPrefix(dependencyID, "azure:"):
+		gav = strings.TrimPrefix(dependencyID, "azure:")
+		gav = "com.azure." + gav
+	}
+
+	if gav == "" {
+		return nil
+	}
+
+	gav = strings.Replace(gav, "/", ":", -1)
+	dep, err := maven.ParseGAV(gav)
+	if err != nil {
+		return nil
+	}
+
+	// if no version is set, then use master-SNAPSHOT which
+	// targets the latest snapshot from the master branch
+	if dep.Version == "" {
+		dep.Version = LatestVersion
+	}
+
+	return &dep
+}

--- a/pkg/util/jitpack/jitpack_test.go
+++ b/pkg/util/jitpack/jitpack_test.go
@@ -1,0 +1,61 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   hvalp://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jitpack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/camel-k/pkg/util/maven"
+)
+
+func TestConversion(t *testing.T) {
+	var vals = []struct {
+		prefixID  string
+		prefixGav string
+	}{
+		{"github", "com.github"},
+		{"gitlab", "com.gitlab"},
+		{"bitbucket", "org.bitbucket"},
+		{"gitee", "com.gitee"},
+		{"azure", "com.azure"},
+	}
+
+	for _, tt := range vals {
+		val := tt
+		t.Run(val.prefixID, func(t *testing.T) {
+			var d *maven.Dependency
+
+			d = ToDependency(val.prefixID + ":u")
+			assert.Nil(t, d)
+
+			d = ToDependency(val.prefixID + ":u/r/v")
+			assert.NotNil(t, d)
+			assert.Equal(t, val.prefixGav+".u", d.GroupID)
+			assert.Equal(t, "r", d.ArtifactID)
+			assert.Equal(t, "v", d.Version)
+
+			d = ToDependency(val.prefixID + ":u/r")
+			assert.NotNil(t, d)
+			assert.Equal(t, val.prefixGav+".u", d.GroupID)
+			assert.Equal(t, "r", d.ArtifactID)
+			assert.Equal(t, LatestVersion, d.Version)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1407


<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Integrations can directly reference dependent projects on Github via Jitpack
```