### PR TITLE
Skip CRD installation if output flag enabled

### DIFF
--- a/pkg/install/cluster.go
+++ b/pkg/install/cluster.go
@@ -80,9 +80,12 @@ func SetupClusterWideResourcesOrCollect(ctx context.Context, clientProvider clie
 		return err
 	}
 
-	// Wait for all CRDs to be installed before proceeding
-	if err := WaitForAllCRDInstallation(ctx, clientProvider, 25*time.Second); err != nil {
-		return err
+	// Don't wait if we're just collecting resources
+	if collection == nil {
+		// Wait for all CRDs to be installed before proceeding
+		if err := WaitForAllCRDInstallation(ctx, clientProvider, 25*time.Second); err != nil {
+			return err
+		}
 	}
 
 	// Installing ClusterRole


### PR DESCRIPTION
Closes #886

<!-- Description -->
This PR should fix a bug that was preventing to output install configuration without their installation.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
