### PR TITLE
Fix #1537: generate json schema for full Kubernetes resources

### DIFF
--- a/cmd/util/json-schema-gen/main.go
+++ b/cmd/util/json-schema-gen/main.go
@@ -1,0 +1,141 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+func main() {
+	if len(os.Args) != 6 {
+		fmt.Println(`Use "json-schema-gen <crd> <schema> <path> <isArray> <destination>`)
+		os.Exit(1)
+	}
+	crd := os.Args[1]
+	schema := os.Args[2]
+	path := os.Args[3]
+	isArray := "true" == os.Args[4]
+	destination := os.Args[5]
+
+	if err := generate(crd, schema, path, isArray, destination); err != nil {
+		panic(err)
+	}
+}
+
+func generate(crd, schema, path string, isArray bool, destination string) error {
+	crdData, err := ioutil.ReadFile(crd)
+	if err != nil {
+		return err
+	}
+
+	var crdObj map[string]interface{}
+	if err := yaml.Unmarshal(crdData, &crdObj); err != nil {
+		return err
+	}
+
+	bigSchema := getSchemaFromCRD(crdObj)
+	ref := bigSchema
+	for _, p := range pathComponents(path) {
+		ref = ref["properties"].(map[string]interface{})[p].(map[string]interface{})
+	}
+
+	dslSchema, err := loadDSLSchema(schema)
+	dslObjectSchema := dslSchema["items"].(map[string]interface{})
+	if err != nil {
+		return err
+	}
+	if !isArray && dslSchema["type"] == "array" {
+		dslSchema = dslObjectSchema
+	}
+
+	// merge schemas
+	for k, v := range dslSchema {
+		if k != "definitions" {
+			ref[k] = v
+		}
+	}
+	// readd definitions
+	if _, alreadyHasDefs := bigSchema["definitions"]; alreadyHasDefs {
+		panic("unexpected definitions found in CRD")
+	}
+	bigSchema["definitions"] = dslObjectSchema["definitions"]
+	rebaseRefs(dslSchema)
+
+	result, err := json.MarshalIndent(bigSchema, "", "  ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(destination, result, 0666)
+}
+
+func remapRef(ref string) string {
+	return "#" + strings.TrimPrefix(ref, "#/items")
+}
+
+func rebaseRefs(schema map[string]interface{}) {
+	for k, v := range schema {
+		if k == "$ref" && reflect.TypeOf(v).Kind() == reflect.String {
+			schema[k] = remapRef(fmt.Sprintf("%v", v))
+		} else if reflect.TypeOf(v).Kind() == reflect.Map {
+			rebaseRefs(v.(map[string]interface{}))
+		} else if reflect.TypeOf(v).Kind() == reflect.Slice {
+			for _, vv := range v.([]interface{}) {
+				if reflect.TypeOf(vv).Kind() == reflect.Map {
+					rebaseRefs(vv.(map[string]interface{}))
+				}
+			}
+		}
+	}
+}
+
+func loadDSLSchema(schema string) (map[string]interface{}, error) {
+	content, err := ioutil.ReadFile(schema)
+	if err != nil {
+		return nil, err
+	}
+	var dslSchema map[string]interface{}
+	if err := json.Unmarshal(content, &dslSchema); err != nil {
+		return nil, err
+	}
+	return dslSchema, nil
+}
+
+func getSchemaFromCRD(crd map[string]interface{}) map[string]interface{} {
+	res := crd["spec"].(map[string]interface{})
+	res = res["validation"].(map[string]interface{})
+	res = res["openAPIV3Schema"].(map[string]interface{})
+	return res
+}
+
+func pathComponents(path string) []string {
+	res := make([]string, 0)
+	for _, p := range strings.Split(path, ".") {
+		if len(strings.TrimSpace(p)) == 0 {
+			continue
+		}
+		res = append(res, p)
+	}
+	return res
+}

--- a/docs/modules/ROOT/assets/attachments/schema/integration-schema.json
+++ b/docs/modules/ROOT/assets/attachments/schema/integration-schema.json
@@ -1,0 +1,8726 @@
+{
+  "definitions": {
+    "dataformats": {
+      "properties": {
+        "any23": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.Any23DataFormat"
+        },
+        "asn1": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+        },
+        "avro": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+        },
+        "barcode": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+        },
+        "base64": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+        },
+        "beanio": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.BeanioDataFormat"
+        },
+        "bindy": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+        },
+        "cbor": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+        },
+        "crypto": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+        },
+        "csv": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+        },
+        "custom-data-format": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+        },
+        "fhir-json": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+        },
+        "fhir-xml": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+        },
+        "flatpack": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+        },
+        "grok": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+        },
+        "gzipdeflater": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.GzipDataFormat"
+        },
+        "hl7": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+        },
+        "ical": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+        },
+        "jacksonxml": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+        },
+        "jaxb": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+        },
+        "json": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+        },
+        "json-api": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+        },
+        "lzf": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+        },
+        "mime-multipart": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+        },
+        "pgp": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+        },
+        "protobuf": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+        },
+        "rss": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+        },
+        "secure-xml": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+        },
+        "soapjaxb": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.SoapJaxbDataFormat"
+        },
+        "syslog": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+        },
+        "tarfile": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+        },
+        "thrift": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+        },
+        "tidy-markup": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+        },
+        "univocity-csv": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+        },
+        "univocity-fixed": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityFixedWidthDataFormat"
+        },
+        "univocity-tsv": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+        },
+        "xmlrpc": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.XmlRpcDataFormat"
+        },
+        "xstream": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+        },
+        "yaml": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+        },
+        "zipdeflater": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+        },
+        "zipfile": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+        }
+      },
+      "type": "object"
+    },
+    "expressions": {
+      "properties": {
+        "constant": {
+          "$ref": "#/definitions/org.apache.camel.model.language.ConstantExpression"
+        },
+        "exchange-property": {
+          "$ref": "#/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+        },
+        "groovy": {
+          "$ref": "#/definitions/org.apache.camel.model.language.GroovyExpression"
+        },
+        "header": {
+          "$ref": "#/definitions/org.apache.camel.model.language.HeaderExpression"
+        },
+        "hl7terser": {
+          "$ref": "#/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+        },
+        "jsonpath": {
+          "$ref": "#/definitions/org.apache.camel.model.language.JsonPathExpression"
+        },
+        "language": {
+          "$ref": "#/definitions/org.apache.camel.model.language.LanguageExpression"
+        },
+        "method": {
+          "$ref": "#/definitions/org.apache.camel.model.language.MethodCallExpression"
+        },
+        "mvel": {
+          "$ref": "#/definitions/org.apache.camel.model.language.MvelExpression"
+        },
+        "ognl": {
+          "$ref": "#/definitions/org.apache.camel.model.language.OgnlExpression"
+        },
+        "ref": {
+          "$ref": "#/definitions/org.apache.camel.model.language.RefExpression"
+        },
+        "simple": {
+          "$ref": "#/definitions/org.apache.camel.model.language.SimpleExpression"
+        },
+        "spel": {
+          "$ref": "#/definitions/org.apache.camel.model.language.SpELExpression"
+        },
+        "tokenize": {
+          "$ref": "#/definitions/org.apache.camel.model.language.TokenizerExpression"
+        },
+        "xpath": {
+          "$ref": "#/definitions/org.apache.camel.model.language.XPathExpression"
+        },
+        "xquery": {
+          "$ref": "#/definitions/org.apache.camel.model.language.XQueryExpression"
+        },
+        "xtokenize": {
+          "$ref": "#/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.builder.DeadLetterChannelBuilder": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "async-delayed-redelivery": {
+              "type": "boolean"
+            },
+            "dead-letter-handle-new-exception": {
+              "type": "boolean"
+            },
+            "use-original-body": {
+              "type": "boolean"
+            },
+            "use-original-message": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.builder.DefaultErrorHandlerBuilder": {
+      "properties": {
+        "async-delayed-redelivery": {
+          "type": "boolean"
+        },
+        "dead-letter-handle-new-exception": {
+          "type": "boolean"
+        },
+        "use-original-body": {
+          "type": "boolean"
+        },
+        "use-original-message": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.builder.ErrorHandlerBuilderRef": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.builder.ErrorHandlerBuilderSupport": {
+      "type": "object"
+    },
+    "org.apache.camel.builder.NoErrorHandlerBuilder": {
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.AggregateStepParser$CorrelationExpression": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {}
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.AggregateStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "aggregate-controller-ref": {
+              "type": "string"
+            },
+            "aggregation-repository-ref": {
+              "type": "string"
+            },
+            "close-correlation-key-on-completion": {
+              "type": "string"
+            },
+            "complete-all-on-stop": {
+              "type": "string"
+            },
+            "completion-from-batch-consumer": {
+              "type": "string"
+            },
+            "completion-interval": {
+              "type": "string"
+            },
+            "completion-on-new-correlation-group": {
+              "type": "string"
+            },
+            "completion-size": {
+              "type": "string"
+            },
+            "completion-timeout": {
+              "type": "string"
+            },
+            "completion-timeout-checker-interval": {
+              "type": "string"
+            },
+            "correlation-expression": {
+              "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.AggregateStepParser$CorrelationExpression"
+            },
+            "discard-on-aggregation-failure": {
+              "type": "string"
+            },
+            "discard-on-completion-timeout": {
+              "type": "string"
+            },
+            "eager-check-completion": {
+              "type": "string"
+            },
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "force-completion-on-stop": {
+              "type": "string"
+            },
+            "ignore-invalid-correlation-keys": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "optimistic-locking": {
+              "type": "string"
+            },
+            "parallel-processing": {
+              "type": "string"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            },
+            "timeout-checker-executor-service-ref": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.BeansStepParser$Definition": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition": {
+      "properties": {
+        "otherwise": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$Otherwise"
+        },
+        "when": {
+          "items": {
+            "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$When"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$Otherwise": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$When": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$CBDefinition": {
+      "properties": {
+        "on-fallback": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$FBDefinition"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$FBDefinition": {
+      "properties": {
+        "fallback-via-network": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DelayStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "async-delayed": {
+              "type": "string"
+            },
+            "caller-runs-when-rejected": {
+              "type": "string"
+            },
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoCatchDefinition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoFinallyDefinition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoTryDefinition": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DynamicRouterStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoints": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "uri-delimiter": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.EnrichStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "aggregate-on-exception": {
+              "type": "string"
+            },
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoint": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "share-unit-of-work": {
+              "type": "string"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ErrorHandlerStepParser$Definition": {
+      "properties": {
+        "dead-letter-channel": {
+          "$ref": "#/definitions/org.apache.camel.builder.DeadLetterChannelBuilder"
+        },
+        "default": {
+          "$ref": "#/definitions/org.apache.camel.builder.DefaultErrorHandlerBuilder"
+        },
+        "no-error-handler": {
+          "$ref": "#/definitions/org.apache.camel.builder.NoErrorHandlerBuilder"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.FilterStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.FromStepParser$Definition": {
+      "properties": {
+        "parameters": {
+          "type": "object"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "steps",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.IdempotentConsumerParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "completion-eager": {
+              "type": "string"
+            },
+            "eager": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "message-id-repository-ref": {
+              "type": "string"
+            },
+            "remove-on-failure": {
+              "type": "string"
+            },
+            "skip-duplicate": {
+              "type": "string"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition": {
+      "properties": {
+        "custom": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition"
+        },
+        "failover": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "random": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition"
+        },
+        "round-robin": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "sticky": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition$Sticky"
+        },
+        "topic": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition"
+        },
+        "type": {
+          "$ref": "#/definitions/org.apache.camel.model.LoadBalancerDefinition"
+        },
+        "weighted": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition$Sticky": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.LoopStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "copy": {
+              "type": "string"
+            },
+            "do-while": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.MarshalStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/dataformats"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.MulticastStepParser$Definition": {
+      "properties": {
+        "executor-service-ref": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "on-prepare-ref": {
+          "type": "string"
+        },
+        "parallel-aggregate": {
+          "type": "string"
+        },
+        "parallel-processing": {
+          "type": "string"
+        },
+        "share-unit-of-work": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "stop-on-aggregate-exception": {
+          "type": "string"
+        },
+        "stop-on-exception": {
+          "type": "string"
+        },
+        "strategy-method-allow-null": {
+          "type": "string"
+        },
+        "strategy-method-name": {
+          "type": "string"
+        },
+        "strategy-ref": {
+          "type": "string"
+        },
+        "streaming": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$ExpressionElement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {}
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$MaybeBooleanExpressionElement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {}
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$When": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.PipelineStepParser$Definition": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.PollEnrichStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "aggregate-on-exception": {
+              "type": "string"
+            },
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoint": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            },
+            "timeout": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ProcessStepParser$Definition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.RecipientListStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "cache-size": {
+              "type": "string"
+            },
+            "delimiter": {
+              "type": "string"
+            },
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoints": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "on-prepare-ref": {
+              "type": "string"
+            },
+            "parallel-aggregate": {
+              "type": "string"
+            },
+            "parallel-processing": {
+              "type": "string"
+            },
+            "share-unit-of-work": {
+              "type": "string"
+            },
+            "stop-on-aggregate-exception": {
+              "type": "string"
+            },
+            "stop-on-exception": {
+              "type": "string"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            },
+            "streaming": {
+              "type": "string"
+            },
+            "timeout": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ResequenceStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "batch-config": {
+              "$ref": "#/definitions/org.apache.camel.model.config.BatchResequencerConfig"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            },
+            "stream-config": {
+              "$ref": "#/definitions/org.apache.camel.model.config.StreamResequencerConfig"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.RestStepParser$Definition": {
+      "properties": {
+        "api-docs": {
+          "type": "boolean"
+        },
+        "binding-mode": {
+          "enum": [
+            "auto",
+            "off",
+            "json",
+            "xml",
+            "json_xml"
+          ]
+        },
+        "consumes": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enable-cors": {
+          "type": "boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "out-type": {
+          "type": "string"
+        },
+        "produces": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "type": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "verb": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.RouteStepParser$Definition": {
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RouteStepParser$From"
+        },
+        "group": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "from",
+        "steps"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.RouteStepParser$From": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "parameters": {
+              "type": "object"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.k.loader.yaml.parser.RoutingSlipStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoints": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "uri-delimiter": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SagaStepParser$Definition": {
+      "properties": {
+        "completion-mode": {
+          "enum": [
+            "AUTO",
+            "MANUAL"
+          ],
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "propagation": {
+          "enum": [
+            "REQUIRED",
+            "REQUIRES_NEW",
+            "MANDATORY",
+            "SUPPORTS",
+            "NOT_SUPPORTED",
+            "NEVER"
+          ],
+          "type": "string"
+        },
+        "saga-service-ref": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "timeout": {
+          "type": "string"
+        },
+        "timeout-in-milliseconds": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SampleStepParser$Definition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "message-frequency": {
+          "type": "string"
+        },
+        "sample-period": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "units": {
+          "enum": [
+            "NANOSECONDS",
+            "MICROSECONDS",
+            "MILLISECONDS",
+            "SECONDS",
+            "MINUTES",
+            "HOURS",
+            "DAYS"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ScriptStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$Definition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/definitions/expressions"
+            },
+            {}
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$ServiceCallExpressionDefinition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "host-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "port-header": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SetBodyStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SetExchangePatternStepParser$Definition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "enum": [
+            "InOnly",
+            "InOut",
+            "InOptionalOut"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SetHeaderStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SetPropertyStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SortStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "comparator-ref": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SplitStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "on-prepare-ref": {
+              "type": "string"
+            },
+            "parallel-aggregate": {
+              "type": "string"
+            },
+            "parallel-processing": {
+              "type": "string"
+            },
+            "share-unit-of-work": {
+              "type": "string"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            },
+            "stop-on-aggregate-exception": {
+              "type": "string"
+            },
+            "stop-on-exception": {
+              "type": "string"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            },
+            "streaming": {
+              "type": "string"
+            },
+            "timeout": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.StepStepParser$Definition": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ThrottleStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "async-delayed": {
+              "type": "string"
+            },
+            "caller-runs-when-rejected": {
+              "type": "string"
+            },
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "reject-execution": {
+              "type": "string"
+            },
+            "time-period-millis": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ThrowExceptionStepParser$Definition": {
+      "properties": {
+        "exception-type": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ToDynamicStepParser$Definition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "allow-optimised-components": {
+              "type": "string"
+            },
+            "auto-start-components": {
+              "type": "string"
+            },
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoint": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "parameters": {
+              "type": "object"
+            },
+            "pattern": {
+              "enum": [
+                "InOnly",
+                "InOut",
+                "InOptionalOut"
+              ],
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.k.loader.yaml.parser.ToStepParser$Definition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "parameters": {
+              "type": "object"
+            },
+            "pattern": {
+              "enum": [
+                "InOnly",
+                "InOut",
+                "InOptionalOut"
+              ],
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.k.loader.yaml.parser.TransactedStepParser$Definition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.TransformStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.UnmarshalStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/dataformats"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ValidateStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$Definition": {
+      "properties": {
+        "allow-optimised-components": {
+          "type": "string"
+        },
+        "auto-start-components": {
+          "type": "string"
+        },
+        "cache-size": {
+          "type": "string"
+        },
+        "ignore-invalid-endpoint": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "enum": [
+            "InOnly",
+            "InOut",
+            "InOptionalOut"
+          ],
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$HeaderDefinition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$NewExchangeDefinition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {}
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.model.BeanDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "bean-type": {
+              "type": "string"
+            },
+            "cache": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "method": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "scope": {
+              "enum": [
+                "Singleton",
+                "Request",
+                "Prototype"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.ClaimCheckDefinition": {
+      "properties": {
+        "filter": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "operation": {
+          "enum": [
+            "Get",
+            "GetAndRemove",
+            "Set",
+            "Push",
+            "Pop"
+          ],
+          "type": "string"
+        },
+        "strategy-method-name": {
+          "type": "string"
+        },
+        "strategy-ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.ConvertBodyDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "charset": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.LoadBalancerDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.LogDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "log-name": {
+              "type": "string"
+            },
+            "logger-ref": {
+              "type": "string"
+            },
+            "logging-level": {
+              "enum": [
+                "TRACE",
+                "DEBUG",
+                "INFO",
+                "WARN",
+                "ERROR",
+                "OFF"
+              ],
+              "type": "string"
+            },
+            "marker": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RemoveHeaderDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "header-name": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RemoveHeadersDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "exclude-pattern": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "pattern": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RemovePropertiesDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "exclude-pattern": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "pattern": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RemovePropertyDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "property-name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RollbackDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "mark-rollback-only": {
+              "type": "string"
+            },
+            "mark-rollback-only-last": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.StopDefinition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.ThreadsDefinition": {
+      "properties": {
+        "allow-core-thread-time-out": {
+          "type": "string"
+        },
+        "caller-runs-when-rejected": {
+          "type": "string"
+        },
+        "executor-service-ref": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "keep-alive-time": {
+          "type": "string"
+        },
+        "max-pool-size": {
+          "type": "string"
+        },
+        "max-queue-size": {
+          "type": "string"
+        },
+        "pool-size": {
+          "type": "string"
+        },
+        "rejected-policy": {
+          "enum": [
+            "Abort",
+            "CallerRuns",
+            "DiscardOldest",
+            "Discard"
+          ],
+          "type": "string"
+        },
+        "thread-name": {
+          "type": "string"
+        },
+        "time-unit": {
+          "enum": [
+            "NANOSECONDS",
+            "MICROSECONDS",
+            "MILLISECONDS",
+            "SECONDS",
+            "MINUTES",
+            "HOURS",
+            "DAYS"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.config.BatchResequencerConfig": {
+      "properties": {
+        "allow-duplicates": {
+          "type": "string"
+        },
+        "batch-size": {
+          "type": "string"
+        },
+        "batch-timeout": {
+          "type": "string"
+        },
+        "ignore-invalid-exchanges": {
+          "type": "string"
+        },
+        "reverse": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.config.StreamResequencerConfig": {
+      "properties": {
+        "capacity": {
+          "type": "string"
+        },
+        "comparator-ref": {
+          "type": "string"
+        },
+        "delivery-attempt-interval": {
+          "type": "string"
+        },
+        "ignore-invalid-exchanges": {
+          "type": "string"
+        },
+        "reject-old": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ASN1DataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "clazz-name": {
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "using-iterator": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.Any23DataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "base-uri": {
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "output-format": {
+              "enum": [
+                "NTRIPLES",
+                "TURTLE",
+                "NQUADS",
+                "RDFXML",
+                "JSONLD",
+                "RDFJSON",
+                "RDF4JMODEL"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.AvroDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "instance-class-name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.BarcodeDataFormat": {
+      "properties": {
+        "barcode-format": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "height": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "image-type": {
+          "type": "string"
+        },
+        "width": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.Base64DataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "line-length": {
+          "type": "string"
+        },
+        "line-separator": {
+          "type": "string"
+        },
+        "url-safe": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.BeanioDataFormat": {
+      "properties": {
+        "bean-reader-error-handler-type": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-invalid-records": {
+          "type": "string"
+        },
+        "ignore-unexpected-records": {
+          "type": "string"
+        },
+        "ignore-unidentified-records": {
+          "type": "string"
+        },
+        "mapping": {
+          "type": "string"
+        },
+        "stream-name": {
+          "type": "string"
+        },
+        "unmarshal-single-object": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.BindyDataFormat": {
+      "properties": {
+        "allow-empty-stream": {
+          "type": "string"
+        },
+        "class-type": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "Csv",
+            "Fixed",
+            "KeyValue"
+          ],
+          "type": "string"
+        },
+        "unwrap-single-instance": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.CBORDataFormat": {
+      "properties": {
+        "allow-jms-type": {
+          "type": "string"
+        },
+        "allow-unmarshall-type": {
+          "type": "string"
+        },
+        "collection-type-name": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "disable-features": {
+          "type": "string"
+        },
+        "enable-features": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "object-mapper": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "unmarshal-type-name": {
+          "type": "string"
+        },
+        "use-default-object-mapper": {
+          "type": "string"
+        },
+        "use-list": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.CryptoDataFormat": {
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "algorithm-parameter-ref": {
+          "type": "string"
+        },
+        "buffersize": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "crypto-provider": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "init-vector-ref": {
+          "type": "string"
+        },
+        "inline": {
+          "type": "string"
+        },
+        "key-ref": {
+          "type": "string"
+        },
+        "mac-algorithm": {
+          "type": "string"
+        },
+        "should-append-hmac": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.CsvDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "allow-missing-column-names": {
+              "type": "string"
+            },
+            "comment-marker": {
+              "type": "string"
+            },
+            "comment-marker-disabled": {
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "delimiter": {
+              "type": "string"
+            },
+            "escape": {
+              "type": "string"
+            },
+            "escape-disabled": {
+              "type": "string"
+            },
+            "format-name": {
+              "enum": [
+                "DEFAULT",
+                "EXCEL",
+                "INFORMIX_UNLOAD",
+                "INFORMIX_UNLOAD_CSV",
+                "MYSQL",
+                "RFC4180"
+              ],
+              "type": "string"
+            },
+            "format-ref": {
+              "type": "string"
+            },
+            "header-disabled": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ignore-empty-lines": {
+              "type": "string"
+            },
+            "ignore-header-case": {
+              "type": "string"
+            },
+            "ignore-surrounding-spaces": {
+              "type": "string"
+            },
+            "lazy-load": {
+              "type": "string"
+            },
+            "marshaller-factory-ref": {
+              "type": "string"
+            },
+            "null-string": {
+              "type": "string"
+            },
+            "null-string-disabled": {
+              "type": "string"
+            },
+            "quote": {
+              "type": "string"
+            },
+            "quote-disabled": {
+              "type": "string"
+            },
+            "quote-mode": {
+              "type": "string"
+            },
+            "record-converter-ref": {
+              "type": "string"
+            },
+            "record-separator": {
+              "type": "string"
+            },
+            "record-separator-disabled": {
+              "type": "string"
+            },
+            "skip-header-record": {
+              "type": "string"
+            },
+            "trailing-delimiter": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            },
+            "use-maps": {
+              "type": "string"
+            },
+            "use-ordered-maps": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.CustomDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.FhirJsonDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "dont-encode-elements": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dont-strip-versions-from-references-at-paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encode-elements": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encode-elements-applies-to-child-resources-only": {
+          "type": "string"
+        },
+        "fhir-version": {
+          "enum": [
+            "DSTU2",
+            "DSTU2_HL7ORG",
+            "DSTU2_1",
+            "DSTU3",
+            "R4"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "omit-resource-id": {
+          "type": "string"
+        },
+        "override-resource-id-with-bundle-entry-full-url": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "server-base-url": {
+          "type": "string"
+        },
+        "strip-versions-from-references": {
+          "type": "string"
+        },
+        "summary-mode": {
+          "type": "string"
+        },
+        "suppress-narratives": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.FhirXmlDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "dont-encode-elements": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dont-strip-versions-from-references-at-paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encode-elements": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encode-elements-applies-to-child-resources-only": {
+          "type": "string"
+        },
+        "fhir-version": {
+          "enum": [
+            "DSTU2",
+            "DSTU2_HL7ORG",
+            "DSTU2_1",
+            "DSTU3",
+            "R4"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "omit-resource-id": {
+          "type": "string"
+        },
+        "override-resource-id-with-bundle-entry-full-url": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "server-base-url": {
+          "type": "string"
+        },
+        "strip-versions-from-references": {
+          "type": "string"
+        },
+        "summary-mode": {
+          "type": "string"
+        },
+        "suppress-narratives": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.FlatpackDataFormat": {
+      "properties": {
+        "allow-short-lines": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "delimiter": {
+          "type": "string"
+        },
+        "fixed": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-extra-columns": {
+          "type": "string"
+        },
+        "ignore-first-record": {
+          "type": "string"
+        },
+        "parser-factory-ref": {
+          "type": "string"
+        },
+        "text-qualifier": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.GrokDataFormat": {
+      "properties": {
+        "allow-multiple-matches-per-line": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "flattened": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "named-only": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.GzipDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.HL7DataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "validate": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.IcalDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "validating": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.JacksonXMLDataFormat": {
+      "properties": {
+        "allow-jms-type": {
+          "type": "string"
+        },
+        "allow-unmarshall-type": {
+          "type": "string"
+        },
+        "collection-type-name": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "disable-features": {
+          "type": "string"
+        },
+        "enable-features": {
+          "type": "string"
+        },
+        "enable-jaxb-annotation-module": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "include": {
+          "type": "string"
+        },
+        "json-view": {
+          "type": "string"
+        },
+        "module-class-names": {
+          "type": "string"
+        },
+        "module-refs": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "unmarshal-type-name": {
+          "type": "string"
+        },
+        "use-list": {
+          "type": "string"
+        },
+        "xml-mapper": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.JaxbDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "context-path": {
+          "type": "string"
+        },
+        "context-path-is-class-name": {
+          "type": "string"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "filter-non-xml-chars": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-jaxb-element": {
+          "type": "string"
+        },
+        "jaxb-provider-properties": {
+          "type": "string"
+        },
+        "must-be-jaxb-element": {
+          "type": "string"
+        },
+        "namespace-prefix-ref": {
+          "type": "string"
+        },
+        "no-namespace-schema-location": {
+          "type": "string"
+        },
+        "object-factory": {
+          "type": "string"
+        },
+        "part-class": {
+          "type": "string"
+        },
+        "part-namespace": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "schema-location": {
+          "type": "string"
+        },
+        "schema-severity-level": {
+          "enum": [
+            "0",
+            "1",
+            "2"
+          ],
+          "type": "string"
+        },
+        "xml-stream-writer-wrapper": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.JsonApiDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "data-format-types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "main-format-type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.JsonDataFormat": {
+      "properties": {
+        "allow-jms-type": {
+          "type": "string"
+        },
+        "allow-unmarshall-type": {
+          "type": "string"
+        },
+        "auto-discover-object-mapper": {
+          "type": "string"
+        },
+        "collection-type-name": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "disable-features": {
+          "type": "string"
+        },
+        "drop-root-node": {
+          "type": "string"
+        },
+        "enable-features": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "include": {
+          "type": "string"
+        },
+        "json-view": {
+          "type": "string"
+        },
+        "library": {
+          "enum": [
+            "XStream",
+            "Jackson",
+            "Johnzon",
+            "Gson",
+            "Fastjson"
+          ]
+        },
+        "module-class-names": {
+          "type": "string"
+        },
+        "module-refs": {
+          "type": "string"
+        },
+        "object-mapper": {
+          "type": "string"
+        },
+        "permissions": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "unmarshal-type-name": {
+          "type": "string"
+        },
+        "use-default-object-mapper": {
+          "type": "string"
+        },
+        "use-list": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.LZFDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "using-parallel-compression": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.MimeMultipartDataFormat": {
+      "properties": {
+        "binary-content": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "headers-inline": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "include-headers": {
+          "type": "string"
+        },
+        "multipart-sub-type": {
+          "type": "string"
+        },
+        "multipart-without-attachment": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.PGPDataFormat": {
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "armored": {
+          "type": "string"
+        },
+        "compression-algorithm": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "hash-algorithm": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "integrity": {
+          "type": "string"
+        },
+        "key-file-name": {
+          "type": "string"
+        },
+        "key-userid": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "signature-key-file-name": {
+          "type": "string"
+        },
+        "signature-key-ring": {
+          "type": "string"
+        },
+        "signature-key-userid": {
+          "type": "string"
+        },
+        "signature-password": {
+          "type": "string"
+        },
+        "signature-verification-option": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ProtobufDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-format": {
+              "enum": [
+                "native",
+                "json"
+              ],
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "instance-class": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.RssDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.SoapJaxbDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-header": {
+              "type": "string"
+            },
+            "context-path": {
+              "type": "string"
+            },
+            "element-name-strategy-ref": {
+              "type": "string"
+            },
+            "encoding": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "namespace-prefix-ref": {
+              "type": "string"
+            },
+            "schema": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.SyslogDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.TarFileDataFormat": {
+      "properties": {
+        "allow-empty-directory": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "preserve-path-elements": {
+          "type": "string"
+        },
+        "using-iterator": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ThriftDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-format": {
+              "enum": [
+                "binary",
+                "json",
+                "sjson"
+              ],
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "instance-class": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.TidyMarkupDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "data-object-type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "omit-xml-declaration": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.UniVocityCsvDataFormat": {
+      "properties": {
+        "as-map": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "delimiter": {
+          "type": "string"
+        },
+        "empty-value": {
+          "type": "string"
+        },
+        "header-extraction-enabled": {
+          "type": "string"
+        },
+        "headers-disabled": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-leading-whitespaces": {
+          "type": "string"
+        },
+        "ignore-trailing-whitespaces": {
+          "type": "string"
+        },
+        "lazy-load": {
+          "type": "string"
+        },
+        "line-separator": {
+          "type": "string"
+        },
+        "normalized-line-separator": {
+          "type": "string"
+        },
+        "null-value": {
+          "type": "string"
+        },
+        "number-of-records-to-read": {
+          "type": "string"
+        },
+        "quote": {
+          "type": "string"
+        },
+        "quote-all-fields": {
+          "type": "string"
+        },
+        "quote-escape": {
+          "type": "string"
+        },
+        "skip-empty-lines": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.UniVocityFixedWidthDataFormat": {
+      "properties": {
+        "as-map": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "empty-value": {
+          "type": "string"
+        },
+        "header-extraction-enabled": {
+          "type": "string"
+        },
+        "headers-disabled": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-leading-whitespaces": {
+          "type": "string"
+        },
+        "ignore-trailing-whitespaces": {
+          "type": "string"
+        },
+        "lazy-load": {
+          "type": "string"
+        },
+        "line-separator": {
+          "type": "string"
+        },
+        "normalized-line-separator": {
+          "type": "string"
+        },
+        "null-value": {
+          "type": "string"
+        },
+        "number-of-records-to-read": {
+          "type": "string"
+        },
+        "padding": {
+          "type": "string"
+        },
+        "record-ends-on-newline": {
+          "type": "string"
+        },
+        "skip-empty-lines": {
+          "type": "string"
+        },
+        "skip-trailing-chars-until-newline": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.UniVocityTsvDataFormat": {
+      "properties": {
+        "as-map": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "empty-value": {
+          "type": "string"
+        },
+        "escape-char": {
+          "type": "string"
+        },
+        "header-extraction-enabled": {
+          "type": "string"
+        },
+        "headers-disabled": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-leading-whitespaces": {
+          "type": "string"
+        },
+        "ignore-trailing-whitespaces": {
+          "type": "string"
+        },
+        "lazy-load": {
+          "type": "string"
+        },
+        "line-separator": {
+          "type": "string"
+        },
+        "normalized-line-separator": {
+          "type": "string"
+        },
+        "null-value": {
+          "type": "string"
+        },
+        "number-of-records-to-read": {
+          "type": "string"
+        },
+        "skip-empty-lines": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.XMLSecurityDataFormat": {
+      "properties": {
+        "add-key-value-for-encrypted-key": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "digest-algorithm": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key-cipher-algorithm": {
+          "type": "string"
+        },
+        "key-or-trust-store-parameters-ref": {
+          "type": "string"
+        },
+        "key-password": {
+          "type": "string"
+        },
+        "mgf-algorithm": {
+          "type": "string"
+        },
+        "pass-phrase": {
+          "type": "string"
+        },
+        "pass-phrase-byte": {
+          "format": "binary",
+          "type": "string"
+        },
+        "recipient-key-alias": {
+          "type": "string"
+        },
+        "secure-tag": {
+          "type": "string"
+        },
+        "secure-tag-contents": {
+          "type": "string"
+        },
+        "xml-cipher-algorithm": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.XStreamDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-header": {
+              "type": "string"
+            },
+            "driver": {
+              "type": "string"
+            },
+            "driver-ref": {
+              "type": "string"
+            },
+            "encoding": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "mode": {
+              "type": "string"
+            },
+            "permissions": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.XmlRpcDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "request": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.YAMLDataFormat": {
+      "properties": {
+        "allow-any-type": {
+          "type": "string"
+        },
+        "allow-recursive-keys": {
+          "type": "string"
+        },
+        "constructor": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "dumper-options": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "library": {
+          "enum": [
+            "SnakeYAML"
+          ]
+        },
+        "max-aliases-for-collections": {
+          "type": "string"
+        },
+        "pretty-flow": {
+          "type": "string"
+        },
+        "representer": {
+          "type": "string"
+        },
+        "resolver": {
+          "type": "string"
+        },
+        "unmarshal-type-name": {
+          "type": "string"
+        },
+        "use-application-context-class-loader": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ZipDeflaterDataFormat": {
+      "properties": {
+        "compression-level": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ZipFileDataFormat": {
+      "properties": {
+        "allow-empty-directory": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "preserve-path-elements": {
+          "type": "string"
+        },
+        "using-iterator": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.language.ConstantExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.ExchangePropertyExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.GroovyExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.HeaderExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.Hl7TerserExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.JsonPathExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "allow-easy-predicate": {
+              "type": "string"
+            },
+            "allow-simple": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "result-type": {
+              "type": "string"
+            },
+            "suppress-exceptions": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            },
+            "write-as-string": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.LanguageExpression": {
+      "properties": {
+        "expression": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "trim": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.model.language.MethodCallExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "bean-type": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "method": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.MvelExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.OgnlExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.RefExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.SimpleExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "result-type": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.SpELExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.TokenizerExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "end-token": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            },
+            "group-delimiter": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "include-tokens": {
+              "type": "string"
+            },
+            "inherit-namespace-tag-name": {
+              "type": "string"
+            },
+            "regex": {
+              "type": "string"
+            },
+            "skip-first": {
+              "type": "string"
+            },
+            "token": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            },
+            "xml": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.XMLTokenizerExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "mode": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.XPathExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "document-type": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "factory-ref": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "log-namespaces": {
+              "type": "string"
+            },
+            "object-model": {
+              "type": "string"
+            },
+            "result-type": {
+              "enum": [
+                "NUMBER",
+                "STRING",
+                "BOOLEAN",
+                "NODESET",
+                "NODE"
+              ],
+              "type": "string"
+            },
+            "saxon": {
+              "type": "string"
+            },
+            "thread-safety": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.XQueryExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "maximum-failover-attempts": {
+          "type": "string"
+        },
+        "round-robin": {
+          "type": "string"
+        },
+        "sticky": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition": {
+      "properties": {
+        "distribution-ratio": {
+          "type": "string"
+        },
+        "distribution-ratio-delimiter": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "round-robin": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "step": {
+      "maxProperties": 1,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.AggregateStepParser$Definition"
+        },
+        "bean": {
+          "$ref": "#/definitions/org.apache.camel.model.BeanDefinition"
+        },
+        "choice": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition"
+        },
+        "circuit-breaker": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$CBDefinition"
+        },
+        "claim-check": {
+          "$ref": "#/definitions/org.apache.camel.model.ClaimCheckDefinition"
+        },
+        "convert-body-to": {
+          "$ref": "#/definitions/org.apache.camel.model.ConvertBodyDefinition"
+        },
+        "delay": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DelayStepParser$Definition"
+        },
+        "do-try": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoTryDefinition"
+        },
+        "dynamic-router": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DynamicRouterStepParser$Definition"
+        },
+        "enrich": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.EnrichStepParser$Definition"
+        },
+        "error-handler": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ErrorHandlerStepParser$Definition"
+        },
+        "filter": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.FilterStepParser$Definition"
+        },
+        "idempotent-consumer": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.IdempotentConsumerParser$Definition"
+        },
+        "load-balance": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition"
+        },
+        "log": {
+          "$ref": "#/definitions/org.apache.camel.model.LogDefinition"
+        },
+        "loop": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoopStepParser$Definition"
+        },
+        "marshal": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.MarshalStepParser$Definition"
+        },
+        "multicast": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.MulticastStepParser$Definition"
+        },
+        "on-exception": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition"
+        },
+        "pipeline": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.PipelineStepParser$Definition"
+        },
+        "poll-enrich": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.PollEnrichStepParser$Definition"
+        },
+        "process": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ProcessStepParser$Definition"
+        },
+        "recipient-list": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RecipientListStepParser$Definition"
+        },
+        "remove-header": {
+          "$ref": "#/definitions/org.apache.camel.model.RemoveHeaderDefinition"
+        },
+        "remove-headers": {
+          "$ref": "#/definitions/org.apache.camel.model.RemoveHeadersDefinition"
+        },
+        "remove-properties": {
+          "$ref": "#/definitions/org.apache.camel.model.RemovePropertiesDefinition"
+        },
+        "remove-property": {
+          "$ref": "#/definitions/org.apache.camel.model.RemovePropertyDefinition"
+        },
+        "resequence": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ResequenceStepParser$Definition"
+        },
+        "rollback": {
+          "$ref": "#/definitions/org.apache.camel.model.RollbackDefinition"
+        },
+        "routing-slip": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RoutingSlipStepParser$Definition"
+        },
+        "saga": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SagaStepParser$Definition"
+        },
+        "sample": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SampleStepParser$Definition"
+        },
+        "script": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ScriptStepParser$Definition"
+        },
+        "service-call": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$Definition"
+        },
+        "set-body": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetBodyStepParser$Definition"
+        },
+        "set-exchange-pattern": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetExchangePatternStepParser$Definition"
+        },
+        "set-header": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetHeaderStepParser$Definition"
+        },
+        "set-property": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetPropertyStepParser$Definition"
+        },
+        "sort": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SortStepParser$Definition"
+        },
+        "split": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SplitStepParser$Definition"
+        },
+        "step": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.StepStepParser$Definition"
+        },
+        "stop": {
+          "$ref": "#/definitions/org.apache.camel.model.StopDefinition"
+        },
+        "threads": {
+          "$ref": "#/definitions/org.apache.camel.model.ThreadsDefinition"
+        },
+        "throttle": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ThrottleStepParser$Definition"
+        },
+        "throw-exception": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ThrowExceptionStepParser$Definition"
+        },
+        "to": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ToStepParser$Definition"
+        },
+        "tod": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ToDynamicStepParser$Definition"
+        },
+        "transacted": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.TransactedStepParser$Definition"
+        },
+        "transform": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.TransformStepParser$Definition"
+        },
+        "unmarshal": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.UnmarshalStepParser$Definition"
+        },
+        "validate": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ValidateStepParser$Definition"
+        },
+        "wiretap": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.WireTapStepParser$Definition"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "description": "Integration is the Schema for the integrations API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "IntegrationSpec defines the desired state of Integration",
+      "properties": {
+        "configuration": {
+          "items": {
+            "description": "ConfigurationSpec --",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "flows": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "items": {
+            "definitions": {
+              "dataformats": {
+                "properties": {
+                  "any23": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.Any23DataFormat"
+                  },
+                  "asn1": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+                  },
+                  "avro": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+                  },
+                  "barcode": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+                  },
+                  "base64": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+                  },
+                  "beanio": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.BeanioDataFormat"
+                  },
+                  "bindy": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+                  },
+                  "cbor": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+                  },
+                  "crypto": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+                  },
+                  "csv": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+                  },
+                  "custom-data-format": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+                  },
+                  "fhir-json": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+                  },
+                  "fhir-xml": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+                  },
+                  "flatpack": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+                  },
+                  "grok": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+                  },
+                  "gzipdeflater": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.GzipDataFormat"
+                  },
+                  "hl7": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+                  },
+                  "ical": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+                  },
+                  "jacksonxml": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+                  },
+                  "jaxb": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+                  },
+                  "json": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+                  },
+                  "json-api": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+                  },
+                  "lzf": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+                  },
+                  "mime-multipart": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+                  },
+                  "pgp": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+                  },
+                  "protobuf": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+                  },
+                  "rss": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+                  },
+                  "secure-xml": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+                  },
+                  "soapjaxb": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.SoapJaxbDataFormat"
+                  },
+                  "syslog": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+                  },
+                  "tarfile": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+                  },
+                  "thrift": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+                  },
+                  "tidy-markup": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+                  },
+                  "univocity-csv": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+                  },
+                  "univocity-fixed": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityFixedWidthDataFormat"
+                  },
+                  "univocity-tsv": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+                  },
+                  "xmlrpc": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.XmlRpcDataFormat"
+                  },
+                  "xstream": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+                  },
+                  "yaml": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+                  },
+                  "zipdeflater": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+                  },
+                  "zipfile": {
+                    "$ref": "#/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+                  }
+                },
+                "type": "object"
+              },
+              "expressions": {
+                "properties": {
+                  "constant": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.ConstantExpression"
+                  },
+                  "exchange-property": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+                  },
+                  "groovy": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.GroovyExpression"
+                  },
+                  "header": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.HeaderExpression"
+                  },
+                  "hl7terser": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+                  },
+                  "jsonpath": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.JsonPathExpression"
+                  },
+                  "language": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.LanguageExpression"
+                  },
+                  "method": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.MethodCallExpression"
+                  },
+                  "mvel": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.MvelExpression"
+                  },
+                  "ognl": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.OgnlExpression"
+                  },
+                  "ref": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.RefExpression"
+                  },
+                  "simple": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.SimpleExpression"
+                  },
+                  "spel": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.SpELExpression"
+                  },
+                  "tokenize": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.TokenizerExpression"
+                  },
+                  "xpath": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.XPathExpression"
+                  },
+                  "xquery": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.XQueryExpression"
+                  },
+                  "xtokenize": {
+                    "$ref": "#/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.builder.DeadLetterChannelBuilder": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "async-delayed-redelivery": {
+                        "type": "boolean"
+                      },
+                      "dead-letter-handle-new-exception": {
+                        "type": "boolean"
+                      },
+                      "use-original-body": {
+                        "type": "boolean"
+                      },
+                      "use-original-message": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.builder.DefaultErrorHandlerBuilder": {
+                "properties": {
+                  "async-delayed-redelivery": {
+                    "type": "boolean"
+                  },
+                  "dead-letter-handle-new-exception": {
+                    "type": "boolean"
+                  },
+                  "use-original-body": {
+                    "type": "boolean"
+                  },
+                  "use-original-message": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.builder.ErrorHandlerBuilderRef": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.builder.ErrorHandlerBuilderSupport": {
+                "type": "object"
+              },
+              "org.apache.camel.builder.NoErrorHandlerBuilder": {
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.AggregateStepParser$CorrelationExpression": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {}
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.AggregateStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "aggregate-controller-ref": {
+                        "type": "string"
+                      },
+                      "aggregation-repository-ref": {
+                        "type": "string"
+                      },
+                      "close-correlation-key-on-completion": {
+                        "type": "string"
+                      },
+                      "complete-all-on-stop": {
+                        "type": "string"
+                      },
+                      "completion-from-batch-consumer": {
+                        "type": "string"
+                      },
+                      "completion-interval": {
+                        "type": "string"
+                      },
+                      "completion-on-new-correlation-group": {
+                        "type": "string"
+                      },
+                      "completion-size": {
+                        "type": "string"
+                      },
+                      "completion-timeout": {
+                        "type": "string"
+                      },
+                      "completion-timeout-checker-interval": {
+                        "type": "string"
+                      },
+                      "correlation-expression": {
+                        "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.AggregateStepParser$CorrelationExpression"
+                      },
+                      "discard-on-aggregation-failure": {
+                        "type": "string"
+                      },
+                      "discard-on-completion-timeout": {
+                        "type": "string"
+                      },
+                      "eager-check-completion": {
+                        "type": "string"
+                      },
+                      "executor-service-ref": {
+                        "type": "string"
+                      },
+                      "force-completion-on-stop": {
+                        "type": "string"
+                      },
+                      "ignore-invalid-correlation-keys": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "optimistic-locking": {
+                        "type": "string"
+                      },
+                      "parallel-processing": {
+                        "type": "string"
+                      },
+                      "strategy-method-allow-null": {
+                        "type": "string"
+                      },
+                      "strategy-method-name": {
+                        "type": "string"
+                      },
+                      "strategy-ref": {
+                        "type": "string"
+                      },
+                      "timeout-checker-executor-service-ref": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.BeansStepParser$Definition": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "type": "object"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition": {
+                "properties": {
+                  "otherwise": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$Otherwise"
+                  },
+                  "when": {
+                    "items": {
+                      "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$When"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$Otherwise": {
+                "properties": {
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$When": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "steps": {
+                        "items": {
+                          "$ref": "#/definitions/step"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$CBDefinition": {
+                "properties": {
+                  "on-fallback": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$FBDefinition"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$FBDefinition": {
+                "properties": {
+                  "fallback-via-network": {
+                    "type": "string"
+                  },
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.DelayStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "async-delayed": {
+                        "type": "string"
+                      },
+                      "caller-runs-when-rejected": {
+                        "type": "string"
+                      },
+                      "executor-service-ref": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoCatchDefinition": {
+                "properties": {
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoFinallyDefinition": {
+                "properties": {
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoTryDefinition": {
+                "properties": {
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.DynamicRouterStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "cache-size": {
+                        "type": "string"
+                      },
+                      "ignore-invalid-endpoints": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "uri-delimiter": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.EnrichStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "aggregate-on-exception": {
+                        "type": "string"
+                      },
+                      "cache-size": {
+                        "type": "string"
+                      },
+                      "ignore-invalid-endpoint": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "share-unit-of-work": {
+                        "type": "string"
+                      },
+                      "strategy-method-allow-null": {
+                        "type": "string"
+                      },
+                      "strategy-method-name": {
+                        "type": "string"
+                      },
+                      "strategy-ref": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ErrorHandlerStepParser$Definition": {
+                "properties": {
+                  "dead-letter-channel": {
+                    "$ref": "#/definitions/org.apache.camel.builder.DeadLetterChannelBuilder"
+                  },
+                  "default": {
+                    "$ref": "#/definitions/org.apache.camel.builder.DefaultErrorHandlerBuilder"
+                  },
+                  "no-error-handler": {
+                    "$ref": "#/definitions/org.apache.camel.builder.NoErrorHandlerBuilder"
+                  },
+                  "ref": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.FilterStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "steps": {
+                        "items": {
+                          "$ref": "#/definitions/step"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.FromStepParser$Definition": {
+                "properties": {
+                  "parameters": {
+                    "type": "object"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  },
+                  "uri": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "steps",
+                  "uri"
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.IdempotentConsumerParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "completion-eager": {
+                        "type": "string"
+                      },
+                      "eager": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "message-id-repository-ref": {
+                        "type": "string"
+                      },
+                      "remove-on-failure": {
+                        "type": "string"
+                      },
+                      "skip-duplicate": {
+                        "type": "string"
+                      },
+                      "steps": {
+                        "items": {
+                          "$ref": "#/definitions/step"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition": {
+                "properties": {
+                  "custom": {
+                    "$ref": "#/definitions/org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition"
+                  },
+                  "failover": {
+                    "$ref": "#/definitions/org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition"
+                  },
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "random": {
+                    "$ref": "#/definitions/org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition"
+                  },
+                  "round-robin": {
+                    "$ref": "#/definitions/org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  },
+                  "sticky": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition$Sticky"
+                  },
+                  "topic": {
+                    "$ref": "#/definitions/org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition"
+                  },
+                  "type": {
+                    "$ref": "#/definitions/org.apache.camel.model.LoadBalancerDefinition"
+                  },
+                  "weighted": {
+                    "$ref": "#/definitions/org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition$Sticky": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.LoopStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "copy": {
+                        "type": "string"
+                      },
+                      "do-while": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "steps": {
+                        "items": {
+                          "$ref": "#/definitions/step"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.MarshalStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/dataformats"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.MulticastStepParser$Definition": {
+                "properties": {
+                  "executor-service-ref": {
+                    "type": "string"
+                  },
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "on-prepare-ref": {
+                    "type": "string"
+                  },
+                  "parallel-aggregate": {
+                    "type": "string"
+                  },
+                  "parallel-processing": {
+                    "type": "string"
+                  },
+                  "share-unit-of-work": {
+                    "type": "string"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  },
+                  "stop-on-aggregate-exception": {
+                    "type": "string"
+                  },
+                  "stop-on-exception": {
+                    "type": "string"
+                  },
+                  "strategy-method-allow-null": {
+                    "type": "string"
+                  },
+                  "strategy-method-name": {
+                    "type": "string"
+                  },
+                  "strategy-ref": {
+                    "type": "string"
+                  },
+                  "streaming": {
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition": {
+                "properties": {
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$ExpressionElement": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {}
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$MaybeBooleanExpressionElement": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {}
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$When": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "steps": {
+                        "items": {
+                          "$ref": "#/definitions/step"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.PipelineStepParser$Definition": {
+                "properties": {
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.PollEnrichStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "aggregate-on-exception": {
+                        "type": "string"
+                      },
+                      "cache-size": {
+                        "type": "string"
+                      },
+                      "ignore-invalid-endpoint": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "strategy-method-allow-null": {
+                        "type": "string"
+                      },
+                      "strategy-method-name": {
+                        "type": "string"
+                      },
+                      "strategy-ref": {
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ProcessStepParser$Definition": {
+                "properties": {
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "ref": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.RecipientListStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "cache-size": {
+                        "type": "string"
+                      },
+                      "delimiter": {
+                        "type": "string"
+                      },
+                      "executor-service-ref": {
+                        "type": "string"
+                      },
+                      "ignore-invalid-endpoints": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "on-prepare-ref": {
+                        "type": "string"
+                      },
+                      "parallel-aggregate": {
+                        "type": "string"
+                      },
+                      "parallel-processing": {
+                        "type": "string"
+                      },
+                      "share-unit-of-work": {
+                        "type": "string"
+                      },
+                      "stop-on-aggregate-exception": {
+                        "type": "string"
+                      },
+                      "stop-on-exception": {
+                        "type": "string"
+                      },
+                      "strategy-method-allow-null": {
+                        "type": "string"
+                      },
+                      "strategy-method-name": {
+                        "type": "string"
+                      },
+                      "strategy-ref": {
+                        "type": "string"
+                      },
+                      "streaming": {
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ResequenceStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "batch-config": {
+                        "$ref": "#/definitions/org.apache.camel.model.config.BatchResequencerConfig"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "steps": {
+                        "items": {
+                          "$ref": "#/definitions/step"
+                        },
+                        "type": "array"
+                      },
+                      "stream-config": {
+                        "$ref": "#/definitions/org.apache.camel.model.config.StreamResequencerConfig"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.RestStepParser$Definition": {
+                "properties": {
+                  "api-docs": {
+                    "type": "boolean"
+                  },
+                  "binding-mode": {
+                    "enum": [
+                      "auto",
+                      "off",
+                      "json",
+                      "xml",
+                      "json_xml"
+                    ]
+                  },
+                  "consumes": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "enable-cors": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "out-type": {
+                    "type": "string"
+                  },
+                  "produces": {
+                    "type": "string"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "uri": {
+                    "type": "string"
+                  },
+                  "verb": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.RouteStepParser$Definition": {
+                "properties": {
+                  "from": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RouteStepParser$From"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "from",
+                  "steps"
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.RouteStepParser$From": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "parameters": {
+                        "type": "object"
+                      },
+                      "uri": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "uri"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.k.loader.yaml.parser.RoutingSlipStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "cache-size": {
+                        "type": "string"
+                      },
+                      "ignore-invalid-endpoints": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "uri-delimiter": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.SagaStepParser$Definition": {
+                "properties": {
+                  "completion-mode": {
+                    "enum": [
+                      "AUTO",
+                      "MANUAL"
+                    ],
+                    "type": "string"
+                  },
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "propagation": {
+                    "enum": [
+                      "REQUIRED",
+                      "REQUIRES_NEW",
+                      "MANDATORY",
+                      "SUPPORTS",
+                      "NOT_SUPPORTED",
+                      "NEVER"
+                    ],
+                    "type": "string"
+                  },
+                  "saga-service-ref": {
+                    "type": "string"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  },
+                  "timeout": {
+                    "type": "string"
+                  },
+                  "timeout-in-milliseconds": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.SampleStepParser$Definition": {
+                "properties": {
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "message-frequency": {
+                    "type": "string"
+                  },
+                  "sample-period": {
+                    "type": "string"
+                  },
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  },
+                  "units": {
+                    "enum": [
+                      "NANOSECONDS",
+                      "MICROSECONDS",
+                      "MILLISECONDS",
+                      "SECONDS",
+                      "MINUTES",
+                      "HOURS",
+                      "DAYS"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ScriptStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$Definition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/expressions"
+                      },
+                      {}
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$ServiceCallExpressionDefinition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "host-header": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "port-header": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.SetBodyStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.SetExchangePatternStepParser$Definition": {
+                "properties": {
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "pattern": {
+                    "enum": [
+                      "InOnly",
+                      "InOut",
+                      "InOptionalOut"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pattern"
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.SetHeaderStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.SetPropertyStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.SortStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "comparator-ref": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.SplitStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "executor-service-ref": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "on-prepare-ref": {
+                        "type": "string"
+                      },
+                      "parallel-aggregate": {
+                        "type": "string"
+                      },
+                      "parallel-processing": {
+                        "type": "string"
+                      },
+                      "share-unit-of-work": {
+                        "type": "string"
+                      },
+                      "steps": {
+                        "items": {
+                          "$ref": "#/definitions/step"
+                        },
+                        "type": "array"
+                      },
+                      "stop-on-aggregate-exception": {
+                        "type": "string"
+                      },
+                      "stop-on-exception": {
+                        "type": "string"
+                      },
+                      "strategy-method-allow-null": {
+                        "type": "string"
+                      },
+                      "strategy-method-name": {
+                        "type": "string"
+                      },
+                      "strategy-ref": {
+                        "type": "string"
+                      },
+                      "streaming": {
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.StepStepParser$Definition": {
+                "properties": {
+                  "steps": {
+                    "items": {
+                      "$ref": "#/definitions/step"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ThrottleStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "async-delayed": {
+                        "type": "string"
+                      },
+                      "caller-runs-when-rejected": {
+                        "type": "string"
+                      },
+                      "executor-service-ref": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "reject-execution": {
+                        "type": "string"
+                      },
+                      "time-period-millis": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ThrowExceptionStepParser$Definition": {
+                "properties": {
+                  "exception-type": {
+                    "type": "string"
+                  },
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "ref": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ToDynamicStepParser$Definition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "allow-optimised-components": {
+                        "type": "string"
+                      },
+                      "auto-start-components": {
+                        "type": "string"
+                      },
+                      "cache-size": {
+                        "type": "string"
+                      },
+                      "ignore-invalid-endpoint": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "parameters": {
+                        "type": "object"
+                      },
+                      "pattern": {
+                        "enum": [
+                          "InOnly",
+                          "InOut",
+                          "InOptionalOut"
+                        ],
+                        "type": "string"
+                      },
+                      "uri": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "uri"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.k.loader.yaml.parser.ToStepParser$Definition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "parameters": {
+                        "type": "object"
+                      },
+                      "pattern": {
+                        "enum": [
+                          "InOnly",
+                          "InOut",
+                          "InOptionalOut"
+                        ],
+                        "type": "string"
+                      },
+                      "uri": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "uri"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.k.loader.yaml.parser.TransactedStepParser$Definition": {
+                "properties": {
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "ref": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.TransformStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.UnmarshalStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/dataformats"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.ValidateStepParser$Definition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$Definition": {
+                "properties": {
+                  "allow-optimised-components": {
+                    "type": "string"
+                  },
+                  "auto-start-components": {
+                    "type": "string"
+                  },
+                  "cache-size": {
+                    "type": "string"
+                  },
+                  "ignore-invalid-endpoint": {
+                    "type": "string"
+                  },
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "pattern": {
+                    "enum": [
+                      "InOnly",
+                      "InOut",
+                      "InOptionalOut"
+                    ],
+                    "type": "string"
+                  },
+                  "uri": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "uri"
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$HeaderDefinition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$NewExchangeDefinition": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/expressions"
+                  },
+                  {}
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.model.BeanDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "bean-type": {
+                        "type": "string"
+                      },
+                      "cache": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "method": {
+                        "type": "string"
+                      },
+                      "ref": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "enum": [
+                          "Singleton",
+                          "Request",
+                          "Prototype"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.ClaimCheckDefinition": {
+                "properties": {
+                  "filter": {
+                    "type": "string"
+                  },
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "operation": {
+                    "enum": [
+                      "Get",
+                      "GetAndRemove",
+                      "Set",
+                      "Push",
+                      "Pop"
+                    ],
+                    "type": "string"
+                  },
+                  "strategy-method-name": {
+                    "type": "string"
+                  },
+                  "strategy-ref": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.ConvertBodyDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "charset": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.LoadBalancerDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.LogDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "log-name": {
+                        "type": "string"
+                      },
+                      "logger-ref": {
+                        "type": "string"
+                      },
+                      "logging-level": {
+                        "enum": [
+                          "TRACE",
+                          "DEBUG",
+                          "INFO",
+                          "WARN",
+                          "ERROR",
+                          "OFF"
+                        ],
+                        "type": "string"
+                      },
+                      "marker": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.RemoveHeaderDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "header-name": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.RemoveHeadersDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "exclude-pattern": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "pattern": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.RemovePropertiesDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "exclude-pattern": {
+                        "type": "string"
+                      },
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "pattern": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.RemovePropertyDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "property-name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.RollbackDefinition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "inherit-error-handler": {
+                        "type": "boolean"
+                      },
+                      "mark-rollback-only": {
+                        "type": "string"
+                      },
+                      "mark-rollback-only-last": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.StopDefinition": {
+                "properties": {
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.ThreadsDefinition": {
+                "properties": {
+                  "allow-core-thread-time-out": {
+                    "type": "string"
+                  },
+                  "caller-runs-when-rejected": {
+                    "type": "string"
+                  },
+                  "executor-service-ref": {
+                    "type": "string"
+                  },
+                  "inherit-error-handler": {
+                    "type": "boolean"
+                  },
+                  "keep-alive-time": {
+                    "type": "string"
+                  },
+                  "max-pool-size": {
+                    "type": "string"
+                  },
+                  "max-queue-size": {
+                    "type": "string"
+                  },
+                  "pool-size": {
+                    "type": "string"
+                  },
+                  "rejected-policy": {
+                    "enum": [
+                      "Abort",
+                      "CallerRuns",
+                      "DiscardOldest",
+                      "Discard"
+                    ],
+                    "type": "string"
+                  },
+                  "thread-name": {
+                    "type": "string"
+                  },
+                  "time-unit": {
+                    "enum": [
+                      "NANOSECONDS",
+                      "MICROSECONDS",
+                      "MILLISECONDS",
+                      "SECONDS",
+                      "MINUTES",
+                      "HOURS",
+                      "DAYS"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.config.BatchResequencerConfig": {
+                "properties": {
+                  "allow-duplicates": {
+                    "type": "string"
+                  },
+                  "batch-size": {
+                    "type": "string"
+                  },
+                  "batch-timeout": {
+                    "type": "string"
+                  },
+                  "ignore-invalid-exchanges": {
+                    "type": "string"
+                  },
+                  "reverse": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.config.StreamResequencerConfig": {
+                "properties": {
+                  "capacity": {
+                    "type": "string"
+                  },
+                  "comparator-ref": {
+                    "type": "string"
+                  },
+                  "delivery-attempt-interval": {
+                    "type": "string"
+                  },
+                  "ignore-invalid-exchanges": {
+                    "type": "string"
+                  },
+                  "reject-old": {
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.ASN1DataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "clazz-name": {
+                        "type": "string"
+                      },
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "using-iterator": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.Any23DataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "base-uri": {
+                        "type": "string"
+                      },
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "output-format": {
+                        "enum": [
+                          "NTRIPLES",
+                          "TURTLE",
+                          "NQUADS",
+                          "RDFXML",
+                          "JSONLD",
+                          "RDFJSON",
+                          "RDF4JMODEL"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.AvroDataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "instance-class-name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.BarcodeDataFormat": {
+                "properties": {
+                  "barcode-format": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "height": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "image-type": {
+                    "type": "string"
+                  },
+                  "width": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.Base64DataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "line-length": {
+                    "type": "string"
+                  },
+                  "line-separator": {
+                    "type": "string"
+                  },
+                  "url-safe": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.BeanioDataFormat": {
+                "properties": {
+                  "bean-reader-error-handler-type": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "ignore-invalid-records": {
+                    "type": "string"
+                  },
+                  "ignore-unexpected-records": {
+                    "type": "string"
+                  },
+                  "ignore-unidentified-records": {
+                    "type": "string"
+                  },
+                  "mapping": {
+                    "type": "string"
+                  },
+                  "stream-name": {
+                    "type": "string"
+                  },
+                  "unmarshal-single-object": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.BindyDataFormat": {
+                "properties": {
+                  "allow-empty-stream": {
+                    "type": "string"
+                  },
+                  "class-type": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "locale": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "enum": [
+                      "Csv",
+                      "Fixed",
+                      "KeyValue"
+                    ],
+                    "type": "string"
+                  },
+                  "unwrap-single-instance": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.CBORDataFormat": {
+                "properties": {
+                  "allow-jms-type": {
+                    "type": "string"
+                  },
+                  "allow-unmarshall-type": {
+                    "type": "string"
+                  },
+                  "collection-type-name": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "disable-features": {
+                    "type": "string"
+                  },
+                  "enable-features": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "object-mapper": {
+                    "type": "string"
+                  },
+                  "pretty-print": {
+                    "type": "string"
+                  },
+                  "unmarshal-type-name": {
+                    "type": "string"
+                  },
+                  "use-default-object-mapper": {
+                    "type": "string"
+                  },
+                  "use-list": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.CryptoDataFormat": {
+                "properties": {
+                  "algorithm": {
+                    "type": "string"
+                  },
+                  "algorithm-parameter-ref": {
+                    "type": "string"
+                  },
+                  "buffersize": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "crypto-provider": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "init-vector-ref": {
+                    "type": "string"
+                  },
+                  "inline": {
+                    "type": "string"
+                  },
+                  "key-ref": {
+                    "type": "string"
+                  },
+                  "mac-algorithm": {
+                    "type": "string"
+                  },
+                  "should-append-hmac": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.CsvDataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "allow-missing-column-names": {
+                        "type": "string"
+                      },
+                      "comment-marker": {
+                        "type": "string"
+                      },
+                      "comment-marker-disabled": {
+                        "type": "string"
+                      },
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "delimiter": {
+                        "type": "string"
+                      },
+                      "escape": {
+                        "type": "string"
+                      },
+                      "escape-disabled": {
+                        "type": "string"
+                      },
+                      "format-name": {
+                        "enum": [
+                          "DEFAULT",
+                          "EXCEL",
+                          "INFORMIX_UNLOAD",
+                          "INFORMIX_UNLOAD_CSV",
+                          "MYSQL",
+                          "RFC4180"
+                        ],
+                        "type": "string"
+                      },
+                      "format-ref": {
+                        "type": "string"
+                      },
+                      "header-disabled": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "ignore-empty-lines": {
+                        "type": "string"
+                      },
+                      "ignore-header-case": {
+                        "type": "string"
+                      },
+                      "ignore-surrounding-spaces": {
+                        "type": "string"
+                      },
+                      "lazy-load": {
+                        "type": "string"
+                      },
+                      "marshaller-factory-ref": {
+                        "type": "string"
+                      },
+                      "null-string": {
+                        "type": "string"
+                      },
+                      "null-string-disabled": {
+                        "type": "string"
+                      },
+                      "quote": {
+                        "type": "string"
+                      },
+                      "quote-disabled": {
+                        "type": "string"
+                      },
+                      "quote-mode": {
+                        "type": "string"
+                      },
+                      "record-converter-ref": {
+                        "type": "string"
+                      },
+                      "record-separator": {
+                        "type": "string"
+                      },
+                      "record-separator-disabled": {
+                        "type": "string"
+                      },
+                      "skip-header-record": {
+                        "type": "string"
+                      },
+                      "trailing-delimiter": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      },
+                      "use-maps": {
+                        "type": "string"
+                      },
+                      "use-ordered-maps": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.CustomDataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "ref": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.FhirJsonDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "dont-encode-elements": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "dont-strip-versions-from-references-at-paths": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "encode-elements": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "encode-elements-applies-to-child-resources-only": {
+                    "type": "string"
+                  },
+                  "fhir-version": {
+                    "enum": [
+                      "DSTU2",
+                      "DSTU2_HL7ORG",
+                      "DSTU2_1",
+                      "DSTU3",
+                      "R4"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "omit-resource-id": {
+                    "type": "string"
+                  },
+                  "override-resource-id-with-bundle-entry-full-url": {
+                    "type": "string"
+                  },
+                  "pretty-print": {
+                    "type": "string"
+                  },
+                  "server-base-url": {
+                    "type": "string"
+                  },
+                  "strip-versions-from-references": {
+                    "type": "string"
+                  },
+                  "summary-mode": {
+                    "type": "string"
+                  },
+                  "suppress-narratives": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.FhirXmlDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "dont-encode-elements": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "dont-strip-versions-from-references-at-paths": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "encode-elements": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "encode-elements-applies-to-child-resources-only": {
+                    "type": "string"
+                  },
+                  "fhir-version": {
+                    "enum": [
+                      "DSTU2",
+                      "DSTU2_HL7ORG",
+                      "DSTU2_1",
+                      "DSTU3",
+                      "R4"
+                    ],
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "omit-resource-id": {
+                    "type": "string"
+                  },
+                  "override-resource-id-with-bundle-entry-full-url": {
+                    "type": "string"
+                  },
+                  "pretty-print": {
+                    "type": "string"
+                  },
+                  "server-base-url": {
+                    "type": "string"
+                  },
+                  "strip-versions-from-references": {
+                    "type": "string"
+                  },
+                  "summary-mode": {
+                    "type": "string"
+                  },
+                  "suppress-narratives": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.FlatpackDataFormat": {
+                "properties": {
+                  "allow-short-lines": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "definition": {
+                    "type": "string"
+                  },
+                  "delimiter": {
+                    "type": "string"
+                  },
+                  "fixed": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "ignore-extra-columns": {
+                    "type": "string"
+                  },
+                  "ignore-first-record": {
+                    "type": "string"
+                  },
+                  "parser-factory-ref": {
+                    "type": "string"
+                  },
+                  "text-qualifier": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.GrokDataFormat": {
+                "properties": {
+                  "allow-multiple-matches-per-line": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "flattened": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "named-only": {
+                    "type": "string"
+                  },
+                  "pattern": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.GzipDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.HL7DataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "validate": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.IcalDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "validating": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.JacksonXMLDataFormat": {
+                "properties": {
+                  "allow-jms-type": {
+                    "type": "string"
+                  },
+                  "allow-unmarshall-type": {
+                    "type": "string"
+                  },
+                  "collection-type-name": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "disable-features": {
+                    "type": "string"
+                  },
+                  "enable-features": {
+                    "type": "string"
+                  },
+                  "enable-jaxb-annotation-module": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "include": {
+                    "type": "string"
+                  },
+                  "json-view": {
+                    "type": "string"
+                  },
+                  "module-class-names": {
+                    "type": "string"
+                  },
+                  "module-refs": {
+                    "type": "string"
+                  },
+                  "pretty-print": {
+                    "type": "string"
+                  },
+                  "unmarshal-type-name": {
+                    "type": "string"
+                  },
+                  "use-list": {
+                    "type": "string"
+                  },
+                  "xml-mapper": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.JaxbDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "context-path": {
+                    "type": "string"
+                  },
+                  "context-path-is-class-name": {
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "type": "string"
+                  },
+                  "filter-non-xml-chars": {
+                    "type": "string"
+                  },
+                  "fragment": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "ignore-jaxb-element": {
+                    "type": "string"
+                  },
+                  "jaxb-provider-properties": {
+                    "type": "string"
+                  },
+                  "must-be-jaxb-element": {
+                    "type": "string"
+                  },
+                  "namespace-prefix-ref": {
+                    "type": "string"
+                  },
+                  "no-namespace-schema-location": {
+                    "type": "string"
+                  },
+                  "object-factory": {
+                    "type": "string"
+                  },
+                  "part-class": {
+                    "type": "string"
+                  },
+                  "part-namespace": {
+                    "type": "string"
+                  },
+                  "pretty-print": {
+                    "type": "string"
+                  },
+                  "schema": {
+                    "type": "string"
+                  },
+                  "schema-location": {
+                    "type": "string"
+                  },
+                  "schema-severity-level": {
+                    "enum": [
+                      "0",
+                      "1",
+                      "2"
+                    ],
+                    "type": "string"
+                  },
+                  "xml-stream-writer-wrapper": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.JsonApiDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "data-format-types": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "main-format-type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.JsonDataFormat": {
+                "properties": {
+                  "allow-jms-type": {
+                    "type": "string"
+                  },
+                  "allow-unmarshall-type": {
+                    "type": "string"
+                  },
+                  "auto-discover-object-mapper": {
+                    "type": "string"
+                  },
+                  "collection-type-name": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "disable-features": {
+                    "type": "string"
+                  },
+                  "drop-root-node": {
+                    "type": "string"
+                  },
+                  "enable-features": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "include": {
+                    "type": "string"
+                  },
+                  "json-view": {
+                    "type": "string"
+                  },
+                  "library": {
+                    "enum": [
+                      "XStream",
+                      "Jackson",
+                      "Johnzon",
+                      "Gson",
+                      "Fastjson"
+                    ]
+                  },
+                  "module-class-names": {
+                    "type": "string"
+                  },
+                  "module-refs": {
+                    "type": "string"
+                  },
+                  "object-mapper": {
+                    "type": "string"
+                  },
+                  "permissions": {
+                    "type": "string"
+                  },
+                  "pretty-print": {
+                    "type": "string"
+                  },
+                  "timezone": {
+                    "type": "string"
+                  },
+                  "unmarshal-type-name": {
+                    "type": "string"
+                  },
+                  "use-default-object-mapper": {
+                    "type": "string"
+                  },
+                  "use-list": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.LZFDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "using-parallel-compression": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.MimeMultipartDataFormat": {
+                "properties": {
+                  "binary-content": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "headers-inline": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "include-headers": {
+                    "type": "string"
+                  },
+                  "multipart-sub-type": {
+                    "type": "string"
+                  },
+                  "multipart-without-attachment": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.PGPDataFormat": {
+                "properties": {
+                  "algorithm": {
+                    "type": "string"
+                  },
+                  "armored": {
+                    "type": "string"
+                  },
+                  "compression-algorithm": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "hash-algorithm": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "integrity": {
+                    "type": "string"
+                  },
+                  "key-file-name": {
+                    "type": "string"
+                  },
+                  "key-userid": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "signature-key-file-name": {
+                    "type": "string"
+                  },
+                  "signature-key-ring": {
+                    "type": "string"
+                  },
+                  "signature-key-userid": {
+                    "type": "string"
+                  },
+                  "signature-password": {
+                    "type": "string"
+                  },
+                  "signature-verification-option": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.ProtobufDataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "content-type-format": {
+                        "enum": [
+                          "native",
+                          "json"
+                        ],
+                        "type": "string"
+                      },
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "instance-class": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.RssDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.SoapJaxbDataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "context-path": {
+                        "type": "string"
+                      },
+                      "element-name-strategy-ref": {
+                        "type": "string"
+                      },
+                      "encoding": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "namespace-prefix-ref": {
+                        "type": "string"
+                      },
+                      "schema": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.SyslogDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.TarFileDataFormat": {
+                "properties": {
+                  "allow-empty-directory": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "preserve-path-elements": {
+                    "type": "string"
+                  },
+                  "using-iterator": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.ThriftDataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "content-type-format": {
+                        "enum": [
+                          "binary",
+                          "json",
+                          "sjson"
+                        ],
+                        "type": "string"
+                      },
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "instance-class": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.TidyMarkupDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "data-object-type": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "omit-xml-declaration": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.UniVocityCsvDataFormat": {
+                "properties": {
+                  "as-map": {
+                    "type": "string"
+                  },
+                  "comment": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "delimiter": {
+                    "type": "string"
+                  },
+                  "empty-value": {
+                    "type": "string"
+                  },
+                  "header-extraction-enabled": {
+                    "type": "string"
+                  },
+                  "headers-disabled": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "ignore-leading-whitespaces": {
+                    "type": "string"
+                  },
+                  "ignore-trailing-whitespaces": {
+                    "type": "string"
+                  },
+                  "lazy-load": {
+                    "type": "string"
+                  },
+                  "line-separator": {
+                    "type": "string"
+                  },
+                  "normalized-line-separator": {
+                    "type": "string"
+                  },
+                  "null-value": {
+                    "type": "string"
+                  },
+                  "number-of-records-to-read": {
+                    "type": "string"
+                  },
+                  "quote": {
+                    "type": "string"
+                  },
+                  "quote-all-fields": {
+                    "type": "string"
+                  },
+                  "quote-escape": {
+                    "type": "string"
+                  },
+                  "skip-empty-lines": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.UniVocityFixedWidthDataFormat": {
+                "properties": {
+                  "as-map": {
+                    "type": "string"
+                  },
+                  "comment": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "empty-value": {
+                    "type": "string"
+                  },
+                  "header-extraction-enabled": {
+                    "type": "string"
+                  },
+                  "headers-disabled": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "ignore-leading-whitespaces": {
+                    "type": "string"
+                  },
+                  "ignore-trailing-whitespaces": {
+                    "type": "string"
+                  },
+                  "lazy-load": {
+                    "type": "string"
+                  },
+                  "line-separator": {
+                    "type": "string"
+                  },
+                  "normalized-line-separator": {
+                    "type": "string"
+                  },
+                  "null-value": {
+                    "type": "string"
+                  },
+                  "number-of-records-to-read": {
+                    "type": "string"
+                  },
+                  "padding": {
+                    "type": "string"
+                  },
+                  "record-ends-on-newline": {
+                    "type": "string"
+                  },
+                  "skip-empty-lines": {
+                    "type": "string"
+                  },
+                  "skip-trailing-chars-until-newline": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.UniVocityTsvDataFormat": {
+                "properties": {
+                  "as-map": {
+                    "type": "string"
+                  },
+                  "comment": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "empty-value": {
+                    "type": "string"
+                  },
+                  "escape-char": {
+                    "type": "string"
+                  },
+                  "header-extraction-enabled": {
+                    "type": "string"
+                  },
+                  "headers-disabled": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "ignore-leading-whitespaces": {
+                    "type": "string"
+                  },
+                  "ignore-trailing-whitespaces": {
+                    "type": "string"
+                  },
+                  "lazy-load": {
+                    "type": "string"
+                  },
+                  "line-separator": {
+                    "type": "string"
+                  },
+                  "normalized-line-separator": {
+                    "type": "string"
+                  },
+                  "null-value": {
+                    "type": "string"
+                  },
+                  "number-of-records-to-read": {
+                    "type": "string"
+                  },
+                  "skip-empty-lines": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.XMLSecurityDataFormat": {
+                "properties": {
+                  "add-key-value-for-encrypted-key": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "digest-algorithm": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "key-cipher-algorithm": {
+                    "type": "string"
+                  },
+                  "key-or-trust-store-parameters-ref": {
+                    "type": "string"
+                  },
+                  "key-password": {
+                    "type": "string"
+                  },
+                  "mgf-algorithm": {
+                    "type": "string"
+                  },
+                  "pass-phrase": {
+                    "type": "string"
+                  },
+                  "pass-phrase-byte": {
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "recipient-key-alias": {
+                    "type": "string"
+                  },
+                  "secure-tag": {
+                    "type": "string"
+                  },
+                  "secure-tag-contents": {
+                    "type": "string"
+                  },
+                  "xml-cipher-algorithm": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.XStreamDataFormat": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "content-type-header": {
+                        "type": "string"
+                      },
+                      "driver": {
+                        "type": "string"
+                      },
+                      "driver-ref": {
+                        "type": "string"
+                      },
+                      "encoding": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "mode": {
+                        "type": "string"
+                      },
+                      "permissions": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.dataformat.XmlRpcDataFormat": {
+                "properties": {
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "request": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.YAMLDataFormat": {
+                "properties": {
+                  "allow-any-type": {
+                    "type": "string"
+                  },
+                  "allow-recursive-keys": {
+                    "type": "string"
+                  },
+                  "constructor": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "dumper-options": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "library": {
+                    "enum": [
+                      "SnakeYAML"
+                    ]
+                  },
+                  "max-aliases-for-collections": {
+                    "type": "string"
+                  },
+                  "pretty-flow": {
+                    "type": "string"
+                  },
+                  "representer": {
+                    "type": "string"
+                  },
+                  "resolver": {
+                    "type": "string"
+                  },
+                  "unmarshal-type-name": {
+                    "type": "string"
+                  },
+                  "use-application-context-class-loader": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.ZipDeflaterDataFormat": {
+                "properties": {
+                  "compression-level": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.dataformat.ZipFileDataFormat": {
+                "properties": {
+                  "allow-empty-directory": {
+                    "type": "string"
+                  },
+                  "content-type-header": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "preserve-path-elements": {
+                    "type": "string"
+                  },
+                  "using-iterator": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.language.ConstantExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.ExchangePropertyExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.GroovyExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.HeaderExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.Hl7TerserExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.JsonPathExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "allow-easy-predicate": {
+                        "type": "string"
+                      },
+                      "allow-simple": {
+                        "type": "string"
+                      },
+                      "expression": {
+                        "type": "string"
+                      },
+                      "header-name": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "result-type": {
+                        "type": "string"
+                      },
+                      "suppress-exceptions": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      },
+                      "write-as-string": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.LanguageExpression": {
+                "properties": {
+                  "expression": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "language": {
+                    "type": "string"
+                  },
+                  "trim": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "expression"
+                ],
+                "type": "object"
+              },
+              "org.apache.camel.model.language.MethodCallExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "bean-type": {
+                        "type": "string"
+                      },
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "method": {
+                        "type": "string"
+                      },
+                      "ref": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.MvelExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.OgnlExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.RefExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.SimpleExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "result-type": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.SpELExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.TokenizerExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "end-token": {
+                        "type": "string"
+                      },
+                      "expression": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "group-delimiter": {
+                        "type": "string"
+                      },
+                      "header-name": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "include-tokens": {
+                        "type": "string"
+                      },
+                      "inherit-namespace-tag-name": {
+                        "type": "string"
+                      },
+                      "regex": {
+                        "type": "string"
+                      },
+                      "skip-first": {
+                        "type": "string"
+                      },
+                      "token": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      },
+                      "xml": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.XMLTokenizerExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "header-name": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "mode": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.XPathExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "document-type": {
+                        "type": "string"
+                      },
+                      "expression": {
+                        "type": "string"
+                      },
+                      "factory-ref": {
+                        "type": "string"
+                      },
+                      "header-name": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "log-namespaces": {
+                        "type": "string"
+                      },
+                      "object-model": {
+                        "type": "string"
+                      },
+                      "result-type": {
+                        "enum": [
+                          "NUMBER",
+                          "STRING",
+                          "BOOLEAN",
+                          "NODESET",
+                          "NODE"
+                        ],
+                        "type": "string"
+                      },
+                      "saxon": {
+                        "type": "string"
+                      },
+                      "thread-safety": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.language.XQueryExpression": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "header-name": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "trim": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition": {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "ref": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition": {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "maximum-failover-attempts": {
+                    "type": "string"
+                  },
+                  "round-robin": {
+                    "type": "string"
+                  },
+                  "sticky": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition": {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition": {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition": {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition": {
+                "properties": {
+                  "distribution-ratio": {
+                    "type": "string"
+                  },
+                  "distribution-ratio-delimiter": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "round-robin": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "step": {
+                "maxProperties": 1,
+                "properties": {
+                  "aggregate": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.AggregateStepParser$Definition"
+                  },
+                  "bean": {
+                    "$ref": "#/definitions/org.apache.camel.model.BeanDefinition"
+                  },
+                  "choice": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition"
+                  },
+                  "circuit-breaker": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$CBDefinition"
+                  },
+                  "claim-check": {
+                    "$ref": "#/definitions/org.apache.camel.model.ClaimCheckDefinition"
+                  },
+                  "convert-body-to": {
+                    "$ref": "#/definitions/org.apache.camel.model.ConvertBodyDefinition"
+                  },
+                  "delay": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DelayStepParser$Definition"
+                  },
+                  "do-try": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoTryDefinition"
+                  },
+                  "dynamic-router": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DynamicRouterStepParser$Definition"
+                  },
+                  "enrich": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.EnrichStepParser$Definition"
+                  },
+                  "error-handler": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ErrorHandlerStepParser$Definition"
+                  },
+                  "filter": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.FilterStepParser$Definition"
+                  },
+                  "idempotent-consumer": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.IdempotentConsumerParser$Definition"
+                  },
+                  "load-balance": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition"
+                  },
+                  "log": {
+                    "$ref": "#/definitions/org.apache.camel.model.LogDefinition"
+                  },
+                  "loop": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoopStepParser$Definition"
+                  },
+                  "marshal": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.MarshalStepParser$Definition"
+                  },
+                  "multicast": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.MulticastStepParser$Definition"
+                  },
+                  "on-exception": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition"
+                  },
+                  "pipeline": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.PipelineStepParser$Definition"
+                  },
+                  "poll-enrich": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.PollEnrichStepParser$Definition"
+                  },
+                  "process": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ProcessStepParser$Definition"
+                  },
+                  "recipient-list": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RecipientListStepParser$Definition"
+                  },
+                  "remove-header": {
+                    "$ref": "#/definitions/org.apache.camel.model.RemoveHeaderDefinition"
+                  },
+                  "remove-headers": {
+                    "$ref": "#/definitions/org.apache.camel.model.RemoveHeadersDefinition"
+                  },
+                  "remove-properties": {
+                    "$ref": "#/definitions/org.apache.camel.model.RemovePropertiesDefinition"
+                  },
+                  "remove-property": {
+                    "$ref": "#/definitions/org.apache.camel.model.RemovePropertyDefinition"
+                  },
+                  "resequence": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ResequenceStepParser$Definition"
+                  },
+                  "rollback": {
+                    "$ref": "#/definitions/org.apache.camel.model.RollbackDefinition"
+                  },
+                  "routing-slip": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RoutingSlipStepParser$Definition"
+                  },
+                  "saga": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SagaStepParser$Definition"
+                  },
+                  "sample": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SampleStepParser$Definition"
+                  },
+                  "script": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ScriptStepParser$Definition"
+                  },
+                  "service-call": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$Definition"
+                  },
+                  "set-body": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetBodyStepParser$Definition"
+                  },
+                  "set-exchange-pattern": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetExchangePatternStepParser$Definition"
+                  },
+                  "set-header": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetHeaderStepParser$Definition"
+                  },
+                  "set-property": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetPropertyStepParser$Definition"
+                  },
+                  "sort": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SortStepParser$Definition"
+                  },
+                  "split": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SplitStepParser$Definition"
+                  },
+                  "step": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.StepStepParser$Definition"
+                  },
+                  "stop": {
+                    "$ref": "#/definitions/org.apache.camel.model.StopDefinition"
+                  },
+                  "threads": {
+                    "$ref": "#/definitions/org.apache.camel.model.ThreadsDefinition"
+                  },
+                  "throttle": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ThrottleStepParser$Definition"
+                  },
+                  "throw-exception": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ThrowExceptionStepParser$Definition"
+                  },
+                  "to": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ToStepParser$Definition"
+                  },
+                  "tod": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ToDynamicStepParser$Definition"
+                  },
+                  "transacted": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.TransactedStepParser$Definition"
+                  },
+                  "transform": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.TransformStepParser$Definition"
+                  },
+                  "unmarshal": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.UnmarshalStepParser$Definition"
+                  },
+                  "validate": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ValidateStepParser$Definition"
+                  },
+                  "wiretap": {
+                    "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.WireTapStepParser$Definition"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "maxProperties": 1,
+            "properties": {
+              "error-handler": {
+                "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ErrorHandlerStepParser$Definition"
+              },
+              "from": {
+                "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.FromStepParser$Definition"
+              },
+              "on-exception": {
+                "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition"
+              },
+              "rest": {
+                "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RestStepParser$Definition"
+              },
+              "route": {
+                "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RouteStepParser$Definition"
+              }
+            }
+          },
+          "type": "array"
+        },
+        "kit": {
+          "type": "string"
+        },
+        "profile": {
+          "description": "TraitProfile represents lists of traits that are enabled for the specific installation/integration",
+          "type": "string"
+        },
+        "replicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "repositories": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "items": {
+            "description": "ResourceSpec --",
+            "properties": {
+              "compression": {
+                "type": "boolean"
+              },
+              "content": {
+                "type": "string"
+              },
+              "contentKey": {
+                "type": "string"
+              },
+              "contentRef": {
+                "type": "string"
+              },
+              "mountPath": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "description": "ResourceType --",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "serviceAccountName": {
+          "type": "string"
+        },
+        "sources": {
+          "items": {
+            "description": "SourceSpec --",
+            "properties": {
+              "compression": {
+                "type": "boolean"
+              },
+              "content": {
+                "type": "string"
+              },
+              "contentKey": {
+                "type": "string"
+              },
+              "contentRef": {
+                "type": "string"
+              },
+              "interceptors": {
+                "description": "Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader uses to pre/post process sources",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "language": {
+                "description": "Language --",
+                "type": "string"
+              },
+              "loader": {
+                "description": "Loader is an optional id of the org.apache.camel.k.RoutesLoader that will interpret this source at runtime",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "property-names": {
+                "description": "List of property names defined in the source (e.g. if type is \"template\")",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": {
+                "description": "Type defines the kind of source described by this object",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "traits": {
+          "additionalProperties": {
+            "description": "A TraitSpec contains the configuration of a trait",
+            "properties": {
+              "configuration": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "configuration"
+            ],
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "IntegrationStatus defines the observed state of Integration",
+      "properties": {
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "items": {
+            "description": "IntegrationCondition describes the state of a resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of integration condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "configuration": {
+          "items": {
+            "description": "ConfigurationSpec --",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "digest": {
+          "type": "string"
+        },
+        "failure": {
+          "description": "Failure --",
+          "properties": {
+            "reason": {
+              "type": "string"
+            },
+            "recovery": {
+              "description": "FailureRecovery --",
+              "properties": {
+                "attempt": {
+                  "type": "integer"
+                },
+                "attemptMax": {
+                  "type": "integer"
+                },
+                "attemptTime": {
+                  "format": "date-time",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "attempt",
+                "attemptMax"
+              ],
+              "type": "object"
+            },
+            "time": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "required": [
+            "reason",
+            "recovery",
+            "time"
+          ],
+          "type": "object"
+        },
+        "generatedResources": {
+          "items": {
+            "description": "ResourceSpec --",
+            "properties": {
+              "compression": {
+                "type": "boolean"
+              },
+              "content": {
+                "type": "string"
+              },
+              "contentKey": {
+                "type": "string"
+              },
+              "contentRef": {
+                "type": "string"
+              },
+              "mountPath": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "description": "ResourceType --",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "generatedSources": {
+          "items": {
+            "description": "SourceSpec --",
+            "properties": {
+              "compression": {
+                "type": "boolean"
+              },
+              "content": {
+                "type": "string"
+              },
+              "contentKey": {
+                "type": "string"
+              },
+              "contentRef": {
+                "type": "string"
+              },
+              "interceptors": {
+                "description": "Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader uses to pre/post process sources",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "language": {
+                "description": "Language --",
+                "type": "string"
+              },
+              "loader": {
+                "description": "Loader is an optional id of the org.apache.camel.k.RoutesLoader that will interpret this source at runtime",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "property-names": {
+                "description": "List of property names defined in the source (e.g. if type is \"template\")",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": {
+                "description": "Type defines the kind of source described by this object",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "image": {
+          "type": "string"
+        },
+        "kit": {
+          "type": "string"
+        },
+        "phase": {
+          "description": "IntegrationPhase --",
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "profile": {
+          "description": "TraitProfile represents lists of traits that are enabled for the specific installation/integration",
+          "type": "string"
+        },
+        "replicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "runtimeProvider": {
+          "description": "RuntimeProvider --",
+          "type": "string"
+        },
+        "runtimeVersion": {
+          "type": "string"
+        },
+        "selector": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/docs/modules/ROOT/assets/attachments/schema/kamelet-schema.json
+++ b/docs/modules/ROOT/assets/attachments/schema/kamelet-schema.json
@@ -1,0 +1,4696 @@
+{
+  "definitions": {
+    "dataformats": {
+      "properties": {
+        "any23": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.Any23DataFormat"
+        },
+        "asn1": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ASN1DataFormat"
+        },
+        "avro": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.AvroDataFormat"
+        },
+        "barcode": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.BarcodeDataFormat"
+        },
+        "base64": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.Base64DataFormat"
+        },
+        "beanio": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.BeanioDataFormat"
+        },
+        "bindy": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.BindyDataFormat"
+        },
+        "cbor": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.CBORDataFormat"
+        },
+        "crypto": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.CryptoDataFormat"
+        },
+        "csv": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.CsvDataFormat"
+        },
+        "custom-data-format": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.CustomDataFormat"
+        },
+        "fhir-json": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.FhirJsonDataFormat"
+        },
+        "fhir-xml": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.FhirXmlDataFormat"
+        },
+        "flatpack": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.FlatpackDataFormat"
+        },
+        "grok": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.GrokDataFormat"
+        },
+        "gzipdeflater": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.GzipDataFormat"
+        },
+        "hl7": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.HL7DataFormat"
+        },
+        "ical": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.IcalDataFormat"
+        },
+        "jacksonxml": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.JacksonXMLDataFormat"
+        },
+        "jaxb": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.JaxbDataFormat"
+        },
+        "json": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.JsonDataFormat"
+        },
+        "json-api": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.JsonApiDataFormat"
+        },
+        "lzf": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.LZFDataFormat"
+        },
+        "mime-multipart": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.MimeMultipartDataFormat"
+        },
+        "pgp": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.PGPDataFormat"
+        },
+        "protobuf": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ProtobufDataFormat"
+        },
+        "rss": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.RssDataFormat"
+        },
+        "secure-xml": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.XMLSecurityDataFormat"
+        },
+        "soapjaxb": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.SoapJaxbDataFormat"
+        },
+        "syslog": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.SyslogDataFormat"
+        },
+        "tarfile": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.TarFileDataFormat"
+        },
+        "thrift": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ThriftDataFormat"
+        },
+        "tidy-markup": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.TidyMarkupDataFormat"
+        },
+        "univocity-csv": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityCsvDataFormat"
+        },
+        "univocity-fixed": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityFixedWidthDataFormat"
+        },
+        "univocity-tsv": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.UniVocityTsvDataFormat"
+        },
+        "xmlrpc": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.XmlRpcDataFormat"
+        },
+        "xstream": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.XStreamDataFormat"
+        },
+        "yaml": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.YAMLDataFormat"
+        },
+        "zipdeflater": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ZipDeflaterDataFormat"
+        },
+        "zipfile": {
+          "$ref": "#/definitions/org.apache.camel.model.dataformat.ZipFileDataFormat"
+        }
+      },
+      "type": "object"
+    },
+    "expressions": {
+      "properties": {
+        "constant": {
+          "$ref": "#/definitions/org.apache.camel.model.language.ConstantExpression"
+        },
+        "exchange-property": {
+          "$ref": "#/definitions/org.apache.camel.model.language.ExchangePropertyExpression"
+        },
+        "groovy": {
+          "$ref": "#/definitions/org.apache.camel.model.language.GroovyExpression"
+        },
+        "header": {
+          "$ref": "#/definitions/org.apache.camel.model.language.HeaderExpression"
+        },
+        "hl7terser": {
+          "$ref": "#/definitions/org.apache.camel.model.language.Hl7TerserExpression"
+        },
+        "jsonpath": {
+          "$ref": "#/definitions/org.apache.camel.model.language.JsonPathExpression"
+        },
+        "language": {
+          "$ref": "#/definitions/org.apache.camel.model.language.LanguageExpression"
+        },
+        "method": {
+          "$ref": "#/definitions/org.apache.camel.model.language.MethodCallExpression"
+        },
+        "mvel": {
+          "$ref": "#/definitions/org.apache.camel.model.language.MvelExpression"
+        },
+        "ognl": {
+          "$ref": "#/definitions/org.apache.camel.model.language.OgnlExpression"
+        },
+        "ref": {
+          "$ref": "#/definitions/org.apache.camel.model.language.RefExpression"
+        },
+        "simple": {
+          "$ref": "#/definitions/org.apache.camel.model.language.SimpleExpression"
+        },
+        "spel": {
+          "$ref": "#/definitions/org.apache.camel.model.language.SpELExpression"
+        },
+        "tokenize": {
+          "$ref": "#/definitions/org.apache.camel.model.language.TokenizerExpression"
+        },
+        "xpath": {
+          "$ref": "#/definitions/org.apache.camel.model.language.XPathExpression"
+        },
+        "xquery": {
+          "$ref": "#/definitions/org.apache.camel.model.language.XQueryExpression"
+        },
+        "xtokenize": {
+          "$ref": "#/definitions/org.apache.camel.model.language.XMLTokenizerExpression"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.builder.DeadLetterChannelBuilder": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "async-delayed-redelivery": {
+              "type": "boolean"
+            },
+            "dead-letter-handle-new-exception": {
+              "type": "boolean"
+            },
+            "use-original-body": {
+              "type": "boolean"
+            },
+            "use-original-message": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.builder.DefaultErrorHandlerBuilder": {
+      "properties": {
+        "async-delayed-redelivery": {
+          "type": "boolean"
+        },
+        "dead-letter-handle-new-exception": {
+          "type": "boolean"
+        },
+        "use-original-body": {
+          "type": "boolean"
+        },
+        "use-original-message": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.builder.ErrorHandlerBuilderRef": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.builder.ErrorHandlerBuilderSupport": {
+      "type": "object"
+    },
+    "org.apache.camel.builder.NoErrorHandlerBuilder": {
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.AggregateStepParser$CorrelationExpression": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {}
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.AggregateStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "aggregate-controller-ref": {
+              "type": "string"
+            },
+            "aggregation-repository-ref": {
+              "type": "string"
+            },
+            "close-correlation-key-on-completion": {
+              "type": "string"
+            },
+            "complete-all-on-stop": {
+              "type": "string"
+            },
+            "completion-from-batch-consumer": {
+              "type": "string"
+            },
+            "completion-interval": {
+              "type": "string"
+            },
+            "completion-on-new-correlation-group": {
+              "type": "string"
+            },
+            "completion-size": {
+              "type": "string"
+            },
+            "completion-timeout": {
+              "type": "string"
+            },
+            "completion-timeout-checker-interval": {
+              "type": "string"
+            },
+            "correlation-expression": {
+              "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.AggregateStepParser$CorrelationExpression"
+            },
+            "discard-on-aggregation-failure": {
+              "type": "string"
+            },
+            "discard-on-completion-timeout": {
+              "type": "string"
+            },
+            "eager-check-completion": {
+              "type": "string"
+            },
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "force-completion-on-stop": {
+              "type": "string"
+            },
+            "ignore-invalid-correlation-keys": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "optimistic-locking": {
+              "type": "string"
+            },
+            "parallel-processing": {
+              "type": "string"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            },
+            "timeout-checker-executor-service-ref": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.BeansStepParser$Definition": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition": {
+      "properties": {
+        "otherwise": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$Otherwise"
+        },
+        "when": {
+          "items": {
+            "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$When"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$Otherwise": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition$When": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$CBDefinition": {
+      "properties": {
+        "on-fallback": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$FBDefinition"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$FBDefinition": {
+      "properties": {
+        "fallback-via-network": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DelayStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "async-delayed": {
+              "type": "string"
+            },
+            "caller-runs-when-rejected": {
+              "type": "string"
+            },
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoCatchDefinition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoFinallyDefinition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoTryDefinition": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.DynamicRouterStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoints": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "uri-delimiter": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.EnrichStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "aggregate-on-exception": {
+              "type": "string"
+            },
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoint": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "share-unit-of-work": {
+              "type": "string"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ErrorHandlerStepParser$Definition": {
+      "properties": {
+        "dead-letter-channel": {
+          "$ref": "#/definitions/org.apache.camel.builder.DeadLetterChannelBuilder"
+        },
+        "default": {
+          "$ref": "#/definitions/org.apache.camel.builder.DefaultErrorHandlerBuilder"
+        },
+        "no-error-handler": {
+          "$ref": "#/definitions/org.apache.camel.builder.NoErrorHandlerBuilder"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.FilterStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.FromStepParser$Definition": {
+      "properties": {
+        "parameters": {
+          "type": "object"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "steps",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.IdempotentConsumerParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "completion-eager": {
+              "type": "string"
+            },
+            "eager": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "message-id-repository-ref": {
+              "type": "string"
+            },
+            "remove-on-failure": {
+              "type": "string"
+            },
+            "skip-duplicate": {
+              "type": "string"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition": {
+      "properties": {
+        "custom": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition"
+        },
+        "failover": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "random": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition"
+        },
+        "round-robin": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "sticky": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition$Sticky"
+        },
+        "topic": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition"
+        },
+        "type": {
+          "$ref": "#/definitions/org.apache.camel.model.LoadBalancerDefinition"
+        },
+        "weighted": {
+          "$ref": "#/definitions/org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition$Sticky": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.LoopStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "copy": {
+              "type": "string"
+            },
+            "do-while": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.MarshalStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/dataformats"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.MulticastStepParser$Definition": {
+      "properties": {
+        "executor-service-ref": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "on-prepare-ref": {
+          "type": "string"
+        },
+        "parallel-aggregate": {
+          "type": "string"
+        },
+        "parallel-processing": {
+          "type": "string"
+        },
+        "share-unit-of-work": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "stop-on-aggregate-exception": {
+          "type": "string"
+        },
+        "stop-on-exception": {
+          "type": "string"
+        },
+        "strategy-method-allow-null": {
+          "type": "string"
+        },
+        "strategy-method-name": {
+          "type": "string"
+        },
+        "strategy-ref": {
+          "type": "string"
+        },
+        "streaming": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$ExpressionElement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {}
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$MaybeBooleanExpressionElement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {}
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition$When": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.PipelineStepParser$Definition": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.PollEnrichStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "aggregate-on-exception": {
+              "type": "string"
+            },
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoint": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            },
+            "timeout": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ProcessStepParser$Definition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.RecipientListStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "cache-size": {
+              "type": "string"
+            },
+            "delimiter": {
+              "type": "string"
+            },
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoints": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "on-prepare-ref": {
+              "type": "string"
+            },
+            "parallel-aggregate": {
+              "type": "string"
+            },
+            "parallel-processing": {
+              "type": "string"
+            },
+            "share-unit-of-work": {
+              "type": "string"
+            },
+            "stop-on-aggregate-exception": {
+              "type": "string"
+            },
+            "stop-on-exception": {
+              "type": "string"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            },
+            "streaming": {
+              "type": "string"
+            },
+            "timeout": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ResequenceStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "batch-config": {
+              "$ref": "#/definitions/org.apache.camel.model.config.BatchResequencerConfig"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            },
+            "stream-config": {
+              "$ref": "#/definitions/org.apache.camel.model.config.StreamResequencerConfig"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.RestStepParser$Definition": {
+      "properties": {
+        "api-docs": {
+          "type": "boolean"
+        },
+        "binding-mode": {
+          "enum": [
+            "auto",
+            "off",
+            "json",
+            "xml",
+            "json_xml"
+          ]
+        },
+        "consumes": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enable-cors": {
+          "type": "boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "out-type": {
+          "type": "string"
+        },
+        "produces": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "type": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "verb": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.RouteStepParser$Definition": {
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RouteStepParser$From"
+        },
+        "group": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "from",
+        "steps"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.RouteStepParser$From": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "parameters": {
+              "type": "object"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.k.loader.yaml.parser.RoutingSlipStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoints": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "uri-delimiter": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SagaStepParser$Definition": {
+      "properties": {
+        "completion-mode": {
+          "enum": [
+            "AUTO",
+            "MANUAL"
+          ],
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "propagation": {
+          "enum": [
+            "REQUIRED",
+            "REQUIRES_NEW",
+            "MANDATORY",
+            "SUPPORTS",
+            "NOT_SUPPORTED",
+            "NEVER"
+          ],
+          "type": "string"
+        },
+        "saga-service-ref": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "timeout": {
+          "type": "string"
+        },
+        "timeout-in-milliseconds": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SampleStepParser$Definition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "message-frequency": {
+          "type": "string"
+        },
+        "sample-period": {
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        },
+        "units": {
+          "enum": [
+            "NANOSECONDS",
+            "MICROSECONDS",
+            "MILLISECONDS",
+            "SECONDS",
+            "MINUTES",
+            "HOURS",
+            "DAYS"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ScriptStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$Definition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/definitions/expressions"
+            },
+            {}
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$ServiceCallExpressionDefinition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "host-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "port-header": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SetBodyStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SetExchangePatternStepParser$Definition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "enum": [
+            "InOnly",
+            "InOut",
+            "InOptionalOut"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SetHeaderStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SetPropertyStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SortStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "comparator-ref": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.SplitStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "on-prepare-ref": {
+              "type": "string"
+            },
+            "parallel-aggregate": {
+              "type": "string"
+            },
+            "parallel-processing": {
+              "type": "string"
+            },
+            "share-unit-of-work": {
+              "type": "string"
+            },
+            "steps": {
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "type": "array"
+            },
+            "stop-on-aggregate-exception": {
+              "type": "string"
+            },
+            "stop-on-exception": {
+              "type": "string"
+            },
+            "strategy-method-allow-null": {
+              "type": "string"
+            },
+            "strategy-method-name": {
+              "type": "string"
+            },
+            "strategy-ref": {
+              "type": "string"
+            },
+            "streaming": {
+              "type": "string"
+            },
+            "timeout": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.StepStepParser$Definition": {
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ThrottleStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "async-delayed": {
+              "type": "string"
+            },
+            "caller-runs-when-rejected": {
+              "type": "string"
+            },
+            "executor-service-ref": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "reject-execution": {
+              "type": "string"
+            },
+            "time-period-millis": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ThrowExceptionStepParser$Definition": {
+      "properties": {
+        "exception-type": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ToDynamicStepParser$Definition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "allow-optimised-components": {
+              "type": "string"
+            },
+            "auto-start-components": {
+              "type": "string"
+            },
+            "cache-size": {
+              "type": "string"
+            },
+            "ignore-invalid-endpoint": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "parameters": {
+              "type": "object"
+            },
+            "pattern": {
+              "enum": [
+                "InOnly",
+                "InOut",
+                "InOptionalOut"
+              ],
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.k.loader.yaml.parser.ToStepParser$Definition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "parameters": {
+              "type": "object"
+            },
+            "pattern": {
+              "enum": [
+                "InOnly",
+                "InOut",
+                "InOptionalOut"
+              ],
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "uri"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.k.loader.yaml.parser.TransactedStepParser$Definition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.TransformStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.UnmarshalStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/dataformats"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.ValidateStepParser$Definition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$Definition": {
+      "properties": {
+        "allow-optimised-components": {
+          "type": "string"
+        },
+        "auto-start-components": {
+          "type": "string"
+        },
+        "cache-size": {
+          "type": "string"
+        },
+        "ignore-invalid-endpoint": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "enum": [
+            "InOnly",
+            "InOut",
+            "InOptionalOut"
+          ],
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$HeaderDefinition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.k.loader.yaml.parser.WireTapStepParser$NewExchangeDefinition": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/expressions"
+        },
+        {}
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.model.BeanDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "bean-type": {
+              "type": "string"
+            },
+            "cache": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "method": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "scope": {
+              "enum": [
+                "Singleton",
+                "Request",
+                "Prototype"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.ClaimCheckDefinition": {
+      "properties": {
+        "filter": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "operation": {
+          "enum": [
+            "Get",
+            "GetAndRemove",
+            "Set",
+            "Push",
+            "Pop"
+          ],
+          "type": "string"
+        },
+        "strategy-method-name": {
+          "type": "string"
+        },
+        "strategy-ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.ConvertBodyDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "charset": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.LoadBalancerDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.LogDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "log-name": {
+              "type": "string"
+            },
+            "logger-ref": {
+              "type": "string"
+            },
+            "logging-level": {
+              "enum": [
+                "TRACE",
+                "DEBUG",
+                "INFO",
+                "WARN",
+                "ERROR",
+                "OFF"
+              ],
+              "type": "string"
+            },
+            "marker": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RemoveHeaderDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "header-name": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RemoveHeadersDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "exclude-pattern": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "pattern": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RemovePropertiesDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "exclude-pattern": {
+              "type": "string"
+            },
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "pattern": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RemovePropertyDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "property-name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.RollbackDefinition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "inherit-error-handler": {
+              "type": "boolean"
+            },
+            "mark-rollback-only": {
+              "type": "string"
+            },
+            "mark-rollback-only-last": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.StopDefinition": {
+      "properties": {
+        "inherit-error-handler": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.ThreadsDefinition": {
+      "properties": {
+        "allow-core-thread-time-out": {
+          "type": "string"
+        },
+        "caller-runs-when-rejected": {
+          "type": "string"
+        },
+        "executor-service-ref": {
+          "type": "string"
+        },
+        "inherit-error-handler": {
+          "type": "boolean"
+        },
+        "keep-alive-time": {
+          "type": "string"
+        },
+        "max-pool-size": {
+          "type": "string"
+        },
+        "max-queue-size": {
+          "type": "string"
+        },
+        "pool-size": {
+          "type": "string"
+        },
+        "rejected-policy": {
+          "enum": [
+            "Abort",
+            "CallerRuns",
+            "DiscardOldest",
+            "Discard"
+          ],
+          "type": "string"
+        },
+        "thread-name": {
+          "type": "string"
+        },
+        "time-unit": {
+          "enum": [
+            "NANOSECONDS",
+            "MICROSECONDS",
+            "MILLISECONDS",
+            "SECONDS",
+            "MINUTES",
+            "HOURS",
+            "DAYS"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.config.BatchResequencerConfig": {
+      "properties": {
+        "allow-duplicates": {
+          "type": "string"
+        },
+        "batch-size": {
+          "type": "string"
+        },
+        "batch-timeout": {
+          "type": "string"
+        },
+        "ignore-invalid-exchanges": {
+          "type": "string"
+        },
+        "reverse": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.config.StreamResequencerConfig": {
+      "properties": {
+        "capacity": {
+          "type": "string"
+        },
+        "comparator-ref": {
+          "type": "string"
+        },
+        "delivery-attempt-interval": {
+          "type": "string"
+        },
+        "ignore-invalid-exchanges": {
+          "type": "string"
+        },
+        "reject-old": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ASN1DataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "clazz-name": {
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "using-iterator": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.Any23DataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "base-uri": {
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "output-format": {
+              "enum": [
+                "NTRIPLES",
+                "TURTLE",
+                "NQUADS",
+                "RDFXML",
+                "JSONLD",
+                "RDFJSON",
+                "RDF4JMODEL"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.AvroDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "instance-class-name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.BarcodeDataFormat": {
+      "properties": {
+        "barcode-format": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "height": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "image-type": {
+          "type": "string"
+        },
+        "width": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.Base64DataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "line-length": {
+          "type": "string"
+        },
+        "line-separator": {
+          "type": "string"
+        },
+        "url-safe": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.BeanioDataFormat": {
+      "properties": {
+        "bean-reader-error-handler-type": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-invalid-records": {
+          "type": "string"
+        },
+        "ignore-unexpected-records": {
+          "type": "string"
+        },
+        "ignore-unidentified-records": {
+          "type": "string"
+        },
+        "mapping": {
+          "type": "string"
+        },
+        "stream-name": {
+          "type": "string"
+        },
+        "unmarshal-single-object": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.BindyDataFormat": {
+      "properties": {
+        "allow-empty-stream": {
+          "type": "string"
+        },
+        "class-type": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "Csv",
+            "Fixed",
+            "KeyValue"
+          ],
+          "type": "string"
+        },
+        "unwrap-single-instance": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.CBORDataFormat": {
+      "properties": {
+        "allow-jms-type": {
+          "type": "string"
+        },
+        "allow-unmarshall-type": {
+          "type": "string"
+        },
+        "collection-type-name": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "disable-features": {
+          "type": "string"
+        },
+        "enable-features": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "object-mapper": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "unmarshal-type-name": {
+          "type": "string"
+        },
+        "use-default-object-mapper": {
+          "type": "string"
+        },
+        "use-list": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.CryptoDataFormat": {
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "algorithm-parameter-ref": {
+          "type": "string"
+        },
+        "buffersize": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "crypto-provider": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "init-vector-ref": {
+          "type": "string"
+        },
+        "inline": {
+          "type": "string"
+        },
+        "key-ref": {
+          "type": "string"
+        },
+        "mac-algorithm": {
+          "type": "string"
+        },
+        "should-append-hmac": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.CsvDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "allow-missing-column-names": {
+              "type": "string"
+            },
+            "comment-marker": {
+              "type": "string"
+            },
+            "comment-marker-disabled": {
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "delimiter": {
+              "type": "string"
+            },
+            "escape": {
+              "type": "string"
+            },
+            "escape-disabled": {
+              "type": "string"
+            },
+            "format-name": {
+              "enum": [
+                "DEFAULT",
+                "EXCEL",
+                "INFORMIX_UNLOAD",
+                "INFORMIX_UNLOAD_CSV",
+                "MYSQL",
+                "RFC4180"
+              ],
+              "type": "string"
+            },
+            "format-ref": {
+              "type": "string"
+            },
+            "header-disabled": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ignore-empty-lines": {
+              "type": "string"
+            },
+            "ignore-header-case": {
+              "type": "string"
+            },
+            "ignore-surrounding-spaces": {
+              "type": "string"
+            },
+            "lazy-load": {
+              "type": "string"
+            },
+            "marshaller-factory-ref": {
+              "type": "string"
+            },
+            "null-string": {
+              "type": "string"
+            },
+            "null-string-disabled": {
+              "type": "string"
+            },
+            "quote": {
+              "type": "string"
+            },
+            "quote-disabled": {
+              "type": "string"
+            },
+            "quote-mode": {
+              "type": "string"
+            },
+            "record-converter-ref": {
+              "type": "string"
+            },
+            "record-separator": {
+              "type": "string"
+            },
+            "record-separator-disabled": {
+              "type": "string"
+            },
+            "skip-header-record": {
+              "type": "string"
+            },
+            "trailing-delimiter": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            },
+            "use-maps": {
+              "type": "string"
+            },
+            "use-ordered-maps": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.CustomDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.FhirJsonDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "dont-encode-elements": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dont-strip-versions-from-references-at-paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encode-elements": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encode-elements-applies-to-child-resources-only": {
+          "type": "string"
+        },
+        "fhir-version": {
+          "enum": [
+            "DSTU2",
+            "DSTU2_HL7ORG",
+            "DSTU2_1",
+            "DSTU3",
+            "R4"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "omit-resource-id": {
+          "type": "string"
+        },
+        "override-resource-id-with-bundle-entry-full-url": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "server-base-url": {
+          "type": "string"
+        },
+        "strip-versions-from-references": {
+          "type": "string"
+        },
+        "summary-mode": {
+          "type": "string"
+        },
+        "suppress-narratives": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.FhirXmlDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "dont-encode-elements": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dont-strip-versions-from-references-at-paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encode-elements": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encode-elements-applies-to-child-resources-only": {
+          "type": "string"
+        },
+        "fhir-version": {
+          "enum": [
+            "DSTU2",
+            "DSTU2_HL7ORG",
+            "DSTU2_1",
+            "DSTU3",
+            "R4"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "omit-resource-id": {
+          "type": "string"
+        },
+        "override-resource-id-with-bundle-entry-full-url": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "server-base-url": {
+          "type": "string"
+        },
+        "strip-versions-from-references": {
+          "type": "string"
+        },
+        "summary-mode": {
+          "type": "string"
+        },
+        "suppress-narratives": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.FlatpackDataFormat": {
+      "properties": {
+        "allow-short-lines": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "delimiter": {
+          "type": "string"
+        },
+        "fixed": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-extra-columns": {
+          "type": "string"
+        },
+        "ignore-first-record": {
+          "type": "string"
+        },
+        "parser-factory-ref": {
+          "type": "string"
+        },
+        "text-qualifier": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.GrokDataFormat": {
+      "properties": {
+        "allow-multiple-matches-per-line": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "flattened": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "named-only": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.GzipDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.HL7DataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "validate": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.IcalDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "validating": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.JacksonXMLDataFormat": {
+      "properties": {
+        "allow-jms-type": {
+          "type": "string"
+        },
+        "allow-unmarshall-type": {
+          "type": "string"
+        },
+        "collection-type-name": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "disable-features": {
+          "type": "string"
+        },
+        "enable-features": {
+          "type": "string"
+        },
+        "enable-jaxb-annotation-module": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "include": {
+          "type": "string"
+        },
+        "json-view": {
+          "type": "string"
+        },
+        "module-class-names": {
+          "type": "string"
+        },
+        "module-refs": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "unmarshal-type-name": {
+          "type": "string"
+        },
+        "use-list": {
+          "type": "string"
+        },
+        "xml-mapper": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.JaxbDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "context-path": {
+          "type": "string"
+        },
+        "context-path-is-class-name": {
+          "type": "string"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "filter-non-xml-chars": {
+          "type": "string"
+        },
+        "fragment": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-jaxb-element": {
+          "type": "string"
+        },
+        "jaxb-provider-properties": {
+          "type": "string"
+        },
+        "must-be-jaxb-element": {
+          "type": "string"
+        },
+        "namespace-prefix-ref": {
+          "type": "string"
+        },
+        "no-namespace-schema-location": {
+          "type": "string"
+        },
+        "object-factory": {
+          "type": "string"
+        },
+        "part-class": {
+          "type": "string"
+        },
+        "part-namespace": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "schema-location": {
+          "type": "string"
+        },
+        "schema-severity-level": {
+          "enum": [
+            "0",
+            "1",
+            "2"
+          ],
+          "type": "string"
+        },
+        "xml-stream-writer-wrapper": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.JsonApiDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "data-format-types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "main-format-type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.JsonDataFormat": {
+      "properties": {
+        "allow-jms-type": {
+          "type": "string"
+        },
+        "allow-unmarshall-type": {
+          "type": "string"
+        },
+        "auto-discover-object-mapper": {
+          "type": "string"
+        },
+        "collection-type-name": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "disable-features": {
+          "type": "string"
+        },
+        "drop-root-node": {
+          "type": "string"
+        },
+        "enable-features": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "include": {
+          "type": "string"
+        },
+        "json-view": {
+          "type": "string"
+        },
+        "library": {
+          "enum": [
+            "XStream",
+            "Jackson",
+            "Johnzon",
+            "Gson",
+            "Fastjson"
+          ]
+        },
+        "module-class-names": {
+          "type": "string"
+        },
+        "module-refs": {
+          "type": "string"
+        },
+        "object-mapper": {
+          "type": "string"
+        },
+        "permissions": {
+          "type": "string"
+        },
+        "pretty-print": {
+          "type": "string"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "unmarshal-type-name": {
+          "type": "string"
+        },
+        "use-default-object-mapper": {
+          "type": "string"
+        },
+        "use-list": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.LZFDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "using-parallel-compression": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.MimeMultipartDataFormat": {
+      "properties": {
+        "binary-content": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "headers-inline": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "include-headers": {
+          "type": "string"
+        },
+        "multipart-sub-type": {
+          "type": "string"
+        },
+        "multipart-without-attachment": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.PGPDataFormat": {
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "armored": {
+          "type": "string"
+        },
+        "compression-algorithm": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "hash-algorithm": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "integrity": {
+          "type": "string"
+        },
+        "key-file-name": {
+          "type": "string"
+        },
+        "key-userid": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "signature-key-file-name": {
+          "type": "string"
+        },
+        "signature-key-ring": {
+          "type": "string"
+        },
+        "signature-key-userid": {
+          "type": "string"
+        },
+        "signature-password": {
+          "type": "string"
+        },
+        "signature-verification-option": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ProtobufDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-format": {
+              "enum": [
+                "native",
+                "json"
+              ],
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "instance-class": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.RssDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.SoapJaxbDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-header": {
+              "type": "string"
+            },
+            "context-path": {
+              "type": "string"
+            },
+            "element-name-strategy-ref": {
+              "type": "string"
+            },
+            "encoding": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "namespace-prefix-ref": {
+              "type": "string"
+            },
+            "schema": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.SyslogDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.TarFileDataFormat": {
+      "properties": {
+        "allow-empty-directory": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "preserve-path-elements": {
+          "type": "string"
+        },
+        "using-iterator": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ThriftDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-format": {
+              "enum": [
+                "binary",
+                "json",
+                "sjson"
+              ],
+              "type": "string"
+            },
+            "content-type-header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "instance-class": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.TidyMarkupDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "data-object-type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "omit-xml-declaration": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.UniVocityCsvDataFormat": {
+      "properties": {
+        "as-map": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "delimiter": {
+          "type": "string"
+        },
+        "empty-value": {
+          "type": "string"
+        },
+        "header-extraction-enabled": {
+          "type": "string"
+        },
+        "headers-disabled": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-leading-whitespaces": {
+          "type": "string"
+        },
+        "ignore-trailing-whitespaces": {
+          "type": "string"
+        },
+        "lazy-load": {
+          "type": "string"
+        },
+        "line-separator": {
+          "type": "string"
+        },
+        "normalized-line-separator": {
+          "type": "string"
+        },
+        "null-value": {
+          "type": "string"
+        },
+        "number-of-records-to-read": {
+          "type": "string"
+        },
+        "quote": {
+          "type": "string"
+        },
+        "quote-all-fields": {
+          "type": "string"
+        },
+        "quote-escape": {
+          "type": "string"
+        },
+        "skip-empty-lines": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.UniVocityFixedWidthDataFormat": {
+      "properties": {
+        "as-map": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "empty-value": {
+          "type": "string"
+        },
+        "header-extraction-enabled": {
+          "type": "string"
+        },
+        "headers-disabled": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-leading-whitespaces": {
+          "type": "string"
+        },
+        "ignore-trailing-whitespaces": {
+          "type": "string"
+        },
+        "lazy-load": {
+          "type": "string"
+        },
+        "line-separator": {
+          "type": "string"
+        },
+        "normalized-line-separator": {
+          "type": "string"
+        },
+        "null-value": {
+          "type": "string"
+        },
+        "number-of-records-to-read": {
+          "type": "string"
+        },
+        "padding": {
+          "type": "string"
+        },
+        "record-ends-on-newline": {
+          "type": "string"
+        },
+        "skip-empty-lines": {
+          "type": "string"
+        },
+        "skip-trailing-chars-until-newline": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.UniVocityTsvDataFormat": {
+      "properties": {
+        "as-map": {
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "empty-value": {
+          "type": "string"
+        },
+        "escape-char": {
+          "type": "string"
+        },
+        "header-extraction-enabled": {
+          "type": "string"
+        },
+        "headers-disabled": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore-leading-whitespaces": {
+          "type": "string"
+        },
+        "ignore-trailing-whitespaces": {
+          "type": "string"
+        },
+        "lazy-load": {
+          "type": "string"
+        },
+        "line-separator": {
+          "type": "string"
+        },
+        "normalized-line-separator": {
+          "type": "string"
+        },
+        "null-value": {
+          "type": "string"
+        },
+        "number-of-records-to-read": {
+          "type": "string"
+        },
+        "skip-empty-lines": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.XMLSecurityDataFormat": {
+      "properties": {
+        "add-key-value-for-encrypted-key": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "digest-algorithm": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key-cipher-algorithm": {
+          "type": "string"
+        },
+        "key-or-trust-store-parameters-ref": {
+          "type": "string"
+        },
+        "key-password": {
+          "type": "string"
+        },
+        "mgf-algorithm": {
+          "type": "string"
+        },
+        "pass-phrase": {
+          "type": "string"
+        },
+        "pass-phrase-byte": {
+          "format": "binary",
+          "type": "string"
+        },
+        "recipient-key-alias": {
+          "type": "string"
+        },
+        "secure-tag": {
+          "type": "string"
+        },
+        "secure-tag-contents": {
+          "type": "string"
+        },
+        "xml-cipher-algorithm": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.XStreamDataFormat": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "content-type-header": {
+              "type": "string"
+            },
+            "driver": {
+              "type": "string"
+            },
+            "driver-ref": {
+              "type": "string"
+            },
+            "encoding": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "mode": {
+              "type": "string"
+            },
+            "permissions": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.dataformat.XmlRpcDataFormat": {
+      "properties": {
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "request": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.YAMLDataFormat": {
+      "properties": {
+        "allow-any-type": {
+          "type": "string"
+        },
+        "allow-recursive-keys": {
+          "type": "string"
+        },
+        "constructor": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "dumper-options": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "library": {
+          "enum": [
+            "SnakeYAML"
+          ]
+        },
+        "max-aliases-for-collections": {
+          "type": "string"
+        },
+        "pretty-flow": {
+          "type": "string"
+        },
+        "representer": {
+          "type": "string"
+        },
+        "resolver": {
+          "type": "string"
+        },
+        "unmarshal-type-name": {
+          "type": "string"
+        },
+        "use-application-context-class-loader": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ZipDeflaterDataFormat": {
+      "properties": {
+        "compression-level": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.dataformat.ZipFileDataFormat": {
+      "properties": {
+        "allow-empty-directory": {
+          "type": "string"
+        },
+        "content-type-header": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "preserve-path-elements": {
+          "type": "string"
+        },
+        "using-iterator": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.language.ConstantExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.ExchangePropertyExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.GroovyExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.HeaderExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.Hl7TerserExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.JsonPathExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "allow-easy-predicate": {
+              "type": "string"
+            },
+            "allow-simple": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "result-type": {
+              "type": "string"
+            },
+            "suppress-exceptions": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            },
+            "write-as-string": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.LanguageExpression": {
+      "properties": {
+        "expression": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "trim": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "type": "object"
+    },
+    "org.apache.camel.model.language.MethodCallExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "bean-type": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "method": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.MvelExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.OgnlExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.RefExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.SimpleExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "result-type": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.SpELExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.TokenizerExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "end-token": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            },
+            "group-delimiter": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "include-tokens": {
+              "type": "string"
+            },
+            "inherit-namespace-tag-name": {
+              "type": "string"
+            },
+            "regex": {
+              "type": "string"
+            },
+            "skip-first": {
+              "type": "string"
+            },
+            "token": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            },
+            "xml": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.XMLTokenizerExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "mode": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.XPathExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "document-type": {
+              "type": "string"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "factory-ref": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "log-namespaces": {
+              "type": "string"
+            },
+            "object-model": {
+              "type": "string"
+            },
+            "result-type": {
+              "enum": [
+                "NUMBER",
+                "STRING",
+                "BOOLEAN",
+                "NODESET",
+                "NODE"
+              ],
+              "type": "string"
+            },
+            "saxon": {
+              "type": "string"
+            },
+            "thread-safety": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.language.XQueryExpression": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "header-name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "trim": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "expression"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "maximum-failover-attempts": {
+          "type": "string"
+        },
+        "round-robin": {
+          "type": "string"
+        },
+        "sticky": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.RandomLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.RoundRobinLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.TopicLoadBalancerDefinition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "org.apache.camel.model.loadbalancer.WeightedLoadBalancerDefinition": {
+      "properties": {
+        "distribution-ratio": {
+          "type": "string"
+        },
+        "distribution-ratio-delimiter": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "round-robin": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "step": {
+      "maxProperties": 1,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.AggregateStepParser$Definition"
+        },
+        "bean": {
+          "$ref": "#/definitions/org.apache.camel.model.BeanDefinition"
+        },
+        "choice": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ChoiceStepParser$Definition"
+        },
+        "circuit-breaker": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.CircuitBreakerStepParser$CBDefinition"
+        },
+        "claim-check": {
+          "$ref": "#/definitions/org.apache.camel.model.ClaimCheckDefinition"
+        },
+        "convert-body-to": {
+          "$ref": "#/definitions/org.apache.camel.model.ConvertBodyDefinition"
+        },
+        "delay": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DelayStepParser$Definition"
+        },
+        "do-try": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DoTryStepParser$DoTryDefinition"
+        },
+        "dynamic-router": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.DynamicRouterStepParser$Definition"
+        },
+        "enrich": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.EnrichStepParser$Definition"
+        },
+        "error-handler": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ErrorHandlerStepParser$Definition"
+        },
+        "filter": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.FilterStepParser$Definition"
+        },
+        "idempotent-consumer": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.IdempotentConsumerParser$Definition"
+        },
+        "load-balance": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoadBalanceStepParser$Definition"
+        },
+        "log": {
+          "$ref": "#/definitions/org.apache.camel.model.LogDefinition"
+        },
+        "loop": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.LoopStepParser$Definition"
+        },
+        "marshal": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.MarshalStepParser$Definition"
+        },
+        "multicast": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.MulticastStepParser$Definition"
+        },
+        "on-exception": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition"
+        },
+        "pipeline": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.PipelineStepParser$Definition"
+        },
+        "poll-enrich": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.PollEnrichStepParser$Definition"
+        },
+        "process": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ProcessStepParser$Definition"
+        },
+        "recipient-list": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RecipientListStepParser$Definition"
+        },
+        "remove-header": {
+          "$ref": "#/definitions/org.apache.camel.model.RemoveHeaderDefinition"
+        },
+        "remove-headers": {
+          "$ref": "#/definitions/org.apache.camel.model.RemoveHeadersDefinition"
+        },
+        "remove-properties": {
+          "$ref": "#/definitions/org.apache.camel.model.RemovePropertiesDefinition"
+        },
+        "remove-property": {
+          "$ref": "#/definitions/org.apache.camel.model.RemovePropertyDefinition"
+        },
+        "resequence": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ResequenceStepParser$Definition"
+        },
+        "rollback": {
+          "$ref": "#/definitions/org.apache.camel.model.RollbackDefinition"
+        },
+        "routing-slip": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RoutingSlipStepParser$Definition"
+        },
+        "saga": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SagaStepParser$Definition"
+        },
+        "sample": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SampleStepParser$Definition"
+        },
+        "script": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ScriptStepParser$Definition"
+        },
+        "service-call": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ServiceCallStepParser$Definition"
+        },
+        "set-body": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetBodyStepParser$Definition"
+        },
+        "set-exchange-pattern": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetExchangePatternStepParser$Definition"
+        },
+        "set-header": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetHeaderStepParser$Definition"
+        },
+        "set-property": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SetPropertyStepParser$Definition"
+        },
+        "sort": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SortStepParser$Definition"
+        },
+        "split": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.SplitStepParser$Definition"
+        },
+        "step": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.StepStepParser$Definition"
+        },
+        "stop": {
+          "$ref": "#/definitions/org.apache.camel.model.StopDefinition"
+        },
+        "threads": {
+          "$ref": "#/definitions/org.apache.camel.model.ThreadsDefinition"
+        },
+        "throttle": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ThrottleStepParser$Definition"
+        },
+        "throw-exception": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ThrowExceptionStepParser$Definition"
+        },
+        "to": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ToStepParser$Definition"
+        },
+        "tod": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ToDynamicStepParser$Definition"
+        },
+        "transacted": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.TransactedStepParser$Definition"
+        },
+        "transform": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.TransformStepParser$Definition"
+        },
+        "unmarshal": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.UnmarshalStepParser$Definition"
+        },
+        "validate": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ValidateStepParser$Definition"
+        },
+        "wiretap": {
+          "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.WireTapStepParser$Definition"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "description": "Kamelet is the Schema for the kamelets API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KameletSpec defines the desired state of Kamelet",
+      "properties": {
+        "authorization": {
+          "description": "AuthorizationSpec is TODO (oauth information)",
+          "type": "object"
+        },
+        "definition": {
+          "description": "JSONSchemaProps is a JSON-Schema definition.",
+          "properties": {
+            "$ref": {
+              "type": "string"
+            },
+            "$schema": {
+              "description": "JSONSchemaURL represents a schema url.",
+              "type": "string"
+            },
+            "additionalItems": {
+              "type": "boolean"
+            },
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "allOf": {
+              "items": {},
+              "type": "array"
+            },
+            "anyOf": {
+              "items": {},
+              "type": "array"
+            },
+            "default": {
+              "description": "default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false."
+            },
+            "definitions": {
+              "additionalProperties": {},
+              "description": "JSONSchemaDefinitions contains the models explicitly defined in this spec.",
+              "type": "object"
+            },
+            "dependencies": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "JSONSchemaDependencies represent a dependencies property.",
+              "type": "object"
+            },
+            "description": {
+              "type": "string"
+            },
+            "enum": {
+              "items": {},
+              "type": "array"
+            },
+            "example": {},
+            "exclusiveMaximum": {
+              "type": "boolean"
+            },
+            "exclusiveMinimum": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "format": {
+              "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "items": {},
+            "maxItems": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "maxLength": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "maxProperties": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "maximum": {
+              "description": "A Number represents a JSON number literal.",
+              "type": "string"
+            },
+            "minItems": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "minLength": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "minProperties": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "minimum": {
+              "description": "A Number represents a JSON number literal.",
+              "type": "string"
+            },
+            "multipleOf": {
+              "description": "A Number represents a JSON number literal.",
+              "type": "string"
+            },
+            "not": {},
+            "nullable": {
+              "type": "boolean"
+            },
+            "oneOf": {
+              "items": {},
+              "type": "array"
+            },
+            "pattern": {
+              "type": "string"
+            },
+            "patternProperties": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "properties": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "uniqueItems": {
+              "type": "boolean"
+            },
+            "x-descriptors": {
+              "description": "x-descriptors annotates an object to define additional display options.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "x-kubernetes-embedded-resource": {
+              "description": "x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).",
+              "type": "boolean"
+            },
+            "x-kubernetes-int-or-string": {
+              "description": "x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns: \n 1) anyOf:    - type: integer    - type: string 2) allOf:    - anyOf:      - type: integer      - type: string    - ... zero or more",
+              "type": "boolean"
+            },
+            "x-kubernetes-list-map-keys": {
+              "description": "x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map. \n This tag MUST only be used on lists that have the \"x-kubernetes-list-type\" extension set to \"map\". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported). \n The properties specified must either be required or have a default value, to ensure those properties are present for all list items.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "x-kubernetes-list-type": {
+              "description": "x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values: \n 1) `atomic`: the list is treated as a single entity, like a scalar.      Atomic lists will be entirely replaced when updated. This extension      may be used on any type of list (struct, scalar, ...). 2) `set`:      Sets are lists that must not have multiple items with the same value. Each      value must be a scalar, an object with x-kubernetes-map-type `atomic` or an      array with x-kubernetes-list-type `atomic`. 3) `map`:      These lists are like maps in that their elements have a non-index key      used to identify them. Order is preserved upon merge. The map tag      must only be used on a list with elements of type object. Defaults to atomic for arrays.",
+              "type": "string"
+            },
+            "x-kubernetes-map-type": {
+              "description": "x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values: \n 1) `granular`:      These maps are actual maps (key-value pairs) and each fields are independent      from each other (they can each be manipulated by separate actors). This is      the default behaviour for all maps. 2) `atomic`: the list is treated as a single entity, like a scalar.      Atomic maps will be entirely replaced when updated.",
+              "type": "string"
+            },
+            "x-kubernetes-preserve-unknown-fields": {
+              "description": "x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "flow": {
+          "maxProperties": 1,
+          "properties": {
+            "error-handler": {
+              "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.ErrorHandlerStepParser$Definition"
+            },
+            "from": {
+              "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.FromStepParser$Definition"
+            },
+            "on-exception": {
+              "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.OnExceptionStepParser$Definition"
+            },
+            "rest": {
+              "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RestStepParser$Definition"
+            },
+            "route": {
+              "$ref": "#/definitions/org.apache.camel.k.loader.yaml.parser.RouteStepParser$Definition"
+            }
+          },
+          "type": "object"
+        },
+        "sources": {
+          "items": {
+            "description": "SourceSpec --",
+            "properties": {
+              "compression": {
+                "type": "boolean"
+              },
+              "content": {
+                "type": "string"
+              },
+              "contentKey": {
+                "type": "string"
+              },
+              "contentRef": {
+                "type": "string"
+              },
+              "interceptors": {
+                "description": "Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader uses to pre/post process sources",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "language": {
+                "description": "Language --",
+                "type": "string"
+              },
+              "loader": {
+                "description": "Loader is an optional id of the org.apache.camel.k.RoutesLoader that will interpret this source at runtime",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "property-names": {
+                "description": "List of property names defined in the source (e.g. if type is \"template\")",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": {
+                "description": "Type defines the kind of source described by this object",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "types": {
+          "additionalProperties": {
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "schema": {
+                "description": "JSONSchemaProps is a JSON-Schema definition.",
+                "properties": {
+                  "$ref": {
+                    "type": "string"
+                  },
+                  "$schema": {
+                    "description": "JSONSchemaURL represents a schema url.",
+                    "type": "string"
+                  },
+                  "additionalItems": {
+                    "type": "boolean"
+                  },
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "allOf": {
+                    "items": {},
+                    "type": "array"
+                  },
+                  "anyOf": {
+                    "items": {},
+                    "type": "array"
+                  },
+                  "default": {
+                    "description": "default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false."
+                  },
+                  "definitions": {
+                    "additionalProperties": {},
+                    "description": "JSONSchemaDefinitions contains the models explicitly defined in this spec.",
+                    "type": "object"
+                  },
+                  "dependencies": {
+                    "additionalProperties": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "description": "JSONSchemaDependencies represent a dependencies property.",
+                    "type": "object"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "enum": {
+                    "items": {},
+                    "type": "array"
+                  },
+                  "example": {},
+                  "exclusiveMaximum": {
+                    "type": "boolean"
+                  },
+                  "exclusiveMinimum": {
+                    "type": "boolean"
+                  },
+                  "externalDocs": {
+                    "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "format": {
+                    "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated: \n - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "items": {},
+                  "maxItems": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "maxLength": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "maxProperties": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "maximum": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": "string"
+                  },
+                  "minItems": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "minLength": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "minProperties": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "minimum": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": "string"
+                  },
+                  "multipleOf": {
+                    "description": "A Number represents a JSON number literal.",
+                    "type": "string"
+                  },
+                  "not": {},
+                  "nullable": {
+                    "type": "boolean"
+                  },
+                  "oneOf": {
+                    "items": {},
+                    "type": "array"
+                  },
+                  "pattern": {
+                    "type": "string"
+                  },
+                  "patternProperties": {
+                    "additionalProperties": {},
+                    "type": "object"
+                  },
+                  "properties": {
+                    "additionalProperties": {},
+                    "type": "object"
+                  },
+                  "required": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "uniqueItems": {
+                    "type": "boolean"
+                  },
+                  "x-descriptors": {
+                    "description": "x-descriptors annotates an object to define additional display options.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "x-kubernetes-embedded-resource": {
+                    "description": "x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).",
+                    "type": "boolean"
+                  },
+                  "x-kubernetes-int-or-string": {
+                    "description": "x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns: \n 1) anyOf:    - type: integer    - type: string 2) allOf:    - anyOf:      - type: integer      - type: string    - ... zero or more",
+                    "type": "boolean"
+                  },
+                  "x-kubernetes-list-map-keys": {
+                    "description": "x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map. \n This tag MUST only be used on lists that have the \"x-kubernetes-list-type\" extension set to \"map\". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported). \n The properties specified must either be required or have a default value, to ensure those properties are present for all list items.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "x-kubernetes-list-type": {
+                    "description": "x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values: \n 1) `atomic`: the list is treated as a single entity, like a scalar.      Atomic lists will be entirely replaced when updated. This extension      may be used on any type of list (struct, scalar, ...). 2) `set`:      Sets are lists that must not have multiple items with the same value. Each      value must be a scalar, an object with x-kubernetes-map-type `atomic` or an      array with x-kubernetes-list-type `atomic`. 3) `map`:      These lists are like maps in that their elements have a non-index key      used to identify them. Order is preserved upon merge. The map tag      must only be used on a list with elements of type object. Defaults to atomic for arrays.",
+                    "type": "string"
+                  },
+                  "x-kubernetes-map-type": {
+                    "description": "x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values: \n 1) `granular`:      These maps are actual maps (key-value pairs) and each fields are independent      from each other (they can each be manipulated by separate actors). This is      the default behaviour for all maps. 2) `atomic`: the list is treated as a single entity, like a scalar.      Atomic maps will be entirely replaced when updated.",
+                    "type": "string"
+                  },
+                  "x-kubernetes-preserve-unknown-fields": {
+                    "description": "x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "KameletStatus defines the observed state of Kamelet",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "KameletCondition describes the state of a resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of kamelet condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "properties": {
+          "items": {
+            "properties": {
+              "default": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	knative.dev/pkg v0.0.0-20200922164940-4bf40ad82aab
 	knative.dev/serving v0.18.0
 	sigs.k8s.io/controller-runtime v0.6.3
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (

--- a/script/Makefile
+++ b/script/Makefile
@@ -120,7 +120,7 @@ codegen:
 	@echo "" >> $(VERSIONFILE)
 	gofmt -w pkg/util/defaults/defaults.go
 
-generate: generate-deepcopy generate-crd generate-client generate-doc generate-strimzi
+generate: generate-deepcopy generate-crd generate-client generate-doc generate-json-schema generate-strimzi
 
 generate-client:
 	./script/gen_client.sh
@@ -133,6 +133,9 @@ generate-doc:
 
 generate-deepcopy: controller-gen
 	cd pkg/apis/camel && $(CONTROLLER_GEN) paths="./..." object
+
+generate-json-schema:
+	./script/gen_json_schema.sh $(RUNTIME_VERSION) $(STAGING_RUNTIME_REPO)
 
 generate-strimzi:
 	cd addons/strimzi/duck && $(CONTROLLER_GEN) paths="./..." object

--- a/script/gen_json_schema.sh
+++ b/script/gen_json_schema.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+location=$(dirname $0)
+cd $location/..
+
+version=$1
+repo=$2
+
+[ -d "./tmpschema" ] && rm -r ./tmpschema
+mkdir  tmpschema
+
+./mvnw dependency:copy \
+  -f build/maven/pom-catalog.xml \
+  -Dartifact=org.apache.camel.k:camel-k-loader-yaml:$version:json:json-schema \
+  -DoutputDirectory=../../tmpschema \
+  -Dmdep.stripVersion \
+  -Druntime.version=$1 \
+  -Dstaging.repo=$repo
+
+schema=./tmpschema/camel-k-loader-yaml-json-schema.json
+
+go run ./cmd/util/json-schema-gen ./deploy/crd-kamelet.yaml $schema .spec.flow false ./docs/modules/ROOT/assets/attachments/schema/kamelet-schema.json
+go run ./cmd/util/json-schema-gen ./deploy/crd-integration.yaml $schema .spec.flows true ./docs/modules/ROOT/assets/attachments/schema/integration-schema.json
+
+rm -r ./tmpschema


### PR DESCRIPTION
<!-- Description -->

Fix #1537

This generates a json schema for validating full Kamelets and integrations, embedding the runtime json schema.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
