### PR TITLE
feat(test): operator command unit test

### DIFF
--- a/pkg/cmd/operator_test.go
+++ b/pkg/cmd/operator_test.go
@@ -1,0 +1,80 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/apache/camel-k/pkg/util/test"
+	"github.com/spf13/cobra"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const cmdOperator = "operator"
+
+func initializeOperatorCmdOptions(t *testing.T) (*operatorCmdOptions, *cobra.Command, RootCmdOptions) {
+	options, rootCmd := kamelTestPreAddCommandInit()
+	operatorCmdOptions := addTestOperatorCmd(*options, rootCmd)
+	kamelTestPostAddCommandInit(t, rootCmd)
+
+	return operatorCmdOptions, rootCmd, *options
+}
+
+func addTestOperatorCmd(options RootCmdOptions, rootCmd *cobra.Command) *operatorCmdOptions {
+	//add a testing version of operator Command
+	operatorCmd, operatorOptions := newCmdOperator()
+	operatorCmd.RunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	operatorCmd.PostRunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	operatorCmd.Args = test.ArbitraryArgs
+	rootCmd.AddCommand(operatorCmd)
+	return operatorOptions
+}
+
+func TestOperatorNoFlag(t *testing.T) {
+	operatorCmdOptions, rootCmd, _ := initializeOperatorCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdOperator)
+	assert.Nil(t, err)
+	//Check default expected values
+	assert.Equal(t, int32(8081), operatorCmdOptions.HealthPort)
+	assert.Equal(t, int32(8080), operatorCmdOptions.MonitoringPort)
+}
+
+func TestOperatorNonExistingFlag(t *testing.T) {
+	_, rootCmd, _ := initializeOperatorCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdOperator, "--nonExistingFlag")
+	assert.NotNil(t, err)
+}
+
+func TestOperatorHealthPortFlag(t *testing.T) {
+	operatorCmdOptions, rootCmd, _ := initializeOperatorCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdOperator, "--health-port", "7171")
+	assert.Nil(t, err)
+	assert.Equal(t, int32(7171), operatorCmdOptions.HealthPort)
+}
+
+func TestOperatorMonitoringPortFlag(t *testing.T) {
+	operatorCmdOptions, rootCmd, _ := initializeOperatorCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdOperator, "--monitoring-port", "7172")
+	assert.Nil(t, err)
+	assert.Equal(t, int32(7172), operatorCmdOptions.MonitoringPort)
+}


### PR DESCRIPTION
Added unit test for operator command flags

Closes #1892

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
