### PR TITLE
fix(trait): using proper contentKey for sources

### DIFF
--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -529,11 +529,14 @@ func (e *Environment) ConfigureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 	//
 	// Volumes :: Sources
 	//
-
 	for i, s := range e.Integration.Sources() {
 		cmName := fmt.Sprintf("%s-source-%03d", e.Integration.Name, i)
 		if s.ContentRef != "" {
 			cmName = s.ContentRef
+		}
+		cmKey := "content"
+		if s.ContentKey != "" {
+			cmKey = s.ContentKey
 		}
 		resName := strings.TrimPrefix(s.Name, "/")
 		refName := fmt.Sprintf("i-source-%03d", i)
@@ -548,7 +551,7 @@ func (e *Environment) ConfigureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 					},
 					Items: []corev1.KeyToPath{
 						{
-							Key:  "content",
+							Key:  cmKey,
 							Path: resName,
 						},
 					},


### PR DESCRIPTION
* If an integration is providing specifically a ConfigMap's item we now use its key, leaving "content" as default
* Added some unit test to check default and content ref behavior also for sources

Fix #1951

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): using proper contentKey for sources
```
