### PR TITLE
Fix #1750: auto-compress/encode binary sources and resources

### DIFF
--- a/pkg/cmd/modeline.go
+++ b/pkg/cmd/modeline.go
@@ -113,7 +113,7 @@ func createKamelWithModelineCommand(ctx context.Context, args []string, processe
 			continue
 		}
 		baseDir := filepath.Dir(f)
-		content, err := loadData(f, false)
+		content, _, err := loadData(f, false, false)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "cannot read file %s", f)
 		}


### PR DESCRIPTION
<!-- Description -->

Fix #1750

Auto-compress and encode binary files by default.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Binary resources are now encoded to avoid corruption
```
