### PR TITLE
Related to #1675: install default Kamelets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /kamel-config.yaml
 /.kamel/kamel-config.yaml
 
+# Kamelet catalog
+/deploy/kamelets
+
 # Released Packages
 *.tar.gz
 

--- a/deploy/resources_support.go
+++ b/deploy/resources_support.go
@@ -71,6 +71,14 @@ func TemplateResource(name string, params interface{}) (string, error) {
 	return buf.String(), nil
 }
 
+// DirExists tells if a directory exists and can be listed for files
+func DirExists(dirName string) bool {
+	if _, err := assets.Open(dirName); err != nil {
+		return false
+	}
+	return true
+}
+
 // Resources lists all file names in the given path (starts with '/')
 func Resources(dirName string) []string {
 	dir, err := assets.Open(dirName)

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -149,7 +149,7 @@ func Run() {
 	// Try to register the OpenShift CLI Download link if possible
 	installCtx, installCancel := context.WithTimeout(context.TODO(), 1*time.Minute)
 	defer installCancel()
-	install.OperatorStartupOptionalTools(installCtx, c, log)
+	install.OperatorStartupOptionalTools(installCtx, c, namespace, log)
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {

--- a/pkg/controller/integrationplatform/create.go
+++ b/pkg/controller/integrationplatform/create.go
@@ -55,6 +55,11 @@ func (action *createAction) Handle(ctx context.Context, platform *v1.Integration
 		}
 	}
 
+	// Kamelet Catalog installed on platform reconciliation for cases where users install a global operator
+	if err := install.KameletCatalog(ctx, action.client, platform.Namespace); err != nil {
+		return nil, err
+	}
+
 	platform.Status.Phase = v1.IntegrationPlatformPhaseReady
 
 	return platform, nil

--- a/pkg/install/kamelets.go
+++ b/pkg/install/kamelets.go
@@ -1,0 +1,91 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	"github.com/apache/camel-k/deploy"
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/client"
+	"github.com/apache/camel-k/pkg/util/defaults"
+	"github.com/apache/camel-k/pkg/util/kubernetes"
+	"github.com/pkg/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const kameletDir = "/kamelets/"
+const kameletBundledLabel = "camel.apache.org/kamelet.bundled"
+const kameletReadOnlyLabel = "camel.apache.org/kamelet.readonly"
+
+// KameletCatalog installs the bundlet KameletCatalog into one namespace
+func KameletCatalog(ctx context.Context, c client.Client, namespace string) error {
+	if deploy.DirExists(kameletDir) {
+		for _, res := range deploy.Resources(kameletDir) {
+			if !strings.HasSuffix(res, ".yaml") && !strings.HasSuffix(res, ".yml") {
+				continue
+			}
+
+			obj, err := kubernetes.LoadResourceFromYaml(c.GetScheme(), deploy.ResourceAsString(path.Join(kameletDir, res)))
+			if err != nil {
+				return err
+			}
+			if k, ok := obj.(*v1alpha1.Kamelet); ok {
+				existing := &v1alpha1.Kamelet{}
+				err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: k.Name}, existing)
+				if err != nil {
+					if k8serrors.IsNotFound(err) {
+						existing = nil
+					} else {
+						return err
+					}
+				}
+
+				if existing == nil || existing.Annotations[kamelVersionAnnotation] != defaults.Version {
+					err := Resource(ctx, c, namespace, true, func(object runtime.Object) runtime.Object {
+						if o, ok := object.(metav1.Object); ok {
+							if o.GetAnnotations() == nil {
+								o.SetAnnotations(make(map[string]string))
+							}
+							o.GetAnnotations()[kamelVersionAnnotation] = defaults.Version
+
+							if o.GetLabels() == nil {
+								o.SetLabels(make(map[string]string))
+							}
+							o.GetLabels()[kameletBundledLabel] = "true"
+							o.GetLabels()[kameletReadOnlyLabel] = "true"
+						}
+						return object
+					}, path.Join(kameletDir, res))
+
+					if err != nil {
+						return errors.Wrapf(err, "could not create resource %q", res)
+					}
+				}
+
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/install/optional.go
+++ b/pkg/install/optional.go
@@ -19,13 +19,14 @@ package install
 
 import (
 	"context"
+	"strings"
 
 	"github.com/apache/camel-k/pkg/client"
 	"github.com/go-logr/logr"
 )
 
 // OperatorStartupOptionalTools tries to install optional tools at operator startup and warns if something goes wrong
-func OperatorStartupOptionalTools(ctx context.Context, c client.Client, log logr.Logger) {
+func OperatorStartupOptionalTools(ctx context.Context, c client.Client, namespace string, log logr.Logger) {
 
 	// Try to register the OpenShift CLI Download link if possible
 	if err := OpenShiftConsoleDownloadLink(ctx, c); err != nil {
@@ -41,6 +42,14 @@ func OperatorStartupOptionalTools(ctx context.Context, c client.Client, log logr
 		if err := installClusterRole(ctx, c, nil); err != nil {
 			log.Info("Cannot install user cluster role: skipping.")
 			log.V(8).Info("Error while installing user cluster role", "error", err)
+		}
+	}
+
+	// Try to install Kamelet Catalog automatically if operator is namespace scoped
+	if namespace != "" && !strings.Contains(namespace, ",") {
+		if err := KameletCatalog(ctx, c, namespace); err != nil {
+			log.Info("Cannot install bundled Kamelet Catalog: skipping.")
+			log.V(8).Info("Error while installing bundled Kamelet Catalog", "error", err)
 		}
 	}
 

--- a/script/Makefile
+++ b/script/Makefile
@@ -32,6 +32,11 @@ STAGING_IMAGE_NAME := docker.io/camelk/camel-k
 
 STAGING_RUNTIME_REPO :=
 
+# Define here the repo containing the default Kamelet catalog (if any)
+KAMELET_CATALOG_REPO :=
+# Optional branch for the default Kamelet catalog
+KAMELET_CATALOG_REPO_BRANCH :=
+
 # When packaging artifacts into the docker image, you can "copy" them from local maven
 # or "download" them from Apache Snapshots and Maven Central
 PACKAGE_ARTIFACTS_STRATEGY := copy
@@ -142,10 +147,13 @@ test-builder: build
 build-kamel:
 	go build $(GOFLAGS) -o kamel ./cmd/kamel/*.go
 
-build-resources:
+build-resources: bundle-kamelets
 	./script/build_catalog.sh $(RUNTIME_VERSION) -Dcatalog.file=camel-catalog-$(RUNTIME_VERSION)-main.yaml -Dstaging.repo="$(STAGING_RUNTIME_REPO)"
 	./script/build_catalog.sh $(RUNTIME_VERSION) -Dcatalog.file=camel-catalog-$(RUNTIME_VERSION)-quarkus.yaml -Dcatalog.runtime=quarkus -Dstaging.repo="$(STAGING_RUNTIME_REPO)"
 	./script/embed_resources.sh deploy
+
+bundle-kamelets:
+	./script/bundle_kamelets.sh $(KAMELET_CATALOG_REPO) $(KAMELET_CATALOG_REPO_BRANCH)
 
 build-submodules:
 	./script/build_submodules.sh
@@ -261,4 +269,4 @@ get-staging-repo:
 get-version:
 	@echo $(VERSION)
 
-.PHONY: build build-kamel build-resources build-olm unsnapshot-olm dep codegen images images-dev images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes check-licenses generate-deepcopy generate-client generate-doc build-resources release-helm release-staging release-nightly get-staging-repo get-version build-submodules set-module-version
+.PHONY: build build-kamel build-resources build-olm unsnapshot-olm dep codegen images images-dev images-push images-push-staging test check test-integration clean release cross-compile package-examples set-version git-tag release-notes check-licenses generate-deepcopy generate-client generate-doc build-resources release-helm release-staging release-nightly get-staging-repo get-version build-submodules set-module-version bundle-kamelets

--- a/script/bundle_kamelets.sh
+++ b/script/bundle_kamelets.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+location=$(dirname $0)
+
+set -e
+
+repo=$1
+branch=$2
+
+cd $location/../
+target=./deploy/kamelets
+rm -rf $target
+
+if [ "$repo" = "" ]; then
+	echo "no kamelet catalog defined: skipping"
+	exit 0
+fi
+
+if [ "$branch" = "" ]; then
+  branch="master"
+fi
+
+echo "Cloning repository $repo on branch $branch to bundle kamelets..."
+
+
+rm -rf ./tmp_kamelet_catalog
+git clone -b $branch --single-branch --depth 1 $repo ./tmp_kamelet_catalog
+
+mkdir $target
+cp ./tmp_kamelet_catalog/*.kamelet.yaml $target
+
+rm -rf ./tmp_kamelet_catalog


### PR DESCRIPTION
<!-- Description -->

This let us build an operator with a catalog of default Kamelets bundled inside.
Currently the catalog repo is left empty.

Kamelets are installed:
- Directly in the namespace, if the operator is single-namespace scoped
- At platform initialization, for cases where a global operator is used




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
