### PR TITLE
Sort the integration configurations before returning

### DIFF
--- a/pkg/trait/util.go
+++ b/pkg/trait/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	user "github.com/mitchellh/go-homedir"
@@ -77,7 +78,9 @@ func CollectConfigurationValues(configurationType string, configurable ...v1.Con
 		}
 	}
 
-	return result.List()
+	s := result.List()
+	sort.Strings(s)
+	return s
 }
 
 // CollectConfigurationPairs --


### PR DESCRIPTION
Fixes #1824 
<!-- Description -->
The list of `spec.configurations` in the `Integration` ends up as volumes and volumeMounts in the Knative service.  The ordering of these is determined by this package: https://github.com/scylladb/go-set
There is no ordering implied here, which is perfectly fine, except that Knative sees the order of the volumes and volume mounts as a change worthy of a new revision.  When there are many configmaps and secrets in the integration, the number of additional revisions is quite large (50-60, sometimes more) and a new pod is generated for each one.  Sorting the list before returning it ensures the ordering is consistent, and Knative will only generate a single revision.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
