### PR TITLE
fix: Do not filter Camel catalogs by runtime provider label

### DIFF
--- a/pkg/util/camel/camel_runtime.go
+++ b/pkg/util/camel/camel_runtime.go
@@ -30,9 +30,6 @@ import (
 func LoadCatalog(ctx context.Context, client client.Client, namespace string, runtime v1.RuntimeSpec) (*RuntimeCatalog, error) {
 	options := []k8sclient.ListOption{
 		k8sclient.InNamespace(namespace),
-		k8sclient.MatchingLabels{
-			"camel.apache.org/runtime.provider": string(runtime.Provider),
-		},
 	}
 
 	list := v1.NewCamelCatalogList()


### PR DESCRIPTION
Fixes #1897.

This PR is intentionally minimal, to limit impacts of back porting it into the 1.3.x branch.

I'll create a follow-up PR to remove all the runtime provider related bits if no one objects.

**Release Note**
```release-note
fix: Do not filter Camel catalogs by runtime provider label
```
