### PR TITLE
Jolokia trait fixes so that it works with Hawtio Online

### DIFF
--- a/pkg/trait/jolokia.go
+++ b/pkg/trait/jolokia.go
@@ -85,12 +85,15 @@ func (t *jolokiaTrait) Configure(e *Environment) (bool, error) {
 func (t *jolokiaTrait) Apply(e *Environment) (err error) {
 	if e.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
 		// Add the Camel management and Jolokia agent dependencies
+		// Also add the Camel JAXB dependency, that's required by Hawtio
 
 		switch e.CamelCatalog.Runtime.Provider {
 		case v1.RuntimeProviderQuarkus:
 			util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus/camel-quarkus-management")
+			util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "camel-quarkus:jaxb")
 		case v1.RuntimeProviderMain:
 			util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel/camel-management")
+			util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "camel:jaxb")
 		}
 
 		// TODO: We may want to make the Jolokia version configurable

--- a/pkg/trait/jolokia.go
+++ b/pkg/trait/jolokia.go
@@ -85,9 +85,17 @@ func (t *jolokiaTrait) Configure(e *Environment) (bool, error) {
 func (t *jolokiaTrait) Apply(e *Environment) (err error) {
 	if e.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
 		// Add the Camel management and Jolokia agent dependencies
-		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel/camel-management")
+
+		switch e.CamelCatalog.Runtime.Provider {
+		case v1.RuntimeProviderQuarkus:
+			util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus/camel-quarkus-management")
+		case v1.RuntimeProviderMain:
+			util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel/camel-management")
+		}
+
 		// TODO: We may want to make the Jolokia version configurable
 		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.jolokia/jolokia-jvm:jar:agent:1.6.2")
+
 		return nil
 	}
 


### PR DESCRIPTION
This PR updates the Jolokia trait according to the latest runtime changes, so that it works with Hawtio Online OOTB: https://github.com/hawtio/hawtio-online.

it also prepares the Jolokia trait for #1562.

**Release Note**
```release-note
fix: Make Jolokia trait compatible with Quarkus runtime
fix: Jolokia trait adds JAXB dependency that required by Hawtio
```
