### PR TITLE
Add command line support for creating, building and running containerized integrations locally

### DIFF
--- a/pkg/cmd/inspect.go
+++ b/pkg/cmd/inspect.go
@@ -71,7 +71,19 @@ type inspectCmdOptions struct {
 }
 
 func (command *inspectCmdOptions) validate(args []string) error {
-	return validateIntegrationForDependencies(args, command.AdditionalDependencies)
+	// Validate integration files.
+	err := validateIntegrationFiles(args)
+	if err != nil {
+		return err
+	}
+
+	// Validate additional dependencies specified by the user.
+	err = validateAdditionalDependencies(command.AdditionalDependencies)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (command *inspectCmdOptions) init() error {

--- a/pkg/cmd/local.go
+++ b/pkg/cmd/local.go
@@ -50,6 +50,7 @@ func addLocalSubCommands(cmd *cobra.Command, options *RootCmdOptions) error {
 	}
 
 	localCmd.AddCommand(cmdOnly(newCmdLocalRun(options)))
+	localCmd.AddCommand(cmdOnly(newCmdLocalCreate(options)))
 
 	return nil
 }

--- a/pkg/cmd/local_create.go
+++ b/pkg/cmd/local_create.go
@@ -136,21 +136,27 @@ func (command *localCreateCmdOptions) init(args []string) error {
 }
 
 func (command *localCreateCmdOptions) run(args []string) error {
-	// Fetch dependencies.
-	dependencies, err := getDependencies(args, command.AdditionalDependencies, true)
-	if err != nil {
-		return err
-	}
+	dependenciesList := []string{}
+	propertyFilesList := []string{}
+	if !command.BaseImage {
+		// Fetch dependencies.
+		dependencies, err := getDependencies(args, command.AdditionalDependencies, true)
+		if err != nil {
+			return err
+		}
+		dependenciesList = dependencies
 
-	// Manage integration properties which may come from files or CLI.
-	propertyFiles, err := updateIntegrationProperties(command.Properties, command.PropertyFiles)
-	if err != nil {
-		return err
+		// Manage integration properties which may come from files or CLI.
+		propertyFiles, err := updateIntegrationProperties(command.Properties, command.PropertyFiles)
+		if err != nil {
+			return err
+		}
+		propertyFilesList = propertyFiles
 	}
 
 	// Create and build integration image.
-	err = createAndBuildIntegrationImage(command.ContainerRegistry, command.BaseImage,
-		command.Image, propertyFiles, dependencies, args)
+	err := createAndBuildIntegrationImage(command.ContainerRegistry, command.BaseImage,
+		command.Image, propertyFilesList, dependenciesList, args)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/local_create.go
+++ b/pkg/cmd/local_create.go
@@ -162,13 +162,16 @@ func (command *localCreateCmdOptions) run(args []string) error {
 			return err
 		}
 
+		// Copy routes to a routes folder under a local directory.
+		err = updateIntegrationRoutes(args)
+		if err != nil {
+			return err
+		}
+
 		// Get integration run command to be run inside the container. This means the command
 		// has to be created with the paths which will be valid inside the container.
 		containerCmd := GetContainerIntegrationRunCommand(propertyFiles, dependencies, args)
-
 		err = createAndBuildIntegrationImage(command.DockerRegistry, containerCmd, command.ImageName)
-		// // Run integration locally.
-		// err = containerCmd.Run()
 		if err != nil {
 			return nil
 		}

--- a/pkg/cmd/local_create.go
+++ b/pkg/cmd/local_create.go
@@ -1,0 +1,97 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func newCmdLocalCreate(rootCmdOptions *RootCmdOptions) (*cobra.Command, *localCreateCmdOptions) {
+	options := localCreateCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		Use:     "create [options]",
+		Short:   "Create integration images locally.",
+		Long:    `Create integration images locally for containerized integrations.`,
+		PreRunE: decode(&options),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := options.validate(args); err != nil {
+				return err
+			}
+			if err := options.init(); err != nil {
+				return err
+			}
+			if err := options.run(args); err != nil {
+				fmt.Println(err.Error())
+			}
+			if err := options.deinit(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Annotations: map[string]string{
+			offlineCommandLabel: "true",
+		},
+	}
+
+	cmd.Flags().Bool("base-image", false, "Create base image used as a starting point for any integration.")
+	cmd.Flags().String("docker-registry", "", "Docker registry to store intermediate images.")
+
+	return &cmd, &options
+}
+
+type localCreateCmdOptions struct {
+	*RootCmdOptions
+	BaseImage      bool   `mapstructure:"base-image"`
+	DockerRegistry string `mapstructure:"docker-registry"`
+}
+
+func (command *localCreateCmdOptions) validate(args []string) error {
+	// If containerize is set then docker registry must be set.
+	if command.BaseImage && command.DockerRegistry == "" {
+		return errors.New("base image cannot be created as no registry has been provided")
+	}
+
+	return nil
+}
+
+func (command *localCreateCmdOptions) init() error {
+	return createDockerBaseWorkingDirectory()
+}
+
+func (command *localCreateCmdOptions) run(args []string) error {
+	// Create the Dockerfile and build the base image.
+	if command.BaseImage {
+		err := createAndBuildBaseImage(command.DockerRegistry)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (command *localCreateCmdOptions) deinit() error {
+	return deleteDockerBaseWorkingDirectory()
+}

--- a/pkg/cmd/local_create.go
+++ b/pkg/cmd/local_create.go
@@ -111,7 +111,12 @@ func (command *localCreateCmdOptions) init(args []string) error {
 
 	// If integration files are provided an integration image will be built.
 	if len(args) > 0 {
-		err := createMavenWorkingDirectory()
+		err := createDockerWorkingDirectory()
+		if err != nil {
+			return err
+		}
+
+		err = createMavenWorkingDirectory()
 		if err != nil {
 			return err
 		}
@@ -158,6 +163,7 @@ func (command *localCreateCmdOptions) deinit(args []string) error {
 
 	// If integration files are provided delete the maven project folder.
 	if len(args) > 0 {
+		deleteDockerWorkingDirectory()
 		deleteMavenWorkingDirectory()
 	}
 

--- a/pkg/cmd/local_create.go
+++ b/pkg/cmd/local_create.go
@@ -38,13 +38,13 @@ func newCmdLocalCreate(rootCmdOptions *RootCmdOptions) (*cobra.Command, *localCr
 			if err := options.validate(args); err != nil {
 				return err
 			}
-			if err := options.init(); err != nil {
+			if err := options.init(args); err != nil {
 				return err
 			}
 			if err := options.run(args); err != nil {
 				fmt.Println(err.Error())
 			}
-			if err := options.deinit(); err != nil {
+			if err := options.deinit(args); err != nil {
 				return err
 			}
 
@@ -57,27 +57,67 @@ func newCmdLocalCreate(rootCmdOptions *RootCmdOptions) (*cobra.Command, *localCr
 
 	cmd.Flags().Bool("base-image", false, "Create base image used as a starting point for any integration.")
 	cmd.Flags().String("docker-registry", "", "Docker registry to store intermediate images.")
+	cmd.Flags().StringArray("property-file", nil, "Add a property file to the integration.")
+	cmd.Flags().StringArrayP("dependency", "d", nil, "Add an additional dependency")
 
 	return &cmd, &options
 }
 
 type localCreateCmdOptions struct {
 	*RootCmdOptions
-	BaseImage      bool   `mapstructure:"base-image"`
-	DockerRegistry string `mapstructure:"docker-registry"`
+	BaseImage              bool     `mapstructure:"base-image"`
+	DockerRegistry         string   `mapstructure:"docker-registry"`
+	AdditionalDependencies []string `mapstructure:"dependencies"`
+	PropertyFiles          []string `mapstructure:"property-files"`
 }
 
 func (command *localCreateCmdOptions) validate(args []string) error {
-	// If containerize is set then docker registry must be set.
-	if command.BaseImage && command.DockerRegistry == "" {
+	// Validate integration files.
+	if len(args) > 0 {
+		err := validateIntegrationFiles(args)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Validate additional dependencies specified by the user.
+	err := validateAdditionalDependencies(command.AdditionalDependencies)
+	if err != nil {
+		return err
+	}
+
+	// Validate properties file.
+	err = validateFiles(command.PropertyFiles)
+	if err != nil {
+		return nil
+	}
+
+	// Docker registry must be set.
+	if command.DockerRegistry == "" {
 		return errors.New("base image cannot be created as no registry has been provided")
 	}
 
 	return nil
 }
 
-func (command *localCreateCmdOptions) init() error {
-	return createDockerBaseWorkingDirectory()
+func (command *localCreateCmdOptions) init(args []string) error {
+	// If base image construction is enabled create a directory for it.
+	if command.BaseImage {
+		err := createDockerBaseWorkingDirectory()
+		if err != nil {
+			return err
+		}
+	}
+
+	// If integration files are provided an integration image will be built.
+	if len(args) > 0 {
+		err := createMavenWorkingDirectory()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (command *localCreateCmdOptions) run(args []string) error {
@@ -89,9 +129,37 @@ func (command *localCreateCmdOptions) run(args []string) error {
 		}
 	}
 
+	// Create integration image if integration files were provided.
+	if len(args) > 0 {
+		// Fetch dependencies.
+		dependencies, err := getDependencies(args, command.AdditionalDependencies, true)
+		if err != nil {
+			return err
+		}
+
+		// Get integration run command.
+		cmd := GetIntegrationRunCommand(command.PropertyFiles, dependencies, args)
+
+		// Run integration locally.
+		err = cmd.Run()
+		if err != nil {
+			return nil
+		}
+	}
+
 	return nil
 }
 
-func (command *localCreateCmdOptions) deinit() error {
-	return deleteDockerBaseWorkingDirectory()
+func (command *localCreateCmdOptions) deinit(args []string) error {
+	// If base image construction is enabled delete the directory for it.
+	if command.BaseImage {
+		deleteDockerBaseWorkingDirectory()
+	}
+
+	// If integration files are provided delete the maven project folder.
+	if len(args) > 0 {
+		deleteMavenWorkingDirectory()
+	}
+
+	return nil
 }

--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -74,8 +74,14 @@ type localRunCmdOptions struct {
 }
 
 func (command *localRunCmdOptions) validate(args []string) error {
+	// Validate integration files.
+	err := validateIntegrationFiles(args)
+	if err != nil {
+		return err
+	}
+
 	// Validate additional dependencies specified by the user.
-	err := validateIntegrationForDependencies(args, command.AdditionalDependencies)
+	err = validateAdditionalDependencies(command.AdditionalDependencies)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -111,8 +111,28 @@ func (command *localRunCmdOptions) run(args []string) error {
 		return nil
 	}
 
-	// Run the integration locally.
-	err = RunLocalIntegration(command.PropertyFiles, dependencies, args)
+	// Run integration inside a local container.
+	if command.Containerize {
+		// Get base image name.
+
+		// Assemble Dockerfile for containerized run.
+		// - copy properties
+		// - copy dependencies
+		// - copy sources
+		// = assemble run command: GetIntegrationRunCommand
+
+		// Build container image.
+
+		// Run container image.
+
+		return nil
+	}
+
+	// Get integration run command.
+	cmd := GetIntegrationRunCommand(command.PropertyFiles, dependencies, args)
+
+	// Run integration locally.
+	err = cmd.Run()
 	if err != nil {
 		return nil
 	}

--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -112,10 +112,13 @@ func (command *localRunCmdOptions) run(args []string) error {
 	}
 
 	// Manage integration properties which may come from files or CLI.
-	err = updateIntegrationProperties(command)
+	propertyFiles, err := updateIntegrationProperties(command.Properties, command.PropertyFiles)
 	if err != nil {
 		return nil
 	}
+
+	// Update property files with relocated files.
+	command.PropertyFiles = propertyFiles
 
 	// Run integration inside a local container.
 	if command.Containerize {

--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -103,6 +103,18 @@ func (command *localRunCmdOptions) validate(args []string) error {
 }
 
 func (command *localRunCmdOptions) init() error {
+	if command.Containerize {
+		err := createDockerBaseWorkingDirectory()
+		if err != nil {
+			return err
+		}
+
+		err = createDockerWorkingDirectory()
+		if err != nil {
+			return err
+		}
+	}
+
 	return createMavenWorkingDirectory()
 }
 
@@ -155,5 +167,17 @@ func (command *localRunCmdOptions) run(args []string) error {
 }
 
 func (command *localRunCmdOptions) deinit() error {
+	if command.Containerize {
+		err := deleteDockerBaseWorkingDirectory()
+		if err != nil {
+			return err
+		}
+
+		err = deleteDockerWorkingDirectory()
+		if err != nil {
+			return err
+		}
+	}
+
 	return deleteMavenWorkingDirectory()
 }

--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -77,7 +77,7 @@ type localRunCmdOptions struct {
 
 func (command *localRunCmdOptions) validate(args []string) error {
 	// Validate integration files.
-	if command.ImageName == "" {
+	if command.ImageName == "" || command.Containerize {
 		err := validateIntegrationFiles(args)
 		if err != nil {
 			return err
@@ -101,7 +101,12 @@ func (command *localRunCmdOptions) validate(args []string) error {
 		return errors.New("containerization is active but no registry has been provided")
 	}
 
-	// If containerize is set then docker registry must be set.
+	// If containerize is set then docker image name must be set.
+	if command.Containerize && command.ImageName == "" {
+		return errors.New("containerization is active but no image name has been provided")
+	}
+
+	// If ImageName is provided then docker registry must be set.
 	if command.ImageName != "" && command.DockerRegistry == "" {
 		return errors.New("cannot get image as no registry has been provided")
 	}
@@ -115,7 +120,7 @@ func (command *localRunCmdOptions) init() error {
 
 func (command *localRunCmdOptions) run(args []string) error {
 	// If local run is provided with an image name, it will just run the image locally and exit.
-	if command.ImageName != "" {
+	if command.ImageName != "" && !command.Containerize {
 		// Run image locally.
 		err := runIntegrationImage(command.DockerRegistry, command.ImageName)
 		if err != nil {

--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -117,28 +117,25 @@ func (command *localRunCmdOptions) run(args []string) error {
 		return nil
 	}
 
-	// Update property files with relocated files.
-	command.PropertyFiles = propertyFiles
+	// // Run integration inside a local container.
+	// if command.Containerize {
+	// 	// Get base image name.
 
-	// Run integration inside a local container.
-	if command.Containerize {
-		// Get base image name.
+	// 	// Assemble Dockerfile for containerized run.
+	// 	// - copy properties
+	// 	// - copy dependencies
+	// 	// - copy sources
+	// 	// = assemble run command: GetIntegrationRunCommand
 
-		// Assemble Dockerfile for containerized run.
-		// - copy properties
-		// - copy dependencies
-		// - copy sources
-		// = assemble run command: GetIntegrationRunCommand
+	// 	// Build container image.
 
-		// Build container image.
+	// 	// Run container image.
 
-		// Run container image.
-
-		return nil
-	}
+	// 	return nil
+	// }
 
 	// Get integration run command.
-	cmd := GetIntegrationRunCommand(command.PropertyFiles, dependencies, args)
+	cmd := GetLocalIntegrationRunCommand(propertyFiles, dependencies, args)
 
 	// Run integration locally.
 	err = cmd.Run()

--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -117,25 +118,11 @@ func (command *localRunCmdOptions) run(args []string) error {
 		return nil
 	}
 
-	// // Run integration inside a local container.
-	// if command.Containerize {
-	// 	// Get base image name.
-
-	// 	// Assemble Dockerfile for containerized run.
-	// 	// - copy properties
-	// 	// - copy dependencies
-	// 	// - copy sources
-	// 	// = assemble run command: GetIntegrationRunCommand
-
-	// 	// Build container image.
-
-	// 	// Run container image.
-
-	// 	return nil
-	// }
-
 	// Get integration run command.
 	cmd := GetLocalIntegrationRunCommand(propertyFiles, dependencies, args)
+
+	// Output command we are about to run.
+	fmt.Printf("Executing: %s", strings.Join(cmd.Args, " "))
 
 	// Run integration locally.
 	err = cmd.Run()

--- a/pkg/cmd/modeline.go
+++ b/pkg/cmd/modeline.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	runCmdName        = "run"
+	createCmdName     = "create"
 	localCmdName      = "local"
 	runCmdSourcesArgs = "source"
 )
@@ -86,7 +87,9 @@ func createKamelWithModelineCommand(ctx context.Context, args []string) (*cobra.
 		return nil, nil, err
 	}
 
-	if target.Name() != runCmdName {
+	isLocalCreate := target.Parent().Name() == localCmdName && target.Name() == createCmdName
+
+	if target.Name() != runCmdName && !isLocalCreate {
 		return rootCmd, args, nil
 	}
 

--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -65,8 +65,8 @@ func assembleClasspatchArgValue(properties []string, dependencies []string, rout
 	return strings.Join(classpathContents, ":")
 }
 
-// RunLocalIntegration --
-func RunLocalIntegration(properties []string, dependencies []string, routes []string) error {
+// GetIntegrationRunCommand --
+func GetIntegrationRunCommand(properties []string, dependencies []string, routes []string) *exec.Cmd {
 	// Create classpath value.
 	classpathValue := assembleClasspatchArgValue(properties, dependencies, routes)
 
@@ -83,13 +83,13 @@ func RunLocalIntegration(properties []string, dependencies []string, routes []st
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 
-	fmt.Printf("executing: %s", strings.Join(cmd.Args, " "))
-
 	// Add directory where the properties file resides.
 	cmd.Env = append(cmd.Env, "CAMEL_K_CONF_D="+getPropertiesDir())
 
 	// Add files to the command line under the CAMEL_K_ROUTES flag.
 	cmd.Env = append(cmd.Env, "CAMEL_K_ROUTES="+strings.Join(formatRoutes(routes), ","))
 
-	return cmd.Run()
+	fmt.Printf("executing: %s", strings.Join(cmd.Args, " "))
+
+	return cmd
 }

--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -49,7 +49,7 @@ func formatRoutes(files []string) []string {
 	return routes
 }
 
-func assembleClasspatchArgValue(properties []string, dependencies []string, routes []string) string {
+func assembleClasspathArgValue(properties []string, dependencies []string, routes []string) string {
 	classpathContents := []string{}
 	classpathContents = append(classpathContents, properties...)
 	classpathContents = append(classpathContents, routes...)
@@ -59,7 +59,7 @@ func assembleClasspatchArgValue(properties []string, dependencies []string, rout
 
 func assembleIntegrationRunCommand(properties []string, dependencies []string, routes []string, propertiesDir string) *exec.Cmd {
 	// Create classpath value.
-	classpathValue := assembleClasspatchArgValue(properties, dependencies, routes)
+	classpathValue := assembleClasspathArgValue(properties, dependencies, routes)
 
 	// Create java command that runs the integration.
 	javaCmd := "java"

--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -80,8 +79,6 @@ func assembleIntegrationRunCommand(properties []string, dependencies []string, r
 
 	// Add files to the command line under the CAMEL_K_ROUTES flag.
 	cmd.Env = append(cmd.Env, "CAMEL_K_ROUTES="+strings.Join(formatRoutes(routes), ","))
-
-	fmt.Printf("executing: %s", strings.Join(cmd.Args, " "))
 
 	return cmd
 }

--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -83,9 +84,20 @@ func assembleIntegrationRunCommand(properties []string, dependencies []string, r
 	return cmd
 }
 
-// GetLocalIntegrationRunCommand --
-func GetLocalIntegrationRunCommand(properties []string, dependencies []string, routes []string) *exec.Cmd {
-	return assembleIntegrationRunCommand(properties, dependencies, routes, util.GetLocalPropertiesDir())
+// RunLocalIntegrationRunCommand --
+func RunLocalIntegrationRunCommand(properties []string, dependencies []string, routes []string) error {
+	cmd := assembleIntegrationRunCommand(properties, dependencies, routes, util.GetLocalPropertiesDir())
+
+	// Output command we are about to run.
+	fmt.Printf("Executing: %s", strings.Join(cmd.Args, " "))
+
+	// Run integration locally.
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // GetContainerIntegrationRunCommand --

--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -81,6 +81,10 @@ func assembleIntegrationRunCommand(properties []string, dependencies []string, r
 	// Add files to the command line under the CAMEL_K_ROUTES flag.
 	cmd.Env = append(cmd.Env, "CAMEL_K_ROUTES="+strings.Join(formatRoutes(routes), ","))
 
+	// Set stdout and stderr.
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
 	return cmd
 }
 

--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -86,7 +86,7 @@ func createAndBuildBaseImage(containerRegistry string) error {
 
 	// Run the command.
 	if err := cmd.Run(); err != nil {
-		errors.Errorf("base image containerization did not run successfully: %v", err)
+		return errors.Errorf("base image containerization did not run successfully: %v", err)
 	}
 
 	return nil
@@ -94,6 +94,11 @@ func createAndBuildBaseImage(containerRegistry string) error {
 
 func createAndBuildIntegrationImage(containerRegistry string, justBaseImage bool, image string,
 	propertyFiles []string, dependencies []string, routes []string) error {
+	// This ensures the Dockerfile for the base image will not end up in an undesired location.
+	if docker.BaseWorkingDirectory == "" {
+		return errors.New("base directory that holds the base image Dockerfile has not been set correctly")
+	}
+
 	docker.RegistryName = containerRegistry
 	if !justBaseImage {
 		registryName, err := docker.ExtractRegistryName(image)
@@ -112,6 +117,10 @@ func createAndBuildIntegrationImage(containerRegistry string, justBaseImage bool
 
 	if justBaseImage {
 		return nil
+	}
+
+	if docker.IntegrationWorkingDirectory == "" {
+		return errors.New("integration directory that holds the image Dockerfile has not been set correctly")
 	}
 
 	// Create integration image if integration files were provided.
@@ -162,7 +171,7 @@ func runIntegrationImage(image string) error {
 
 	// Run the command.
 	if err := cmd.Run(); err != nil {
-		errors.Errorf("integration image did not run successfully: %v", err)
+		return errors.Errorf("integration image did not run successfully: %v", err)
 	}
 
 	return nil

--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -63,7 +63,7 @@ func createAndBuildBaseImage(dockerRegistry string) error {
 	cmd := exec.CommandContext(ctx, "docker", args...)
 
 	// Output executed command.
-	fmt.Printf("Executing: " + strings.Join(cmd.Args, " "))
+	fmt.Printf("Executing: " + strings.Join(cmd.Args, " ") + "\n")
 
 	// Run the command.
 	if err := cmd.Run(); err != nil {

--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -48,6 +48,26 @@ func deleteDockerBaseWorkingDirectory() error {
 	return nil
 }
 
+func createDockerWorkingDirectory() error {
+	// Create local docker base directory.
+	temporaryDirectory, err := ioutil.TempDir(os.TempDir(), "docker-")
+	if err != nil {
+		return err
+	}
+
+	// Set the Docker base directory to the default value.
+	docker.WorkingDirectory = temporaryDirectory
+
+	return nil
+}
+
+func deleteDockerWorkingDirectory() error {
+	// Remove directory used for computing the dependencies.
+	defer os.RemoveAll(docker.WorkingDirectory)
+
+	return nil
+}
+
 func createAndBuildBaseImage(dockerRegistry string) error {
 	// Set docker registry.
 	docker.RegistryName = dockerRegistry

--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -1,0 +1,74 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/apache/camel-k/pkg/util/docker"
+	"github.com/pkg/errors"
+)
+
+func createDockerBaseWorkingDirectory() error {
+	// Create local docker base directory.
+	temporaryDirectory, err := ioutil.TempDir(os.TempDir(), "docker-base-")
+	if err != nil {
+		return err
+	}
+
+	// Set the Docker base directory to the default value.
+	docker.BaseWorkingDirectory = temporaryDirectory
+
+	return nil
+}
+
+func deleteDockerBaseWorkingDirectory() error {
+	// Remove directory used for computing the dependencies.
+	defer os.RemoveAll(docker.BaseWorkingDirectory)
+
+	return nil
+}
+
+func createAndBuildBaseImage(dockerRegistry string) error {
+	// Set docker registry.
+	docker.RegistryName = dockerRegistry
+
+	// Create the base image Docker file.
+	err := docker.CreateBaseImageDockerFile()
+	if err != nil {
+		return err
+	}
+
+	// Get the Docker command arguments for building the base image and create the command.
+	args := docker.BuildBaseImageArgs()
+	cmd := exec.CommandContext(ctx, "docker", args...)
+
+	// Output executed command.
+	fmt.Printf("Executing: " + strings.Join(cmd.Args, " "))
+
+	// Run the command.
+	if err := cmd.Run(); err != nil {
+		errors.Errorf("base image containerization did not run successfully: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -150,6 +150,10 @@ func createAndBuildIntegrationImage(containerRegistry string, justBaseImage bool
 	args := docker.BuildIntegrationImageArgs(image)
 	cmd := exec.CommandContext(ctx, "docker", args...)
 
+	// Set stdout and stderr.
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
 	// Output executed command.
 	fmt.Printf("Executing: " + strings.Join(cmd.Args, " ") + "\n")
 
@@ -165,6 +169,10 @@ func runIntegrationImage(image string) error {
 	// Get the docker command line argument for running an image.
 	args := docker.RunIntegrationImageArgs(image)
 	cmd := exec.CommandContext(ctx, "docker", args...)
+
+	// Set stdout and stderr.
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
 
 	// Output executed command.
 	fmt.Printf("Executing: " + strings.Join(cmd.Args, " ") + "\n")

--- a/pkg/cmd/util_dependencies.go
+++ b/pkg/cmd/util_dependencies.go
@@ -336,36 +336,34 @@ func createPropertiesDirectory() error {
 	return nil
 }
 
-func updateIntegrationProperties(command *localRunCmdOptions) error {
+func updateIntegrationProperties(properties []string, propertyFiles []string) ([]string, error) {
 	// Create properties directory under Maven working directory. This ensures that
 	// property files of different integrations do not clash.
 	err := createPropertiesDirectory()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Relocate properties files to this integration's property directory.
 	relocatedPropertyFiles := []string{}
-	for _, propertyFile := range command.PropertyFiles {
+	for _, propertyFile := range propertyFiles {
 		relocatedPropertyFile := path.Join(getPropertiesDir(), path.Base(propertyFile))
 		util.CopyFile(propertyFile, relocatedPropertyFile)
 		relocatedPropertyFiles = append(relocatedPropertyFiles, relocatedPropertyFile)
 	}
 
 	// Output list of properties to property file if any CLI properties were given.
-	if len(command.Properties) > 0 {
+	if len(properties) > 0 {
 		propertyFilePath := path.Join(getPropertiesDir(), "CLI.properties")
-		err = ioutil.WriteFile(propertyFilePath, []byte(strings.Join(command.Properties, "\n")), 0777)
+		err = ioutil.WriteFile(propertyFilePath, []byte(strings.Join(properties, "\n")), 0777)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		relocatedPropertyFiles = append(relocatedPropertyFiles, propertyFilePath)
 	}
 
-	// Update command PropertyFiles.
-	command.PropertyFiles = relocatedPropertyFiles
-
-	return nil
+	// Return relocated PropertyFiles.
+	return relocatedPropertyFiles, nil
 }
 
 func createMavenWorkingDirectory() error {

--- a/pkg/cmd/util_dependencies.go
+++ b/pkg/cmd/util_dependencies.go
@@ -349,8 +349,24 @@ func updateIntegrationDependencies(dependencies []string) error {
 
 	// Relocate dependencies files to this integration's dependencies directory.
 	for _, dependency := range dependencies {
-		relocatedDependency := path.Join(util.GetLocalDependenciesDir(), path.Base(dependency))
-		util.CopyFile(dependency, relocatedDependency)
+		util.CopyFile(dependency, path.Join(util.GetLocalDependenciesDir(), path.Base(dependency)))
+	}
+
+	// Return relocated PropertyFiles.
+	return nil
+}
+
+func updateIntegrationRoutes(routes []string) error {
+	// Create dependencies directory under Maven working directory. This ensures that
+	// dependencies will be removed after they are not needed.
+	err := util.CreateLocalRoutesDirectory()
+	if err != nil {
+		return err
+	}
+
+	// Relocate dependencies files to this integration's dependencies directory.
+	for _, route := range routes {
+		util.CopyFile(route, path.Join(util.GetLocalRoutesDir(), path.Base(route)))
 	}
 
 	// Return relocated PropertyFiles.

--- a/pkg/cmd/util_dependencies.go
+++ b/pkg/cmd/util_dependencies.go
@@ -60,6 +60,10 @@ func getDependencies(args []string, additionalDependencies []string, allDependen
 
 	// Compute transitive dependencies.
 	if allDependencies {
+		// Add runtime dependency since this dependency is always required for running
+		// an integration.
+		dependencies = append(dependencies, "camel-k:runtime-quarkus")
+
 		dependencies, err = getTransitiveDependencies(catalog, dependencies)
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/util_dependencies.go
+++ b/pkg/cmd/util_dependencies.go
@@ -61,8 +61,17 @@ func getDependencies(args []string, additionalDependencies []string, allDependen
 	// Compute transitive dependencies.
 	if allDependencies {
 		// Add runtime dependency since this dependency is always required for running
-		// an integration.
-		dependencies = append(dependencies, "camel-k:runtime-quarkus")
+		// an integration. Only add this dependency if it has not been added already.
+		runtimeDepExists := false
+		for _, dependency := range dependencies {
+			// TODO: add checks for other runtimes when more are supported.
+			if strings.Contains(dependency, "runtime-quarkus") {
+				runtimeDepExists = true
+			}
+		}
+		if !runtimeDepExists {
+			dependencies = append(dependencies, "camel-k:runtime-quarkus")
+		}
 
 		dependencies, err = getTransitiveDependencies(catalog, dependencies)
 		if err != nil {

--- a/pkg/cmd/util_dependencies.go
+++ b/pkg/cmd/util_dependencies.go
@@ -284,7 +284,7 @@ func validateDependency(additionalDependency string) bool {
 	return TypeIsValid
 }
 
-func validateIntegrationForDependencies(args []string, additionalDependencies []string) error {
+func validateIntegrationFiles(args []string) error {
 	// If no source files have been provided there is nothing to inspect.
 	if len(args) == 0 {
 		return errors.New("no integration files have been provided")
@@ -294,12 +294,6 @@ func validateIntegrationForDependencies(args []string, additionalDependencies []
 	err := validateFiles(args)
 	if err != nil {
 		return nil
-	}
-
-	// Validate additional dependencies specified by the user.
-	err = validateAdditionalDependencies(additionalDependencies)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/kamelet/repository/go.mod
+++ b/pkg/kamelet/repository/go.mod
@@ -7,11 +7,12 @@ require (
 	github.com/apache/camel-k/pkg/client/camel v0.0.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	k8s.io/apimachinery v0.18.9
-	github.com/stretchr/testify v1.5.1
 )
 
 // Local modules
 replace github.com/apache/camel-k/pkg/apis/camel => ../../apis/camel
+
 replace github.com/apache/camel-k/pkg/client/camel => ../../client/camel

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -52,7 +52,7 @@ func CreateIntegrationImageDockerFile(integrationRunCmd *exec.Cmd) error {
 	dockerFile := []string{}
 
 	// Start from the base image that contains the maven install: <RegistryName>/<BaseImageName>
-	dockerFile = append(dockerFile, FROM(GetFullDockerImage(BaseImageName, latestTag)))
+	dockerFile = append(dockerFile, FROM(GetFullDockerImage(GetBaseImagePath(), latestTag)))
 
 	// Create container workspace directory.
 	dockerFile = append(dockerFile, RUNMakeDir(GetContainerWorkspaceDir()))
@@ -90,16 +90,17 @@ func BuildBaseImageArgs() []string {
 	//
 	// docker build -f <BaseWorkingDirectory>/Dockerfile -t <dockerRegistry>/<BaseImageName> <BaseWorkingDirectory>
 	//
-	return BuildImageArgs(BaseWorkingDirectory, BaseImageName, BaseWorkingDirectory)
+	// Add register
+	return BuildImageArgs(BaseWorkingDirectory, GetBaseImagePath(), BaseWorkingDirectory)
 }
 
 // BuildIntegrationImageArgs --
-func BuildIntegrationImageArgs(imageName string) []string {
+func BuildIntegrationImageArgs(imagePath string) []string {
 	// Construct the docker command:
 	//
-	// docker build -f <BaseWorkingDirectory>/Dockerfile -t <dockerRegistry>/<ImageName> <MavenWorkingDirectory>
+	// docker build -f <BaseWorkingDirectory>/Dockerfile -t <imagePath> <MavenWorkingDirectory>
 	//
-	return BuildImageArgs(IntegrationWorkingDirectory, imageName, util.MavenWorkingDirectory)
+	return BuildImageArgs(IntegrationWorkingDirectory, imagePath, util.MavenWorkingDirectory)
 }
 
 // RunIntegrationImageArgs --

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -1,0 +1,54 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"path"
+	"strings"
+
+	"github.com/apache/camel-k/pkg/util"
+)
+
+// CreateBaseImageDockerFile --
+func CreateBaseImageDockerFile() error {
+	dockerFile := []string{}
+
+	// Base image is a java-only image since the integration command is just a java command.
+	dockerFile = append(dockerFile, FROM("adoptopenjdk/openjdk11:alpine"))
+
+	// Ensure Maven is already installed.
+	dockerFile = append(dockerFile, RUNMavenInstall())
+
+	// Write <base-work-dir>/Dockerfile
+	baseDockerFilePath := path.Join(BaseWorkingDirectory, "Dockerfile")
+	err := util.WriteToFile(baseDockerFilePath, strings.Join(dockerFile, "\n"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BuildBaseImageArgs --
+func BuildBaseImageArgs() []string {
+	// Construct the docker command:
+	//
+	// docker build -f <BaseWorkingDirectory>/Dockerfile -t <dockerRegistry>/<BaseImageName>
+	//
+	return BuildImageArgs(BaseWorkingDirectory, BaseImageName, BaseWorkingDirectory)
+}

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/apache/camel-k/pkg/util"
+	"github.com/apache/camel-k/pkg/util/defaults"
 	"github.com/pkg/errors"
 )
 
@@ -31,7 +32,7 @@ func CreateBaseImageDockerFile() error {
 	dockerFile := []string{}
 
 	// Base image is a java-only image since the integration command is just a java command.
-	dockerFile = append(dockerFile, FROM("adoptopenjdk/openjdk11:alpine"))
+	dockerFile = append(dockerFile, FROM(defaults.BaseImage))
 
 	// Ensure Maven is already installed.
 	dockerFile = append(dockerFile, RUNMavenInstall())

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -95,9 +95,18 @@ func BuildBaseImageArgs() []string {
 func BuildIntegrationImageArgs(imageName string) []string {
 	// Construct the docker command:
 	//
-	// docker build -f <BaseWorkingDirectory>/Dockerfile -t <dockerRegistry>/<BaseImageName> <MavenWorkingDirectory>
+	// docker build -f <BaseWorkingDirectory>/Dockerfile -t <dockerRegistry>/<ImageName> <MavenWorkingDirectory>
 	//
 	return BuildImageArgs(IntegrationWorkingDirectory, imageName, util.MavenWorkingDirectory)
+}
+
+// RunIntegrationImageArgs --
+func RunIntegrationImageArgs(imageName string) []string {
+	// Construct the docker command:
+	//
+	// docker run --network="host" <dockerRegistry>/<ImageName>
+	//
+	return RunImageArgs(imageName, latestTag)
 }
 
 // GetContainerWorkspaceDir -- directory inside the container where all the integration files are copied.

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -57,13 +57,10 @@ func CreateIntegrationImageDockerFile(integrationRunCmd *exec.Cmd) error {
 	// Create container workspace directory.
 	dockerFile = append(dockerFile, RUNMakeDir(GetContainerWorkspaceDir()))
 
-	// Set workspace directory.
-	dockerFile = append(dockerFile, WORKDIR(GetContainerWorkspaceDir()))
-
 	// Copy files from local directory to container directories.
-	dockerFile = append(dockerFile, COPY(util.DefaultRoutesDirectoryName, util.DefaultRoutesDirectoryName))
-	dockerFile = append(dockerFile, COPY(util.DefaultPropertiesDirectoryName, util.DefaultPropertiesDirectoryName))
-	dockerFile = append(dockerFile, COPY(util.DefaultDependenciesDirectoryName, util.DefaultDependenciesDirectoryName))
+	dockerFile = append(dockerFile, COPY(util.DefaultRoutesDirectoryName, GetContainerRoutesDir()))
+	dockerFile = append(dockerFile, COPY(util.DefaultPropertiesDirectoryName, GetContainerPropertiesDir()))
+	dockerFile = append(dockerFile, COPY(util.DefaultDependenciesDirectoryName, GetContainerDependenciesDir()))
 
 	// All Env variables the command requires need to be set in the container.
 	for _, keyValue := range integrationRunCmd.Env {
@@ -119,17 +116,17 @@ func GetContainerWorkspaceDir() string {
 
 // GetContainerPropertiesDir -- directory inside the container where all the integration property files are copied.
 func GetContainerPropertiesDir() string {
-	return GetContainerWorkspaceDir() + containerFileSeparator + util.DefaultPropertiesDirectoryName
+	return util.ContainerPropertiesDirectory
 }
 
 // GetContainerDependenciesDir -- directory inside the container where all the integration dependencies are copied.
 func GetContainerDependenciesDir() string {
-	return GetContainerWorkspaceDir() + containerFileSeparator + util.DefaultDependenciesDirectoryName
+	return util.ContainerDependenciesDirectory
 }
 
 // GetContainerRoutesDir -- directory inside the container where all the integration routes are copied.
 func GetContainerRoutesDir() string {
-	return GetContainerWorkspaceDir() + containerFileSeparator + util.DefaultRoutesDirectoryName
+	return util.ContainerRoutesDirectory
 }
 
 // ContainerizeFilePaths -- make paths valid container paths given a valid container directory in newDir.

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -102,12 +102,12 @@ func BuildIntegrationImageArgs(imageName string) []string {
 }
 
 // RunIntegrationImageArgs --
-func RunIntegrationImageArgs(image string) []string {
+func RunIntegrationImageArgs(imagePath string) []string {
 	// Construct the docker command:
 	//
 	// docker run --network="host" <dockerRegistry>/<ImageName>
 	//
-	return RunImageArgs(image, latestTag)
+	return RunImageArgs(imagePath, latestTag)
 }
 
 // GetContainerWorkspaceDir -- directory inside the container where all the integration files are copied.

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -58,9 +58,7 @@ func BuildImageArgs(dockerFileDir string, imageName string, sourceDir string) []
 	args = append(args, ImageArg(imageName, "")...)
 
 	// Root of source directory.
-	if sourceDir != "" {
-		args = append(args, sourceDir)
-	}
+	args = append(args, sourceDir)
 
 	return args
 }

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -31,6 +31,9 @@ var BaseImageName string = "integration-base-image"
 // BaseWorkingDirectory -- directory used by Docker to construct the base image.
 var BaseWorkingDirectory string = ""
 
+// WorkingDirectory -- directory used by Docker to construct the integration image.
+var WorkingDirectory string = ""
+
 // Internal variables.
 var (
 	dockerEndpointSeparator = "/"

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -1,0 +1,228 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"path"
+	"strings"
+)
+
+// RegistryName -- the docker registry name.
+var RegistryName = ""
+
+// BaseImageName -- base image name.
+var BaseImageName string = "integration-base-image"
+
+// BaseWorkingDirectory -- directory used by Docker to construct the base image.
+var BaseWorkingDirectory string = ""
+
+// Internal variables.
+var (
+	dockerEndpointSeparator = "/"
+	containerFileSeparator  = "/"
+	latestTag               = "latest"
+)
+
+// BuildImageArgs - standard docker build arguments.
+func BuildImageArgs(dockerFileDir string, imageName string, sourceDir string) []string {
+	// Construct the docker command:
+	//
+	// docker build -f <docker-file> -t <image-name> <source-directory>
+	//
+	args := make([]string, 0)
+	args = append(args, "build")
+
+	// Add path to Dockerfile:
+	dockerFile := path.Join(dockerFileDir, "Dockerfile")
+	args = append(args, DockerfilePathArg(dockerFile)...)
+
+	// Image name:
+	args = append(args, ImageArg(imageName, "")...)
+
+	// Root of source directory.
+	if sourceDir != "" {
+		args = append(args, sourceDir)
+	}
+
+	return args
+}
+
+// RunImageArgs -- standard docker run arguments.
+func RunImageArgs(imageName string, imageTag string) []string {
+	// Construct the docker command:
+	//
+	// docker run --network="host" <image-name>:<tag>
+	//
+	// TODO: support other types of network connections.
+	args := make([]string, 0)
+	args = append(args, "run")
+
+	// TODO: support other networks.
+	args = append(args, "--network=host")
+
+	// Path to Docker image:
+	args = append(args, ImageArg(imageName, imageTag)...)
+
+	return args
+}
+
+//
+// Arguments to docker command line.
+//
+
+// DockerfilePathArg --
+func DockerfilePathArg(dockerfilePath string) []string {
+	args := make([]string, 0)
+	args = append(args, "-f")
+	args = append(args, dockerfilePath)
+	return args
+}
+
+// ImageArg --
+func ImageArg(dockerImageName string, tag string) []string {
+	args := make([]string, 0)
+	args = append(args, "-t")
+	args = append(args, GetFullDockerImage(dockerImageName, tag))
+	return args
+}
+
+// LatestImageArg --
+func LatestImageArg(dockerImageName string) []string {
+	args := make([]string, 0)
+	args = append(args, "-t")
+	args = append(args, GetFullDockerImage(dockerImageName, latestTag))
+	return args
+}
+
+//
+// Docker-spcific helper functions.
+//
+
+// GetImage - <image-name>:<tag>
+func GetImage(dockerImageName string, tag string) string {
+	image := make([]string, 0)
+	image = append(image, dockerImageName)
+	image = append(image, tag)
+	return strings.Join(image, ":")
+}
+
+// GetLatestImage - <image-name>:latest
+func GetLatestImage(dockerImageName string) string {
+	return GetImage(dockerImageName, latestTag)
+}
+
+// GetFullDockerImage - <docker-registry>/<image-name>:<tag>
+func GetFullDockerImage(dockerImageName string, tag string) string {
+	fullImagePath := make([]string, 0)
+	fullImagePath = append(fullImagePath, RegistryName)
+	if tag == "" {
+		fullImagePath = append(fullImagePath, dockerImageName)
+	} else {
+		fullImagePath = append(fullImagePath, GetImage(dockerImageName, tag))
+	}
+
+	return strings.Join(fullImagePath, dockerEndpointSeparator)
+}
+
+//
+// Container file management.
+//
+
+// JoinPath -- for container paths.
+func JoinPath(lhsPath string, rhsPath string) string {
+	p := []string{lhsPath, rhsPath}
+	return strings.Join(p, containerFileSeparator)
+}
+
+//
+// Docker syntax functions.
+//
+
+// Generic commands.
+
+// COPY --
+func COPY(from string, to string) string {
+	c := []string{"COPY", from, to}
+	return strings.Join(c, " ")
+}
+
+// RUN --
+func RUN(command string) string {
+	c := []string{"RUN", command}
+	return strings.Join(c, " ")
+}
+
+// FROM --
+func FROM(imageName string) string {
+	c := []string{"FROM", imageName}
+	return strings.Join(c, " ")
+}
+
+// WORKDIR --
+func WORKDIR(workDir string) string {
+	c := []string{"WORKDIR", workDir}
+	return strings.Join(c, " ")
+}
+
+// ENV --
+func ENV(envVar string, value string) string {
+	p := []string{envVar, value}
+	c := []string{"ENV", strings.Join(p, "=")}
+	return strings.Join(c, " ")
+}
+
+// AS --
+func AS(image string, alias string) string {
+	c := []string{image, "as", alias}
+	return strings.Join(c, " ")
+}
+
+// CMD --
+func CMD(command string) string {
+	c := []string{"CMD", command}
+	return strings.Join(c, " ")
+}
+
+// // COPYFromBuilder --
+// func COPYFromBuilder(from string, to string) string {
+// 	flag := []string{"--from", internalBuilderImageName}
+// 	newFrom := []string{strings.Join(flag, "="), from}
+// 	return COPY(strings.Join(newFrom, " "), to)
+// }
+
+// RUNMavenInstall --
+func RUNMavenInstall() string {
+	return RUN("apk add --update maven && apk update && apk upgrade")
+}
+
+// RUNMakeDir --
+func RUNMakeDir(dirName string) string {
+	c := []string{"mkdir", "-p", dirName}
+	return RUN(strings.Join(c, " "))
+}
+
+// ENVAppend --
+func ENVAppend(envVar string, value string) string {
+	tail := []string{value, "$" + envVar}
+	return ENV(envVar, strings.Join(tail, ":"))
+}
+
+// CMDShellWrap --
+func CMDShellWrap(command string) string {
+	return CMD("/bin/sh -c \"" + command + "\"")
+}

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -31,8 +31,8 @@ var BaseImageName string = "integration-base-image"
 // BaseWorkingDirectory -- directory used by Docker to construct the base image.
 var BaseWorkingDirectory string = ""
 
-// WorkingDirectory -- directory used by Docker to construct the integration image.
-var WorkingDirectory string = ""
+// IntegrationWorkingDirectory -- directory used by Docker to construct the integration image.
+var IntegrationWorkingDirectory string = ""
 
 // Internal variables.
 var (

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -52,6 +52,7 @@ func BuildImageArgs(dockerFileDir string, imageName string, sourceDir string) []
 
 	// Add path to Dockerfile:
 	dockerFile := path.Join(dockerFileDir, "Dockerfile")
+
 	args = append(args, DockerfilePathArg(dockerFile)...)
 
 	// Image name:
@@ -219,7 +220,7 @@ func CMD(command string) string {
 
 // RUNMavenInstall --
 func RUNMavenInstall() string {
-	return RUN("apk add --update maven && apk update && apk upgrade")
+	return RUN("apt-get update && apt-get install maven -y && apt-get upgrade -y")
 }
 
 // RUNMakeDir --

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -144,11 +144,6 @@ func GetLatestImage(dockerImageName string) string {
 func GetFullDockerImage(dockerImageName string, tag string) string {
 	fullImagePath := make([]string, 0)
 
-	// If register is specified, add it.
-	if RegistryName != "" {
-		fullImagePath = append(fullImagePath, RegistryName)
-	}
-
 	// Add image and tag.
 	if tag == "" {
 		fullImagePath = append(fullImagePath, dockerImageName)
@@ -157,6 +152,11 @@ func GetFullDockerImage(dockerImageName string, tag string) string {
 	}
 
 	return strings.Join(fullImagePath, dockerEndpointSeparator)
+}
+
+// GetBaseImagePath --
+func GetBaseImagePath() string {
+	return RegistryName + dockerEndpointSeparator + BaseImageName
 }
 
 //

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -64,7 +64,7 @@ func BuildImageArgs(dockerFileDir string, imageName string, sourceDir string) []
 }
 
 // RunImageArgs -- standard docker run arguments.
-func RunImageArgs(imageName string, imageTag string) []string {
+func RunImageArgs(imagePath string, imageTag string) []string {
 	// Construct the docker command:
 	//
 	// docker run --network="host" <image-name>:<tag>
@@ -77,7 +77,7 @@ func RunImageArgs(imageName string, imageTag string) []string {
 	args = append(args, "--network=host")
 
 	// Path to Docker image:
-	args = append(args, ImageArg(imageName, imageTag)...)
+	args = append(args, FullImageArg(imagePath)...)
 
 	return args
 }
@@ -110,6 +110,18 @@ func LatestImageArg(dockerImageName string) []string {
 	return args
 }
 
+// FullImageArg --
+func FullImageArg(dockerImage string) []string {
+	imageComponents := strings.Split(dockerImage, ":")
+	if len(imageComponents) == 2 {
+		// Image has a tag already.
+		return ImageArg(imageComponents[0], imageComponents[1])
+	}
+
+	// Image has no tag, latest tag will be added automatically.
+	return LatestImageArg(dockerImage)
+}
+
 //
 // Docker-spcific helper functions.
 //
@@ -130,7 +142,13 @@ func GetLatestImage(dockerImageName string) string {
 // GetFullDockerImage - <docker-registry>/<image-name>:<tag>
 func GetFullDockerImage(dockerImageName string, tag string) string {
 	fullImagePath := make([]string, 0)
-	fullImagePath = append(fullImagePath, RegistryName)
+
+	// If register is specified, add it.
+	if RegistryName != "" {
+		fullImagePath = append(fullImagePath, RegistryName)
+	}
+
+	// Add image and tag.
 	if tag == "" {
 		fullImagePath = append(fullImagePath, dockerImageName)
 	} else {
@@ -198,13 +216,6 @@ func CMD(command string) string {
 	c := []string{"CMD", command}
 	return strings.Join(c, " ")
 }
-
-// // COPYFromBuilder --
-// func COPYFromBuilder(from string, to string) string {
-// 	flag := []string{"--from", internalBuilderImageName}
-// 	newFrom := []string{strings.Join(flag, "="), from}
-// 	return COPY(strings.Join(newFrom, " "), to)
-// }
 
 // RUNMavenInstall --
 func RUNMavenInstall() string {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -375,6 +375,11 @@ func GetLocalRoutesDir() string {
 
 // CreateLocalPropertiesDirectory --
 func CreateLocalPropertiesDirectory() error {
+	// Do not create a directory unless the maven directory contains a valid value.
+	if MavenWorkingDirectory == "" {
+		return nil
+	}
+
 	directoryExists, err := DirectoryExists(GetLocalPropertiesDir())
 	if err != nil {
 		return err
@@ -391,6 +396,11 @@ func CreateLocalPropertiesDirectory() error {
 
 // CreateLocalDependenciesDirectory --
 func CreateLocalDependenciesDirectory() error {
+	// Do not create a directory unless the maven directory contains a valid value.
+	if MavenWorkingDirectory == "" {
+		return nil
+	}
+
 	directoryExists, err := DirectoryExists(GetLocalDependenciesDir())
 	if err != nil {
 		return err
@@ -407,6 +417,11 @@ func CreateLocalDependenciesDirectory() error {
 
 // CreateLocalRoutesDirectory --
 func CreateLocalRoutesDirectory() error {
+	// Do not create a directory unless the maven directory contains a valid value.
+	if MavenWorkingDirectory == "" {
+		return nil
+	}
+
 	directoryExists, err := DirectoryExists(GetLocalRoutesDir())
 	if err != nil {
 		return err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -53,6 +53,18 @@ const DefaultRoutesDirectoryName = "routes"
 // DefaultWorkingDirectoryName --
 const DefaultWorkingDirectoryName = "workspace"
 
+// ContainerDependenciesDirectory --
+var ContainerDependenciesDirectory = "/deployments/dependencies"
+
+// ContainerPropertiesDirectory --
+var ContainerPropertiesDirectory = "/etc/camel/conf.d"
+
+// ContainerRoutesDirectory --
+var ContainerRoutesDirectory = "/etc/camel/sources"
+
+// ContainerResourcesDirectory --
+var ContainerResourcesDirectory = "/etc/camel/resources"
+
 // StringSliceJoin --
 func StringSliceJoin(slices ...[]string) []string {
 	size := 0

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -36,6 +36,20 @@ import (
 	yaml2 "gopkg.in/yaml.v2"
 )
 
+/// Directories and file names:
+
+// MavenWorkingDirectory --  Directory used by Maven for an invocation of the kamel local command. By default a temporary folder will be used.
+var MavenWorkingDirectory string = ""
+
+// DefaultDependenciesDirectoryName --
+const DefaultDependenciesDirectoryName = "dependencies"
+
+// DefaultPropertiesDirectoryName --
+const DefaultPropertiesDirectoryName = "properties"
+
+// DefaultRoutesDirectoryName --
+const DefaultRoutesDirectoryName = "routes"
+
 // StringSliceJoin --
 func StringSliceJoin(slices ...[]string) []string {
 	size := 0
@@ -336,5 +350,70 @@ func WriteToFile(filePath string, fileContents string) error {
 	}
 
 	// All went well, return true.
+	return nil
+}
+
+/// Local directories:
+
+// GetLocalPropertiesDir -- <mavenWorkingDirectory>/properties
+func GetLocalPropertiesDir() string {
+	return path.Join(MavenWorkingDirectory, DefaultPropertiesDirectoryName)
+}
+
+// GetLocalDependenciesDir --<mavenWorkingDirectory>/dependencies
+func GetLocalDependenciesDir() string {
+	return path.Join(MavenWorkingDirectory, DefaultDependenciesDirectoryName)
+}
+
+// GetLocalRoutesDir -- <mavenWorkingDirectory>/routes
+func GetLocalRoutesDir() string {
+	return path.Join(MavenWorkingDirectory, DefaultDependenciesDirectoryName)
+}
+
+// CreateLocalPropertiesDirectory --
+func CreateLocalPropertiesDirectory() error {
+	directoryExists, err := DirectoryExists(GetLocalPropertiesDir())
+	if err != nil {
+		return err
+	}
+
+	if !directoryExists {
+		err := os.MkdirAll(GetLocalPropertiesDir(), 0777)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateLocalDependenciesDirectory --
+func CreateLocalDependenciesDirectory() error {
+	directoryExists, err := DirectoryExists(GetLocalDependenciesDir())
+	if err != nil {
+		return err
+	}
+
+	if !directoryExists {
+		err := os.MkdirAll(GetLocalDependenciesDir(), 0777)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateLocalRoutesDirectory --
+func CreateLocalRoutesDirectory() error {
+	directoryExists, err := DirectoryExists(GetLocalRoutesDir())
+	if err != nil {
+		return err
+	}
+
+	if !directoryExists {
+		err := os.MkdirAll(GetLocalRoutesDir(), 0777)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -50,6 +50,9 @@ const DefaultPropertiesDirectoryName = "properties"
 // DefaultRoutesDirectoryName --
 const DefaultRoutesDirectoryName = "routes"
 
+// DefaultWorkingDirectoryName --
+const DefaultWorkingDirectoryName = "workspace"
+
 // StringSliceJoin --
 func StringSliceJoin(slices ...[]string) []string {
 	size := 0
@@ -367,7 +370,7 @@ func GetLocalDependenciesDir() string {
 
 // GetLocalRoutesDir -- <mavenWorkingDirectory>/routes
 func GetLocalRoutesDir() string {
-	return path.Join(MavenWorkingDirectory, DefaultDependenciesDirectoryName)
+	return path.Join(MavenWorkingDirectory, DefaultRoutesDirectoryName)
 }
 
 // CreateLocalPropertiesDirectory --

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -447,3 +447,17 @@ func CreateLocalRoutesDirectory() error {
 	}
 	return nil
 }
+
+// GetEnvironmentVariable --
+func GetEnvironmentVariable(variable string) (string, error) {
+	value, isPresent := os.LookupEnv(variable)
+	if !isPresent {
+		return "", errors.Errorf("environment variable %v does not exist", variable)
+	}
+
+	if value == "" {
+		return "", errors.Errorf("environment variable %v is not set", variable)
+	}
+
+	return value, nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,6 +23,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -74,6 +75,7 @@ func StringSliceExists(slice []string, item string) bool {
 	return false
 }
 
+// StringSliceContainsAnyOf --
 func StringSliceContainsAnyOf(slice []string, items ...string) bool {
 	for i := 0; i < len(slice); i++ {
 		for j := 0; j < len(items); j++ {
@@ -324,4 +326,15 @@ func JSONToYAML(src []byte) ([]byte, error) {
 	}
 
 	return yamldata, nil
+}
+
+// WriteToFile --
+func WriteToFile(filePath string, fileContents string) error {
+	err := ioutil.WriteFile(filePath, []byte(fileContents), 0777)
+	if err != nil {
+		return errors.Errorf("error writing file: %v", filePath)
+	}
+
+	// All went well, return true.
+	return nil
 }


### PR DESCRIPTION
<!-- Description -->

This patch adds command line options for creating, building and running local images.

A new local command, `local create` has been added to construct images.

The first image kind it can produce is a base image to be used as a starter for all integration images. Example of building a base image, the image will be saved under the default name of `integration-base-image`:

```
kamel local create --base-image --container-registry <registry-name>
```

The image can then be used as a base for creating and building integration images, the image will be used automatically every time an integration image is created. If a base image isn't available it will be created automatically. Example of building an integration image (without running it):

```
kamel local create --image <registry-name>/<my-image-name> -d <dep> -p <prop> --property-file <file> route1.java route2.yaml
```

The resulting image can then be run locally using the following invocation:

```
kamel local run --image <registry-name>/<my-image-name>
```

Local run has been enhanced with containerization capabilities i.e. it can now create, build and run container images locally. The following command containerizes and runs the integration (i.e. performs all previous steps automatically: base image creation and building, integration image creation and building, integration image running):

```
kamel local run --containerize --image <registry-name>/<my-image-name> -d <dep> -p <prop> --property-file <file> route1.java route2.yaml
```


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Added ability to package and run integrations as container images
```
