### PR TITLE
Related to #1638 kamel init - should not create source file with ASF …

### DIFF
--- a/deploy/templates/groovy.tmpl
+++ b/deploy/templates/groovy.tmpl
@@ -1,20 +1,4 @@
 // camel-k: language=groovy
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 // Write your routes here, for example:
 from('timer:groovy?period=1000')


### PR DESCRIPTION
…license header

Fixes #1638 

**Release Note**
```release-note
NONE
```
