### PR TITLE
Environment variables evaluated only at integration runtime

### DIFF
--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -58,6 +58,7 @@ func newCmdLocalRun(rootCmdOptions *RootCmdOptions) (*cobra.Command, *localRunCm
 	cmd.Flags().Bool("containerize", false, "Run integration in a local container.")
 	cmd.Flags().String("image", "", "Full path to integration image including registry.")
 	cmd.Flags().String("network", "", "Custom network name to be used by the underlying Docker command.")
+	cmd.Flags().StringArrayP("env", "e", nil, "Flag to specify an environment variable [--env VARIABLE=value].")
 	cmd.Flags().StringArray("property-file", nil, "Add a property file to the integration.")
 	cmd.Flags().StringArrayP("property", "p", nil, "Add a Camel property to the integration.")
 	cmd.Flags().StringArrayP("dependency", "d", nil, additionalDependencyUsageMessage)
@@ -71,6 +72,7 @@ type localRunCmdOptions struct {
 	Containerize           bool     `mapstructure:"containerize"`
 	Image                  string   `mapstructure:"image"`
 	Network                string   `mapstructure:"network"`
+	EnvironmentVariables   []string `mapstructure:"envs"`
 	PropertyFiles          []string `mapstructure:"property-files"`
 	Properties             []string `mapstructure:"properties"`
 	AdditionalDependencies []string `mapstructure:"dependencies"`
@@ -117,9 +119,11 @@ func (command *localRunCmdOptions) init() error {
 		if err != nil {
 			return err
 		}
-
-		setDockerNetworkName(command.Network)
 	}
+
+	setDockerNetworkName(command.Network)
+
+	setDockerEnvVars(command.EnvironmentVariables)
 
 	return createMavenWorkingDirectory()
 }

--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -79,12 +79,12 @@ func assembleIntegrationRunCommand(ctx context.Context, properties []string, dep
 		// If we are running locally then this is as late as we can evaluate the
 		// lazy environment variables since we are going to run the command
 		// immediately after the generation of these arguments.
-		for _, lazyEnvVar := range util.ListOfLazyEvaluatedEnvVars {
-			value, err := util.GetEnvironmentVariable(lazyEnvVar)
-			if err != nil {
-				return nil, err
-			}
-			cmd.Env = append(cmd.Env, lazyEnvVar+"="+value)
+		setEnvVars, err := util.EvaluateCLIAndLazyEnvVars()
+		if err != nil {
+			return nil, err
+		}
+		for _, envVar := range setEnvVars {
+			cmd.Env = append(cmd.Env, envVar)
 		}
 	} else {
 		// If we are running in containerized mode then we should not evaluate the

--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -87,11 +87,9 @@ func assembleIntegrationRunCommand(ctx context.Context, properties []string, dep
 			cmd.Env = append(cmd.Env, envVar)
 		}
 	} else {
-		// If we are running in containerized mode then we should not evaluate the
-		// variables at this point since we are only generating the run command and
-		// not actually running it. Running the command is performed via:
-		// docker run [...] and it will be at that point that we should evaluate the
-		// variables.
+		// If we are running in containerized or just building an image, we should
+		// not evaluate the variables at this point since we are only generating the
+		// run command and not actually running it.
 		for _, lazyEnvVar := range util.ListOfLazyEvaluatedEnvVars {
 			cmd.Env = append(cmd.Env, lazyEnvVar+"={{env:"+lazyEnvVar+"}}")
 		}

--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -148,7 +148,10 @@ func createAndBuildIntegrationImage(ctx context.Context, containerRegistry strin
 
 	// Get integration run command to be run inside the container. This means the command
 	// has to be created with the paths which will be valid inside the container.
-	containerCmd := GetContainerIntegrationRunCommand(ctx, propertyFiles, dependencies, routes, stdout, stderr)
+	containerCmd, err := GetContainerIntegrationRunCommand(ctx, propertyFiles, dependencies, routes, stdout, stderr)
+	if err != nil {
+		return err
+	}
 
 	// Create the integration image Docker file.
 	err = docker.CreateIntegrationImageDockerFile(containerCmd)
@@ -186,7 +189,11 @@ func runIntegrationImage(ctx context.Context, image string, stdout, stderr io.Wr
 	}()
 
 	// Get the docker command line argument for running an image.
-	args := docker.RunIntegrationImageArgs(image)
+	args, err := docker.RunIntegrationImageArgs(image)
+	if err != nil {
+		return err
+	}
+
 	cmd := exec.CommandContext(dockerCtx, "docker", args...)
 
 	// Set stdout and stderr.

--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/docker"
 	"github.com/pkg/errors"
 )
@@ -77,6 +78,12 @@ func deleteDockerWorkingDirectory() error {
 func setDockerNetworkName(networkName string) {
 	if networkName != "" {
 		docker.NetworkName = networkName
+	}
+}
+
+func setDockerEnvVars(envVars []string) {
+	if envVars != nil && len(envVars) > 0 {
+		util.CLIEnvVars = envVars
 	}
 }
 

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -101,10 +101,10 @@ func BuildIntegrationImageArgs(imagePath string) []string {
 }
 
 // RunIntegrationImageArgs --
-func RunIntegrationImageArgs(imagePath string) []string {
+func RunIntegrationImageArgs(imagePath string) ([]string, error) {
 	// Construct the docker command:
 	//
-	// docker run --network=<network-name> <dockerRegistry>/<ImageName>
+	// docker run --network=<network-name> --env LAZY_ENV_VAR=value <dockerRegistry>/<ImageName>
 	//
 	return RunImageArgs(imagePath, latestTag)
 }

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -81,13 +81,12 @@ func RunImageArgs(imagePath string, imageTag string) ([]string, error) {
 	// Add network flag.
 	args = append(args, "--network="+NetworkName)
 
-	// Add lazily evaluates environment variables and evaluate them.
-	for _, lazyEnvVar := range util.ListOfLazyEvaluatedEnvVars {
-		value, err := util.GetEnvironmentVariable(lazyEnvVar)
-		if err != nil {
-			return nil, err
-		}
-		args = append(args, "--env="+lazyEnvVar+"="+value)
+	setEnvVars, err := util.EvaluateCLIAndLazyEnvVars()
+	if err != nil {
+		return nil, err
+	}
+	for _, envVar := range setEnvVars {
+		args = append(args, "--env="+envVar)
 	}
 
 	// Path to Docker image:

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -65,6 +65,12 @@ var ContainerRoutesDirectory = "/etc/camel/sources"
 // ContainerResourcesDirectory --
 var ContainerResourcesDirectory = "/etc/camel/resources"
 
+// ListOfLazyEvaluatedEnvVars -- List of unevaluated environment variables.
+// These are sensitive values or values that may have different values depending
+// where the integration is run (locally vs. the cloud). These environment variables
+// are evaluated at the time of the integration invocation.
+var ListOfLazyEvaluatedEnvVars []string = []string{}
+
 // StringSliceJoin --
 func StringSliceJoin(slices ...[]string) []string {
 	size := 0


### PR DESCRIPTION
<!-- Description -->

This patch adds a way to pass environment variables that only get resolved at integration runtime.

These values can be passed as modeline options in this way:
```
# camel-k: property=camel.component.kafka.brokers={{env:KAFKA_BROKERS}}
```

This allows images built locally with `kamel local create` to be deployed in the cloud. If the image depends on any such environment variables, their value needs to be resolved in the deployment script. This ensures that the same modeline option that is provided locally works when run in the cloud environment.

Moreover it provides a safe way to pass sensitive properties such as web hooks. The value of `{{env:SLACK_WEBHOOK}}` will only become available when the integrations is run. The value will be taken from the parent environment which is either the local machine or a container.

For the case when the parent environment is a container, this patch also adds an `--env` flag to `kamel local run`. Previously to run an existing image, it was sufficient to provide the image name:
```
kamel local run --image <registry>/<image-name>
```
This still holds if no delayed environment variables are used as modeline options.

If delayed environment variables such as {{env:KAFKA_BROKERS}} are used then the `kamel local run` command needs to also provide values for these variables:
```
kamel local run --image <registry>/<image-name> --env KAFKA_BROKERS=localhost:9092
```
(This is similar to what a `docker run` command would require)

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
