### PR TITLE
Fix ENTESB-15219: only use default values when user doesn't provide a kamelet property value in integration

### DIFF
--- a/pkg/trait/kamelets.go
+++ b/pkg/trait/kamelets.go
@@ -169,7 +169,19 @@ func (t *kameletsTrait) configureApplicationProperties(e *Environment) error {
 		// Configuring defaults from Kamelet
 		for _, prop := range kamelet.Status.Properties {
 			if prop.Default != "" {
-				e.ApplicationProperties[fmt.Sprintf("camel.kamelet.%s.%s", kamelet.Name, prop.Name)] = prop.Default
+				// Check whether user specified a value
+				userDefined := false
+				propName := fmt.Sprintf("camel.kamelet.%s.%s", kamelet.Name, prop.Name)
+				propPrefix := propName + "="
+				for _, userProp := range e.Integration.Spec.Configuration {
+					if strings.HasPrefix(userProp.Value, propPrefix) {
+						userDefined = true
+						break
+					}
+				}
+				if !userDefined {
+					e.ApplicationProperties[propName] = prop.Default
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Description -->

Default kamelet values were overriding user defined properties in an integration's user defined configmap.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fixed kamelet properties default value handling.
```