### PR TITLE
fix(util): line break after "Monitoring pod ..." message

### DIFF
--- a/pkg/util/kubernetes/log/annotation_scraper.go
+++ b/pkg/util/kubernetes/log/annotation_scraper.go
@@ -137,7 +137,7 @@ func (s *SelectorScraper) addPodScraper(ctx context.Context, podName string, out
 	go func() {
 		defer podCancel()
 
-		if _, err := out.WriteString(prefix + "Monitoring pod " + podName); err != nil {
+		if _, err := out.WriteString(prefix + "Monitoring pod " + podName + "\n"); err != nil {
 			s.L.Error(err, "Cannot write to output")
 			return
 		}


### PR DESCRIPTION
<!-- Description -->

When there are multiple pods the "Monitoring pod ..." lines are concatenated due to lack of break lines.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
