### PR TITLE
feat(test): kit create command unit test

### DIFF
--- a/pkg/cmd/kit_create_test.go
+++ b/pkg/cmd/kit_create_test.go
@@ -18,22 +18,112 @@ limitations under the License.
 package cmd
 
 import (
+	"testing"
+
 	"github.com/apache/camel-k/pkg/util/test"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
-//nolint:deadcode,unused
+const subCmdKit = "create"
+
+func initializeKitCreateCmdOptions(t *testing.T) (*kitCreateCommandOptions, *cobra.Command, RootCmdOptions) {
+	options, rootCmd := kamelTestPreAddCommandInit()
+	kitCreateCmdOptions := addTestKitCreateCmd(*options, rootCmd)
+	kamelTestPostAddCommandInit(t, rootCmd)
+
+	return kitCreateCmdOptions, rootCmd, *options
+}
+
 func addTestKitCreateCmd(options RootCmdOptions, rootCmd *cobra.Command) *kitCreateCommandOptions {
-	//add a testing version of kitCreate Command
-	kitCreateCmd, kitCreateCmdOptions := newKitCreateCmd(&options)
+	//add a testing version of kit create Command
+	kitCreateCmd, kitCreateOptions := newKitCreateCmd(&options)
 	kitCreateCmd.RunE = func(c *cobra.Command, args []string) error {
 		return nil
 	}
+	kitCreateCmd.PostRunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
 	kitCreateCmd.Args = test.ArbitraryArgs
-	kitCmd := newTestCmdKit(&options)
-	kitCmd.AddCommand(kitCreateCmd)
-	rootCmd.AddCommand(kitCmd)
-	return kitCreateCmdOptions
+	rootCmd.AddCommand(kitCreateCmd)
+	return kitCreateOptions
 }
 
-//TODO: add a proper test, take inspiration by run_test.go
+func TestKitCreateNonExistingFlag(t *testing.T) {
+	_, rootCmd, _ := initializeKitCreateCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, subCmdKit, "--nonExistingFlag")
+	assert.NotNil(t, err)
+}
+
+func TestKitCreateConfigMapFlag(t *testing.T) {
+	kitCreateCmdOptions, rootCmd, _ := initializeKitCreateCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, subCmdKit,
+		"--configmap", "someString1",
+		"--configmap", "someString2")
+	assert.Nil(t, err)
+	assert.Len(t, kitCreateCmdOptions.Configmaps, 2)
+	assert.Equal(t, "someString1", kitCreateCmdOptions.Configmaps[0])
+	assert.Equal(t, "someString2", kitCreateCmdOptions.Configmaps[1])
+}
+
+func TestKitCreateDependencyFlag(t *testing.T) {
+	kitCreateCmdOptions, rootCmd, _ := initializeKitCreateCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, subCmdKit,
+		"--dependency", "someString1",
+		"--dependency", "someString2")
+	assert.Nil(t, err)
+	assert.Len(t, kitCreateCmdOptions.Dependencies, 2)
+	assert.Equal(t, "someString1", kitCreateCmdOptions.Dependencies[0])
+	assert.Equal(t, "someString2", kitCreateCmdOptions.Dependencies[1])
+}
+
+func TestKitCreateImageFlag(t *testing.T) {
+	kitCreateCmdOptions, rootCmd, _ := initializeKitCreateCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, subCmdKit, "--image", "someString")
+	assert.Nil(t, err)
+	assert.Equal(t, "someString", kitCreateCmdOptions.Image)
+}
+
+func TestKitCreatePropertyFlag(t *testing.T) {
+	kitCreateCmdOptions, rootCmd, _ := initializeKitCreateCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, subCmdKit,
+		"--property", "someString1",
+		"--property", "someString2")
+	assert.Nil(t, err)
+	assert.Len(t, kitCreateCmdOptions.Properties, 2)
+	assert.Equal(t, "someString1", kitCreateCmdOptions.Properties[0])
+	assert.Equal(t, "someString2", kitCreateCmdOptions.Properties[1])
+}
+
+func TestKitCreateRepositoryFlag(t *testing.T) {
+	kitCreateCmdOptions, rootCmd, _ := initializeKitCreateCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, subCmdKit,
+		"--repository", "someString1",
+		"--repository", "someString2")
+	assert.Nil(t, err)
+	assert.Len(t, kitCreateCmdOptions.Repositories, 2)
+	assert.Equal(t, "someString1", kitCreateCmdOptions.Repositories[0])
+	assert.Equal(t, "someString2", kitCreateCmdOptions.Repositories[1])
+}
+
+func TestKitCreateSecretFlag(t *testing.T) {
+	kitCreateCmdOptions, rootCmd, _ := initializeKitCreateCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, subCmdKit,
+		"--secret", "someString1",
+		"--secret", "someString2")
+	assert.Nil(t, err)
+	assert.Len(t, kitCreateCmdOptions.Secrets, 2)
+	assert.Equal(t, "someString1", kitCreateCmdOptions.Secrets[0])
+	assert.Equal(t, "someString2", kitCreateCmdOptions.Secrets[1])
+}
+
+func TestKitCreateTraitFlag(t *testing.T) {
+	kitCreateCmdOptions, rootCmd, _ := initializeKitCreateCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, subCmdKit,
+		"--trait", "someString1",
+		"--trait", "someString2")
+	assert.Nil(t, err)
+	assert.Len(t, kitCreateCmdOptions.Traits, 2)
+	assert.Equal(t, "someString1", kitCreateCmdOptions.Traits[0])
+	assert.Equal(t, "someString2", kitCreateCmdOptions.Traits[1])
+}


### PR DESCRIPTION
Added a suite of testcases to verify kit create command flags

Closes #1159

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
kind/feature
```
