### PR TITLE
doc: local development environment

### DIFF
--- a/docs/modules/ROOT/nav-end.adoc
+++ b/docs/modules/ROOT/nav-end.adoc
@@ -14,4 +14,5 @@
 ** xref:architecture/traits.adoc[Traits]
 ** xref:architecture/sources.adoc[Sources]
 * xref:uninstalling.adoc[Uninstalling]
-* xref:developers.adoc[Contributing]
+* xref:contributing/developers.adoc[Contributing]
+** xref:contributing/local-development.adoc[Local development]

--- a/docs/modules/ROOT/pages/contributing/developers.adoc
+++ b/docs/modules/ROOT/pages/contributing/developers.adoc
@@ -155,6 +155,10 @@ To add additional dependencies to your routes:
 ./kamel run -d camel:dns examples/dns.js
 ----
 
+[[local-development]]
+== Local development environment
+If you need to develop and test your Camel K operator locally, you can follow the link:local-development.html[local development procedure].
+
 [[debugging]]
 == Debugging and Running from IDE
 

--- a/docs/modules/ROOT/pages/contributing/local-development.adoc
+++ b/docs/modules/ROOT/pages/contributing/local-development.adoc
@@ -1,0 +1,59 @@
+[[development-environment]]
+= Local development environment
+
+If you plan to contribute to Camel K, you will end up needing to run and troubleshoot your operator code locally. Here a guideline that will help you configure your local operator running.
+
+[[local-operator]]
+== Running operator locally
+
+As soon as you build your operator locally you will ask yourself how to test it. The idea is that you execute it locally and instruct it to **watch** a namespace on a Kubernetes cluster (it may be remote or any local environment). Let's use a namespace called ``operator-test``.
+
+* We start by setting the environment variable ``WATCH_NAMESPACE`` with the namespace you'd like your operator to watch.
+----
+export WATCH_NAMESPACE=operator-test
+----
+
+* The next step is to install an ``IntegrationPlatform`` on the cluster namespace. You probably need to tweak the registry parameters in order to be able to authenticate against an image repository (see below paragraph for local repository instructions).
+----
+./kamel install --skip-operator-setup -n operator-test --registry my-registry:5000
+----
+
+* Finally, assuming you've builded your application correctly we can run the operator:
+-----
+./kamel operator
+-----
+
+* Test the local operator by creating a test `Integration`.
+-----
+./kamel run xyz.abc -n operator-test
+-----
+
+IMPORTANT: make sure no other Camel K Operators are watching that namespace, neither you have a global Camel K Operator installed on your cluster.
+
+[[local-minikube]]
+== Local operator and local cluster
+
+If you want to run a local operator togheter with ``Minikube`` you will need an additional step in order to let the local operator being able to push images in the local registry. We need to expose the local registry as described in https://minikube.sigs.k8s.io/docs/handbook/registry/#docker-on-windows[this procedure]:
+
+* Enable the addon registry (this should be already in place):
+----
+minikube addons enable registry
+----
+
+* Get the ``Pod`` name that is in charge to run the registry and proxy the registry 5000 port to be used locally.
+----
+kubectl get pods -n kube-system
+NAME                               READY   STATUS    RESTARTS   AGE
+...
+registry-fttbv                     1/1     Running   40         89d
+...
+
+kubectl port-forward --namespace kube-system registry-fttbv 5000:5000
+----
+
+* Update the ``IntegrationPlatform`` to instruct it to use the ``localhost`` registry:
+----
+./kamel install --skip-operator-setup -n operator-test --registry localhost:5000 --force
+----
+
+A similar procedure may work if you use other local environments. The idea is to expose the docker registry and be able to use it from your local operator.


### PR DESCRIPTION
Added a section to instruct how to run a Camel K operator locally.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
