### PR TITLE
Fix operator monitoring test

### DIFF
--- a/e2e/yaks/openshift/monitoring/dependencyInstall.sh
+++ b/e2e/yaks/openshift/monitoring/dependencyInstall.sh
@@ -19,7 +19,7 @@ SOURCE_DIR=$( dirname "${BASH_SOURCE[0]}")
 APP_FOLDER="${SOURCE_DIR}/app"
 
 VERSION_CAMEL_K_RUNTIME=$(oc -n ${YAKS_NAMESPACE} get IntegrationPlatform camel-k -o 'jsonpath={.status.build.runtimeVersion}')
-VERSION_CAMEL_QUARKUS=$(oc -n ${YAKS_NAMESPACE} get CamelCatalog camel-catalog-${VERSION_CAMEL_K_RUNTIME}-main -o 'jsonpath={.spec.runtime.metadata.camel-quarkus\.version}')
+VERSION_CAMEL_QUARKUS=$(oc -n ${YAKS_NAMESPACE} get CamelCatalog camel-catalog-${VERSION_CAMEL_K_RUNTIME} -o 'jsonpath={.spec.runtime.metadata.camel-quarkus\.version}')
 
 mvn clean install -f $APP_FOLDER -Dversion.camel.quarkus=${VERSION_CAMEL_QUARKUS}
 LOCAL_MVN_HOME=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)

--- a/e2e/yaks/openshift/monitoring/obtainToken.sh
+++ b/e2e/yaks/openshift/monitoring/obtainToken.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TOKEN=`oc config view --minify --output 'jsonpath={..token}'`
+TOKEN=`oc whoami --show-token`
 echo "openshift.token=${TOKEN}" > openshift-token.properties
 oc -n ${YAKS_NAMESPACE} create secret generic openshift-token-secret-metrics --from-file=openshift-token.properties
 oc -n ${YAKS_NAMESPACE} create secret generic openshift-token-secret-alerting --from-file=openshift-token.properties


### PR DESCRIPTION
Fix for operator monitoring test. After making quarkus as default, there is no more `-main` suffix. @astefanutti could we somehow backport it to 1.3.0 release ?