### PR TITLE
fix(cli): help command offline

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -160,6 +160,7 @@ func addHelpSubCommands(cmd *cobra.Command, options *RootCmdOptions) error {
 	if helpCmd == nil {
 		return errors.New("could not find any configured help command")
 	}
+	helpCmd.Annotations = map[string]string{offlineCommandLabel: "true"}
 
 	helpCmd.AddCommand(cmdOnly(newTraitHelpCmd(options)))
 


### PR DESCRIPTION
Added an annotation to mark the help command to work also disconnected from cluster

Closes #1906

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): help command offline
```
