### PR TITLE
Avoid requirements of a kubeconfig when using  command

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -47,6 +47,9 @@ func newCmdInit(rootCmdOptions *RootCmdOptions) (*cobra.Command, *initCmdOptions
 			}
 			return nil
 		},
+		Annotations: map[string]string{
+			offlineCommandLabel: "true",
+		},
 	}
 
 	return &cmd, &options


### PR DESCRIPTION
Fixes #1368


<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```