### PR TITLE
chore: Make scripts portable

### DIFF
--- a/script/gen_crd.sh
+++ b/script/gen_crd.sh
@@ -40,9 +40,16 @@ deploy_crd_file() {
   for dest in ${@:2}; do
     cat ./script/headers/yaml.txt > $dest
     echo "" >> $dest
-    cat $source | sed -n '/^---/,/^status/p;/^status/q' \
-      | sed '1d;$d' \
-      | sed 's/^metadata:/metadata:\n  labels:\n    app: "camel-k"/' >> $dest
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      cat $source | sed -n '/^---/,/^status/p;/^status/q' \
+        | sed '1d;$d' \
+        | sed 's/^metadata:/metadata:\n  labels:\n    app: "camel-k"/' >> $dest
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      # Mac OSX
+      cat $source | sed -n '/^---/,/^status/p;/^status/q' \
+        | sed '1d;$d' \
+        | sed $'s/^metadata:/metadata:\\\n  labels:\\\n    app: "camel-k"/' >> $dest
+    fi
   done
 
 }

--- a/script/set_go_modules_version.sh
+++ b/script/set_go_modules_version.sh
@@ -29,7 +29,13 @@ target_tag=v$target_version
 api_rule="s/github.com\/apache\/camel-k\/pkg\/apis\/camel [A-Za-z0-9\.\-]+.*$/github.com\/apache\/camel-k\/pkg\/apis\/camel $target_tag/"
 client_rule="s/github.com\/apache\/camel-k\/pkg\/client\/camel [A-Za-z0-9\.\-]+.*$/github.com\/apache\/camel-k\/pkg\/client\/camel $target_tag/"
 
-sed -i -r "$api_rule" $location/../go.mod
-sed -i -r "$client_rule" $location/../go.mod
-
-sed -i -r "$api_rule" $location/../pkg/client/camel/go.mod
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  sed -i -r "$api_rule" $location/../go.mod
+  sed -i -r "$client_rule" $location/../go.mod
+  sed -i -r "$api_rule" $location/../pkg/client/camel/go.mod
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # Mac OSX
+  sed -i '' -E "$api_rule" $location/../go.mod
+  sed -i '' -E "$client_rule" $location/../go.mod
+  sed -i '' -E "$api_rule" $location/../pkg/client/camel/go.mod
+fi

--- a/script/set_version.sh
+++ b/script/set_version.sh
@@ -30,11 +30,22 @@ sanitized_image_name=${image_name//\//\\\/}
 
 for f in $(find $location/../deploy -type f -name "*.yaml" | grep -v olm-catalog);
 do
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sed -i -r "s/docker.io\/apache\/camel-k:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $f
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    sed -i '' -E "s/docker.io\/apache\/camel-k:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $f
+  fi
 done
 
 # Update helm chart
-sed -i -r "s/docker.io\/apache\/camel-k:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $location/../helm/camel-k/values.yaml
-sed -i -r "s/appVersion:\s([0-9]+[a-zA-Z0-9\-\.].*).*/appVersion: ${version}/" $location/../helm/camel-k/Chart.yaml
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  sed -i -r "s/docker.io\/apache\/camel-k:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $location/../helm/camel-k/values.yaml
+  sed -i -r "s/appVersion:\s([0-9]+[a-zA-Z0-9\-\.].*).*/appVersion: ${version}/" $location/../helm/camel-k/Chart.yaml
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # Mac OSX
+  sed -i '' -E "s/docker.io\/apache\/camel-k:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $location/../helm/camel-k/values.yaml
+  sed -i '' -E "s/appVersion:\s([0-9]+[a-zA-Z0-9\-\.].*).*/appVersion: ${version}/" $location/../helm/camel-k/Chart.yaml
+fi
 
 echo "Camel K version set to: $version and image name to: $image_name"

--- a/script/unsnapshot_olm.sh
+++ b/script/unsnapshot_olm.sh
@@ -41,9 +41,19 @@ done
 
 for f in $(find ${olm_catalog}/camel-k-dev -type f);
 do
-  sed -i 's/-SNAPSHOT//g' $f
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sed -i 's/-SNAPSHOT//g' $f
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    sed -i '' 's/-SNAPSHOT//g' $f
+  fi
 done
 for f in $(find ${olm_catalog}/camel-k-dev -type f);
 do
-  sed -i 's/-snapshot//g' $f
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sed -i 's/-snapshot//g' $f
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    sed -i '' 's/-snapshot//g' $f
+  fi
 done


### PR DESCRIPTION
<!-- Description -->
Use portable sed command options -E instead of -r and explicitly add empty extension as -i option (required for MacOs)

**Release Note**
```release-note
NONE
```
