### PR TITLE
docs: add section describing secret ref in properties files

### DIFF
--- a/docs/modules/ROOT/pages/configuration/configmap-secret.adoc
+++ b/docs/modules/ROOT/pages/configuration/configmap-secret.adoc
@@ -77,3 +77,43 @@ You can now run the integration with the following command to reference the _Sec
 ```
 kamel run --secret=my-secret props.groovy
 ```
+
+== Reference a Secret in Properties
+
+Suppose you have an existing _Secret_ that contains sensitive information that your integration requires. You might want to reference the values from this _Secret_ in your configuration properties.
+
+For example, a _Secret_ named *secret-message*:
+
+[source,yaml]
+.secret-message.yaml
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-message
+data:
+  MESSAGE: SGVsbG8gV29ybGQK
+type: Opaque
+----
+
+You can reference this _Secret_ in configuration properties using the `{{secret:secret-name/key-name}}` syntax.
+
+For example, the following configuration stored in a _ConfigMap_ references the example _Secret_ defined previously:
+
+[source,yaml]
+.my-config.yaml
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+data:
+  application.properties: |
+    my.message=={{secret:secret-message/MESSAGE}}
+----
+
+You can now run the integration with the following command to include necessary the _Secret_ and _ConfigMap_:
+
+```
+kamel run --secret=secret-message --configmap=my-config props.groovy
+```

--- a/docs/modules/ROOT/pages/configuration/configmap-secret.adoc
+++ b/docs/modules/ROOT/pages/configuration/configmap-secret.adoc
@@ -112,8 +112,9 @@ data:
     my.message=={{secret:secret-message/MESSAGE}}
 ----
 
-You can now run the integration with the following command to include necessary the _Secret_ and _ConfigMap_:
+You can now run the integration with the following commands to include necessary the _Secret_ and _ConfigMap_:
 
 ```
+kubectl apply -f my-config.yaml -f secret-message.yaml
 kamel run --secret=secret-message --configmap=my-config props.groovy
 ```


### PR DESCRIPTION
Related to #1715. CC @lburgazzoli 

This PR adds a section to the config/secrets section of docs. The new section demonstrates how to reference secrets in configuration properties. 


**Release Note**
```release-note
NONE
```
