### PR TITLE
Fixes incomplete help message

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -34,7 +34,7 @@ func newCmdInit(rootCmdOptions *RootCmdOptions) (*cobra.Command, *initCmdOptions
 		RootCmdOptions: rootCmdOptions,
 	}
 	cmd := cobra.Command{
-		Use:     "init",
+		Use:     "init [flags] IntegrationFile.java",
 		Short:   "Initialize empty Camel K files",
 		Long:    `Initialize empty Camel K integrations and other resources.`,
 		PreRunE: decode(&options),


### PR DESCRIPTION
<!-- Description -->
Proposed fix for Github issue #1585. 

Just add the missing bits on the help string.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fixed issue missing help details as reported on #1585 
```
