### PR TITLE
fix: JVM trait overrides other traits JVM arguments

### DIFF
--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -113,7 +113,8 @@ func (t *jvmTrait) Apply(e *Environment) error {
 	}
 
 	// Build the container command
-	var args []string
+	// Other traits may have already contributed some arguments
+	args := container.Args
 
 	// Remote debugging
 	if t.Debug {


### PR DESCRIPTION
Fixes #1525.

**Release Note**
```release-note
fix: JVM trait overrides other traits JVM arguments
```
