### PR TITLE
fix(jvm): Integration do not shutdown gracefully when jvm.print-command is set

### DIFF
--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -165,7 +165,7 @@ func (t *jvmTrait) Apply(e *Environment) error {
 	args = append(args, e.CamelCatalog.Runtime.ApplicationClass)
 
 	if t.PrintCommand {
-		args = append([]string{"java"}, args...)
+		args = append([]string{"exec", "java"}, args...)
 		container.Command = []string{"/bin/sh", "-c"}
 		cmd := strings.Join(args, " ")
 		container.Args = []string{"echo " + cmd + " && " + cmd}


### PR DESCRIPTION
Fixes #1557.

The wrapping shell does not forward signals like `SIGTERM` to the JVM process it is waiting on, and `exec` should be used to have the shell replaced with the JVM process being opened.

**Release Note**
```release-note
fix(jvm): Integration do not shutdown gracefully when jvm.print-command is set
```
