### PR TITLE
Backport fix for #1511 in release-1.0.x

### DIFF
--- a/pkg/cmd/trait_help.go
+++ b/pkg/cmd/trait_help.go
@@ -108,11 +108,6 @@ func (command *traitHelpCommandOptions) run(cmd *cobra.Command, args []string) e
 	if err != nil {
 		return err
 	}
-	res, err := yaml.Marshal(traitMetaData)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(cmd.OutOrStdout(), string(res))
 
 	for _, tp := range v1.AllTraitProfiles {
 		traits := catalog.TraitsForProfile(tp)


### PR DESCRIPTION
Can we setup an automatic bot do do these tasks?

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
