### PR TITLE
chore(api): make KameletSpec.Authorization a pointer so it can be omitted

### DIFF
--- a/pkg/apis/camel/v1alpha1/kamelet_types.go
+++ b/pkg/apis/camel/v1alpha1/kamelet_types.go
@@ -36,7 +36,7 @@ type KameletSpec struct {
 	Definition    JSONSchemaProps             `json:"definition,omitempty"`
 	Sources       []camelv1.SourceSpec        `json:"sources,omitempty"`
 	Flow          *camelv1.Flow               `json:"flow,omitempty"`
-	Authorization AuthorizationSpec           `json:"authorization,omitempty"`
+	Authorization *AuthorizationSpec          `json:"authorization,omitempty"`
 	Types         map[EventSlot]EventTypeSpec `json:"types,omitempty"`
 	Dependencies  []string                    `json:"dependencies,omitempty"`
 }

--- a/pkg/apis/camel/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/camel/v1alpha1/zz_generated.deepcopy.go
@@ -602,7 +602,11 @@ func (in *KameletSpec) DeepCopyInto(out *KameletSpec) {
 		*out = new(v1.Flow)
 		(*in).DeepCopyInto(*out)
 	}
-	out.Authorization = in.Authorization
+	if in.Authorization != nil {
+		in, out := &in.Authorization, &out.Authorization
+		*out = new(AuthorizationSpec)
+		**out = **in
+	}
 	if in.Types != nil {
 		in, out := &in.Types, &out.Types
 		*out = make(map[EventSlot]EventTypeSpec, len(*in))


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```