### PR TITLE
chore: Fix operator sdk download url in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Prerequisites
       run: |
         export OPERATOR_SDK_VERSION=v0.17.1
-        curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.15.2/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk
+        curl -L https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk
         chmod a+x operator-sdk
         sudo mv operator-sdk /usr/local/bin
 


### PR DESCRIPTION
<!-- Description -->

Fix operator sdk download url in release workflow


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
