### PR TITLE
Backport fix #1936: avoid patching if the target resource contains all expecte…

### DIFF
--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -485,6 +485,7 @@ func mountRegistrySecret(name string, secret registrySecret, volumes *[]corev1.V
 	*volumeMounts = append(*volumeMounts, corev1.VolumeMount{
 		Name:      "registry-secret",
 		MountPath: secret.mountPath,
+		ReadOnly:  true,
 	})
 
 	if secret.refEnv != "" {
@@ -530,6 +531,7 @@ func mountRegistryConfigMap(name string, config registryConfigMap, volumes *[]co
 	*volumeMounts = append(*volumeMounts, corev1.VolumeMount{
 		Name:      "registry-config",
 		MountPath: config.mountPath,
+		ReadOnly:  true,
 	})
 }
 

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -559,6 +559,7 @@ func (e *Environment) ConfigureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 		*mnts = append(*mnts, corev1.VolumeMount{
 			Name:      refName,
 			MountPath: resPath,
+			ReadOnly:  true,
 		})
 	}
 
@@ -603,6 +604,7 @@ func (e *Environment) ConfigureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 		*mnts = append(*mnts, corev1.VolumeMount{
 			Name:      refName,
 			MountPath: resPath,
+			ReadOnly:  true,
 		})
 	}
 
@@ -639,6 +641,7 @@ func (e *Environment) ConfigureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 				*mnts = append(*mnts, corev1.VolumeMount{
 					Name:      propertiesType + "-properties",
 					MountPath: mountPath,
+					ReadOnly:  true,
 				})
 			}
 		})
@@ -665,6 +668,7 @@ func (e *Environment) ConfigureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 		*mnts = append(*mnts, corev1.VolumeMount{
 			Name:      refName,
 			MountPath: path.Join(ConfigMapsMountPath, strings.ToLower(cmName)),
+			ReadOnly:  true,
 		})
 	}
 
@@ -687,6 +691,7 @@ func (e *Environment) ConfigureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 		*mnts = append(*mnts, corev1.VolumeMount{
 			Name:      refName,
 			MountPath: path.Join(SecretsMountPath, strings.ToLower(secretName)),
+			ReadOnly:  true,
 		})
 	}
 

--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -88,4 +89,23 @@ func removeNilValues(v reflect.Value, parent reflect.Value) {
 			removeNilValues(parent, reflect.Value{})
 		}
 	}
+}
+
+func SpecEqualDeepDerivative(object runtime.Object, expected runtime.Object) (res bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			res = false
+		}
+	}()
+
+	if expected == nil {
+		return true
+	} else if object == nil {
+		return false
+	}
+
+	objectSpec := reflect.ValueOf(object).Elem().FieldByName("Spec").Interface()
+	expectedSpec := reflect.ValueOf(expected).Elem().FieldByName("Spec").Interface()
+
+	return equality.Semantic.DeepDerivative(expectedSpec, objectSpec)
 }


### PR DESCRIPTION
…d fields

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fixed compatibility bug with Knative 0.20 that prevented deploying services that also produce data
```
