### PR TITLE
Add suport for gists

### DIFF
--- a/docs/modules/ROOT/pages/running/run-from-github.adoc
+++ b/docs/modules/ROOT/pages/running/run-from-github.adoc
@@ -1,25 +1,64 @@
 [[run-from-github]]
 = Run from GitHub
 
-It is possible to run integrations from GitHub with a dedicated URL
-syntax:
+It is possible to run integrations from a GitHub repository or Gist with dedicated URL syntax:
 
-```
+== Repository
+
+.Syntax
+[source]
+----
 kamel run github:$user/$repo/$path?branch=$branch
-```
+----
 
 As example, running the following command
 
-```
+
+[source]
+----
 kamel run github:apache/camel-k/examples/Sample.java
-```
+----
 
 is equivalent to:
 
-```
+[source]
+----
 kamel run https://raw.githubusercontent.com/apache/camel-k/master/examples/Sample.java
-```
+----
 
 but does not require to type the full GitHub RAW URL.
 
 Declaring the branch query param is not required and defaults to `master` if not explicit set.
+
+== Gist
+
+.Syntax
+[source]
+----
+kamel run https://gist.github.com/${user-id}/${gist-id}
+kamel run gist:${gist-id}
+----
+
+camel-k will add any file that is part of the Gist as a source.
+
+As example, assuming there are two files listed as part of a Gist, beans.yaml and routes.yaml, then the following command
+
+
+[source]
+----
+kamel run gist:${gist-id}
+----
+
+is equivalent to:
+
+[source]
+----
+kamel run \
+    https://gist.githubusercontent.com/${user-id}/${gist-id}/raw/${...}/beans.yaml \
+    https://gist.githubusercontent.com/${user-id}/${gist-id}/raw/${...}/routes.yaml
+----
+
+[NOTE]
+====
+GitHub applies rate limiting to its APIs and as Authenticated requests get a higher rate limit, the camel-k cli honour the env var GITHUB_TOKEN and if it is found, then it is used for GitHub authentication.
+====

--- a/e2e/common/run_test.go
+++ b/e2e/common/run_test.go
@@ -44,24 +44,6 @@ func TestRunSimpleExamples(t *testing.T) {
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
 		})
 
-		t.Run("run java from GitHub", func(t *testing.T) {
-			RegisterTestingT(t)
-			Expect(Kamel("run", "-n", ns, "github:apache/camel-k/e2e/common/files/Java.java").Execute()).Should(BeNil())
-			Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
-			Eventually(IntegrationCondition(ns, "java", camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
-			Eventually(IntegrationLogs(ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
-		})
-
-		t.Run("run java from GitHub (RAW)", func(t *testing.T) {
-			RegisterTestingT(t)
-			Expect(Kamel("run", "-n", ns, "https://raw.githubusercontent.com/apache/camel-k/master/e2e/common/files/Java.java").Execute()).Should(BeNil())
-			Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
-			Eventually(IntegrationCondition(ns, "java", camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
-			Eventually(IntegrationLogs(ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
-		})
-
 		t.Run("run java with properties", func(t *testing.T) {
 			RegisterTestingT(t)
 			Expect(Kamel("run", "-n", ns, "files/Prop.java", "--property-file", "files/prop.properties").Execute()).Should(BeNil())
@@ -136,5 +118,51 @@ func TestRunSimpleExamples(t *testing.T) {
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
 		})
 
+	})
+}
+
+func TestRunExamplesFromGitHUB(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		Expect(Kamel("install", "-n", ns).Execute()).Should(BeNil())
+
+		t.Run("run java from GitHub", func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(Kamel("run", "-n", ns, "github:apache/camel-k/e2e/common/files/Java.java").Execute()).Should(BeNil())
+			Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(IntegrationCondition(ns, "java", camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+		})
+
+		t.Run("run java from GitHub (RAW)", func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(Kamel("run", "-n", ns, "https://raw.githubusercontent.com/apache/camel-k/master/e2e/common/files/Java.java").Execute()).Should(BeNil())
+			Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(IntegrationCondition(ns, "java", camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+		})
+
+		t.Run("run from GitHub Gist (ID)", func(t *testing.T) {
+			name := "github-gist-id"
+			RegisterTestingT(t)
+			Expect(Kamel("run", "-n", ns, "--name", name, "gist:e2c3f9a5fd0d9e79b21b04809786f17a").Execute()).Should(BeNil())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(IntegrationCondition(ns, name, camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Tick!"))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+		})
+
+		t.Run("run from GitHub Gist (URL)", func(t *testing.T) {
+			name := "github-gist-url"
+			RegisterTestingT(t)
+			Expect(Kamel("run", "-n", ns, "--name", name, "https://gist.github.com/lburgazzoli/e2c3f9a5fd0d9e79b21b04809786f17a").Execute()).Should(BeNil())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(IntegrationCondition(ns, name, camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Tick!"))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+		})
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/gertd/go-pluralize v0.1.1
 	github.com/go-logr/logr v0.1.0
+	github.com/google/go-github/v32 v32.1.0
 	github.com/google/uuid v1.1.1
 	github.com/jpillora/backoff v1.0.0
 	github.com/magiconair/properties v1.8.1
@@ -35,6 +36,7 @@ require (
 	github.com/stoewer/go-strcase v1.0.2
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/multierr v1.5.0
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	gopkg.in/inf.v0 v0.9.1
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.9

--- a/go.sum
+++ b/go.sum
@@ -585,11 +585,15 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v27 v27.0.6/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
 github.com/google/go-github/v29 v29.0.3/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
+github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-licenses v0.0.0-20191112164736-212ea350c932/go.mod h1:16wa6pRqNDUIhOtwF0GcROVqMeXHZJ7H6eGDFUh5Pfk=
 github.com/google/go-licenses v0.0.0-20200227160636-0fa8c766a591/go.mod h1:JWeTIGPLQ9gF618ZOdlUitd1gRR/l99WOkHOlmR/UVA=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=

--- a/pkg/cmd/modeline_test.go
+++ b/pkg/cmd/modeline_test.go
@@ -82,23 +82,23 @@ func TestModelineRunMultipleFiles(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	file := `
-		// camel-k: source=ext.groovy
+		// camel-k: dependency=mvn:org.my/lib1:3.0
 	`
 	fileName := path.Join(dir, "simple.groovy")
 	err = ioutil.WriteFile(fileName, []byte(file), 0777)
 	assert.NoError(t, err)
 
 	file2 := `
-		// camel-k: dependency=mvn:org.my/lib:3.0
+		// camel-k: dependency=mvn:org.my/lib2:3.0
 	`
 	fileName2 := path.Join(dir, "ext.groovy")
 	err = ioutil.WriteFile(fileName2, []byte(file2), 0777)
 	assert.NoError(t, err)
 
-	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
+	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName, fileName2})
 	assert.NoError(t, err)
 	assert.NotNil(t, cmd)
-	assert.Equal(t, []string{"run", fileName, "--source=" + fileName2, "--dependency=mvn:org.my/lib:3.0"}, flags)
+	assert.Equal(t, []string{"run", fileName, fileName2, "--dependency=mvn:org.my/lib1:3.0", "--dependency=mvn:org.my/lib2:3.0"}, flags)
 }
 
 func TestModelineRunPropertyFiles(t *testing.T) {

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -18,10 +18,13 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"github.com/apache/camel-k/pkg/util/gzip"
 	"log"
 	"reflect"
 	"strings"
@@ -236,4 +239,14 @@ func fieldByMapstructureTagName(target reflect.Value, tagName string) (reflect.S
 	}
 
 	return reflect.StructField{}, false
+}
+
+func compressToString(content []byte) (string, error) {
+	var b bytes.Buffer
+
+	if err := gzip.Compress(&b, content); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(b.Bytes()), nil
 }

--- a/pkg/cmd/util_sources.go
+++ b/pkg/cmd/util_sources.go
@@ -1,0 +1,201 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/apache/camel-k/pkg/util"
+
+	"golang.org/x/oauth2"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/pkg/errors"
+)
+
+// Source ---
+type Source struct {
+	Origin   string
+	Location string
+	Name     string
+	Content  string
+	Compress bool
+	Local    bool
+}
+
+func (s *Source) setContent(content []byte) error {
+	if s.Compress {
+		result, err := compressToString(content)
+		if err != nil {
+			return err
+		}
+
+		s.Content = result
+	} else {
+		s.Content = string(content)
+	}
+
+	return nil
+}
+
+// ResolveSources ---
+func ResolveSources(ctx context.Context, locations []string, compress bool) ([]Source, error) {
+	sources := make([]Source, 0, len(locations))
+
+	for _, location := range locations {
+		if isLocal(location) {
+			if _, err := os.Stat(location); err != nil && os.IsNotExist(err) {
+				return sources, errors.Wrapf(err, "file %s does not exist", location)
+			} else if err != nil {
+				return sources, errors.Wrapf(err, "error while accessing file %s", location)
+			}
+
+			answer := Source{
+				Name:     path.Base(location),
+				Origin:   location,
+				Location: location,
+				Compress: compress,
+				Local:    true,
+			}
+
+			content, err := ioutil.ReadFile(location)
+			if err != nil {
+				return sources, err
+			}
+			if err := answer.setContent(content); err != nil {
+				return sources, err
+			}
+
+			sources = append(sources, answer)
+		} else {
+			u, err := url.Parse(location)
+			if err != nil {
+				return sources, err
+			}
+
+			switch {
+			case u.Scheme == "gist" || strings.HasPrefix(location, "https://gist.github.com/"):
+				var tc *http.Client
+
+				if token, ok := os.LookupEnv("GITHUB_TOKEN"); ok {
+					ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+					tc = oauth2.NewClient(ctx, ts)
+
+					fmt.Println("GITHUB_TOKEN env var detected, using it for GitHub APIs authentication")
+				}
+
+				gc := github.NewClient(tc)
+				gistID := ""
+
+				if strings.HasPrefix(location, "https://gist.github.com/") {
+					names := util.FindNamedMatches(`^https://gist.github.com/(([a-zA-Z0-9]*)/)?(?P<gistid>[a-zA-Z0-9]*)$`, location)
+					if value, ok := names["gistid"]; ok {
+						gistID = value
+					}
+				} else {
+					gistID = u.Opaque
+				}
+
+				if gistID == "" {
+					return sources, fmt.Errorf("unable to determing gist id from %s", location)
+				}
+
+				gists, _, err := gc.Gists.Get(ctx, gistID)
+				if err != nil {
+					return sources, err
+				}
+
+				for _, v := range gists.Files {
+					if v.Filename == nil || v.Content == nil {
+						continue
+					}
+
+					answer := Source{
+						Name:     *v.Filename,
+						Compress: compress,
+						Origin:   location,
+					}
+					if v.RawURL != nil {
+						answer.Location = *v.RawURL
+					}
+					if err := answer.setContent([]byte(*v.Content)); err != nil {
+						return sources, err
+					}
+					sources = append(sources, answer)
+				}
+			case u.Scheme == "github":
+				answer := Source{
+					Name:     path.Base(location),
+					Origin:   location,
+					Location: location,
+					Compress: compress,
+				}
+
+				content, err := loadContentGitHub(u)
+				if err != nil {
+					return sources, err
+				}
+				if err := answer.setContent(content); err != nil {
+					return sources, err
+				}
+				sources = append(sources, answer)
+			case u.Scheme == "http":
+				answer := Source{
+					Name:     path.Base(location),
+					Origin:   location,
+					Location: location,
+					Compress: compress,
+				}
+
+				content, err := loadContentHTTP(u)
+				if err != nil {
+					return sources, err
+				}
+				if err := answer.setContent(content); err != nil {
+					return sources, err
+				}
+				sources = append(sources, answer)
+			case u.Scheme == "https":
+				answer := Source{
+					Name:     path.Base(location),
+					Origin:   location,
+					Location: location,
+					Compress: compress,
+				}
+
+				content, err := loadContentHTTP(u)
+				if err != nil {
+					return sources, err
+				}
+				if err := answer.setContent(content); err != nil {
+					return sources, err
+				}
+				sources = append(sources, answer)
+			}
+		}
+	}
+
+	return sources, nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -209,6 +209,18 @@ func FindAllDistinctStringSubmatch(data string, regexps ...*regexp.Regexp) []str
 	return submatchs.List()
 }
 
+// FindNamedMatches ---
+func FindNamedMatches(expr string, str string) map[string]string {
+	regex := regexp.MustCompile(expr)
+	match := regex.FindStringSubmatch(str)
+
+	results := map[string]string{}
+	for i, name := range match {
+		results[regex.SubexpNames()[i]] = name
+	}
+	return results
+}
+
 // FileExists --
 func FileExists(name string) (bool, error) {
 	info, err := os.Stat(name)


### PR DESCRIPTION
Fixes #1740


<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
integrations stored on gist can be referenced from the cli:

  kamel run --dev https://gist.github.com/$i{user-id}/${gist-id}
  kamel run --dev gist:${gist-id}

if the environment variable `GITHUB_TOKEN` is detected, them it
will be used for GitHub authentication.
```