### PR TITLE
fix(jvm): Bind all interfaces to restore remote debugging with newer JDK versions

### DIFF
--- a/deploy/traits.yaml
+++ b/deploy/traits.yaml
@@ -415,7 +415,8 @@ traits:
     description: Suspends the target JVM immediately before the main class is loaded
   - name: debug-address
     type: string
-    description: Transport address at which to listen for the newly launched JVM
+    description: Transport address at which to listen for the newly launched JVM (default
+      `*:5005`)
   - name: options
     type: string
     description: A comma-separated list of JVM options

--- a/docs/modules/traits/pages/jvm.adoc
+++ b/docs/modules/traits/pages/jvm.adoc
@@ -36,7 +36,7 @@ The following configuration options are available:
 
 | jvm.debug-address
 | string
-| Transport address at which to listen for the newly launched JVM
+| Transport address at which to listen for the newly launched JVM (default `*:5005`)
 
 | jvm.options
 | string

--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -44,7 +44,7 @@ type jvmTrait struct {
 	Debug bool `property:"debug"`
 	// Suspends the target JVM immediately before the main class is loaded
 	DebugSuspend bool `property:"debug-suspend"`
-	// Transport address at which to listen for the newly launched JVM
+	// Transport address at which to listen for the newly launched JVM (default `*:5005`)
 	DebugAddress string `property:"debug-address"`
 	// A comma-separated list of JVM options
 	Options *string `property:"options"`
@@ -54,9 +54,8 @@ type jvmTrait struct {
 
 func newJvmTrait() Trait {
 	return &jvmTrait{
-		BaseTrait: NewBaseTrait("jvm", 2000),
-		// To be defaulted to "*:5005" when upgrading the default base image to JDK9+
-		DebugAddress: "5005",
+		BaseTrait:    NewBaseTrait("jvm", 2000),
+		DebugAddress: "*:5005",
 		PrintCommand: true,
 	}
 }

--- a/pkg/trait/jvm_test.go
+++ b/pkg/trait/jvm_test.go
@@ -174,7 +174,7 @@ func TestApplyJvmTraitWithDebugEnabled(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Contains(t, d.Spec.Template.Spec.Containers[0].Args,
-		"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005",
+		"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005",
 	)
 }
 


### PR DESCRIPTION
See https://www.oracle.com/technetwork/java/javase/9-notes-3745703.html#JDK-8041435.

**Release Note**
```release-note
fix(jvm): Bind all interfaces to restore remote debugging with newer JDK versions
```
