### PR TITLE
Fix image location extraction

### DIFF
--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -87,7 +87,7 @@ func setDockerEnvVars(envVars []string) {
 	}
 }
 
-func createAndBuildBaseImage(ctx context.Context, containerRegistry string) error {
+func createAndBuildBaseImage(ctx context.Context) error {
 	// Create the base image Docker file.
 	err := docker.CreateBaseImageDockerFile()
 	if err != nil {
@@ -117,6 +117,9 @@ func createAndBuildIntegrationImage(ctx context.Context, containerRegistry strin
 	}
 
 	docker.RegistryName = containerRegistry
+
+	// If we build a normal image, i.e. not the base image, we need to parse
+	// the location where images will be pushed.
 	if !justBaseImage {
 		registryName, err := docker.ExtractRegistryName(image)
 		if err != nil {
@@ -127,7 +130,7 @@ func createAndBuildIntegrationImage(ctx context.Context, containerRegistry strin
 	}
 
 	// Create the Dockerfile and build the base image.
-	err := createAndBuildBaseImage(ctx, containerRegistry)
+	err := createAndBuildBaseImage(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -146,14 +146,13 @@ func ExtractRegistryName(image string) (string, error) {
 
 	// There must be at least two components in the path:
 	//  - docker.io/registry/imageName
-	//  - registry/imageName
+	//  - localhost:5000/<dir>/imageName
+	//  - localhost:5000/<dir>/.../<dir>/imageName
+	//  - localhost:5000/imageName
 	if len(pathComponents) < 2 {
-		return "", errors.New("image path is too short, usage: docker.io/registry/imageName or registry/imageName")
+		return "", errors.New("image path is too short, usage: registry/imageName or registry/*/imageName")
 	}
 
-	// Check if path starts with docker.io if not, add it.
-	if pathComponents[0] == "docker.io" {
-		return strings.Join(pathComponents[0:2], containerFileSeparator), nil
-	}
-	return "docker.io" + containerFileSeparator + pathComponents[1], nil
+	// Register name is given by the path to the image.
+	return strings.Join(pathComponents[0:len(pathComponents)-1], containerFileSeparator), nil
 }

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -153,6 +153,6 @@ func ExtractRegistryName(image string) (string, error) {
 		return "", errors.New("image path is too short, usage: registry/imageName or registry/*/imageName")
 	}
 
-	// Register name is given by the path to the image.
+	// Registry name is given by the path to the image.
 	return strings.Join(pathComponents[0:len(pathComponents)-1], containerFileSeparator), nil
 }


### PR DESCRIPTION
<!-- Description -->

Make image registry extraction more general.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fix local image registry name extraction.
```
