### PR TITLE
fix(#1717) Automatic changelog update should not be run on forks

### DIFF
--- a/.github/workflows/automatic-changelog-update.yml
+++ b/.github/workflows/automatic-changelog-update.yml
@@ -26,6 +26,7 @@ jobs:
   generate_changelog:
     runs-on: ubuntu-latest
     name: Generate changelog for master branch
+    if: github.ref == 'refs/heads/master' && github.repository == 'apache/camel-k'
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
<!-- Description -->
Fixes #1717

Add a condition on the github actions workflow job to run only on refs/heads/master and github.repository apache/camel-k

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
