### PR TITLE
Fix #1710: auto-generate CRD specification on "generate" task (and fix Kamelets)

### DIFF
--- a/deploy/crd-build.yaml
+++ b/deploy/crd-build.yaml
@@ -18,42 +18,45 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: builds.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: builds.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The build phase
-      name: Phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: The time at which the build was created
-      name: Age
-      type: date
-    - JSONPath: .status.startedAt
-      description: The time at which the build was last (re-)started
-      name: Started
-      type: date
-    - JSONPath: .status.duration
-      description: The build last execution duration
-      name: Duration
-      type: string
-    - JSONPath: .status.failure.recovery.attempt
-      description: The number of execution attempts
-      name: Attempts
-      type: integer
+  - JSONPath: .status.phase
+    description: The build phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The time at which the build was created
+    name: Age
+    type: date
+  - JSONPath: .status.startedAt
+    description: The time at which the build was last (re-)started
+    name: Started
+    type: date
+  - JSONPath: .status.duration
+    description: The build last execution duration
+    name: Duration
+    type: string
+  - JSONPath: .status.failure.recovery.attempt
+    description: The number of execution attempts
+    name: Attempts
+    type: integer
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: Build
     listKind: BuildList
     plural: builds
     shortNames:
-      - ikb
+    - ikb
     singular: build
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     status: {}
@@ -150,8 +153,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -188,8 +191,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
@@ -200,8 +203,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - preference
-                                    - weight
+                                  - preference
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -256,8 +259,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -294,14 +297,14 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
                                     type: array
                                 required:
-                                  - nodeSelectorTerms
+                                - nodeSelectorTerms
                                 type: object
                             type: object
                           podAffinity:
@@ -370,8 +373,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -407,7 +410,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -416,8 +419,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -478,8 +481,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -511,7 +514,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -581,8 +584,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -618,7 +621,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -627,8 +630,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -689,8 +692,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -722,7 +725,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -762,7 +765,7 @@ spec:
                                       its key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                               secretKeyRef:
                                 description: Selects a key of a secret.
@@ -782,7 +785,7 @@ spec:
                                       key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                             type: object
                           timeout:
@@ -840,8 +843,8 @@ spec:
                                       version:
                                         type: string
                                     required:
-                                      - artifactId
-                                      - groupId
+                                    - artifactId
+                                    - groupId
                                     type: object
                                   type: array
                                 metadata:
@@ -849,7 +852,7 @@ spec:
                                     type: string
                                   type: object
                               required:
-                                - dependencies
+                              - dependencies
                               type: object
                             type: object
                           dependencies:
@@ -863,8 +866,8 @@ spec:
                                 version:
                                   type: string
                               required:
-                                - artifactId
-                                - groupId
+                              - artifactId
+                              - groupId
                               type: object
                             type: array
                           metadata:
@@ -877,10 +880,10 @@ spec:
                           version:
                             type: string
                         required:
-                          - applicationClass
-                          - dependencies
-                          - provider
-                          - version
+                        - applicationClass
+                        - dependencies
+                        - provider
+                        - version
                         type: object
                       sources:
                         items:
@@ -909,6 +912,16 @@ spec:
                                 that will interpret this source at runtime
                               type: string
                             name:
+                              type: string
+                            property-names:
+                              description: List of property names defined in the source
+                                (e.g. if type is "template")
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: Type defines the kind of source described
+                                by this object
                               type: string
                           type: object
                         type: array
@@ -954,8 +967,8 @@ spec:
                                 are mutually exclusive.
                               type: string
                           required:
-                            - mountPath
-                            - name
+                          - mountPath
+                          - name
                           type: object
                         type: array
                       volumes:
@@ -996,7 +1009,7 @@ spec:
                                     in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             azureDisk:
                               description: AzureDisk represents an Azure Data Disk
@@ -1031,8 +1044,8 @@ spec:
                                     here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
-                                - diskName
-                                - diskURI
+                              - diskName
+                              - diskURI
                               type: object
                             azureFile:
                               description: AzureFile represents an Azure File Service
@@ -1050,8 +1063,8 @@ spec:
                                   description: Share Name
                                   type: string
                               required:
-                                - secretName
-                                - shareName
+                              - secretName
+                              - shareName
                               type: object
                             cephfs:
                               description: CephFS represents a Ceph FS mount on the
@@ -1094,7 +1107,7 @@ spec:
                                     default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - monitors
+                              - monitors
                               type: object
                             cinder:
                               description: 'Cinder represents a cinder volume attached
@@ -1128,7 +1141,7 @@ spec:
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             configMap:
                               description: ConfigMap represents a configMap that should
@@ -1180,8 +1193,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 name:
@@ -1240,7 +1253,7 @@ spec:
                                     values.
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             downwardAPI:
                               description: DownwardAPI represents downward API about
@@ -1279,7 +1292,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                          - fieldPath
+                                        - fieldPath
                                         type: object
                                       mode:
                                         description: 'Optional: mode bits to use on
@@ -1310,8 +1323,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                              - type: integer
-                                              - type: string
+                                            - type: integer
+                                            - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -1321,10 +1334,10 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                          - resource
+                                        - resource
                                         type: object
                                     required:
-                                      - path
+                                    - path
                                     type: object
                                   type: array
                               type: object
@@ -1340,8 +1353,8 @@ spec:
                                   type: string
                                 sizeLimit:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   description: 'Total amount of local storage required
                                     for this EmptyDir volume. The size limit is also
                                     applicable for memory medium. The maximum usage
@@ -1431,7 +1444,7 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             flocker:
                               description: Flocker represents a Flocker volume attached
@@ -1482,7 +1495,7 @@ spec:
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
-                                - pdName
+                              - pdName
                               type: object
                             gitRepo:
                               description: 'GitRepo represents a git repository at
@@ -1507,7 +1520,7 @@ spec:
                                   description: Commit hash for the specified revision.
                                   type: string
                               required:
-                                - repository
+                              - repository
                               type: object
                             glusterfs:
                               description: 'Glusterfs represents a Glusterfs mount
@@ -1528,8 +1541,8 @@ spec:
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
-                                - endpoints
-                                - path
+                              - endpoints
+                              - path
                               type: object
                             hostPath:
                               description: 'HostPath represents a pre-existing file
@@ -1552,7 +1565,7 @@ spec:
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
-                                - path
+                              - path
                               type: object
                             iscsi:
                               description: 'ISCSI represents an ISCSI Disk resource
@@ -1622,9 +1635,9 @@ spec:
                                     than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
-                                - iqn
-                                - lun
-                                - targetPortal
+                              - iqn
+                              - lun
+                              - targetPortal
                               type: object
                             name:
                               description: 'Volume''s name. Must be a DNS_LABEL and
@@ -1648,8 +1661,8 @@ spec:
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
-                                - path
-                                - server
+                              - path
+                              - server
                               type: object
                             persistentVolumeClaim:
                               description: 'PersistentVolumeClaimVolumeSource represents
@@ -1666,7 +1679,7 @@ spec:
                                     VolumeMounts. Default false.
                                   type: boolean
                               required:
-                                - claimName
+                              - claimName
                               type: object
                             photonPersistentDisk:
                               description: PhotonPersistentDisk represents a PhotonController
@@ -1684,7 +1697,7 @@ spec:
                                     persistent disk
                                   type: string
                               required:
-                                - pdID
+                              - pdID
                               type: object
                             portworxVolume:
                               description: PortworxVolume represents a portworx volume
@@ -1705,7 +1718,7 @@ spec:
                                     volume
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             projected:
                               description: Items for all in one resources secrets,
@@ -1772,8 +1785,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -1816,7 +1829,7 @@ spec:
                                                         API version.
                                                       type: string
                                                   required:
-                                                    - fieldPath
+                                                  - fieldPath
                                                   type: object
                                                 mode:
                                                   description: 'Optional: mode bits
@@ -1854,8 +1867,8 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                        - type: integer
-                                                        - type: string
+                                                      - type: integer
+                                                      - type: string
                                                       description: Specifies the output
                                                         format of the exposed resources,
                                                         defaults to "1"
@@ -1866,10 +1879,10 @@ spec:
                                                         to select'
                                                       type: string
                                                   required:
-                                                    - resource
+                                                  - resource
                                                   type: object
                                               required:
-                                                - path
+                                              - path
                                               type: object
                                             type: array
                                         type: object
@@ -1919,8 +1932,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -1967,12 +1980,12 @@ spec:
                                               the token into.
                                             type: string
                                         required:
-                                          - path
+                                        - path
                                         type: object
                                     type: object
                                   type: array
                               required:
-                                - sources
+                              - sources
                               type: object
                             quobyte:
                               description: Quobyte represents a Quobyte mount on the
@@ -2008,8 +2021,8 @@ spec:
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
-                                - registry
-                                - volume
+                              - registry
+                              - volume
                               type: object
                             rbd:
                               description: 'RBD represents a Rados Block Device mount
@@ -2065,8 +2078,8 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - image
-                                - monitors
+                              - image
+                              - monitors
                               type: object
                             scaleIO:
                               description: ScaleIO represents a ScaleIO persistent
@@ -2126,9 +2139,9 @@ spec:
                                     this volume source.
                                   type: string
                               required:
-                                - gateway
-                                - secretRef
-                                - system
+                              - gateway
+                              - secretRef
+                              - system
                               type: object
                             secret:
                               description: 'Secret represents a secret that should
@@ -2180,8 +2193,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 optional:
@@ -2259,10 +2272,10 @@ spec:
                                     vmdk
                                   type: string
                               required:
-                                - volumePath
+                              - volumePath
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                     type: object
@@ -2333,8 +2346,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -2371,8 +2384,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
@@ -2383,8 +2396,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - preference
-                                    - weight
+                                  - preference
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2439,8 +2452,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -2477,14 +2490,14 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
                                     type: array
                                 required:
-                                  - nodeSelectorTerms
+                                - nodeSelectorTerms
                                 type: object
                             type: object
                           podAffinity:
@@ -2553,8 +2566,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -2590,7 +2603,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -2599,8 +2612,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2661,8 +2674,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -2694,7 +2707,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -2764,8 +2777,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -2801,7 +2814,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -2810,8 +2823,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2872,8 +2885,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -2905,7 +2918,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -2961,7 +2974,7 @@ spec:
                                         its key must be defined
                                       type: boolean
                                   required:
-                                    - key
+                                  - key
                                   type: object
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
@@ -2978,7 +2991,7 @@ spec:
                                         the specified API version.
                                       type: string
                                   required:
-                                    - fieldPath
+                                  - fieldPath
                                   type: object
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
@@ -2993,8 +3006,8 @@ spec:
                                       type: string
                                     divisor:
                                       anyOf:
-                                        - type: integer
-                                        - type: string
+                                      - type: integer
+                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -3003,7 +3016,7 @@ spec:
                                       description: 'Required: resource to select'
                                       type: string
                                   required:
-                                    - resource
+                                  - resource
                                   type: object
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
@@ -3024,11 +3037,11 @@ spec:
                                         key must be defined
                                       type: boolean
                                   required:
-                                    - key
+                                  - key
                                   type: object
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                       image:
@@ -3199,8 +3212,8 @@ spec:
                                 are mutually exclusive.
                               type: string
                           required:
-                            - mountPath
-                            - name
+                          - mountPath
+                          - name
                           type: object
                         type: array
                       volumes:
@@ -3241,7 +3254,7 @@ spec:
                                     in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             azureDisk:
                               description: AzureDisk represents an Azure Data Disk
@@ -3276,8 +3289,8 @@ spec:
                                     here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
-                                - diskName
-                                - diskURI
+                              - diskName
+                              - diskURI
                               type: object
                             azureFile:
                               description: AzureFile represents an Azure File Service
@@ -3295,8 +3308,8 @@ spec:
                                   description: Share Name
                                   type: string
                               required:
-                                - secretName
-                                - shareName
+                              - secretName
+                              - shareName
                               type: object
                             cephfs:
                               description: CephFS represents a Ceph FS mount on the
@@ -3339,7 +3352,7 @@ spec:
                                     default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - monitors
+                              - monitors
                               type: object
                             cinder:
                               description: 'Cinder represents a cinder volume attached
@@ -3373,7 +3386,7 @@ spec:
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             configMap:
                               description: ConfigMap represents a configMap that should
@@ -3425,8 +3438,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 name:
@@ -3485,7 +3498,7 @@ spec:
                                     values.
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             downwardAPI:
                               description: DownwardAPI represents downward API about
@@ -3524,7 +3537,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                          - fieldPath
+                                        - fieldPath
                                         type: object
                                       mode:
                                         description: 'Optional: mode bits to use on
@@ -3555,8 +3568,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                              - type: integer
-                                              - type: string
+                                            - type: integer
+                                            - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -3566,10 +3579,10 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                          - resource
+                                        - resource
                                         type: object
                                     required:
-                                      - path
+                                    - path
                                     type: object
                                   type: array
                               type: object
@@ -3585,8 +3598,8 @@ spec:
                                   type: string
                                 sizeLimit:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   description: 'Total amount of local storage required
                                     for this EmptyDir volume. The size limit is also
                                     applicable for memory medium. The maximum usage
@@ -3676,7 +3689,7 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             flocker:
                               description: Flocker represents a Flocker volume attached
@@ -3727,7 +3740,7 @@ spec:
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
-                                - pdName
+                              - pdName
                               type: object
                             gitRepo:
                               description: 'GitRepo represents a git repository at
@@ -3752,7 +3765,7 @@ spec:
                                   description: Commit hash for the specified revision.
                                   type: string
                               required:
-                                - repository
+                              - repository
                               type: object
                             glusterfs:
                               description: 'Glusterfs represents a Glusterfs mount
@@ -3773,8 +3786,8 @@ spec:
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
-                                - endpoints
-                                - path
+                              - endpoints
+                              - path
                               type: object
                             hostPath:
                               description: 'HostPath represents a pre-existing file
@@ -3797,7 +3810,7 @@ spec:
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
-                                - path
+                              - path
                               type: object
                             iscsi:
                               description: 'ISCSI represents an ISCSI Disk resource
@@ -3867,9 +3880,9 @@ spec:
                                     than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
-                                - iqn
-                                - lun
-                                - targetPortal
+                              - iqn
+                              - lun
+                              - targetPortal
                               type: object
                             name:
                               description: 'Volume''s name. Must be a DNS_LABEL and
@@ -3893,8 +3906,8 @@ spec:
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
-                                - path
-                                - server
+                              - path
+                              - server
                               type: object
                             persistentVolumeClaim:
                               description: 'PersistentVolumeClaimVolumeSource represents
@@ -3911,7 +3924,7 @@ spec:
                                     VolumeMounts. Default false.
                                   type: boolean
                               required:
-                                - claimName
+                              - claimName
                               type: object
                             photonPersistentDisk:
                               description: PhotonPersistentDisk represents a PhotonController
@@ -3929,7 +3942,7 @@ spec:
                                     persistent disk
                                   type: string
                               required:
-                                - pdID
+                              - pdID
                               type: object
                             portworxVolume:
                               description: PortworxVolume represents a portworx volume
@@ -3950,7 +3963,7 @@ spec:
                                     volume
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             projected:
                               description: Items for all in one resources secrets,
@@ -4017,8 +4030,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -4061,7 +4074,7 @@ spec:
                                                         API version.
                                                       type: string
                                                   required:
-                                                    - fieldPath
+                                                  - fieldPath
                                                   type: object
                                                 mode:
                                                   description: 'Optional: mode bits
@@ -4099,8 +4112,8 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                        - type: integer
-                                                        - type: string
+                                                      - type: integer
+                                                      - type: string
                                                       description: Specifies the output
                                                         format of the exposed resources,
                                                         defaults to "1"
@@ -4111,10 +4124,10 @@ spec:
                                                         to select'
                                                       type: string
                                                   required:
-                                                    - resource
+                                                  - resource
                                                   type: object
                                               required:
-                                                - path
+                                              - path
                                               type: object
                                             type: array
                                         type: object
@@ -4164,8 +4177,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -4212,12 +4225,12 @@ spec:
                                               the token into.
                                             type: string
                                         required:
-                                          - path
+                                        - path
                                         type: object
                                     type: object
                                   type: array
                               required:
-                                - sources
+                              - sources
                               type: object
                             quobyte:
                               description: Quobyte represents a Quobyte mount on the
@@ -4253,8 +4266,8 @@ spec:
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
-                                - registry
-                                - volume
+                              - registry
+                              - volume
                               type: object
                             rbd:
                               description: 'RBD represents a Rados Block Device mount
@@ -4310,8 +4323,8 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - image
-                                - monitors
+                              - image
+                              - monitors
                               type: object
                             scaleIO:
                               description: ScaleIO represents a ScaleIO persistent
@@ -4371,9 +4384,9 @@ spec:
                                     this volume source.
                                   type: string
                               required:
-                                - gateway
-                                - secretRef
-                                - system
+                              - gateway
+                              - secretRef
+                              - system
                               type: object
                             secret:
                               description: 'Secret represents a secret that should
@@ -4425,8 +4438,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 optional:
@@ -4504,10 +4517,10 @@ spec:
                                     vmdk
                                   type: string
                               required:
-                                - volumePath
+                              - volumePath
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                       workingDir:
@@ -4532,7 +4545,7 @@ spec:
                   target:
                     type: string
                 required:
-                  - id
+                - id
                 type: object
               type: array
             baseImage:
@@ -4565,8 +4578,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             digest:
@@ -4593,16 +4606,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             image:
               type: string
@@ -4618,6 +4631,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/crd-camel-catalog.yaml
+++ b/deploy/crd-camel-catalog.yaml
@@ -1,4 +1,3 @@
-
 # ---------------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -19,30 +18,33 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: camelcatalogs.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: camelcatalogs.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .spec.runtime.version
-      description: The Camel K Runtime version
-      name: Runtime Version
-      type: string
-    - JSONPath: .spec.runtime.provider
-      description: The Camel K Runtime provider
-      name: Runtime Provider
-      type: string
+  - JSONPath: .spec.runtime.version
+    description: The Camel K Runtime version
+    name: Runtime Version
+    type: string
+  - JSONPath: .spec.runtime.provider
+    description: The Camel K Runtime provider
+    name: Runtime Provider
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: CamelCatalog
     listKind: CamelCatalogList
     plural: camelcatalogs
     shortNames:
-      - cc
+    - cc
     singular: camelcatalog
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     status: {}
@@ -90,8 +92,8 @@ spec:
                               groupId:
                                 type: string
                             required:
-                              - artifactId
-                              - groupId
+                            - artifactId
+                            - groupId
                             type: object
                           type: array
                         groupId:
@@ -99,8 +101,8 @@ spec:
                         version:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   exclusions:
@@ -112,8 +114,8 @@ spec:
                         groupId:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   groupId:
@@ -137,16 +139,16 @@ spec:
                         passive:
                           type: boolean
                       required:
-                        - http
-                        - id
-                        - passive
+                      - http
+                      - id
+                      - passive
                       type: object
                     type: array
                   version:
                     type: string
                 required:
-                  - artifactId
-                  - groupId
+                - artifactId
+                - groupId
                 type: object
               type: object
             loaders:
@@ -166,8 +168,8 @@ spec:
                         version:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   groupId:
@@ -179,8 +181,8 @@ spec:
                   version:
                     type: string
                 required:
-                  - artifactId
-                  - groupId
+                - artifactId
+                - groupId
                 type: object
               type: object
             runtime:
@@ -203,8 +205,8 @@ spec:
                             version:
                               type: string
                           required:
-                            - artifactId
-                            - groupId
+                          - artifactId
+                          - groupId
                           type: object
                         type: array
                       metadata:
@@ -212,7 +214,7 @@ spec:
                           type: string
                         type: object
                     required:
-                      - dependencies
+                    - dependencies
                     type: object
                   type: object
                 dependencies:
@@ -226,8 +228,8 @@ spec:
                       version:
                         type: string
                     required:
-                      - artifactId
-                      - groupId
+                    - artifactId
+                    - groupId
                     type: object
                   type: array
                 metadata:
@@ -240,15 +242,15 @@ spec:
                 version:
                   type: string
               required:
-                - applicationClass
-                - dependencies
-                - provider
-                - version
+              - applicationClass
+              - dependencies
+              - provider
+              - version
               type: object
           required:
-            - artifacts
-            - loaders
-            - runtime
+          - artifacts
+          - loaders
+          - runtime
           type: object
         status:
           description: CamelCatalogStatus defines the observed state of CamelCatalog
@@ -256,6 +258,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/crd-integration-kit.yaml
+++ b/deploy/crd-integration-kit.yaml
@@ -18,34 +18,37 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrationkits.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrationkits.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration kit phase
-      name: Phase
-      type: string
-    - JSONPath: .metadata.labels.camel\.apache\.org\/kit\.type
-      description: The integration kit type
-      name: Type
-      type: string
-    - JSONPath: .status.image
-      description: The integration kit image
-      name: Image
-      type: string
+  - JSONPath: .status.phase
+    description: The integration kit phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.labels.camel\.apache\.org\/kit\.type
+    description: The integration kit type
+    name: Type
+    type: string
+  - JSONPath: .status.image
+    description: The integration kit image
+    name: Image
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: IntegrationKit
     listKind: IntegrationKitList
     plural: integrationkits
     shortNames:
-      - ik
+    - ik
     singular: integrationkit
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     status: {}
@@ -77,8 +80,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -97,6 +100,12 @@ spec:
               type: array
             traits:
               additionalProperties:
+                description: A TraitSpec contains the configuration of a trait
+                properties:
+                  configuration:
+                    type: object
+                required:
+                - configuration
                 type: object
               type: object
           type: object
@@ -116,7 +125,7 @@ spec:
                   target:
                     type: string
                 required:
-                  - id
+                - id
                 type: object
               type: array
             baseImage:
@@ -149,8 +158,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             digest:
@@ -171,16 +180,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             image:
               type: string
@@ -200,6 +209,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/crd-integration-platform.yaml
+++ b/deploy/crd-integration-platform.yaml
@@ -18,26 +18,29 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrationplatforms.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrationplatforms.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration platform phase
-      name: Phase
-      type: string
+  - JSONPath: .status.phase
+    description: The integration platform phase
+    name: Phase
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: IntegrationPlatform
     listKind: IntegrationPlatformList
     plural: integrationplatforms
     shortNames:
-      - ip
+    - ip
     singular: integrationplatform
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     status: {}
@@ -98,7 +101,7 @@ spec:
                                 must be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                         secretKeyRef:
                           description: Selects a key of a secret.
@@ -116,7 +119,7 @@ spec:
                                 be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                       type: object
                     timeout:
@@ -167,8 +170,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             profile:
@@ -178,14 +181,15 @@ spec:
             resources:
               description: IntegrationPlatformResourcesSpec contains platform related
                 resources
-              properties:
-                kits:
-                  items:
-                    type: string
-                  type: array
               type: object
             traits:
               additionalProperties:
+                description: A TraitSpec contains the configuration of a trait
+                properties:
+                  configuration:
+                    type: object
+                required:
+                - configuration
                 type: object
               type: object
           type: object
@@ -229,7 +233,7 @@ spec:
                                 must be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                         secretKeyRef:
                           description: Selects a key of a secret.
@@ -247,7 +251,7 @@ spec:
                                 be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                       type: object
                     timeout:
@@ -317,8 +321,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             configuration:
@@ -330,8 +334,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             phase:
@@ -344,14 +348,15 @@ spec:
             resources:
               description: IntegrationPlatformResourcesSpec contains platform related
                 resources
-              properties:
-                kits:
-                  items:
-                    type: string
-                  type: array
               type: object
             traits:
               additionalProperties:
+                description: A TraitSpec contains the configuration of a trait
+                properties:
+                  configuration:
+                    type: object
+                required:
+                - configuration
                 type: object
               type: object
             version:
@@ -360,6 +365,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/crd-integration.yaml
+++ b/deploy/crd-integration.yaml
@@ -18,34 +18,37 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrations.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrations.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration phase
-      name: Phase
-      type: string
-    - JSONPath: .status.kit
-      description: The integration kit
-      name: Kit
-      type: string
-    - JSONPath: .status.replicas
-      description: The number of pods
-      name: Replicas
-      type: integer
+  - JSONPath: .status.phase
+    description: The integration phase
+    name: Phase
+    type: string
+  - JSONPath: .status.kit
+    description: The integration kit
+    name: Kit
+    type: string
+  - JSONPath: .status.replicas
+    description: The number of pods
+    name: Replicas
+    type: integer
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: Integration
     listKind: IntegrationList
     plural: integrations
     shortNames:
-      - it
+    - it
     singular: integration
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     scale:
@@ -81,8 +84,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -156,6 +159,16 @@ spec:
                     type: string
                   name:
                     type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
                 type: object
               type: array
             traits:
@@ -165,7 +178,7 @@ spec:
                   configuration:
                     type: object
                 required:
-                  - configuration
+                - configuration
                 type: object
               type: object
           type: object
@@ -204,8 +217,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             configuration:
@@ -217,8 +230,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -243,16 +256,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             generatedResources:
               items:
@@ -302,6 +315,16 @@ spec:
                     type: string
                   name:
                     type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
                 type: object
               type: array
             image:
@@ -333,6 +356,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/crd-kamelet-binding.yaml
+++ b/deploy/crd-kamelet-binding.yaml
@@ -18,28 +18,298 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kameletbindings.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: kameletbindings.camel.apache.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The Kamelet Binding phase
+    name: Phase
+    type: string
   group: camel.apache.org
+  names:
+    categories:
+    - kamel
+    - camel
+    kind: KameletBinding
+    listKind: KameletBindingList
+    plural: kameletbindings
+    shortNames:
+    - klb
+    singular: kameletbinding
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KameletBinding is the Schema for the kamelets binding API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KameletBindingSpec --
+          properties:
+            integration:
+              description: Integration is an optional integration used to specify
+                custom parameters
+              properties:
+                configuration:
+                  items:
+                    description: ConfigurationSpec --
+                    properties:
+                      type:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - type
+                    - value
+                    type: object
+                  type: array
+                dependencies:
+                  items:
+                    type: string
+                  type: array
+                flows:
+                  items:
+                    type: object
+                  type: array
+                kit:
+                  type: string
+                profile:
+                  description: TraitProfile represents lists of traits that are enabled
+                    for the specific installation/integration
+                  type: string
+                replicas:
+                  format: int32
+                  type: integer
+                repositories:
+                  items:
+                    type: string
+                  type: array
+                resources:
+                  items:
+                    description: ResourceSpec --
+                    properties:
+                      compression:
+                        type: boolean
+                      content:
+                        type: string
+                      contentKey:
+                        type: string
+                      contentRef:
+                        type: string
+                      mountPath:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        description: ResourceType --
+                        type: string
+                    type: object
+                  type: array
+                serviceAccountName:
+                  type: string
+                sources:
+                  items:
+                    description: SourceSpec --
+                    properties:
+                      compression:
+                        type: boolean
+                      content:
+                        type: string
+                      contentKey:
+                        type: string
+                      contentRef:
+                        type: string
+                      interceptors:
+                        description: Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader
+                          uses to pre/post process sources
+                        items:
+                          type: string
+                        type: array
+                      language:
+                        description: Language --
+                        type: string
+                      loader:
+                        description: Loader is an optional id of the org.apache.camel.k.RoutesLoader
+                          that will interpret this source at runtime
+                        type: string
+                      name:
+                        type: string
+                      property-names:
+                        description: List of property names defined in the source
+                          (e.g. if type is "template")
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: Type defines the kind of source described by
+                          this object
+                        type: string
+                    type: object
+                  type: array
+                traits:
+                  additionalProperties:
+                    description: A TraitSpec contains the configuration of a trait
+                    properties:
+                      configuration:
+                        type: object
+                    required:
+                    - configuration
+                    type: object
+                  type: object
+              type: object
+            sink:
+              description: Sink is the destination of the integration defined by this
+                binding
+              properties:
+                properties:
+                  description: Properties are a key value representation of endpoint
+                    properties
+                  type: object
+                ref:
+                  description: Ref can be used to declare a Kubernetes resource as
+                    source/sink endpoint
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    blockOwnerDeletion:
+                      description: If true, AND if the owner has the "foregroundDeletion"
+                        finalizer, then the owner cannot be deleted from the key-value
+                        store until this reference is removed. Defaults to false.
+                        To set this field, a user needs "delete" permission of the
+                        owner, otherwise 422 (Unprocessable Entity) will be returned.
+                      type: boolean
+                    controller:
+                      description: If true, this reference points to the managing
+                        controller.
+                      type: boolean
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
+                  type: object
+                uri:
+                  description: URI can alternatively be used to specify the (Camel)
+                    endpoint explicitly
+                  type: string
+              type: object
+            source:
+              description: Source is the starting point of the integration defined
+                by this binding
+              properties:
+                properties:
+                  description: Properties are a key value representation of endpoint
+                    properties
+                  type: object
+                ref:
+                  description: Ref can be used to declare a Kubernetes resource as
+                    source/sink endpoint
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    blockOwnerDeletion:
+                      description: If true, AND if the owner has the "foregroundDeletion"
+                        finalizer, then the owner cannot be deleted from the key-value
+                        store until this reference is removed. Defaults to false.
+                        To set this field, a user needs "delete" permission of the
+                        owner, otherwise 422 (Unprocessable Entity) will be returned.
+                      type: boolean
+                    controller:
+                      description: If true, this reference points to the managing
+                        controller.
+                      type: boolean
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
+                  type: object
+                uri:
+                  description: URI can alternatively be used to specify the (Camel)
+                    endpoint explicitly
+                  type: string
+              type: object
+          type: object
+        status:
+          description: KameletBindingStatus --
+          properties:
+            conditions:
+              description: Conditions --
+              items:
+                description: KameletBindingCondition describes the state of a resource
+                  at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of kameletBinding condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            phase:
+              description: Phase --
+              type: string
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
-  subresources:
-    status: {}
-  names:
-    kind: KameletBinding
-    listKind: KameletBindingList
-    plural: kameletbindings
-    singular: kameletbinding
-    shortNames:
-    - klb
-  additionalPrinterColumns:
-  - name: Phase
-    type: string
-    description: The KameletBinding phase
-    JSONPath: .status.phase

--- a/deploy/crd-kamelet.yaml
+++ b/deploy/crd-kamelet.yaml
@@ -18,28 +18,594 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kamelets.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: kamelets.camel.apache.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The Kamelet phase
+    name: Phase
+    type: string
   group: camel.apache.org
+  names:
+    categories:
+    - kamel
+    - camel
+    kind: Kamelet
+    listKind: KameletList
+    plural: kamelets
+    shortNames:
+    - kl
+    singular: kamelet
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Kamelet is the Schema for the kamelets API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KameletSpec defines the desired state of Kamelet
+          properties:
+            authorization:
+              description: AuthorizationSpec is TODO (oauth information)
+              type: object
+            definition:
+              description: JSONSchemaProps is a JSON-Schema following Specification
+                Draft 4 (http://json-schema.org/).
+              properties:
+                $ref:
+                  type: string
+                $schema:
+                  description: JSONSchemaURL represents a schema url.
+                  type: string
+                additionalItems:
+                  type: boolean
+                additionalProperties:
+                  type: boolean
+                allOf:
+                  items: {}
+                  type: array
+                anyOf:
+                  items: {}
+                  type: array
+                default:
+                  description: default is a default value for undefined object fields.
+                    Defaulting is a beta feature under the CustomResourceDefaulting
+                    feature gate. Defaulting requires spec.preserveUnknownFields to
+                    be false.
+                  type: Any
+                definitions:
+                  additionalProperties: {}
+                  description: JSONSchemaDefinitions contains the models explicitly
+                    defined in this spec.
+                  type: object
+                dependencies:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: JSONSchemaDependencies represent a dependencies property.
+                  type: object
+                description:
+                  type: string
+                enum:
+                  items:
+                    type: Any
+                  type: array
+                example:
+                  type: Any
+                exclusiveMaximum:
+                  type: boolean
+                exclusiveMinimum:
+                  type: boolean
+                externalDocs:
+                  description: ExternalDocumentation allows referencing an external
+                    resource for extended documentation.
+                  properties:
+                    description:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                format:
+                  description: "format is an OpenAPI v3 format string. Unknown formats
+                    are ignored. The following formats are validated: \n - bsonobjectid:
+                    a bson object ID, i.e. a 24 characters hex string - uri: an URI
+                    as parsed by Golang net/url.ParseRequestURI - email: an email
+                    address as parsed by Golang net/mail.ParseAddress - hostname:
+                    a valid representation for an Internet host name, as defined by
+                    RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed
+                    by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP
+                    - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC
+                    address as parsed by Golang net.ParseMAC - uuid: an UUID that
+                    allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                    - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                    - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                    - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                    - isbn: an ISBN10 or ISBN13 number string like \"0321751043\"
+                    or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\"
+                    - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard:
+                    a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$
+                    with any non digit characters mixed in - ssn: a U.S. social security
+                    number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$
+                    - hexcolor: an hexadecimal color code like \"#FFFFFF: following
+                    the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB
+                    color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded
+                    binary data - password: any kind of string - date: a date string
+                    like \"2006-01-02\" as defined by full-date in RFC3339 - duration:
+                    a duration string like \"22 ns\" as parsed by Golang time.ParseDuration
+                    or compatible with Scala duration format - datetime: a date time
+                    string like \"2014-12-15T19:30:20.000Z\" as defined by date-time
+                    in RFC3339."
+                  type: string
+                id:
+                  type: string
+                items: {}
+                maxItems:
+                  format: int64
+                  type: integer
+                maxLength:
+                  format: int64
+                  type: integer
+                maxProperties:
+                  format: int64
+                  type: integer
+                maximum:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                minItems:
+                  format: int64
+                  type: integer
+                minLength:
+                  format: int64
+                  type: integer
+                minProperties:
+                  format: int64
+                  type: integer
+                minimum:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                multipleOf:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                not: {}
+                nullable:
+                  type: boolean
+                oneOf:
+                  items: {}
+                  type: array
+                pattern:
+                  type: string
+                patternProperties:
+                  additionalProperties: {}
+                  type: object
+                properties:
+                  additionalProperties: {}
+                  type: object
+                required:
+                  items:
+                    type: string
+                  type: array
+                title:
+                  type: string
+                type:
+                  type: string
+                uniqueItems:
+                  type: boolean
+                x-descriptors:
+                  description: x-descriptors annotates an object to define additional
+                    display options.
+                  items:
+                    type: string
+                  type: array
+                x-kubernetes-embedded-resource:
+                  description: x-kubernetes-embedded-resource defines that the value
+                    is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta.
+                    The type must be object. It is allowed to further restrict the
+                    embedded object. kind, apiVersion and metadata are validated automatically.
+                    x-kubernetes-preserve-unknown-fields is allowed to be true, but
+                    does not have to be if the object is fully specified (up to kind,
+                    apiVersion, metadata).
+                  type: boolean
+                x-kubernetes-int-or-string:
+                  description: "x-kubernetes-int-or-string specifies that this value
+                    is either an integer or a string. If this is true, an empty type
+                    is allowed and type as child of anyOf is permitted if following
+                    one of the following patterns: \n 1) anyOf:    - type: integer
+                    \   - type: string 2) allOf:    - anyOf:      - type: integer
+                    \     - type: string    - ... zero or more"
+                  type: boolean
+                x-kubernetes-list-map-keys:
+                  description: "x-kubernetes-list-map-keys annotates an array with
+                    the x-kubernetes-list-type `map` by specifying the keys used as
+                    the index of the map. \n This tag MUST only be used on lists that
+                    have the \"x-kubernetes-list-type\" extension set to \"map\".
+                    Also, the values specified for this attribute must be a scalar
+                    typed field of the child structure (no nesting is supported).
+                    \n The properties specified must either be required or have a
+                    default value, to ensure those properties are present for all
+                    list items."
+                  items:
+                    type: string
+                  type: array
+                x-kubernetes-list-type:
+                  description: "x-kubernetes-list-type annotates an array to further
+                    describe its topology. This extension must only be used on lists
+                    and may have 3 possible values: \n 1) `atomic`: the list is treated
+                    as a single entity, like a scalar.      Atomic lists will be entirely
+                    replaced when updated. This extension      may be used on any
+                    type of list (struct, scalar, ...). 2) `set`:      Sets are lists
+                    that must not have multiple items with the same value. Each      value
+                    must be a scalar, an object with x-kubernetes-map-type `atomic`
+                    or an      array with x-kubernetes-list-type `atomic`. 3) `map`:
+                    \     These lists are like maps in that their elements have a
+                    non-index key      used to identify them. Order is preserved upon
+                    merge. The map tag      must only be used on a list with elements
+                    of type object. Defaults to atomic for arrays."
+                  type: string
+                x-kubernetes-map-type:
+                  description: "x-kubernetes-map-type annotates an object to further
+                    describe its topology. This extension must only be used when type
+                    is object and may have 2 possible values: \n 1) `granular`:      These
+                    maps are actual maps (key-value pairs) and each fields are independent
+                    \     from each other (they can each be manipulated by separate
+                    actors). This is      the default behaviour for all maps. 2) `atomic`:
+                    the list is treated as a single entity, like a scalar.      Atomic
+                    maps will be entirely replaced when updated."
+                  type: string
+                x-kubernetes-preserve-unknown-fields:
+                  description: x-kubernetes-preserve-unknown-fields stops the API
+                    server decoding step from pruning fields which are not specified
+                    in the validation schema. This affects fields recursively, but
+                    switches back to normal pruning behaviour if nested properties
+                    or additionalProperties are specified in the schema. This can
+                    either be true or undefined. False is forbidden.
+                  type: boolean
+              type: object
+            dependencies:
+              items:
+                type: string
+              type: array
+            flow:
+              type: object
+            sources:
+              items:
+                description: SourceSpec --
+                properties:
+                  compression:
+                    type: boolean
+                  content:
+                    type: string
+                  contentKey:
+                    type: string
+                  contentRef:
+                    type: string
+                  interceptors:
+                    description: Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader
+                      uses to pre/post process sources
+                    items:
+                      type: string
+                    type: array
+                  language:
+                    description: Language --
+                    type: string
+                  loader:
+                    description: Loader is an optional id of the org.apache.camel.k.RoutesLoader
+                      that will interpret this source at runtime
+                    type: string
+                  name:
+                    type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
+                type: object
+              type: array
+            types:
+              additionalProperties:
+                properties:
+                  mediaType:
+                    type: string
+                  schema:
+                    description: JSONSchemaProps is a JSON-Schema following Specification
+                      Draft 4 (http://json-schema.org/).
+                    properties:
+                      $ref:
+                        type: string
+                      $schema:
+                        description: JSONSchemaURL represents a schema url.
+                        type: string
+                      additionalItems:
+                        type: boolean
+                      additionalProperties:
+                        type: boolean
+                      allOf:
+                        items: {}
+                        type: array
+                      anyOf:
+                        items: {}
+                        type: array
+                      default:
+                        description: default is a default value for undefined object
+                          fields. Defaulting is a beta feature under the CustomResourceDefaulting
+                          feature gate. Defaulting requires spec.preserveUnknownFields
+                          to be false.
+                        type: Any
+                      definitions:
+                        additionalProperties: {}
+                        description: JSONSchemaDefinitions contains the models explicitly
+                          defined in this spec.
+                        type: object
+                      dependencies:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: JSONSchemaDependencies represent a dependencies
+                          property.
+                        type: object
+                      description:
+                        type: string
+                      enum:
+                        items:
+                          type: Any
+                        type: array
+                      example:
+                        type: Any
+                      exclusiveMaximum:
+                        type: boolean
+                      exclusiveMinimum:
+                        type: boolean
+                      externalDocs:
+                        description: ExternalDocumentation allows referencing an external
+                          resource for extended documentation.
+                        properties:
+                          description:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                      format:
+                        description: "format is an OpenAPI v3 format string. Unknown
+                          formats are ignored. The following formats are validated:
+                          \n - bsonobjectid: a bson object ID, i.e. a 24 characters
+                          hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI
+                          - email: an email address as parsed by Golang net/mail.ParseAddress
+                          - hostname: a valid representation for an Internet host
+                          name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4:
+                          an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6
+                          IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed
+                          by Golang net.ParseCIDR - mac: a MAC address as parsed by
+                          Golang net.ParseMAC - uuid: an UUID that allows uppercase
+                          defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                          - uuid3: an UUID3 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                          - uuid4: an UUID4 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                          - uuid5: an UUID5 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                          - isbn: an ISBN10 or ISBN13 number string like \"0321751043\"
+                          or \"978-0321751041\" - isbn10: an ISBN10 number string
+                          like \"0321751043\" - isbn13: an ISBN13 number string like
+                          \"978-0321751041\" - creditcard: a credit card number defined
+                          by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$
+                          with any non digit characters mixed in - ssn: a U.S. social
+                          security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[-
+                          ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF:
+                          following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                          - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\"
+                          - byte: base64 encoded binary data - password: any kind
+                          of string - date: a date string like \"2006-01-02\" as defined
+                          by full-date in RFC3339 - duration: a duration string like
+                          \"22 ns\" as parsed by Golang time.ParseDuration or compatible
+                          with Scala duration format - datetime: a date time string
+                          like \"2014-12-15T19:30:20.000Z\" as defined by date-time
+                          in RFC3339."
+                        type: string
+                      id:
+                        type: string
+                      items: {}
+                      maxItems:
+                        format: int64
+                        type: integer
+                      maxLength:
+                        format: int64
+                        type: integer
+                      maxProperties:
+                        format: int64
+                        type: integer
+                      maximum:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      minItems:
+                        format: int64
+                        type: integer
+                      minLength:
+                        format: int64
+                        type: integer
+                      minProperties:
+                        format: int64
+                        type: integer
+                      minimum:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      multipleOf:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      not: {}
+                      nullable:
+                        type: boolean
+                      oneOf:
+                        items: {}
+                        type: array
+                      pattern:
+                        type: string
+                      patternProperties:
+                        additionalProperties: {}
+                        type: object
+                      properties:
+                        additionalProperties: {}
+                        type: object
+                      required:
+                        items:
+                          type: string
+                        type: array
+                      title:
+                        type: string
+                      type:
+                        type: string
+                      uniqueItems:
+                        type: boolean
+                      x-descriptors:
+                        description: x-descriptors annotates an object to define additional
+                          display options.
+                        items:
+                          type: string
+                        type: array
+                      x-kubernetes-embedded-resource:
+                        description: x-kubernetes-embedded-resource defines that the
+                          value is an embedded Kubernetes runtime.Object, with TypeMeta
+                          and ObjectMeta. The type must be object. It is allowed to
+                          further restrict the embedded object. kind, apiVersion and
+                          metadata are validated automatically. x-kubernetes-preserve-unknown-fields
+                          is allowed to be true, but does not have to be if the object
+                          is fully specified (up to kind, apiVersion, metadata).
+                        type: boolean
+                      x-kubernetes-int-or-string:
+                        description: "x-kubernetes-int-or-string specifies that this
+                          value is either an integer or a string. If this is true,
+                          an empty type is allowed and type as child of anyOf is permitted
+                          if following one of the following patterns: \n 1) anyOf:
+                          \   - type: integer    - type: string 2) allOf:    - anyOf:
+                          \     - type: integer      - type: string    - ... zero
+                          or more"
+                        type: boolean
+                      x-kubernetes-list-map-keys:
+                        description: "x-kubernetes-list-map-keys annotates an array
+                          with the x-kubernetes-list-type `map` by specifying the
+                          keys used as the index of the map. \n This tag MUST only
+                          be used on lists that have the \"x-kubernetes-list-type\"
+                          extension set to \"map\". Also, the values specified for
+                          this attribute must be a scalar typed field of the child
+                          structure (no nesting is supported). \n The properties specified
+                          must either be required or have a default value, to ensure
+                          those properties are present for all list items."
+                        items:
+                          type: string
+                        type: array
+                      x-kubernetes-list-type:
+                        description: "x-kubernetes-list-type annotates an array to
+                          further describe its topology. This extension must only
+                          be used on lists and may have 3 possible values: \n 1) `atomic`:
+                          the list is treated as a single entity, like a scalar.      Atomic
+                          lists will be entirely replaced when updated. This extension
+                          \     may be used on any type of list (struct, scalar, ...).
+                          2) `set`:      Sets are lists that must not have multiple
+                          items with the same value. Each      value must be a scalar,
+                          an object with x-kubernetes-map-type `atomic` or an      array
+                          with x-kubernetes-list-type `atomic`. 3) `map`:      These
+                          lists are like maps in that their elements have a non-index
+                          key      used to identify them. Order is preserved upon
+                          merge. The map tag      must only be used on a list with
+                          elements of type object. Defaults to atomic for arrays."
+                        type: string
+                      x-kubernetes-map-type:
+                        description: "x-kubernetes-map-type annotates an object to
+                          further describe its topology. This extension must only
+                          be used when type is object and may have 2 possible values:
+                          \n 1) `granular`:      These maps are actual maps (key-value
+                          pairs) and each fields are independent      from each other
+                          (they can each be manipulated by separate actors). This
+                          is      the default behaviour for all maps. 2) `atomic`:
+                          the list is treated as a single entity, like a scalar.      Atomic
+                          maps will be entirely replaced when updated."
+                        type: string
+                      x-kubernetes-preserve-unknown-fields:
+                        description: x-kubernetes-preserve-unknown-fields stops the
+                          API server decoding step from pruning fields which are not
+                          specified in the validation schema. This affects fields
+                          recursively, but switches back to normal pruning behaviour
+                          if nested properties or additionalProperties are specified
+                          in the schema. This can either be true or undefined. False
+                          is forbidden.
+                        type: boolean
+                    type: object
+                type: object
+              type: object
+          type: object
+        status:
+          description: KameletStatus defines the observed state of Kamelet
+          properties:
+            conditions:
+              items:
+                description: KameletCondition describes the state of a resource at
+                  a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of kamelet condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            phase:
+              type: string
+            properties:
+              items:
+                properties:
+                  default:
+                    type: string
+                  name:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
-  subresources:
-    status: {}
-  names:
-    kind: Kamelet
-    listKind: KameletList
-    plural: kamelets
-    singular: kamelet
-    shortNames:
-    - kl
-  additionalPrinterColumns:
-  - name: Phase
-    type: string
-    description: The Kamelet phase
-    JSONPath: .status.phase

--- a/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/builds.camel.apache.org.crd.yaml
+++ b/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/builds.camel.apache.org.crd.yaml
@@ -18,38 +18,44 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: builds.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: builds.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The build phase
-      name: Phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: The time at which the build was created
-      name: Age
-      type: date
-    - JSONPath: .status.startedAt
-      description: The time at which the build was last (re-)started
-      name: Started
-      type: date
-    - JSONPath: .status.duration
-      description: The build last execution duration
-      name: Duration
-      type: string
-    - JSONPath: .status.failure.recovery.attempt
-      description: The number of execution attempts
-      name: Attempts
-      type: integer
+  - JSONPath: .status.phase
+    description: The build phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The time at which the build was created
+    name: Age
+    type: date
+  - JSONPath: .status.startedAt
+    description: The time at which the build was last (re-)started
+    name: Started
+    type: date
+  - JSONPath: .status.duration
+    description: The build last execution duration
+    name: Duration
+    type: string
+  - JSONPath: .status.failure.recovery.attempt
+    description: The number of execution attempts
+    name: Attempts
+    type: integer
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: Build
     listKind: BuildList
     plural: builds
     shortNames:
-      - ikb
+    - ikb
     singular: build
   scope: Namespaced
   subresources:
@@ -147,8 +153,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -185,8 +191,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
@@ -197,8 +203,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - preference
-                                    - weight
+                                  - preference
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -253,8 +259,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -291,14 +297,14 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
                                     type: array
                                 required:
-                                  - nodeSelectorTerms
+                                - nodeSelectorTerms
                                 type: object
                             type: object
                           podAffinity:
@@ -367,8 +373,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -404,7 +410,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -413,8 +419,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -475,8 +481,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -508,7 +514,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -578,8 +584,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -615,7 +621,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -624,8 +630,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -686,8 +692,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -719,7 +725,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -759,7 +765,7 @@ spec:
                                       its key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                               secretKeyRef:
                                 description: Selects a key of a secret.
@@ -779,7 +785,7 @@ spec:
                                       key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                             type: object
                           timeout:
@@ -837,8 +843,8 @@ spec:
                                       version:
                                         type: string
                                     required:
-                                      - artifactId
-                                      - groupId
+                                    - artifactId
+                                    - groupId
                                     type: object
                                   type: array
                                 metadata:
@@ -846,7 +852,7 @@ spec:
                                     type: string
                                   type: object
                               required:
-                                - dependencies
+                              - dependencies
                               type: object
                             type: object
                           dependencies:
@@ -860,8 +866,8 @@ spec:
                                 version:
                                   type: string
                               required:
-                                - artifactId
-                                - groupId
+                              - artifactId
+                              - groupId
                               type: object
                             type: array
                           metadata:
@@ -874,10 +880,10 @@ spec:
                           version:
                             type: string
                         required:
-                          - applicationClass
-                          - dependencies
-                          - provider
-                          - version
+                        - applicationClass
+                        - dependencies
+                        - provider
+                        - version
                         type: object
                       sources:
                         items:
@@ -906,6 +912,16 @@ spec:
                                 that will interpret this source at runtime
                               type: string
                             name:
+                              type: string
+                            property-names:
+                              description: List of property names defined in the source
+                                (e.g. if type is "template")
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: Type defines the kind of source described
+                                by this object
                               type: string
                           type: object
                         type: array
@@ -951,8 +967,8 @@ spec:
                                 are mutually exclusive.
                               type: string
                           required:
-                            - mountPath
-                            - name
+                          - mountPath
+                          - name
                           type: object
                         type: array
                       volumes:
@@ -993,7 +1009,7 @@ spec:
                                     in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             azureDisk:
                               description: AzureDisk represents an Azure Data Disk
@@ -1028,8 +1044,8 @@ spec:
                                     here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
-                                - diskName
-                                - diskURI
+                              - diskName
+                              - diskURI
                               type: object
                             azureFile:
                               description: AzureFile represents an Azure File Service
@@ -1047,8 +1063,8 @@ spec:
                                   description: Share Name
                                   type: string
                               required:
-                                - secretName
-                                - shareName
+                              - secretName
+                              - shareName
                               type: object
                             cephfs:
                               description: CephFS represents a Ceph FS mount on the
@@ -1091,7 +1107,7 @@ spec:
                                     default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - monitors
+                              - monitors
                               type: object
                             cinder:
                               description: 'Cinder represents a cinder volume attached
@@ -1125,7 +1141,7 @@ spec:
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             configMap:
                               description: ConfigMap represents a configMap that should
@@ -1177,8 +1193,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 name:
@@ -1237,7 +1253,7 @@ spec:
                                     values.
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             downwardAPI:
                               description: DownwardAPI represents downward API about
@@ -1276,7 +1292,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                          - fieldPath
+                                        - fieldPath
                                         type: object
                                       mode:
                                         description: 'Optional: mode bits to use on
@@ -1307,8 +1323,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                              - type: integer
-                                              - type: string
+                                            - type: integer
+                                            - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -1318,10 +1334,10 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                          - resource
+                                        - resource
                                         type: object
                                     required:
-                                      - path
+                                    - path
                                     type: object
                                   type: array
                               type: object
@@ -1337,8 +1353,8 @@ spec:
                                   type: string
                                 sizeLimit:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   description: 'Total amount of local storage required
                                     for this EmptyDir volume. The size limit is also
                                     applicable for memory medium. The maximum usage
@@ -1428,7 +1444,7 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             flocker:
                               description: Flocker represents a Flocker volume attached
@@ -1479,7 +1495,7 @@ spec:
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
-                                - pdName
+                              - pdName
                               type: object
                             gitRepo:
                               description: 'GitRepo represents a git repository at
@@ -1504,7 +1520,7 @@ spec:
                                   description: Commit hash for the specified revision.
                                   type: string
                               required:
-                                - repository
+                              - repository
                               type: object
                             glusterfs:
                               description: 'Glusterfs represents a Glusterfs mount
@@ -1525,8 +1541,8 @@ spec:
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
-                                - endpoints
-                                - path
+                              - endpoints
+                              - path
                               type: object
                             hostPath:
                               description: 'HostPath represents a pre-existing file
@@ -1549,7 +1565,7 @@ spec:
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
-                                - path
+                              - path
                               type: object
                             iscsi:
                               description: 'ISCSI represents an ISCSI Disk resource
@@ -1619,9 +1635,9 @@ spec:
                                     than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
-                                - iqn
-                                - lun
-                                - targetPortal
+                              - iqn
+                              - lun
+                              - targetPortal
                               type: object
                             name:
                               description: 'Volume''s name. Must be a DNS_LABEL and
@@ -1645,8 +1661,8 @@ spec:
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
-                                - path
-                                - server
+                              - path
+                              - server
                               type: object
                             persistentVolumeClaim:
                               description: 'PersistentVolumeClaimVolumeSource represents
@@ -1663,7 +1679,7 @@ spec:
                                     VolumeMounts. Default false.
                                   type: boolean
                               required:
-                                - claimName
+                              - claimName
                               type: object
                             photonPersistentDisk:
                               description: PhotonPersistentDisk represents a PhotonController
@@ -1681,7 +1697,7 @@ spec:
                                     persistent disk
                                   type: string
                               required:
-                                - pdID
+                              - pdID
                               type: object
                             portworxVolume:
                               description: PortworxVolume represents a portworx volume
@@ -1702,7 +1718,7 @@ spec:
                                     volume
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             projected:
                               description: Items for all in one resources secrets,
@@ -1769,8 +1785,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -1813,7 +1829,7 @@ spec:
                                                         API version.
                                                       type: string
                                                   required:
-                                                    - fieldPath
+                                                  - fieldPath
                                                   type: object
                                                 mode:
                                                   description: 'Optional: mode bits
@@ -1851,8 +1867,8 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                        - type: integer
-                                                        - type: string
+                                                      - type: integer
+                                                      - type: string
                                                       description: Specifies the output
                                                         format of the exposed resources,
                                                         defaults to "1"
@@ -1863,10 +1879,10 @@ spec:
                                                         to select'
                                                       type: string
                                                   required:
-                                                    - resource
+                                                  - resource
                                                   type: object
                                               required:
-                                                - path
+                                              - path
                                               type: object
                                             type: array
                                         type: object
@@ -1916,8 +1932,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -1964,12 +1980,12 @@ spec:
                                               the token into.
                                             type: string
                                         required:
-                                          - path
+                                        - path
                                         type: object
                                     type: object
                                   type: array
                               required:
-                                - sources
+                              - sources
                               type: object
                             quobyte:
                               description: Quobyte represents a Quobyte mount on the
@@ -2005,8 +2021,8 @@ spec:
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
-                                - registry
-                                - volume
+                              - registry
+                              - volume
                               type: object
                             rbd:
                               description: 'RBD represents a Rados Block Device mount
@@ -2062,8 +2078,8 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - image
-                                - monitors
+                              - image
+                              - monitors
                               type: object
                             scaleIO:
                               description: ScaleIO represents a ScaleIO persistent
@@ -2123,9 +2139,9 @@ spec:
                                     this volume source.
                                   type: string
                               required:
-                                - gateway
-                                - secretRef
-                                - system
+                              - gateway
+                              - secretRef
+                              - system
                               type: object
                             secret:
                               description: 'Secret represents a secret that should
@@ -2177,8 +2193,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 optional:
@@ -2256,10 +2272,10 @@ spec:
                                     vmdk
                                   type: string
                               required:
-                                - volumePath
+                              - volumePath
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                     type: object
@@ -2330,8 +2346,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -2368,8 +2384,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
@@ -2380,8 +2396,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - preference
-                                    - weight
+                                  - preference
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2436,8 +2452,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -2474,14 +2490,14 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
                                     type: array
                                 required:
-                                  - nodeSelectorTerms
+                                - nodeSelectorTerms
                                 type: object
                             type: object
                           podAffinity:
@@ -2550,8 +2566,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -2587,7 +2603,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -2596,8 +2612,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2658,8 +2674,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -2691,7 +2707,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -2761,8 +2777,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -2798,7 +2814,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -2807,8 +2823,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2869,8 +2885,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -2902,7 +2918,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -2958,7 +2974,7 @@ spec:
                                         its key must be defined
                                       type: boolean
                                   required:
-                                    - key
+                                  - key
                                   type: object
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
@@ -2975,7 +2991,7 @@ spec:
                                         the specified API version.
                                       type: string
                                   required:
-                                    - fieldPath
+                                  - fieldPath
                                   type: object
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
@@ -2990,8 +3006,8 @@ spec:
                                       type: string
                                     divisor:
                                       anyOf:
-                                        - type: integer
-                                        - type: string
+                                      - type: integer
+                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -3000,7 +3016,7 @@ spec:
                                       description: 'Required: resource to select'
                                       type: string
                                   required:
-                                    - resource
+                                  - resource
                                   type: object
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
@@ -3021,11 +3037,11 @@ spec:
                                         key must be defined
                                       type: boolean
                                   required:
-                                    - key
+                                  - key
                                   type: object
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                       image:
@@ -3196,8 +3212,8 @@ spec:
                                 are mutually exclusive.
                               type: string
                           required:
-                            - mountPath
-                            - name
+                          - mountPath
+                          - name
                           type: object
                         type: array
                       volumes:
@@ -3238,7 +3254,7 @@ spec:
                                     in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             azureDisk:
                               description: AzureDisk represents an Azure Data Disk
@@ -3273,8 +3289,8 @@ spec:
                                     here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
-                                - diskName
-                                - diskURI
+                              - diskName
+                              - diskURI
                               type: object
                             azureFile:
                               description: AzureFile represents an Azure File Service
@@ -3292,8 +3308,8 @@ spec:
                                   description: Share Name
                                   type: string
                               required:
-                                - secretName
-                                - shareName
+                              - secretName
+                              - shareName
                               type: object
                             cephfs:
                               description: CephFS represents a Ceph FS mount on the
@@ -3336,7 +3352,7 @@ spec:
                                     default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - monitors
+                              - monitors
                               type: object
                             cinder:
                               description: 'Cinder represents a cinder volume attached
@@ -3370,7 +3386,7 @@ spec:
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             configMap:
                               description: ConfigMap represents a configMap that should
@@ -3422,8 +3438,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 name:
@@ -3482,7 +3498,7 @@ spec:
                                     values.
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             downwardAPI:
                               description: DownwardAPI represents downward API about
@@ -3521,7 +3537,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                          - fieldPath
+                                        - fieldPath
                                         type: object
                                       mode:
                                         description: 'Optional: mode bits to use on
@@ -3552,8 +3568,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                              - type: integer
-                                              - type: string
+                                            - type: integer
+                                            - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -3563,10 +3579,10 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                          - resource
+                                        - resource
                                         type: object
                                     required:
-                                      - path
+                                    - path
                                     type: object
                                   type: array
                               type: object
@@ -3582,8 +3598,8 @@ spec:
                                   type: string
                                 sizeLimit:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   description: 'Total amount of local storage required
                                     for this EmptyDir volume. The size limit is also
                                     applicable for memory medium. The maximum usage
@@ -3673,7 +3689,7 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             flocker:
                               description: Flocker represents a Flocker volume attached
@@ -3724,7 +3740,7 @@ spec:
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
-                                - pdName
+                              - pdName
                               type: object
                             gitRepo:
                               description: 'GitRepo represents a git repository at
@@ -3749,7 +3765,7 @@ spec:
                                   description: Commit hash for the specified revision.
                                   type: string
                               required:
-                                - repository
+                              - repository
                               type: object
                             glusterfs:
                               description: 'Glusterfs represents a Glusterfs mount
@@ -3770,8 +3786,8 @@ spec:
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
-                                - endpoints
-                                - path
+                              - endpoints
+                              - path
                               type: object
                             hostPath:
                               description: 'HostPath represents a pre-existing file
@@ -3794,7 +3810,7 @@ spec:
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
-                                - path
+                              - path
                               type: object
                             iscsi:
                               description: 'ISCSI represents an ISCSI Disk resource
@@ -3864,9 +3880,9 @@ spec:
                                     than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
-                                - iqn
-                                - lun
-                                - targetPortal
+                              - iqn
+                              - lun
+                              - targetPortal
                               type: object
                             name:
                               description: 'Volume''s name. Must be a DNS_LABEL and
@@ -3890,8 +3906,8 @@ spec:
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
-                                - path
-                                - server
+                              - path
+                              - server
                               type: object
                             persistentVolumeClaim:
                               description: 'PersistentVolumeClaimVolumeSource represents
@@ -3908,7 +3924,7 @@ spec:
                                     VolumeMounts. Default false.
                                   type: boolean
                               required:
-                                - claimName
+                              - claimName
                               type: object
                             photonPersistentDisk:
                               description: PhotonPersistentDisk represents a PhotonController
@@ -3926,7 +3942,7 @@ spec:
                                     persistent disk
                                   type: string
                               required:
-                                - pdID
+                              - pdID
                               type: object
                             portworxVolume:
                               description: PortworxVolume represents a portworx volume
@@ -3947,7 +3963,7 @@ spec:
                                     volume
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             projected:
                               description: Items for all in one resources secrets,
@@ -4014,8 +4030,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -4058,7 +4074,7 @@ spec:
                                                         API version.
                                                       type: string
                                                   required:
-                                                    - fieldPath
+                                                  - fieldPath
                                                   type: object
                                                 mode:
                                                   description: 'Optional: mode bits
@@ -4096,8 +4112,8 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                        - type: integer
-                                                        - type: string
+                                                      - type: integer
+                                                      - type: string
                                                       description: Specifies the output
                                                         format of the exposed resources,
                                                         defaults to "1"
@@ -4108,10 +4124,10 @@ spec:
                                                         to select'
                                                       type: string
                                                   required:
-                                                    - resource
+                                                  - resource
                                                   type: object
                                               required:
-                                                - path
+                                              - path
                                               type: object
                                             type: array
                                         type: object
@@ -4161,8 +4177,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -4209,12 +4225,12 @@ spec:
                                               the token into.
                                             type: string
                                         required:
-                                          - path
+                                        - path
                                         type: object
                                     type: object
                                   type: array
                               required:
-                                - sources
+                              - sources
                               type: object
                             quobyte:
                               description: Quobyte represents a Quobyte mount on the
@@ -4250,8 +4266,8 @@ spec:
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
-                                - registry
-                                - volume
+                              - registry
+                              - volume
                               type: object
                             rbd:
                               description: 'RBD represents a Rados Block Device mount
@@ -4307,8 +4323,8 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - image
-                                - monitors
+                              - image
+                              - monitors
                               type: object
                             scaleIO:
                               description: ScaleIO represents a ScaleIO persistent
@@ -4368,9 +4384,9 @@ spec:
                                     this volume source.
                                   type: string
                               required:
-                                - gateway
-                                - secretRef
-                                - system
+                              - gateway
+                              - secretRef
+                              - system
                               type: object
                             secret:
                               description: 'Secret represents a secret that should
@@ -4422,8 +4438,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 optional:
@@ -4501,10 +4517,10 @@ spec:
                                     vmdk
                                   type: string
                               required:
-                                - volumePath
+                              - volumePath
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                       workingDir:
@@ -4529,7 +4545,7 @@ spec:
                   target:
                     type: string
                 required:
-                  - id
+                - id
                 type: object
               type: array
             baseImage:
@@ -4562,8 +4578,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             digest:
@@ -4590,16 +4606,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             image:
               type: string
@@ -4615,6 +4631,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/camelcatalogs.camel.apache.org.crd.yaml
+++ b/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/camelcatalogs.camel.apache.org.crd.yaml
@@ -1,4 +1,3 @@
-
 # ---------------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -19,26 +18,32 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: camelcatalogs.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: camelcatalogs.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .spec.runtime.version
-      description: The Camel K Runtime version
-      name: Runtime Version
-      type: string
-    - JSONPath: .spec.runtime.provider
-      description: The Camel K Runtime provider
-      name: Runtime Provider
-      type: string
+  - JSONPath: .spec.runtime.version
+    description: The Camel K Runtime version
+    name: Runtime Version
+    type: string
+  - JSONPath: .spec.runtime.provider
+    description: The Camel K Runtime provider
+    name: Runtime Provider
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: CamelCatalog
     listKind: CamelCatalogList
     plural: camelcatalogs
     shortNames:
-      - cc
+    - cc
     singular: camelcatalog
   scope: Namespaced
   subresources:
@@ -87,8 +92,8 @@ spec:
                               groupId:
                                 type: string
                             required:
-                              - artifactId
-                              - groupId
+                            - artifactId
+                            - groupId
                             type: object
                           type: array
                         groupId:
@@ -96,8 +101,8 @@ spec:
                         version:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   exclusions:
@@ -109,8 +114,8 @@ spec:
                         groupId:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   groupId:
@@ -134,16 +139,16 @@ spec:
                         passive:
                           type: boolean
                       required:
-                        - http
-                        - id
-                        - passive
+                      - http
+                      - id
+                      - passive
                       type: object
                     type: array
                   version:
                     type: string
                 required:
-                  - artifactId
-                  - groupId
+                - artifactId
+                - groupId
                 type: object
               type: object
             loaders:
@@ -163,8 +168,8 @@ spec:
                         version:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   groupId:
@@ -176,8 +181,8 @@ spec:
                   version:
                     type: string
                 required:
-                  - artifactId
-                  - groupId
+                - artifactId
+                - groupId
                 type: object
               type: object
             runtime:
@@ -200,8 +205,8 @@ spec:
                             version:
                               type: string
                           required:
-                            - artifactId
-                            - groupId
+                          - artifactId
+                          - groupId
                           type: object
                         type: array
                       metadata:
@@ -209,7 +214,7 @@ spec:
                           type: string
                         type: object
                     required:
-                      - dependencies
+                    - dependencies
                     type: object
                   type: object
                 dependencies:
@@ -223,8 +228,8 @@ spec:
                       version:
                         type: string
                     required:
-                      - artifactId
-                      - groupId
+                    - artifactId
+                    - groupId
                     type: object
                   type: array
                 metadata:
@@ -237,15 +242,15 @@ spec:
                 version:
                   type: string
               required:
-                - applicationClass
-                - dependencies
-                - provider
-                - version
+              - applicationClass
+              - dependencies
+              - provider
+              - version
               type: object
           required:
-            - artifacts
-            - loaders
-            - runtime
+          - artifacts
+          - loaders
+          - runtime
           type: object
         status:
           description: CamelCatalogStatus defines the observed state of CamelCatalog
@@ -253,6 +258,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/integrationkits.camel.apache.org.crd.yaml
+++ b/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/integrationkits.camel.apache.org.crd.yaml
@@ -18,30 +18,36 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrationkits.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrationkits.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration kit phase
-      name: Phase
-      type: string
-    - JSONPath: .metadata.labels.camel\.apache\.org\/kit\.type
-      description: The integration kit type
-      name: Type
-      type: string
-    - JSONPath: .status.image
-      description: The integration kit image
-      name: Image
-      type: string
+  - JSONPath: .status.phase
+    description: The integration kit phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.labels.camel\.apache\.org\/kit\.type
+    description: The integration kit type
+    name: Type
+    type: string
+  - JSONPath: .status.image
+    description: The integration kit image
+    name: Image
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: IntegrationKit
     listKind: IntegrationKitList
     plural: integrationkits
     shortNames:
-      - ik
+    - ik
     singular: integrationkit
   scope: Namespaced
   subresources:
@@ -74,8 +80,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -97,9 +103,9 @@ spec:
                 description: A TraitSpec contains the configuration of a trait
                 properties:
                   configuration:
-                    additionalProperties:
-                      type: string
                     type: object
+                required:
+                - configuration
                 type: object
               type: object
           type: object
@@ -119,7 +125,7 @@ spec:
                   target:
                     type: string
                 required:
-                  - id
+                - id
                 type: object
               type: array
             baseImage:
@@ -152,8 +158,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             digest:
@@ -174,16 +180,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             image:
               type: string
@@ -203,6 +209,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/integrationplatforms.camel.apache.org.crd.yaml
+++ b/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/integrationplatforms.camel.apache.org.crd.yaml
@@ -18,22 +18,28 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrationplatforms.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrationplatforms.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration platform phase
-      name: Phase
-      type: string
+  - JSONPath: .status.phase
+    description: The integration platform phase
+    name: Phase
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: IntegrationPlatform
     listKind: IntegrationPlatformList
     plural: integrationplatforms
     shortNames:
-      - ip
+    - ip
     singular: integrationplatform
   scope: Namespaced
   subresources:
@@ -95,7 +101,7 @@ spec:
                                 must be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                         secretKeyRef:
                           description: Selects a key of a secret.
@@ -113,7 +119,7 @@ spec:
                                 be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                       type: object
                     timeout:
@@ -164,8 +170,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             profile:
@@ -175,20 +181,15 @@ spec:
             resources:
               description: IntegrationPlatformResourcesSpec contains platform related
                 resources
-              properties:
-                kits:
-                  items:
-                    type: string
-                  type: array
               type: object
             traits:
               additionalProperties:
                 description: A TraitSpec contains the configuration of a trait
                 properties:
                   configuration:
-                    additionalProperties:
-                      type: string
                     type: object
+                required:
+                - configuration
                 type: object
               type: object
           type: object
@@ -232,7 +233,7 @@ spec:
                                 must be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                         secretKeyRef:
                           description: Selects a key of a secret.
@@ -250,7 +251,7 @@ spec:
                                 be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                       type: object
                     timeout:
@@ -320,8 +321,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             configuration:
@@ -333,8 +334,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             phase:
@@ -347,20 +348,15 @@ spec:
             resources:
               description: IntegrationPlatformResourcesSpec contains platform related
                 resources
-              properties:
-                kits:
-                  items:
-                    type: string
-                  type: array
               type: object
             traits:
               additionalProperties:
                 description: A TraitSpec contains the configuration of a trait
                 properties:
                   configuration:
-                    additionalProperties:
-                      type: string
                     type: object
+                required:
+                - configuration
                 type: object
               type: object
             version:
@@ -369,6 +365,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/integrations.camel.apache.org.crd.yaml
+++ b/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/integrations.camel.apache.org.crd.yaml
@@ -18,30 +18,36 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrations.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrations.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration phase
-      name: Phase
-      type: string
-    - JSONPath: .status.kit
-      description: The integration kit
-      name: Kit
-      type: string
-    - JSONPath: .status.replicas
-      description: The number of pods
-      name: Replicas
-      type: integer
+  - JSONPath: .status.phase
+    description: The integration phase
+    name: Phase
+    type: string
+  - JSONPath: .status.kit
+    description: The integration kit
+    name: Kit
+    type: string
+  - JSONPath: .status.replicas
+    description: The number of pods
+    name: Replicas
+    type: integer
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: Integration
     listKind: IntegrationList
     plural: integrations
     shortNames:
-      - it
+    - it
     singular: integration
   scope: Namespaced
   subresources:
@@ -78,8 +84,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -153,6 +159,16 @@ spec:
                     type: string
                   name:
                     type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
                 type: object
               type: array
             traits:
@@ -162,7 +178,7 @@ spec:
                   configuration:
                     type: object
                 required:
-                  - configuration
+                - configuration
                 type: object
               type: object
           type: object
@@ -201,8 +217,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             configuration:
@@ -214,8 +230,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -240,16 +256,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             generatedResources:
               items:
@@ -299,6 +315,16 @@ spec:
                     type: string
                   name:
                     type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
                 type: object
               type: array
             image:
@@ -330,6 +356,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/kameletbindings.camel.apache.org.crd.yaml
+++ b/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/kameletbindings.camel.apache.org.crd.yaml
@@ -18,28 +18,298 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kameletbindings.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: kameletbindings.camel.apache.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The Kamelet Binding phase
+    name: Phase
+    type: string
   group: camel.apache.org
+  names:
+    categories:
+    - kamel
+    - camel
+    kind: KameletBinding
+    listKind: KameletBindingList
+    plural: kameletbindings
+    shortNames:
+    - klb
+    singular: kameletbinding
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KameletBinding is the Schema for the kamelets binding API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KameletBindingSpec --
+          properties:
+            integration:
+              description: Integration is an optional integration used to specify
+                custom parameters
+              properties:
+                configuration:
+                  items:
+                    description: ConfigurationSpec --
+                    properties:
+                      type:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - type
+                    - value
+                    type: object
+                  type: array
+                dependencies:
+                  items:
+                    type: string
+                  type: array
+                flows:
+                  items:
+                    type: object
+                  type: array
+                kit:
+                  type: string
+                profile:
+                  description: TraitProfile represents lists of traits that are enabled
+                    for the specific installation/integration
+                  type: string
+                replicas:
+                  format: int32
+                  type: integer
+                repositories:
+                  items:
+                    type: string
+                  type: array
+                resources:
+                  items:
+                    description: ResourceSpec --
+                    properties:
+                      compression:
+                        type: boolean
+                      content:
+                        type: string
+                      contentKey:
+                        type: string
+                      contentRef:
+                        type: string
+                      mountPath:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        description: ResourceType --
+                        type: string
+                    type: object
+                  type: array
+                serviceAccountName:
+                  type: string
+                sources:
+                  items:
+                    description: SourceSpec --
+                    properties:
+                      compression:
+                        type: boolean
+                      content:
+                        type: string
+                      contentKey:
+                        type: string
+                      contentRef:
+                        type: string
+                      interceptors:
+                        description: Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader
+                          uses to pre/post process sources
+                        items:
+                          type: string
+                        type: array
+                      language:
+                        description: Language --
+                        type: string
+                      loader:
+                        description: Loader is an optional id of the org.apache.camel.k.RoutesLoader
+                          that will interpret this source at runtime
+                        type: string
+                      name:
+                        type: string
+                      property-names:
+                        description: List of property names defined in the source
+                          (e.g. if type is "template")
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: Type defines the kind of source described by
+                          this object
+                        type: string
+                    type: object
+                  type: array
+                traits:
+                  additionalProperties:
+                    description: A TraitSpec contains the configuration of a trait
+                    properties:
+                      configuration:
+                        type: object
+                    required:
+                    - configuration
+                    type: object
+                  type: object
+              type: object
+            sink:
+              description: Sink is the destination of the integration defined by this
+                binding
+              properties:
+                properties:
+                  description: Properties are a key value representation of endpoint
+                    properties
+                  type: object
+                ref:
+                  description: Ref can be used to declare a Kubernetes resource as
+                    source/sink endpoint
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    blockOwnerDeletion:
+                      description: If true, AND if the owner has the "foregroundDeletion"
+                        finalizer, then the owner cannot be deleted from the key-value
+                        store until this reference is removed. Defaults to false.
+                        To set this field, a user needs "delete" permission of the
+                        owner, otherwise 422 (Unprocessable Entity) will be returned.
+                      type: boolean
+                    controller:
+                      description: If true, this reference points to the managing
+                        controller.
+                      type: boolean
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
+                  type: object
+                uri:
+                  description: URI can alternatively be used to specify the (Camel)
+                    endpoint explicitly
+                  type: string
+              type: object
+            source:
+              description: Source is the starting point of the integration defined
+                by this binding
+              properties:
+                properties:
+                  description: Properties are a key value representation of endpoint
+                    properties
+                  type: object
+                ref:
+                  description: Ref can be used to declare a Kubernetes resource as
+                    source/sink endpoint
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    blockOwnerDeletion:
+                      description: If true, AND if the owner has the "foregroundDeletion"
+                        finalizer, then the owner cannot be deleted from the key-value
+                        store until this reference is removed. Defaults to false.
+                        To set this field, a user needs "delete" permission of the
+                        owner, otherwise 422 (Unprocessable Entity) will be returned.
+                      type: boolean
+                    controller:
+                      description: If true, this reference points to the managing
+                        controller.
+                      type: boolean
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
+                  type: object
+                uri:
+                  description: URI can alternatively be used to specify the (Camel)
+                    endpoint explicitly
+                  type: string
+              type: object
+          type: object
+        status:
+          description: KameletBindingStatus --
+          properties:
+            conditions:
+              description: Conditions --
+              items:
+                description: KameletBindingCondition describes the state of a resource
+                  at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of kameletBinding condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            phase:
+              description: Phase --
+              type: string
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
-  subresources:
-    status: {}
-  names:
-    kind: KameletBinding
-    listKind: KameletBindingList
-    plural: kameletbindings
-    singular: kameletbinding
-    shortNames:
-    - klb
-  additionalPrinterColumns:
-  - name: Phase
-    type: string
-    description: The KameletBinding phase
-    JSONPath: .status.phase

--- a/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/kamelets.camel.apache.org.crd.yaml
+++ b/deploy/olm-catalog/camel-k-dev/1.2.0-snapshot/kamelets.camel.apache.org.crd.yaml
@@ -18,28 +18,594 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kamelets.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: kamelets.camel.apache.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The Kamelet phase
+    name: Phase
+    type: string
   group: camel.apache.org
+  names:
+    categories:
+    - kamel
+    - camel
+    kind: Kamelet
+    listKind: KameletList
+    plural: kamelets
+    shortNames:
+    - kl
+    singular: kamelet
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Kamelet is the Schema for the kamelets API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KameletSpec defines the desired state of Kamelet
+          properties:
+            authorization:
+              description: AuthorizationSpec is TODO (oauth information)
+              type: object
+            definition:
+              description: JSONSchemaProps is a JSON-Schema following Specification
+                Draft 4 (http://json-schema.org/).
+              properties:
+                $ref:
+                  type: string
+                $schema:
+                  description: JSONSchemaURL represents a schema url.
+                  type: string
+                additionalItems:
+                  type: boolean
+                additionalProperties:
+                  type: boolean
+                allOf:
+                  items: {}
+                  type: array
+                anyOf:
+                  items: {}
+                  type: array
+                default:
+                  description: default is a default value for undefined object fields.
+                    Defaulting is a beta feature under the CustomResourceDefaulting
+                    feature gate. Defaulting requires spec.preserveUnknownFields to
+                    be false.
+                  type: Any
+                definitions:
+                  additionalProperties: {}
+                  description: JSONSchemaDefinitions contains the models explicitly
+                    defined in this spec.
+                  type: object
+                dependencies:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: JSONSchemaDependencies represent a dependencies property.
+                  type: object
+                description:
+                  type: string
+                enum:
+                  items:
+                    type: Any
+                  type: array
+                example:
+                  type: Any
+                exclusiveMaximum:
+                  type: boolean
+                exclusiveMinimum:
+                  type: boolean
+                externalDocs:
+                  description: ExternalDocumentation allows referencing an external
+                    resource for extended documentation.
+                  properties:
+                    description:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                format:
+                  description: "format is an OpenAPI v3 format string. Unknown formats
+                    are ignored. The following formats are validated: \n - bsonobjectid:
+                    a bson object ID, i.e. a 24 characters hex string - uri: an URI
+                    as parsed by Golang net/url.ParseRequestURI - email: an email
+                    address as parsed by Golang net/mail.ParseAddress - hostname:
+                    a valid representation for an Internet host name, as defined by
+                    RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed
+                    by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP
+                    - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC
+                    address as parsed by Golang net.ParseMAC - uuid: an UUID that
+                    allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                    - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                    - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                    - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                    - isbn: an ISBN10 or ISBN13 number string like \"0321751043\"
+                    or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\"
+                    - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard:
+                    a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$
+                    with any non digit characters mixed in - ssn: a U.S. social security
+                    number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$
+                    - hexcolor: an hexadecimal color code like \"#FFFFFF: following
+                    the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB
+                    color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded
+                    binary data - password: any kind of string - date: a date string
+                    like \"2006-01-02\" as defined by full-date in RFC3339 - duration:
+                    a duration string like \"22 ns\" as parsed by Golang time.ParseDuration
+                    or compatible with Scala duration format - datetime: a date time
+                    string like \"2014-12-15T19:30:20.000Z\" as defined by date-time
+                    in RFC3339."
+                  type: string
+                id:
+                  type: string
+                items: {}
+                maxItems:
+                  format: int64
+                  type: integer
+                maxLength:
+                  format: int64
+                  type: integer
+                maxProperties:
+                  format: int64
+                  type: integer
+                maximum:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                minItems:
+                  format: int64
+                  type: integer
+                minLength:
+                  format: int64
+                  type: integer
+                minProperties:
+                  format: int64
+                  type: integer
+                minimum:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                multipleOf:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                not: {}
+                nullable:
+                  type: boolean
+                oneOf:
+                  items: {}
+                  type: array
+                pattern:
+                  type: string
+                patternProperties:
+                  additionalProperties: {}
+                  type: object
+                properties:
+                  additionalProperties: {}
+                  type: object
+                required:
+                  items:
+                    type: string
+                  type: array
+                title:
+                  type: string
+                type:
+                  type: string
+                uniqueItems:
+                  type: boolean
+                x-descriptors:
+                  description: x-descriptors annotates an object to define additional
+                    display options.
+                  items:
+                    type: string
+                  type: array
+                x-kubernetes-embedded-resource:
+                  description: x-kubernetes-embedded-resource defines that the value
+                    is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta.
+                    The type must be object. It is allowed to further restrict the
+                    embedded object. kind, apiVersion and metadata are validated automatically.
+                    x-kubernetes-preserve-unknown-fields is allowed to be true, but
+                    does not have to be if the object is fully specified (up to kind,
+                    apiVersion, metadata).
+                  type: boolean
+                x-kubernetes-int-or-string:
+                  description: "x-kubernetes-int-or-string specifies that this value
+                    is either an integer or a string. If this is true, an empty type
+                    is allowed and type as child of anyOf is permitted if following
+                    one of the following patterns: \n 1) anyOf:    - type: integer
+                    \   - type: string 2) allOf:    - anyOf:      - type: integer
+                    \     - type: string    - ... zero or more"
+                  type: boolean
+                x-kubernetes-list-map-keys:
+                  description: "x-kubernetes-list-map-keys annotates an array with
+                    the x-kubernetes-list-type `map` by specifying the keys used as
+                    the index of the map. \n This tag MUST only be used on lists that
+                    have the \"x-kubernetes-list-type\" extension set to \"map\".
+                    Also, the values specified for this attribute must be a scalar
+                    typed field of the child structure (no nesting is supported).
+                    \n The properties specified must either be required or have a
+                    default value, to ensure those properties are present for all
+                    list items."
+                  items:
+                    type: string
+                  type: array
+                x-kubernetes-list-type:
+                  description: "x-kubernetes-list-type annotates an array to further
+                    describe its topology. This extension must only be used on lists
+                    and may have 3 possible values: \n 1) `atomic`: the list is treated
+                    as a single entity, like a scalar.      Atomic lists will be entirely
+                    replaced when updated. This extension      may be used on any
+                    type of list (struct, scalar, ...). 2) `set`:      Sets are lists
+                    that must not have multiple items with the same value. Each      value
+                    must be a scalar, an object with x-kubernetes-map-type `atomic`
+                    or an      array with x-kubernetes-list-type `atomic`. 3) `map`:
+                    \     These lists are like maps in that their elements have a
+                    non-index key      used to identify them. Order is preserved upon
+                    merge. The map tag      must only be used on a list with elements
+                    of type object. Defaults to atomic for arrays."
+                  type: string
+                x-kubernetes-map-type:
+                  description: "x-kubernetes-map-type annotates an object to further
+                    describe its topology. This extension must only be used when type
+                    is object and may have 2 possible values: \n 1) `granular`:      These
+                    maps are actual maps (key-value pairs) and each fields are independent
+                    \     from each other (they can each be manipulated by separate
+                    actors). This is      the default behaviour for all maps. 2) `atomic`:
+                    the list is treated as a single entity, like a scalar.      Atomic
+                    maps will be entirely replaced when updated."
+                  type: string
+                x-kubernetes-preserve-unknown-fields:
+                  description: x-kubernetes-preserve-unknown-fields stops the API
+                    server decoding step from pruning fields which are not specified
+                    in the validation schema. This affects fields recursively, but
+                    switches back to normal pruning behaviour if nested properties
+                    or additionalProperties are specified in the schema. This can
+                    either be true or undefined. False is forbidden.
+                  type: boolean
+              type: object
+            dependencies:
+              items:
+                type: string
+              type: array
+            flow:
+              type: object
+            sources:
+              items:
+                description: SourceSpec --
+                properties:
+                  compression:
+                    type: boolean
+                  content:
+                    type: string
+                  contentKey:
+                    type: string
+                  contentRef:
+                    type: string
+                  interceptors:
+                    description: Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader
+                      uses to pre/post process sources
+                    items:
+                      type: string
+                    type: array
+                  language:
+                    description: Language --
+                    type: string
+                  loader:
+                    description: Loader is an optional id of the org.apache.camel.k.RoutesLoader
+                      that will interpret this source at runtime
+                    type: string
+                  name:
+                    type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
+                type: object
+              type: array
+            types:
+              additionalProperties:
+                properties:
+                  mediaType:
+                    type: string
+                  schema:
+                    description: JSONSchemaProps is a JSON-Schema following Specification
+                      Draft 4 (http://json-schema.org/).
+                    properties:
+                      $ref:
+                        type: string
+                      $schema:
+                        description: JSONSchemaURL represents a schema url.
+                        type: string
+                      additionalItems:
+                        type: boolean
+                      additionalProperties:
+                        type: boolean
+                      allOf:
+                        items: {}
+                        type: array
+                      anyOf:
+                        items: {}
+                        type: array
+                      default:
+                        description: default is a default value for undefined object
+                          fields. Defaulting is a beta feature under the CustomResourceDefaulting
+                          feature gate. Defaulting requires spec.preserveUnknownFields
+                          to be false.
+                        type: Any
+                      definitions:
+                        additionalProperties: {}
+                        description: JSONSchemaDefinitions contains the models explicitly
+                          defined in this spec.
+                        type: object
+                      dependencies:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: JSONSchemaDependencies represent a dependencies
+                          property.
+                        type: object
+                      description:
+                        type: string
+                      enum:
+                        items:
+                          type: Any
+                        type: array
+                      example:
+                        type: Any
+                      exclusiveMaximum:
+                        type: boolean
+                      exclusiveMinimum:
+                        type: boolean
+                      externalDocs:
+                        description: ExternalDocumentation allows referencing an external
+                          resource for extended documentation.
+                        properties:
+                          description:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                      format:
+                        description: "format is an OpenAPI v3 format string. Unknown
+                          formats are ignored. The following formats are validated:
+                          \n - bsonobjectid: a bson object ID, i.e. a 24 characters
+                          hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI
+                          - email: an email address as parsed by Golang net/mail.ParseAddress
+                          - hostname: a valid representation for an Internet host
+                          name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4:
+                          an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6
+                          IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed
+                          by Golang net.ParseCIDR - mac: a MAC address as parsed by
+                          Golang net.ParseMAC - uuid: an UUID that allows uppercase
+                          defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                          - uuid3: an UUID3 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                          - uuid4: an UUID4 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                          - uuid5: an UUID5 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                          - isbn: an ISBN10 or ISBN13 number string like \"0321751043\"
+                          or \"978-0321751041\" - isbn10: an ISBN10 number string
+                          like \"0321751043\" - isbn13: an ISBN13 number string like
+                          \"978-0321751041\" - creditcard: a credit card number defined
+                          by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$
+                          with any non digit characters mixed in - ssn: a U.S. social
+                          security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[-
+                          ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF:
+                          following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                          - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\"
+                          - byte: base64 encoded binary data - password: any kind
+                          of string - date: a date string like \"2006-01-02\" as defined
+                          by full-date in RFC3339 - duration: a duration string like
+                          \"22 ns\" as parsed by Golang time.ParseDuration or compatible
+                          with Scala duration format - datetime: a date time string
+                          like \"2014-12-15T19:30:20.000Z\" as defined by date-time
+                          in RFC3339."
+                        type: string
+                      id:
+                        type: string
+                      items: {}
+                      maxItems:
+                        format: int64
+                        type: integer
+                      maxLength:
+                        format: int64
+                        type: integer
+                      maxProperties:
+                        format: int64
+                        type: integer
+                      maximum:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      minItems:
+                        format: int64
+                        type: integer
+                      minLength:
+                        format: int64
+                        type: integer
+                      minProperties:
+                        format: int64
+                        type: integer
+                      minimum:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      multipleOf:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      not: {}
+                      nullable:
+                        type: boolean
+                      oneOf:
+                        items: {}
+                        type: array
+                      pattern:
+                        type: string
+                      patternProperties:
+                        additionalProperties: {}
+                        type: object
+                      properties:
+                        additionalProperties: {}
+                        type: object
+                      required:
+                        items:
+                          type: string
+                        type: array
+                      title:
+                        type: string
+                      type:
+                        type: string
+                      uniqueItems:
+                        type: boolean
+                      x-descriptors:
+                        description: x-descriptors annotates an object to define additional
+                          display options.
+                        items:
+                          type: string
+                        type: array
+                      x-kubernetes-embedded-resource:
+                        description: x-kubernetes-embedded-resource defines that the
+                          value is an embedded Kubernetes runtime.Object, with TypeMeta
+                          and ObjectMeta. The type must be object. It is allowed to
+                          further restrict the embedded object. kind, apiVersion and
+                          metadata are validated automatically. x-kubernetes-preserve-unknown-fields
+                          is allowed to be true, but does not have to be if the object
+                          is fully specified (up to kind, apiVersion, metadata).
+                        type: boolean
+                      x-kubernetes-int-or-string:
+                        description: "x-kubernetes-int-or-string specifies that this
+                          value is either an integer or a string. If this is true,
+                          an empty type is allowed and type as child of anyOf is permitted
+                          if following one of the following patterns: \n 1) anyOf:
+                          \   - type: integer    - type: string 2) allOf:    - anyOf:
+                          \     - type: integer      - type: string    - ... zero
+                          or more"
+                        type: boolean
+                      x-kubernetes-list-map-keys:
+                        description: "x-kubernetes-list-map-keys annotates an array
+                          with the x-kubernetes-list-type `map` by specifying the
+                          keys used as the index of the map. \n This tag MUST only
+                          be used on lists that have the \"x-kubernetes-list-type\"
+                          extension set to \"map\". Also, the values specified for
+                          this attribute must be a scalar typed field of the child
+                          structure (no nesting is supported). \n The properties specified
+                          must either be required or have a default value, to ensure
+                          those properties are present for all list items."
+                        items:
+                          type: string
+                        type: array
+                      x-kubernetes-list-type:
+                        description: "x-kubernetes-list-type annotates an array to
+                          further describe its topology. This extension must only
+                          be used on lists and may have 3 possible values: \n 1) `atomic`:
+                          the list is treated as a single entity, like a scalar.      Atomic
+                          lists will be entirely replaced when updated. This extension
+                          \     may be used on any type of list (struct, scalar, ...).
+                          2) `set`:      Sets are lists that must not have multiple
+                          items with the same value. Each      value must be a scalar,
+                          an object with x-kubernetes-map-type `atomic` or an      array
+                          with x-kubernetes-list-type `atomic`. 3) `map`:      These
+                          lists are like maps in that their elements have a non-index
+                          key      used to identify them. Order is preserved upon
+                          merge. The map tag      must only be used on a list with
+                          elements of type object. Defaults to atomic for arrays."
+                        type: string
+                      x-kubernetes-map-type:
+                        description: "x-kubernetes-map-type annotates an object to
+                          further describe its topology. This extension must only
+                          be used when type is object and may have 2 possible values:
+                          \n 1) `granular`:      These maps are actual maps (key-value
+                          pairs) and each fields are independent      from each other
+                          (they can each be manipulated by separate actors). This
+                          is      the default behaviour for all maps. 2) `atomic`:
+                          the list is treated as a single entity, like a scalar.      Atomic
+                          maps will be entirely replaced when updated."
+                        type: string
+                      x-kubernetes-preserve-unknown-fields:
+                        description: x-kubernetes-preserve-unknown-fields stops the
+                          API server decoding step from pruning fields which are not
+                          specified in the validation schema. This affects fields
+                          recursively, but switches back to normal pruning behaviour
+                          if nested properties or additionalProperties are specified
+                          in the schema. This can either be true or undefined. False
+                          is forbidden.
+                        type: boolean
+                    type: object
+                type: object
+              type: object
+          type: object
+        status:
+          description: KameletStatus defines the observed state of Kamelet
+          properties:
+            conditions:
+              items:
+                description: KameletCondition describes the state of a resource at
+                  a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of kamelet condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            phase:
+              type: string
+            properties:
+              items:
+                properties:
+                  default:
+                    type: string
+                  name:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
-  subresources:
-    status: {}
-  names:
-    kind: Kamelet
-    listKind: KameletList
-    plural: kamelets
-    singular: kamelet
-    shortNames:
-    - kl
-  additionalPrinterColumns:
-  - name: Phase
-    type: string
-    description: The Kamelet phase
-    JSONPath: .status.phase

--- a/helm/camel-k/crds/crd-build.yaml
+++ b/helm/camel-k/crds/crd-build.yaml
@@ -18,42 +18,45 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: builds.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: builds.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The build phase
-      name: Phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: The time at which the build was created
-      name: Age
-      type: date
-    - JSONPath: .status.startedAt
-      description: The time at which the build was last (re-)started
-      name: Started
-      type: date
-    - JSONPath: .status.duration
-      description: The build last execution duration
-      name: Duration
-      type: string
-    - JSONPath: .status.failure.recovery.attempt
-      description: The number of execution attempts
-      name: Attempts
-      type: integer
+  - JSONPath: .status.phase
+    description: The build phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The time at which the build was created
+    name: Age
+    type: date
+  - JSONPath: .status.startedAt
+    description: The time at which the build was last (re-)started
+    name: Started
+    type: date
+  - JSONPath: .status.duration
+    description: The build last execution duration
+    name: Duration
+    type: string
+  - JSONPath: .status.failure.recovery.attempt
+    description: The number of execution attempts
+    name: Attempts
+    type: integer
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: Build
     listKind: BuildList
     plural: builds
     shortNames:
-      - ikb
+    - ikb
     singular: build
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     status: {}
@@ -150,8 +153,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -188,8 +191,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
@@ -200,8 +203,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - preference
-                                    - weight
+                                  - preference
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -256,8 +259,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -294,14 +297,14 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
                                     type: array
                                 required:
-                                  - nodeSelectorTerms
+                                - nodeSelectorTerms
                                 type: object
                             type: object
                           podAffinity:
@@ -370,8 +373,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -407,7 +410,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -416,8 +419,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -478,8 +481,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -511,7 +514,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -581,8 +584,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -618,7 +621,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -627,8 +630,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -689,8 +692,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -722,7 +725,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -762,7 +765,7 @@ spec:
                                       its key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                               secretKeyRef:
                                 description: Selects a key of a secret.
@@ -782,7 +785,7 @@ spec:
                                       key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                             type: object
                           timeout:
@@ -840,8 +843,8 @@ spec:
                                       version:
                                         type: string
                                     required:
-                                      - artifactId
-                                      - groupId
+                                    - artifactId
+                                    - groupId
                                     type: object
                                   type: array
                                 metadata:
@@ -849,7 +852,7 @@ spec:
                                     type: string
                                   type: object
                               required:
-                                - dependencies
+                              - dependencies
                               type: object
                             type: object
                           dependencies:
@@ -863,8 +866,8 @@ spec:
                                 version:
                                   type: string
                               required:
-                                - artifactId
-                                - groupId
+                              - artifactId
+                              - groupId
                               type: object
                             type: array
                           metadata:
@@ -877,10 +880,10 @@ spec:
                           version:
                             type: string
                         required:
-                          - applicationClass
-                          - dependencies
-                          - provider
-                          - version
+                        - applicationClass
+                        - dependencies
+                        - provider
+                        - version
                         type: object
                       sources:
                         items:
@@ -909,6 +912,16 @@ spec:
                                 that will interpret this source at runtime
                               type: string
                             name:
+                              type: string
+                            property-names:
+                              description: List of property names defined in the source
+                                (e.g. if type is "template")
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: Type defines the kind of source described
+                                by this object
                               type: string
                           type: object
                         type: array
@@ -954,8 +967,8 @@ spec:
                                 are mutually exclusive.
                               type: string
                           required:
-                            - mountPath
-                            - name
+                          - mountPath
+                          - name
                           type: object
                         type: array
                       volumes:
@@ -996,7 +1009,7 @@ spec:
                                     in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             azureDisk:
                               description: AzureDisk represents an Azure Data Disk
@@ -1031,8 +1044,8 @@ spec:
                                     here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
-                                - diskName
-                                - diskURI
+                              - diskName
+                              - diskURI
                               type: object
                             azureFile:
                               description: AzureFile represents an Azure File Service
@@ -1050,8 +1063,8 @@ spec:
                                   description: Share Name
                                   type: string
                               required:
-                                - secretName
-                                - shareName
+                              - secretName
+                              - shareName
                               type: object
                             cephfs:
                               description: CephFS represents a Ceph FS mount on the
@@ -1094,7 +1107,7 @@ spec:
                                     default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - monitors
+                              - monitors
                               type: object
                             cinder:
                               description: 'Cinder represents a cinder volume attached
@@ -1128,7 +1141,7 @@ spec:
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             configMap:
                               description: ConfigMap represents a configMap that should
@@ -1180,8 +1193,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 name:
@@ -1240,7 +1253,7 @@ spec:
                                     values.
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             downwardAPI:
                               description: DownwardAPI represents downward API about
@@ -1279,7 +1292,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                          - fieldPath
+                                        - fieldPath
                                         type: object
                                       mode:
                                         description: 'Optional: mode bits to use on
@@ -1310,8 +1323,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                              - type: integer
-                                              - type: string
+                                            - type: integer
+                                            - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -1321,10 +1334,10 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                          - resource
+                                        - resource
                                         type: object
                                     required:
-                                      - path
+                                    - path
                                     type: object
                                   type: array
                               type: object
@@ -1340,8 +1353,8 @@ spec:
                                   type: string
                                 sizeLimit:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   description: 'Total amount of local storage required
                                     for this EmptyDir volume. The size limit is also
                                     applicable for memory medium. The maximum usage
@@ -1431,7 +1444,7 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             flocker:
                               description: Flocker represents a Flocker volume attached
@@ -1482,7 +1495,7 @@ spec:
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
-                                - pdName
+                              - pdName
                               type: object
                             gitRepo:
                               description: 'GitRepo represents a git repository at
@@ -1507,7 +1520,7 @@ spec:
                                   description: Commit hash for the specified revision.
                                   type: string
                               required:
-                                - repository
+                              - repository
                               type: object
                             glusterfs:
                               description: 'Glusterfs represents a Glusterfs mount
@@ -1528,8 +1541,8 @@ spec:
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
-                                - endpoints
-                                - path
+                              - endpoints
+                              - path
                               type: object
                             hostPath:
                               description: 'HostPath represents a pre-existing file
@@ -1552,7 +1565,7 @@ spec:
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
-                                - path
+                              - path
                               type: object
                             iscsi:
                               description: 'ISCSI represents an ISCSI Disk resource
@@ -1622,9 +1635,9 @@ spec:
                                     than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
-                                - iqn
-                                - lun
-                                - targetPortal
+                              - iqn
+                              - lun
+                              - targetPortal
                               type: object
                             name:
                               description: 'Volume''s name. Must be a DNS_LABEL and
@@ -1648,8 +1661,8 @@ spec:
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
-                                - path
-                                - server
+                              - path
+                              - server
                               type: object
                             persistentVolumeClaim:
                               description: 'PersistentVolumeClaimVolumeSource represents
@@ -1666,7 +1679,7 @@ spec:
                                     VolumeMounts. Default false.
                                   type: boolean
                               required:
-                                - claimName
+                              - claimName
                               type: object
                             photonPersistentDisk:
                               description: PhotonPersistentDisk represents a PhotonController
@@ -1684,7 +1697,7 @@ spec:
                                     persistent disk
                                   type: string
                               required:
-                                - pdID
+                              - pdID
                               type: object
                             portworxVolume:
                               description: PortworxVolume represents a portworx volume
@@ -1705,7 +1718,7 @@ spec:
                                     volume
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             projected:
                               description: Items for all in one resources secrets,
@@ -1772,8 +1785,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -1816,7 +1829,7 @@ spec:
                                                         API version.
                                                       type: string
                                                   required:
-                                                    - fieldPath
+                                                  - fieldPath
                                                   type: object
                                                 mode:
                                                   description: 'Optional: mode bits
@@ -1854,8 +1867,8 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                        - type: integer
-                                                        - type: string
+                                                      - type: integer
+                                                      - type: string
                                                       description: Specifies the output
                                                         format of the exposed resources,
                                                         defaults to "1"
@@ -1866,10 +1879,10 @@ spec:
                                                         to select'
                                                       type: string
                                                   required:
-                                                    - resource
+                                                  - resource
                                                   type: object
                                               required:
-                                                - path
+                                              - path
                                               type: object
                                             type: array
                                         type: object
@@ -1919,8 +1932,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -1967,12 +1980,12 @@ spec:
                                               the token into.
                                             type: string
                                         required:
-                                          - path
+                                        - path
                                         type: object
                                     type: object
                                   type: array
                               required:
-                                - sources
+                              - sources
                               type: object
                             quobyte:
                               description: Quobyte represents a Quobyte mount on the
@@ -2008,8 +2021,8 @@ spec:
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
-                                - registry
-                                - volume
+                              - registry
+                              - volume
                               type: object
                             rbd:
                               description: 'RBD represents a Rados Block Device mount
@@ -2065,8 +2078,8 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - image
-                                - monitors
+                              - image
+                              - monitors
                               type: object
                             scaleIO:
                               description: ScaleIO represents a ScaleIO persistent
@@ -2126,9 +2139,9 @@ spec:
                                     this volume source.
                                   type: string
                               required:
-                                - gateway
-                                - secretRef
-                                - system
+                              - gateway
+                              - secretRef
+                              - system
                               type: object
                             secret:
                               description: 'Secret represents a secret that should
@@ -2180,8 +2193,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 optional:
@@ -2259,10 +2272,10 @@ spec:
                                     vmdk
                                   type: string
                               required:
-                                - volumePath
+                              - volumePath
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                     type: object
@@ -2333,8 +2346,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -2371,8 +2384,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
@@ -2383,8 +2396,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - preference
-                                    - weight
+                                  - preference
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2439,8 +2452,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchFields:
@@ -2477,14 +2490,14 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                       type: object
                                     type: array
                                 required:
-                                  - nodeSelectorTerms
+                                - nodeSelectorTerms
                                 type: object
                             type: object
                           podAffinity:
@@ -2553,8 +2566,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -2590,7 +2603,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -2599,8 +2612,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2661,8 +2674,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -2694,7 +2707,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -2764,8 +2777,8 @@ spec:
                                                       type: string
                                                     type: array
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                             matchLabels:
@@ -2801,7 +2814,7 @@ spec:
                                             topologyKey is not allowed.
                                           type: string
                                       required:
-                                        - topologyKey
+                                      - topologyKey
                                       type: object
                                     weight:
                                       description: weight associated with matching
@@ -2810,8 +2823,8 @@ spec:
                                       format: int32
                                       type: integer
                                   required:
-                                    - podAffinityTerm
-                                    - weight
+                                  - podAffinityTerm
+                                  - weight
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
@@ -2872,8 +2885,8 @@ spec:
                                                   type: string
                                                 type: array
                                             required:
-                                              - key
-                                              - operator
+                                            - key
+                                            - operator
                                             type: object
                                           type: array
                                         matchLabels:
@@ -2905,7 +2918,7 @@ spec:
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
-                                    - topologyKey
+                                  - topologyKey
                                   type: object
                                 type: array
                             type: object
@@ -2961,7 +2974,7 @@ spec:
                                         its key must be defined
                                       type: boolean
                                   required:
-                                    - key
+                                  - key
                                   type: object
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
@@ -2978,7 +2991,7 @@ spec:
                                         the specified API version.
                                       type: string
                                   required:
-                                    - fieldPath
+                                  - fieldPath
                                   type: object
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
@@ -2993,8 +3006,8 @@ spec:
                                       type: string
                                     divisor:
                                       anyOf:
-                                        - type: integer
-                                        - type: string
+                                      - type: integer
+                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -3003,7 +3016,7 @@ spec:
                                       description: 'Required: resource to select'
                                       type: string
                                   required:
-                                    - resource
+                                  - resource
                                   type: object
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
@@ -3024,11 +3037,11 @@ spec:
                                         key must be defined
                                       type: boolean
                                   required:
-                                    - key
+                                  - key
                                   type: object
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                       image:
@@ -3199,8 +3212,8 @@ spec:
                                 are mutually exclusive.
                               type: string
                           required:
-                            - mountPath
-                            - name
+                          - mountPath
+                          - name
                           type: object
                         type: array
                       volumes:
@@ -3241,7 +3254,7 @@ spec:
                                     in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             azureDisk:
                               description: AzureDisk represents an Azure Data Disk
@@ -3276,8 +3289,8 @@ spec:
                                     here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
-                                - diskName
-                                - diskURI
+                              - diskName
+                              - diskURI
                               type: object
                             azureFile:
                               description: AzureFile represents an Azure File Service
@@ -3295,8 +3308,8 @@ spec:
                                   description: Share Name
                                   type: string
                               required:
-                                - secretName
-                                - shareName
+                              - secretName
+                              - shareName
                               type: object
                             cephfs:
                               description: CephFS represents a Ceph FS mount on the
@@ -3339,7 +3352,7 @@ spec:
                                     default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - monitors
+                              - monitors
                               type: object
                             cinder:
                               description: 'Cinder represents a cinder volume attached
@@ -3373,7 +3386,7 @@ spec:
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             configMap:
                               description: ConfigMap represents a configMap that should
@@ -3425,8 +3438,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 name:
@@ -3485,7 +3498,7 @@ spec:
                                     values.
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             downwardAPI:
                               description: DownwardAPI represents downward API about
@@ -3524,7 +3537,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                          - fieldPath
+                                        - fieldPath
                                         type: object
                                       mode:
                                         description: 'Optional: mode bits to use on
@@ -3555,8 +3568,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                              - type: integer
-                                              - type: string
+                                            - type: integer
+                                            - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -3566,10 +3579,10 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                          - resource
+                                        - resource
                                         type: object
                                     required:
-                                      - path
+                                    - path
                                     type: object
                                   type: array
                               type: object
@@ -3585,8 +3598,8 @@ spec:
                                   type: string
                                 sizeLimit:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   description: 'Total amount of local storage required
                                     for this EmptyDir volume. The size limit is also
                                     applicable for memory medium. The maximum usage
@@ -3676,7 +3689,7 @@ spec:
                                       type: string
                                   type: object
                               required:
-                                - driver
+                              - driver
                               type: object
                             flocker:
                               description: Flocker represents a Flocker volume attached
@@ -3727,7 +3740,7 @@ spec:
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
-                                - pdName
+                              - pdName
                               type: object
                             gitRepo:
                               description: 'GitRepo represents a git repository at
@@ -3752,7 +3765,7 @@ spec:
                                   description: Commit hash for the specified revision.
                                   type: string
                               required:
-                                - repository
+                              - repository
                               type: object
                             glusterfs:
                               description: 'Glusterfs represents a Glusterfs mount
@@ -3773,8 +3786,8 @@ spec:
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
-                                - endpoints
-                                - path
+                              - endpoints
+                              - path
                               type: object
                             hostPath:
                               description: 'HostPath represents a pre-existing file
@@ -3797,7 +3810,7 @@ spec:
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
-                                - path
+                              - path
                               type: object
                             iscsi:
                               description: 'ISCSI represents an ISCSI Disk resource
@@ -3867,9 +3880,9 @@ spec:
                                     than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
-                                - iqn
-                                - lun
-                                - targetPortal
+                              - iqn
+                              - lun
+                              - targetPortal
                               type: object
                             name:
                               description: 'Volume''s name. Must be a DNS_LABEL and
@@ -3893,8 +3906,8 @@ spec:
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
-                                - path
-                                - server
+                              - path
+                              - server
                               type: object
                             persistentVolumeClaim:
                               description: 'PersistentVolumeClaimVolumeSource represents
@@ -3911,7 +3924,7 @@ spec:
                                     VolumeMounts. Default false.
                                   type: boolean
                               required:
-                                - claimName
+                              - claimName
                               type: object
                             photonPersistentDisk:
                               description: PhotonPersistentDisk represents a PhotonController
@@ -3929,7 +3942,7 @@ spec:
                                     persistent disk
                                   type: string
                               required:
-                                - pdID
+                              - pdID
                               type: object
                             portworxVolume:
                               description: PortworxVolume represents a portworx volume
@@ -3950,7 +3963,7 @@ spec:
                                     volume
                                   type: string
                               required:
-                                - volumeID
+                              - volumeID
                               type: object
                             projected:
                               description: Items for all in one resources secrets,
@@ -4017,8 +4030,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -4061,7 +4074,7 @@ spec:
                                                         API version.
                                                       type: string
                                                   required:
-                                                    - fieldPath
+                                                  - fieldPath
                                                   type: object
                                                 mode:
                                                   description: 'Optional: mode bits
@@ -4099,8 +4112,8 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                        - type: integer
-                                                        - type: string
+                                                      - type: integer
+                                                      - type: string
                                                       description: Specifies the output
                                                         format of the exposed resources,
                                                         defaults to "1"
@@ -4111,10 +4124,10 @@ spec:
                                                         to select'
                                                       type: string
                                                   required:
-                                                    - resource
+                                                  - resource
                                                   type: object
                                               required:
-                                                - path
+                                              - path
                                               type: object
                                             type: array
                                         type: object
@@ -4164,8 +4177,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - key
+                                              - path
                                               type: object
                                             type: array
                                           name:
@@ -4212,12 +4225,12 @@ spec:
                                               the token into.
                                             type: string
                                         required:
-                                          - path
+                                        - path
                                         type: object
                                     type: object
                                   type: array
                               required:
-                                - sources
+                              - sources
                               type: object
                             quobyte:
                               description: Quobyte represents a Quobyte mount on the
@@ -4253,8 +4266,8 @@ spec:
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
-                                - registry
-                                - volume
+                              - registry
+                              - volume
                               type: object
                             rbd:
                               description: 'RBD represents a Rados Block Device mount
@@ -4310,8 +4323,8 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
-                                - image
-                                - monitors
+                              - image
+                              - monitors
                               type: object
                             scaleIO:
                               description: ScaleIO represents a ScaleIO persistent
@@ -4371,9 +4384,9 @@ spec:
                                     this volume source.
                                   type: string
                               required:
-                                - gateway
-                                - secretRef
-                                - system
+                              - gateway
+                              - secretRef
+                              - system
                               type: object
                             secret:
                               description: 'Secret represents a secret that should
@@ -4425,8 +4438,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                      - key
-                                      - path
+                                    - key
+                                    - path
                                     type: object
                                   type: array
                                 optional:
@@ -4504,10 +4517,10 @@ spec:
                                     vmdk
                                   type: string
                               required:
-                                - volumePath
+                              - volumePath
                               type: object
                           required:
-                            - name
+                          - name
                           type: object
                         type: array
                       workingDir:
@@ -4532,7 +4545,7 @@ spec:
                   target:
                     type: string
                 required:
-                  - id
+                - id
                 type: object
               type: array
             baseImage:
@@ -4565,8 +4578,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             digest:
@@ -4593,16 +4606,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             image:
               type: string
@@ -4618,6 +4631,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/helm/camel-k/crds/crd-camel-catalog.yaml
+++ b/helm/camel-k/crds/crd-camel-catalog.yaml
@@ -1,4 +1,3 @@
-
 # ---------------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -19,30 +18,33 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: camelcatalogs.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: camelcatalogs.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .spec.runtime.version
-      description: The Camel K Runtime version
-      name: Runtime Version
-      type: string
-    - JSONPath: .spec.runtime.provider
-      description: The Camel K Runtime provider
-      name: Runtime Provider
-      type: string
+  - JSONPath: .spec.runtime.version
+    description: The Camel K Runtime version
+    name: Runtime Version
+    type: string
+  - JSONPath: .spec.runtime.provider
+    description: The Camel K Runtime provider
+    name: Runtime Provider
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: CamelCatalog
     listKind: CamelCatalogList
     plural: camelcatalogs
     shortNames:
-      - cc
+    - cc
     singular: camelcatalog
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     status: {}
@@ -90,8 +92,8 @@ spec:
                               groupId:
                                 type: string
                             required:
-                              - artifactId
-                              - groupId
+                            - artifactId
+                            - groupId
                             type: object
                           type: array
                         groupId:
@@ -99,8 +101,8 @@ spec:
                         version:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   exclusions:
@@ -112,8 +114,8 @@ spec:
                         groupId:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   groupId:
@@ -137,16 +139,16 @@ spec:
                         passive:
                           type: boolean
                       required:
-                        - http
-                        - id
-                        - passive
+                      - http
+                      - id
+                      - passive
                       type: object
                     type: array
                   version:
                     type: string
                 required:
-                  - artifactId
-                  - groupId
+                - artifactId
+                - groupId
                 type: object
               type: object
             loaders:
@@ -166,8 +168,8 @@ spec:
                         version:
                           type: string
                       required:
-                        - artifactId
-                        - groupId
+                      - artifactId
+                      - groupId
                       type: object
                     type: array
                   groupId:
@@ -179,8 +181,8 @@ spec:
                   version:
                     type: string
                 required:
-                  - artifactId
-                  - groupId
+                - artifactId
+                - groupId
                 type: object
               type: object
             runtime:
@@ -203,8 +205,8 @@ spec:
                             version:
                               type: string
                           required:
-                            - artifactId
-                            - groupId
+                          - artifactId
+                          - groupId
                           type: object
                         type: array
                       metadata:
@@ -212,7 +214,7 @@ spec:
                           type: string
                         type: object
                     required:
-                      - dependencies
+                    - dependencies
                     type: object
                   type: object
                 dependencies:
@@ -226,8 +228,8 @@ spec:
                       version:
                         type: string
                     required:
-                      - artifactId
-                      - groupId
+                    - artifactId
+                    - groupId
                     type: object
                   type: array
                 metadata:
@@ -240,15 +242,15 @@ spec:
                 version:
                   type: string
               required:
-                - applicationClass
-                - dependencies
-                - provider
-                - version
+              - applicationClass
+              - dependencies
+              - provider
+              - version
               type: object
           required:
-            - artifacts
-            - loaders
-            - runtime
+          - artifacts
+          - loaders
+          - runtime
           type: object
         status:
           description: CamelCatalogStatus defines the observed state of CamelCatalog
@@ -256,6 +258,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/helm/camel-k/crds/crd-integration-kit.yaml
+++ b/helm/camel-k/crds/crd-integration-kit.yaml
@@ -18,34 +18,37 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrationkits.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrationkits.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration kit phase
-      name: Phase
-      type: string
-    - JSONPath: .metadata.labels.camel\.apache\.org\/kit\.type
-      description: The integration kit type
-      name: Type
-      type: string
-    - JSONPath: .status.image
-      description: The integration kit image
-      name: Image
-      type: string
+  - JSONPath: .status.phase
+    description: The integration kit phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.labels.camel\.apache\.org\/kit\.type
+    description: The integration kit type
+    name: Type
+    type: string
+  - JSONPath: .status.image
+    description: The integration kit image
+    name: Image
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: IntegrationKit
     listKind: IntegrationKitList
     plural: integrationkits
     shortNames:
-      - ik
+    - ik
     singular: integrationkit
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     status: {}
@@ -77,8 +80,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -100,9 +103,9 @@ spec:
                 description: A TraitSpec contains the configuration of a trait
                 properties:
                   configuration:
-                    additionalProperties:
-                      type: string
                     type: object
+                required:
+                - configuration
                 type: object
               type: object
           type: object
@@ -122,7 +125,7 @@ spec:
                   target:
                     type: string
                 required:
-                  - id
+                - id
                 type: object
               type: array
             baseImage:
@@ -155,8 +158,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             digest:
@@ -177,16 +180,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             image:
               type: string
@@ -206,6 +209,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -18,26 +18,29 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrationplatforms.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrationplatforms.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration platform phase
-      name: Phase
-      type: string
+  - JSONPath: .status.phase
+    description: The integration platform phase
+    name: Phase
+    type: string
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: IntegrationPlatform
     listKind: IntegrationPlatformList
     plural: integrationplatforms
     shortNames:
-      - ip
+    - ip
     singular: integrationplatform
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     status: {}
@@ -98,7 +101,7 @@ spec:
                                 must be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                         secretKeyRef:
                           description: Selects a key of a secret.
@@ -116,7 +119,7 @@ spec:
                                 be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                       type: object
                     timeout:
@@ -167,8 +170,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             profile:
@@ -178,20 +181,15 @@ spec:
             resources:
               description: IntegrationPlatformResourcesSpec contains platform related
                 resources
-              properties:
-                kits:
-                  items:
-                    type: string
-                  type: array
               type: object
             traits:
               additionalProperties:
                 description: A TraitSpec contains the configuration of a trait
                 properties:
                   configuration:
-                    additionalProperties:
-                      type: string
                     type: object
+                required:
+                - configuration
                 type: object
               type: object
           type: object
@@ -235,7 +233,7 @@ spec:
                                 must be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                         secretKeyRef:
                           description: Selects a key of a secret.
@@ -253,7 +251,7 @@ spec:
                                 be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                       type: object
                     timeout:
@@ -323,8 +321,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             configuration:
@@ -336,8 +334,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             phase:
@@ -350,20 +348,15 @@ spec:
             resources:
               description: IntegrationPlatformResourcesSpec contains platform related
                 resources
-              properties:
-                kits:
-                  items:
-                    type: string
-                  type: array
               type: object
             traits:
               additionalProperties:
                 description: A TraitSpec contains the configuration of a trait
                 properties:
                   configuration:
-                    additionalProperties:
-                      type: string
                     type: object
+                required:
+                - configuration
                 type: object
               type: object
             version:
@@ -372,6 +365,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -18,34 +18,37 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: integrations.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: integrations.camel.apache.org
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.phase
-      description: The integration phase
-      name: Phase
-      type: string
-    - JSONPath: .status.kit
-      description: The integration kit
-      name: Kit
-      type: string
-    - JSONPath: .status.replicas
-      description: The number of pods
-      name: Replicas
-      type: integer
+  - JSONPath: .status.phase
+    description: The integration phase
+    name: Phase
+    type: string
+  - JSONPath: .status.kit
+    description: The integration kit
+    name: Kit
+    type: string
+  - JSONPath: .status.replicas
+    description: The number of pods
+    name: Replicas
+    type: integer
   group: camel.apache.org
   names:
+    categories:
+    - kamel
+    - camel
     kind: Integration
     listKind: IntegrationList
     plural: integrations
     shortNames:
-      - it
+    - it
     singular: integration
-    categories:
-      - kamel
-      - camel
   scope: Namespaced
   subresources:
     scale:
@@ -81,8 +84,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -156,6 +159,16 @@ spec:
                     type: string
                   name:
                     type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
                 type: object
               type: array
             traits:
@@ -165,7 +178,7 @@ spec:
                   configuration:
                     type: object
                 required:
-                  - configuration
+                - configuration
                 type: object
               type: object
           type: object
@@ -204,8 +217,8 @@ spec:
                     description: Type of integration condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             configuration:
@@ -217,8 +230,8 @@ spec:
                   value:
                     type: string
                 required:
-                  - type
-                  - value
+                - type
+                - value
                 type: object
               type: array
             dependencies:
@@ -243,16 +256,16 @@ spec:
                       format: date-time
                       type: string
                   required:
-                    - attempt
-                    - attemptMax
+                  - attempt
+                  - attemptMax
                   type: object
                 time:
                   format: date-time
                   type: string
               required:
-                - reason
-                - recovery
-                - time
+              - reason
+              - recovery
+              - time
               type: object
             generatedResources:
               items:
@@ -302,6 +315,16 @@ spec:
                     type: string
                   name:
                     type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
                 type: object
               type: array
             image:
@@ -333,6 +356,6 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -18,28 +18,298 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kameletbindings.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: kameletbindings.camel.apache.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The Kamelet Binding phase
+    name: Phase
+    type: string
   group: camel.apache.org
+  names:
+    categories:
+    - kamel
+    - camel
+    kind: KameletBinding
+    listKind: KameletBindingList
+    plural: kameletbindings
+    shortNames:
+    - klb
+    singular: kameletbinding
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KameletBinding is the Schema for the kamelets binding API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KameletBindingSpec --
+          properties:
+            integration:
+              description: Integration is an optional integration used to specify
+                custom parameters
+              properties:
+                configuration:
+                  items:
+                    description: ConfigurationSpec --
+                    properties:
+                      type:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - type
+                    - value
+                    type: object
+                  type: array
+                dependencies:
+                  items:
+                    type: string
+                  type: array
+                flows:
+                  items:
+                    type: object
+                  type: array
+                kit:
+                  type: string
+                profile:
+                  description: TraitProfile represents lists of traits that are enabled
+                    for the specific installation/integration
+                  type: string
+                replicas:
+                  format: int32
+                  type: integer
+                repositories:
+                  items:
+                    type: string
+                  type: array
+                resources:
+                  items:
+                    description: ResourceSpec --
+                    properties:
+                      compression:
+                        type: boolean
+                      content:
+                        type: string
+                      contentKey:
+                        type: string
+                      contentRef:
+                        type: string
+                      mountPath:
+                        type: string
+                      name:
+                        type: string
+                      type:
+                        description: ResourceType --
+                        type: string
+                    type: object
+                  type: array
+                serviceAccountName:
+                  type: string
+                sources:
+                  items:
+                    description: SourceSpec --
+                    properties:
+                      compression:
+                        type: boolean
+                      content:
+                        type: string
+                      contentKey:
+                        type: string
+                      contentRef:
+                        type: string
+                      interceptors:
+                        description: Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader
+                          uses to pre/post process sources
+                        items:
+                          type: string
+                        type: array
+                      language:
+                        description: Language --
+                        type: string
+                      loader:
+                        description: Loader is an optional id of the org.apache.camel.k.RoutesLoader
+                          that will interpret this source at runtime
+                        type: string
+                      name:
+                        type: string
+                      property-names:
+                        description: List of property names defined in the source
+                          (e.g. if type is "template")
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: Type defines the kind of source described by
+                          this object
+                        type: string
+                    type: object
+                  type: array
+                traits:
+                  additionalProperties:
+                    description: A TraitSpec contains the configuration of a trait
+                    properties:
+                      configuration:
+                        type: object
+                    required:
+                    - configuration
+                    type: object
+                  type: object
+              type: object
+            sink:
+              description: Sink is the destination of the integration defined by this
+                binding
+              properties:
+                properties:
+                  description: Properties are a key value representation of endpoint
+                    properties
+                  type: object
+                ref:
+                  description: Ref can be used to declare a Kubernetes resource as
+                    source/sink endpoint
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    blockOwnerDeletion:
+                      description: If true, AND if the owner has the "foregroundDeletion"
+                        finalizer, then the owner cannot be deleted from the key-value
+                        store until this reference is removed. Defaults to false.
+                        To set this field, a user needs "delete" permission of the
+                        owner, otherwise 422 (Unprocessable Entity) will be returned.
+                      type: boolean
+                    controller:
+                      description: If true, this reference points to the managing
+                        controller.
+                      type: boolean
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
+                  type: object
+                uri:
+                  description: URI can alternatively be used to specify the (Camel)
+                    endpoint explicitly
+                  type: string
+              type: object
+            source:
+              description: Source is the starting point of the integration defined
+                by this binding
+              properties:
+                properties:
+                  description: Properties are a key value representation of endpoint
+                    properties
+                  type: object
+                ref:
+                  description: Ref can be used to declare a Kubernetes resource as
+                    source/sink endpoint
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    blockOwnerDeletion:
+                      description: If true, AND if the owner has the "foregroundDeletion"
+                        finalizer, then the owner cannot be deleted from the key-value
+                        store until this reference is removed. Defaults to false.
+                        To set this field, a user needs "delete" permission of the
+                        owner, otherwise 422 (Unprocessable Entity) will be returned.
+                      type: boolean
+                    controller:
+                      description: If true, this reference points to the managing
+                        controller.
+                      type: boolean
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
+                  type: object
+                uri:
+                  description: URI can alternatively be used to specify the (Camel)
+                    endpoint explicitly
+                  type: string
+              type: object
+          type: object
+        status:
+          description: KameletBindingStatus --
+          properties:
+            conditions:
+              description: Conditions --
+              items:
+                description: KameletBindingCondition describes the state of a resource
+                  at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of kameletBinding condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            phase:
+              description: Phase --
+              type: string
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
-  subresources:
-    status: {}
-  names:
-    kind: KameletBinding
-    listKind: KameletBindingList
-    plural: kameletbindings
-    singular: kameletbinding
-    shortNames:
-    - klb
-  additionalPrinterColumns:
-  - name: Phase
-    type: string
-    description: The KameletBinding phase
-    JSONPath: .status.phase

--- a/helm/camel-k/crds/crd-kamelet.yaml
+++ b/helm/camel-k/crds/crd-kamelet.yaml
@@ -18,28 +18,594 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kamelets.camel.apache.org
   labels:
     app: "camel-k"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.0.0-20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: kamelets.camel.apache.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The Kamelet phase
+    name: Phase
+    type: string
   group: camel.apache.org
+  names:
+    categories:
+    - kamel
+    - camel
+    kind: Kamelet
+    listKind: KameletList
+    plural: kamelets
+    shortNames:
+    - kl
+    singular: kamelet
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Kamelet is the Schema for the kamelets API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KameletSpec defines the desired state of Kamelet
+          properties:
+            authorization:
+              description: AuthorizationSpec is TODO (oauth information)
+              type: object
+            definition:
+              description: JSONSchemaProps is a JSON-Schema following Specification
+                Draft 4 (http://json-schema.org/).
+              properties:
+                $ref:
+                  type: string
+                $schema:
+                  description: JSONSchemaURL represents a schema url.
+                  type: string
+                additionalItems:
+                  type: boolean
+                additionalProperties:
+                  type: boolean
+                allOf:
+                  items: {}
+                  type: array
+                anyOf:
+                  items: {}
+                  type: array
+                default:
+                  description: default is a default value for undefined object fields.
+                    Defaulting is a beta feature under the CustomResourceDefaulting
+                    feature gate. Defaulting requires spec.preserveUnknownFields to
+                    be false.
+                  type: Any
+                definitions:
+                  additionalProperties: {}
+                  description: JSONSchemaDefinitions contains the models explicitly
+                    defined in this spec.
+                  type: object
+                dependencies:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: JSONSchemaDependencies represent a dependencies property.
+                  type: object
+                description:
+                  type: string
+                enum:
+                  items:
+                    type: Any
+                  type: array
+                example:
+                  type: Any
+                exclusiveMaximum:
+                  type: boolean
+                exclusiveMinimum:
+                  type: boolean
+                externalDocs:
+                  description: ExternalDocumentation allows referencing an external
+                    resource for extended documentation.
+                  properties:
+                    description:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                format:
+                  description: "format is an OpenAPI v3 format string. Unknown formats
+                    are ignored. The following formats are validated: \n - bsonobjectid:
+                    a bson object ID, i.e. a 24 characters hex string - uri: an URI
+                    as parsed by Golang net/url.ParseRequestURI - email: an email
+                    address as parsed by Golang net/mail.ParseAddress - hostname:
+                    a valid representation for an Internet host name, as defined by
+                    RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed
+                    by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP
+                    - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC
+                    address as parsed by Golang net.ParseMAC - uuid: an UUID that
+                    allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                    - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                    - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                    - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                    - isbn: an ISBN10 or ISBN13 number string like \"0321751043\"
+                    or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\"
+                    - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard:
+                    a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$
+                    with any non digit characters mixed in - ssn: a U.S. social security
+                    number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$
+                    - hexcolor: an hexadecimal color code like \"#FFFFFF: following
+                    the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB
+                    color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded
+                    binary data - password: any kind of string - date: a date string
+                    like \"2006-01-02\" as defined by full-date in RFC3339 - duration:
+                    a duration string like \"22 ns\" as parsed by Golang time.ParseDuration
+                    or compatible with Scala duration format - datetime: a date time
+                    string like \"2014-12-15T19:30:20.000Z\" as defined by date-time
+                    in RFC3339."
+                  type: string
+                id:
+                  type: string
+                items: {}
+                maxItems:
+                  format: int64
+                  type: integer
+                maxLength:
+                  format: int64
+                  type: integer
+                maxProperties:
+                  format: int64
+                  type: integer
+                maximum:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                minItems:
+                  format: int64
+                  type: integer
+                minLength:
+                  format: int64
+                  type: integer
+                minProperties:
+                  format: int64
+                  type: integer
+                minimum:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                multipleOf:
+                  description: A Number represents a JSON number literal.
+                  type: string
+                not: {}
+                nullable:
+                  type: boolean
+                oneOf:
+                  items: {}
+                  type: array
+                pattern:
+                  type: string
+                patternProperties:
+                  additionalProperties: {}
+                  type: object
+                properties:
+                  additionalProperties: {}
+                  type: object
+                required:
+                  items:
+                    type: string
+                  type: array
+                title:
+                  type: string
+                type:
+                  type: string
+                uniqueItems:
+                  type: boolean
+                x-descriptors:
+                  description: x-descriptors annotates an object to define additional
+                    display options.
+                  items:
+                    type: string
+                  type: array
+                x-kubernetes-embedded-resource:
+                  description: x-kubernetes-embedded-resource defines that the value
+                    is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta.
+                    The type must be object. It is allowed to further restrict the
+                    embedded object. kind, apiVersion and metadata are validated automatically.
+                    x-kubernetes-preserve-unknown-fields is allowed to be true, but
+                    does not have to be if the object is fully specified (up to kind,
+                    apiVersion, metadata).
+                  type: boolean
+                x-kubernetes-int-or-string:
+                  description: "x-kubernetes-int-or-string specifies that this value
+                    is either an integer or a string. If this is true, an empty type
+                    is allowed and type as child of anyOf is permitted if following
+                    one of the following patterns: \n 1) anyOf:    - type: integer
+                    \   - type: string 2) allOf:    - anyOf:      - type: integer
+                    \     - type: string    - ... zero or more"
+                  type: boolean
+                x-kubernetes-list-map-keys:
+                  description: "x-kubernetes-list-map-keys annotates an array with
+                    the x-kubernetes-list-type `map` by specifying the keys used as
+                    the index of the map. \n This tag MUST only be used on lists that
+                    have the \"x-kubernetes-list-type\" extension set to \"map\".
+                    Also, the values specified for this attribute must be a scalar
+                    typed field of the child structure (no nesting is supported).
+                    \n The properties specified must either be required or have a
+                    default value, to ensure those properties are present for all
+                    list items."
+                  items:
+                    type: string
+                  type: array
+                x-kubernetes-list-type:
+                  description: "x-kubernetes-list-type annotates an array to further
+                    describe its topology. This extension must only be used on lists
+                    and may have 3 possible values: \n 1) `atomic`: the list is treated
+                    as a single entity, like a scalar.      Atomic lists will be entirely
+                    replaced when updated. This extension      may be used on any
+                    type of list (struct, scalar, ...). 2) `set`:      Sets are lists
+                    that must not have multiple items with the same value. Each      value
+                    must be a scalar, an object with x-kubernetes-map-type `atomic`
+                    or an      array with x-kubernetes-list-type `atomic`. 3) `map`:
+                    \     These lists are like maps in that their elements have a
+                    non-index key      used to identify them. Order is preserved upon
+                    merge. The map tag      must only be used on a list with elements
+                    of type object. Defaults to atomic for arrays."
+                  type: string
+                x-kubernetes-map-type:
+                  description: "x-kubernetes-map-type annotates an object to further
+                    describe its topology. This extension must only be used when type
+                    is object and may have 2 possible values: \n 1) `granular`:      These
+                    maps are actual maps (key-value pairs) and each fields are independent
+                    \     from each other (they can each be manipulated by separate
+                    actors). This is      the default behaviour for all maps. 2) `atomic`:
+                    the list is treated as a single entity, like a scalar.      Atomic
+                    maps will be entirely replaced when updated."
+                  type: string
+                x-kubernetes-preserve-unknown-fields:
+                  description: x-kubernetes-preserve-unknown-fields stops the API
+                    server decoding step from pruning fields which are not specified
+                    in the validation schema. This affects fields recursively, but
+                    switches back to normal pruning behaviour if nested properties
+                    or additionalProperties are specified in the schema. This can
+                    either be true or undefined. False is forbidden.
+                  type: boolean
+              type: object
+            dependencies:
+              items:
+                type: string
+              type: array
+            flow:
+              type: object
+            sources:
+              items:
+                description: SourceSpec --
+                properties:
+                  compression:
+                    type: boolean
+                  content:
+                    type: string
+                  contentKey:
+                    type: string
+                  contentRef:
+                    type: string
+                  interceptors:
+                    description: Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader
+                      uses to pre/post process sources
+                    items:
+                      type: string
+                    type: array
+                  language:
+                    description: Language --
+                    type: string
+                  loader:
+                    description: Loader is an optional id of the org.apache.camel.k.RoutesLoader
+                      that will interpret this source at runtime
+                    type: string
+                  name:
+                    type: string
+                  property-names:
+                    description: List of property names defined in the source (e.g.
+                      if type is "template")
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    description: Type defines the kind of source described by this
+                      object
+                    type: string
+                type: object
+              type: array
+            types:
+              additionalProperties:
+                properties:
+                  mediaType:
+                    type: string
+                  schema:
+                    description: JSONSchemaProps is a JSON-Schema following Specification
+                      Draft 4 (http://json-schema.org/).
+                    properties:
+                      $ref:
+                        type: string
+                      $schema:
+                        description: JSONSchemaURL represents a schema url.
+                        type: string
+                      additionalItems:
+                        type: boolean
+                      additionalProperties:
+                        type: boolean
+                      allOf:
+                        items: {}
+                        type: array
+                      anyOf:
+                        items: {}
+                        type: array
+                      default:
+                        description: default is a default value for undefined object
+                          fields. Defaulting is a beta feature under the CustomResourceDefaulting
+                          feature gate. Defaulting requires spec.preserveUnknownFields
+                          to be false.
+                        type: Any
+                      definitions:
+                        additionalProperties: {}
+                        description: JSONSchemaDefinitions contains the models explicitly
+                          defined in this spec.
+                        type: object
+                      dependencies:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: JSONSchemaDependencies represent a dependencies
+                          property.
+                        type: object
+                      description:
+                        type: string
+                      enum:
+                        items:
+                          type: Any
+                        type: array
+                      example:
+                        type: Any
+                      exclusiveMaximum:
+                        type: boolean
+                      exclusiveMinimum:
+                        type: boolean
+                      externalDocs:
+                        description: ExternalDocumentation allows referencing an external
+                          resource for extended documentation.
+                        properties:
+                          description:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                      format:
+                        description: "format is an OpenAPI v3 format string. Unknown
+                          formats are ignored. The following formats are validated:
+                          \n - bsonobjectid: a bson object ID, i.e. a 24 characters
+                          hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI
+                          - email: an email address as parsed by Golang net/mail.ParseAddress
+                          - hostname: a valid representation for an Internet host
+                          name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4:
+                          an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6
+                          IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed
+                          by Golang net.ParseCIDR - mac: a MAC address as parsed by
+                          Golang net.ParseMAC - uuid: an UUID that allows uppercase
+                          defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                          - uuid3: an UUID3 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+                          - uuid4: an UUID4 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                          - uuid5: an UUID5 that allows uppercase defined by the regex
+                          (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+                          - isbn: an ISBN10 or ISBN13 number string like \"0321751043\"
+                          or \"978-0321751041\" - isbn10: an ISBN10 number string
+                          like \"0321751043\" - isbn13: an ISBN13 number string like
+                          \"978-0321751041\" - creditcard: a credit card number defined
+                          by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$
+                          with any non digit characters mixed in - ssn: a U.S. social
+                          security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[-
+                          ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF:
+                          following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                          - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\"
+                          - byte: base64 encoded binary data - password: any kind
+                          of string - date: a date string like \"2006-01-02\" as defined
+                          by full-date in RFC3339 - duration: a duration string like
+                          \"22 ns\" as parsed by Golang time.ParseDuration or compatible
+                          with Scala duration format - datetime: a date time string
+                          like \"2014-12-15T19:30:20.000Z\" as defined by date-time
+                          in RFC3339."
+                        type: string
+                      id:
+                        type: string
+                      items: {}
+                      maxItems:
+                        format: int64
+                        type: integer
+                      maxLength:
+                        format: int64
+                        type: integer
+                      maxProperties:
+                        format: int64
+                        type: integer
+                      maximum:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      minItems:
+                        format: int64
+                        type: integer
+                      minLength:
+                        format: int64
+                        type: integer
+                      minProperties:
+                        format: int64
+                        type: integer
+                      minimum:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      multipleOf:
+                        description: A Number represents a JSON number literal.
+                        type: string
+                      not: {}
+                      nullable:
+                        type: boolean
+                      oneOf:
+                        items: {}
+                        type: array
+                      pattern:
+                        type: string
+                      patternProperties:
+                        additionalProperties: {}
+                        type: object
+                      properties:
+                        additionalProperties: {}
+                        type: object
+                      required:
+                        items:
+                          type: string
+                        type: array
+                      title:
+                        type: string
+                      type:
+                        type: string
+                      uniqueItems:
+                        type: boolean
+                      x-descriptors:
+                        description: x-descriptors annotates an object to define additional
+                          display options.
+                        items:
+                          type: string
+                        type: array
+                      x-kubernetes-embedded-resource:
+                        description: x-kubernetes-embedded-resource defines that the
+                          value is an embedded Kubernetes runtime.Object, with TypeMeta
+                          and ObjectMeta. The type must be object. It is allowed to
+                          further restrict the embedded object. kind, apiVersion and
+                          metadata are validated automatically. x-kubernetes-preserve-unknown-fields
+                          is allowed to be true, but does not have to be if the object
+                          is fully specified (up to kind, apiVersion, metadata).
+                        type: boolean
+                      x-kubernetes-int-or-string:
+                        description: "x-kubernetes-int-or-string specifies that this
+                          value is either an integer or a string. If this is true,
+                          an empty type is allowed and type as child of anyOf is permitted
+                          if following one of the following patterns: \n 1) anyOf:
+                          \   - type: integer    - type: string 2) allOf:    - anyOf:
+                          \     - type: integer      - type: string    - ... zero
+                          or more"
+                        type: boolean
+                      x-kubernetes-list-map-keys:
+                        description: "x-kubernetes-list-map-keys annotates an array
+                          with the x-kubernetes-list-type `map` by specifying the
+                          keys used as the index of the map. \n This tag MUST only
+                          be used on lists that have the \"x-kubernetes-list-type\"
+                          extension set to \"map\". Also, the values specified for
+                          this attribute must be a scalar typed field of the child
+                          structure (no nesting is supported). \n The properties specified
+                          must either be required or have a default value, to ensure
+                          those properties are present for all list items."
+                        items:
+                          type: string
+                        type: array
+                      x-kubernetes-list-type:
+                        description: "x-kubernetes-list-type annotates an array to
+                          further describe its topology. This extension must only
+                          be used on lists and may have 3 possible values: \n 1) `atomic`:
+                          the list is treated as a single entity, like a scalar.      Atomic
+                          lists will be entirely replaced when updated. This extension
+                          \     may be used on any type of list (struct, scalar, ...).
+                          2) `set`:      Sets are lists that must not have multiple
+                          items with the same value. Each      value must be a scalar,
+                          an object with x-kubernetes-map-type `atomic` or an      array
+                          with x-kubernetes-list-type `atomic`. 3) `map`:      These
+                          lists are like maps in that their elements have a non-index
+                          key      used to identify them. Order is preserved upon
+                          merge. The map tag      must only be used on a list with
+                          elements of type object. Defaults to atomic for arrays."
+                        type: string
+                      x-kubernetes-map-type:
+                        description: "x-kubernetes-map-type annotates an object to
+                          further describe its topology. This extension must only
+                          be used when type is object and may have 2 possible values:
+                          \n 1) `granular`:      These maps are actual maps (key-value
+                          pairs) and each fields are independent      from each other
+                          (they can each be manipulated by separate actors). This
+                          is      the default behaviour for all maps. 2) `atomic`:
+                          the list is treated as a single entity, like a scalar.      Atomic
+                          maps will be entirely replaced when updated."
+                        type: string
+                      x-kubernetes-preserve-unknown-fields:
+                        description: x-kubernetes-preserve-unknown-fields stops the
+                          API server decoding step from pruning fields which are not
+                          specified in the validation schema. This affects fields
+                          recursively, but switches back to normal pruning behaviour
+                          if nested properties or additionalProperties are specified
+                          in the schema. This can either be true or undefined. False
+                          is forbidden.
+                        type: boolean
+                    type: object
+                type: object
+              type: object
+          type: object
+        status:
+          description: KameletStatus defines the observed state of Kamelet
+          properties:
+            conditions:
+              items:
+                description: KameletCondition describes the state of a resource at
+                  a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of kamelet condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            phase:
+              type: string
+            properties:
+              items:
+                properties:
+                  default:
+                    type: string
+                  name:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
-  subresources:
-    status: {}
-  names:
-    kind: Kamelet
-    listKind: KameletList
-    plural: kamelets
-    singular: kamelet
-    shortNames:
-    - kl
-  additionalPrinterColumns:
-  - name: Phase
-    type: string
-    description: The Kamelet phase
-    JSONPath: .status.phase

--- a/pkg/apis/camel/go.sum
+++ b/pkg/apis/camel/go.sum
@@ -327,6 +327,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/apis/camel/v1alpha1/jsonschema_types.go
+++ b/pkg/apis/camel/v1alpha1/jsonschema_types.go
@@ -61,36 +61,45 @@ type JSONSchemaProps struct {
 	// default is a default value for undefined object fields.
 	// Defaulting is a beta feature under the CustomResourceDefaulting feature gate.
 	// Defaulting requires spec.preserveUnknownFields to be false.
-	Default              *json.RawMessage           `json:"default,omitempty" protobuf:"bytes,8,opt,name=default"`
-	Maximum              *float64                   `json:"maximum,omitempty" protobuf:"bytes,9,opt,name=maximum"`
-	ExclusiveMaximum     bool                       `json:"exclusiveMaximum,omitempty" protobuf:"bytes,10,opt,name=exclusiveMaximum"`
-	Minimum              *float64                   `json:"minimum,omitempty" protobuf:"bytes,11,opt,name=minimum"`
-	ExclusiveMinimum     bool                       `json:"exclusiveMinimum,omitempty" protobuf:"bytes,12,opt,name=exclusiveMinimum"`
-	MaxLength            *int64                     `json:"maxLength,omitempty" protobuf:"bytes,13,opt,name=maxLength"`
-	MinLength            *int64                     `json:"minLength,omitempty" protobuf:"bytes,14,opt,name=minLength"`
-	Pattern              string                     `json:"pattern,omitempty" protobuf:"bytes,15,opt,name=pattern"`
-	MaxItems             *int64                     `json:"maxItems,omitempty" protobuf:"bytes,16,opt,name=maxItems"`
-	MinItems             *int64                     `json:"minItems,omitempty" protobuf:"bytes,17,opt,name=minItems"`
-	UniqueItems          bool                       `json:"uniqueItems,omitempty" protobuf:"bytes,18,opt,name=uniqueItems"`
-	MultipleOf           *float64                   `json:"multipleOf,omitempty" protobuf:"bytes,19,opt,name=multipleOf"`
-	Enum                 []*json.RawMessage         `json:"enum,omitempty" protobuf:"bytes,20,rep,name=enum"`
-	MaxProperties        *int64                     `json:"maxProperties,omitempty" protobuf:"bytes,21,opt,name=maxProperties"`
-	MinProperties        *int64                     `json:"minProperties,omitempty" protobuf:"bytes,22,opt,name=minProperties"`
-	Required             []string                   `json:"required,omitempty" protobuf:"bytes,23,rep,name=required"`
-	Items                *JSONSchemaPropsOrArray    `json:"items,omitempty" protobuf:"bytes,24,opt,name=items"`
-	AllOf                []JSONSchemaProps          `json:"allOf,omitempty" protobuf:"bytes,25,rep,name=allOf"`
-	OneOf                []JSONSchemaProps          `json:"oneOf,omitempty" protobuf:"bytes,26,rep,name=oneOf"`
-	AnyOf                []JSONSchemaProps          `json:"anyOf,omitempty" protobuf:"bytes,27,rep,name=anyOf"`
-	Not                  *JSONSchemaProps           `json:"not,omitempty" protobuf:"bytes,28,opt,name=not"`
-	Properties           map[string]JSONSchemaProps `json:"properties,omitempty" protobuf:"bytes,29,rep,name=properties"`
-	AdditionalProperties *JSONSchemaPropsOrBool     `json:"additionalProperties,omitempty" protobuf:"bytes,30,opt,name=additionalProperties"`
+	Default          *json.RawMessage   `json:"default,omitempty" protobuf:"bytes,8,opt,name=default"`
+	Maximum          *json.Number       `json:"maximum,omitempty" protobuf:"bytes,9,opt,name=maximum"`
+	ExclusiveMaximum bool               `json:"exclusiveMaximum,omitempty" protobuf:"bytes,10,opt,name=exclusiveMaximum"`
+	Minimum          *json.Number       `json:"minimum,omitempty" protobuf:"bytes,11,opt,name=minimum"`
+	ExclusiveMinimum bool               `json:"exclusiveMinimum,omitempty" protobuf:"bytes,12,opt,name=exclusiveMinimum"`
+	MaxLength        *int64             `json:"maxLength,omitempty" protobuf:"bytes,13,opt,name=maxLength"`
+	MinLength        *int64             `json:"minLength,omitempty" protobuf:"bytes,14,opt,name=minLength"`
+	Pattern          string             `json:"pattern,omitempty" protobuf:"bytes,15,opt,name=pattern"`
+	MaxItems         *int64             `json:"maxItems,omitempty" protobuf:"bytes,16,opt,name=maxItems"`
+	MinItems         *int64             `json:"minItems,omitempty" protobuf:"bytes,17,opt,name=minItems"`
+	UniqueItems      bool               `json:"uniqueItems,omitempty" protobuf:"bytes,18,opt,name=uniqueItems"`
+	MultipleOf       *json.Number       `json:"multipleOf,omitempty" protobuf:"bytes,19,opt,name=multipleOf"`
+	Enum             []*json.RawMessage `json:"enum,omitempty" protobuf:"bytes,20,rep,name=enum"`
+	MaxProperties    *int64             `json:"maxProperties,omitempty" protobuf:"bytes,21,opt,name=maxProperties"`
+	MinProperties    *int64             `json:"minProperties,omitempty" protobuf:"bytes,22,opt,name=minProperties"`
+	Required         []string           `json:"required,omitempty" protobuf:"bytes,23,rep,name=required"`
+
+	//Items                *JSONSchemaPropsOrArray    `json:"items,omitempty" protobuf:"bytes,24,opt,name=items"`
+
+	Items      *JSONSchemaProps           `json:"items,omitempty" protobuf:"bytes,24,opt,name=items"`
+	AllOf      []JSONSchemaProps          `json:"allOf,omitempty" protobuf:"bytes,25,rep,name=allOf"`
+	OneOf      []JSONSchemaProps          `json:"oneOf,omitempty" protobuf:"bytes,26,rep,name=oneOf"`
+	AnyOf      []JSONSchemaProps          `json:"anyOf,omitempty" protobuf:"bytes,27,rep,name=anyOf"`
+	Not        *JSONSchemaProps           `json:"not,omitempty" protobuf:"bytes,28,opt,name=not"`
+	Properties map[string]JSONSchemaProps `json:"properties,omitempty" protobuf:"bytes,29,rep,name=properties"`
+
+	//AdditionalProperties *JSONSchemaPropsOrBool     `json:"additionalProperties,omitempty" protobuf:"bytes,30,opt,name=additionalProperties"`
+
+	AdditionalProperties *bool                      `json:"additionalProperties,omitempty" protobuf:"bytes,30,opt,name=additionalProperties"`
 	PatternProperties    map[string]JSONSchemaProps `json:"patternProperties,omitempty" protobuf:"bytes,31,rep,name=patternProperties"`
 	Dependencies         JSONSchemaDependencies     `json:"dependencies,omitempty" protobuf:"bytes,32,opt,name=dependencies"`
-	AdditionalItems      *JSONSchemaPropsOrBool     `json:"additionalItems,omitempty" protobuf:"bytes,33,opt,name=additionalItems"`
-	Definitions          JSONSchemaDefinitions      `json:"definitions,omitempty" protobuf:"bytes,34,opt,name=definitions"`
-	ExternalDocs         *ExternalDocumentation     `json:"externalDocs,omitempty" protobuf:"bytes,35,opt,name=externalDocs"`
-	Example              *json.RawMessage           `json:"example,omitempty" protobuf:"bytes,36,opt,name=example"`
-	Nullable             bool                       `json:"nullable,omitempty" protobuf:"bytes,37,opt,name=nullable"`
+
+	//AdditionalItems      *JSONSchemaPropsOrBool     `json:"additionalItems,omitempty" protobuf:"bytes,33,opt,name=additionalItems"`
+
+	AdditionalItems *bool                  `json:"additionalItems,omitempty" protobuf:"bytes,33,opt,name=additionalItems"`
+	Definitions     JSONSchemaDefinitions  `json:"definitions,omitempty" protobuf:"bytes,34,opt,name=definitions"`
+	ExternalDocs    *ExternalDocumentation `json:"externalDocs,omitempty" protobuf:"bytes,35,opt,name=externalDocs"`
+	Example         *json.RawMessage       `json:"example,omitempty" protobuf:"bytes,36,opt,name=example"`
+	Nullable        bool                   `json:"nullable,omitempty" protobuf:"bytes,37,opt,name=nullable"`
 
 	// x-kubernetes-preserve-unknown-fields stops the API server
 	// decoding step from pruning fields which are not specified
@@ -235,7 +244,9 @@ func (_ JSONSchemaPropsOrBool) OpenAPISchemaType() []string {
 func (_ JSONSchemaPropsOrBool) OpenAPISchemaFormat() string { return "" }
 
 // JSONSchemaDependencies represent a dependencies property.
-type JSONSchemaDependencies map[string]JSONSchemaPropsOrStringArray
+type JSONSchemaDependencies map[string][]string
+
+//type JSONSchemaDependencies map[string]JSONSchemaPropsOrStringArray
 
 // JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array.
 type JSONSchemaPropsOrStringArray struct {

--- a/pkg/apis/camel/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/camel/v1alpha1/zz_generated.deepcopy.go
@@ -162,7 +162,15 @@ func (in JSONSchemaDependencies) DeepCopyInto(out *JSONSchemaDependencies) {
 		in := &in
 		*out = make(JSONSchemaDependencies, len(*in))
 		for key, val := range *in {
-			(*out)[key] = *val.DeepCopy()
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
 		}
 		return
 	}
@@ -197,12 +205,12 @@ func (in *JSONSchemaProps) DeepCopyInto(out *JSONSchemaProps) {
 	}
 	if in.Maximum != nil {
 		in, out := &in.Maximum, &out.Maximum
-		*out = new(float64)
+		*out = new(json.Number)
 		**out = **in
 	}
 	if in.Minimum != nil {
 		in, out := &in.Minimum, &out.Minimum
-		*out = new(float64)
+		*out = new(json.Number)
 		**out = **in
 	}
 	if in.MaxLength != nil {
@@ -227,7 +235,7 @@ func (in *JSONSchemaProps) DeepCopyInto(out *JSONSchemaProps) {
 	}
 	if in.MultipleOf != nil {
 		in, out := &in.MultipleOf, &out.MultipleOf
-		*out = new(float64)
+		*out = new(json.Number)
 		**out = **in
 	}
 	if in.Enum != nil {
@@ -262,7 +270,7 @@ func (in *JSONSchemaProps) DeepCopyInto(out *JSONSchemaProps) {
 	}
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = new(JSONSchemaPropsOrArray)
+		*out = new(JSONSchemaProps)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.AllOf != nil {
@@ -300,8 +308,8 @@ func (in *JSONSchemaProps) DeepCopyInto(out *JSONSchemaProps) {
 	}
 	if in.AdditionalProperties != nil {
 		in, out := &in.AdditionalProperties, &out.AdditionalProperties
-		*out = new(JSONSchemaPropsOrBool)
-		(*in).DeepCopyInto(*out)
+		*out = new(bool)
+		**out = **in
 	}
 	if in.PatternProperties != nil {
 		in, out := &in.PatternProperties, &out.PatternProperties
@@ -314,13 +322,21 @@ func (in *JSONSchemaProps) DeepCopyInto(out *JSONSchemaProps) {
 		in, out := &in.Dependencies, &out.Dependencies
 		*out = make(JSONSchemaDependencies, len(*in))
 		for key, val := range *in {
-			(*out)[key] = *val.DeepCopy()
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.AdditionalItems != nil {
 		in, out := &in.AdditionalItems, &out.AdditionalItems
-		*out = new(JSONSchemaPropsOrBool)
-		(*in).DeepCopyInto(*out)
+		*out = new(bool)
+		**out = **in
 	}
 	if in.Definitions != nil {
 		in, out := &in.Definitions, &out.Definitions

--- a/script/Makefile
+++ b/script/Makefile
@@ -108,7 +108,7 @@ codegen:
 	@echo "" >> $(VERSIONFILE)
 	gofmt -w pkg/util/defaults/defaults.go
 
-generate: generate-deepcopy generate-client generate-doc
+generate: generate-deepcopy generate-crd generate-client generate-doc
 
 generate-client:
 	./script/gen_client.sh


### PR DESCRIPTION
<!-- Description -->

Fix #1710


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
