### PR TITLE
fix: Kamelet example

### DIFF
--- a/examples/kamelets/timer-source.kamelet.yaml
+++ b/examples/kamelets/timer-source.kamelet.yaml
@@ -50,5 +50,5 @@ spec:
         period: "#property:period"
       steps:
       - set-body:
-          constant: "#property:message"
+          constant: "{{message}}"
       - to: "kamelet:sink"

--- a/examples/kamelets/usage.groovy
+++ b/examples/kamelets/usage.groovy
@@ -17,5 +17,5 @@
  * limitations under the License.
  */
 
-from('kamelet:timer?message=Hello+Kamelets&period=1000')
+from('kamelet:timer-source?message=Hello+Kamelets&period=1000')
     .log('${body}')


### PR DESCRIPTION
<!-- Description -->

Kamelet example was using wrong `message` property expression in flow and wrong Kamelet name in integration

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
