### PR TITLE
#1556 - Add the camel category to Camel K CRDs

### DIFF
--- a/deploy/crd-build.yaml
+++ b/deploy/crd-build.yaml
@@ -51,6 +51,9 @@ spec:
     shortNames:
       - ikb
     singular: build
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/crd-camel-catalog.yaml
+++ b/deploy/crd-camel-catalog.yaml
@@ -40,6 +40,9 @@ spec:
     shortNames:
       - cc
     singular: camelcatalog
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/crd-integration-kit.yaml
+++ b/deploy/crd-integration-kit.yaml
@@ -43,6 +43,9 @@ spec:
     shortNames:
       - ik
     singular: integrationkit
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/crd-integration-platform.yaml
+++ b/deploy/crd-integration-platform.yaml
@@ -35,6 +35,9 @@ spec:
     shortNames:
       - ip
     singular: integrationplatform
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/crd-integration.yaml
+++ b/deploy/crd-integration.yaml
@@ -43,6 +43,9 @@ spec:
     shortNames:
       - it
     singular: integration
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     scale:

--- a/helm/camel-k/crds/crd-build.yaml
+++ b/helm/camel-k/crds/crd-build.yaml
@@ -51,6 +51,9 @@ spec:
     shortNames:
       - ikb
     singular: build
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     status: {}

--- a/helm/camel-k/crds/crd-camel-catalog.yaml
+++ b/helm/camel-k/crds/crd-camel-catalog.yaml
@@ -40,6 +40,9 @@ spec:
     shortNames:
       - cc
     singular: camelcatalog
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     status: {}

--- a/helm/camel-k/crds/crd-integration-kit.yaml
+++ b/helm/camel-k/crds/crd-integration-kit.yaml
@@ -43,6 +43,9 @@ spec:
     shortNames:
       - ik
     singular: integrationkit
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     status: {}

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -35,6 +35,9 @@ spec:
     shortNames:
       - ip
     singular: integrationplatform
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     status: {}

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -43,6 +43,9 @@ spec:
     shortNames:
       - it
     singular: integration
+    categories:
+      - kamel
+      - camel
   scope: Namespaced
   subresources:
     scale:

--- a/pkg/apis/camel/v1/build_types.go
+++ b/pkg/apis/camel/v1/build_types.go
@@ -139,7 +139,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +genclient
-// +kubebuilder:resource:path=builds,scope=Namespaced,shortName=ikb
+// +kubebuilder:resource:path=builds,scope=Namespaced,shortName=ikb,categories=kamel;camel
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The build phase"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The time at which the build was created"

--- a/pkg/apis/camel/v1/camelcatalog_types.go
+++ b/pkg/apis/camel/v1/camelcatalog_types.go
@@ -71,7 +71,7 @@ type CamelCatalogStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +genclient
-// +kubebuilder:resource:path=camelcatalogs,scope=Namespaced,shortName=cc
+// +kubebuilder:resource:path=camelcatalogs,scope=Namespaced,shortName=cc,categories=kamel;camel
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Runtime Version",type=string,JSONPath=`.spec.runtime.version`,description="The Camel K Runtime version"
 // +kubebuilder:printcolumn:name="Runtime Provider",type=string,JSONPath=`.spec.runtime.provider`,description="The Camel K Runtime provider"

--- a/pkg/apis/camel/v1/integration_types.go
+++ b/pkg/apis/camel/v1/integration_types.go
@@ -64,7 +64,7 @@ type IntegrationStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +genclient
-// +kubebuilder:resource:path=integrations,scope=Namespaced,shortName=it
+// +kubebuilder:resource:path=integrations,scope=Namespaced,shortName=it,categories=kamel;camel
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The integration phase"

--- a/pkg/apis/camel/v1/integrationkit_types.go
+++ b/pkg/apis/camel/v1/integrationkit_types.go
@@ -52,7 +52,7 @@ type IntegrationKitStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +genclient
-// +kubebuilder:resource:path=integrationkits,scope=Namespaced,shortName=ik
+// +kubebuilder:resource:path=integrationkits,scope=Namespaced,shortName=ik,categories=kamel;camel
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The integration kit phase"
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.metadata.labels.camel\.apache\.org\/kit\.type`,description="The integration kit type"

--- a/pkg/apis/camel/v1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1/integrationplatform_types.go
@@ -51,7 +51,7 @@ type IntegrationPlatformStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +genclient
-// +kubebuilder:resource:path=integrationplatforms,scope=Namespaced,shortName=ip
+// +kubebuilder:resource:path=integrationplatforms,scope=Namespaced,shortName=ip,categories=kamel;camel
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The integration platform phase"
 


### PR DESCRIPTION
Added 'kamel' & 'camel'  categories to Camel-K CRDs _(i.e Build, CamelCatalog, Integration, IntegrationKit)_

Please see below example usage:

```
$ kamel install 
Camel K installed in namespace myproject 

$ kubectl get kamel
NAME                                           PHASE
integrationplatform.camel.apache.org/camel-k   

$ kubectl get camel
NAME                                           PHASE
integrationplatform.camel.apache.org/camel-k   

$ kamel run examples/simple.groovy 
integration "simple" created

$ kubectl get kamel                                       
NAME                                           PHASE
integrationplatform.camel.apache.org/camel-k   

NAME                                  PHASE   KIT   REPLICAS
integration.camel.apache.org/simple                 

```