### PR TITLE
Fix contributing documentation for integration test naming convention

### DIFF
--- a/docs/modules/ROOT/pages/developers.adoc
+++ b/docs/modules/ROOT/pages/developers.adoc
@@ -87,7 +87,7 @@ Unit tests are executed automatically as part of the build. They use the standar
 
 Integration tests (aimed at ensuring that the code integrates correctly with Kubernetes and OpenShift), need special care.
 
-The **convention** used in this repo is to name unit tests `xxx_test.go`, and name integration tests `yyy_integration_test.go`.
+The **convention** used in this repo is to name tests `xxx_test.go`.
 Integration tests are all in the https://github.com/apache/camel-k/tree/master/e2e[/e2e] dir.
 
 Since both names end with `_test.go`, both would be executed by go during the build, so you need to put a special **build tag** to mark


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
