### PR TITLE
fix: Correct operator leader election ConfigMap lock name

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -91,7 +91,7 @@ func Run() {
 	}
 
 	// Become the leader before proceeding
-	err = leader.Become(context.TODO(), "hawtio-lock")
+	err = leader.Become(context.TODO(), "camel-k-lock")
 	if err != nil {
 		if err == leader.ErrNoNamespace {
 			log.Info("Local run detected, leader election is disabled")


### PR DESCRIPTION
Fixes the discrepancy introduced with #1741.

**Release Note**
```release-note
NONE
```
