### PR TITLE
Make inspect subcommand run locally.

### DIFF
--- a/pkg/cmd/inspect.go
+++ b/pkg/cmd/inspect.go
@@ -52,6 +52,9 @@ func newCmdInspect(rootCmdOptions *RootCmdOptions) (*cobra.Command, *inspectCmdO
 
 			return nil
 		},
+		Annotations: map[string]string{
+			offlineCommandLabel: "true",
+		},
 	}
 
 	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml")


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
kind/feature
```

This patch enables the inspect subcommand to run without requiring the Kubernetes configuration. This patch is related to issue https://github.com/apache/camel-k/issues/1738.
