### PR TITLE
[backport 1.3.x] fix(cli): check run sources exists

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -380,7 +380,7 @@ func (o *runCmdOptions) syncIntegration(cmd *cobra.Command, c client.Client, sou
 	files = append(files, o.OpenAPIs...)
 
 	for _, s := range files {
-		if isLocal(s) {
+		if isLocalAndFileExists(s) {
 			changes, err := sync.File(o.Context, s)
 			if err != nil {
 				return err
@@ -645,7 +645,7 @@ func (*runCmdOptions) configureTraits(integration *v1.Integration, options []str
 	return nil
 }
 
-func isLocal(fileName string) bool {
+func isLocalAndFileExists(fileName string) bool {
 	info, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
 		return false

--- a/pkg/cmd/util_content.go
+++ b/pkg/cmd/util_content.go
@@ -30,7 +30,7 @@ func loadContent(source string, compress bool, compressBinary bool) (string, boo
 	var content []byte
 	var err error
 
-	if isLocal(source) {
+	if isLocalAndFileExists(source) {
 		content, err = ioutil.ReadFile(source)
 	} else {
 		u, err := url.Parse(source)

--- a/pkg/cmd/util_sources.go
+++ b/pkg/cmd/util_sources.go
@@ -65,7 +65,7 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 	sources := make([]Source, 0, len(locations))
 
 	for _, location := range locations {
-		if isLocal(location) {
+		if isLocalAndFileExists(location) {
 			answer, err := ResolveLocalSource(location, compress)
 			if err != nil {
 				return sources, err
@@ -176,6 +176,8 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 					return sources, err
 				}
 				sources = append(sources, answer)
+			default:
+				return sources, fmt.Errorf("Missing file or unsupported scheme in %s", location)
 			}
 		}
 	}


### PR DESCRIPTION
* Changed the name of run.isLocal func to run.isLocalAndExists as the function does both things
* Added a default switch case to report either the file doesn't exist or the URI scheme cannot be parsed
* Added some unit test to verify error messages expected

Fixes #1911

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): check run sources exists
```
