### PR TITLE
Fix helm chart so it is compatible with Go 1.14

### DIFF
--- a/helm/camel-k/templates/NOTES.txt
+++ b/helm/camel-k/templates/NOTES.txt
@@ -1,7 +1,7 @@
 {{/*
 Constraints
 */}}
-{{- if (not .Values.platform.cluster) or (.Values.platform.cluster ne "OpenShift") }}
+{{- if or (not .Values.platform.cluster) (ne .Values.platform.cluster "OpenShift") }}
 {{ required "Field \"platform.build.registry.address\" is required when not running on OpenShift (set \"platform.cluster=OpenShift\" if you're using OpenShift instead)!" .Values.platform.build.registry.address | substr 0 0 }}
 {{- end }}
 

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -28,3 +28,4 @@ operator:
 platform:
   build:
     registry: {}
+  cluster: ""


### PR DESCRIPTION
Additionally, add 'cluster' to fix type error.

See https://github.com/helm/helm/issues/7711#issuecomment-593113347

Fixes #1664
