### PR TITLE
Fix #1939: workaround for catalogs with duplicate entries

### DIFF
--- a/pkg/util/camel/camel_runtime_catalog.go
+++ b/pkg/util/camel/camel_runtime_catalog.go
@@ -36,6 +36,15 @@ func NewRuntimeCatalog(spec v1.CamelCatalogSpec) *RuntimeCatalog {
 	for id, artifact := range catalog.Artifacts {
 		for _, scheme := range artifact.Schemes {
 			scheme := scheme
+
+			// In case of duplicate only, choose the "org.apache.camel.quarkus" artifact (if present).
+			// Workaround for https://github.com/apache/camel-k-runtime/issues/592
+			if _, duplicate := catalog.artifactByScheme[scheme.ID]; duplicate {
+				if artifact.GroupID != "org.apache.camel.quarkus" {
+					continue
+				}
+			}
+
 			catalog.artifactByScheme[scheme.ID] = id
 			catalog.schemesByID[scheme.ID] = scheme
 		}


### PR DESCRIPTION
<!-- Description -->

Fix #1939

Add a workaround to fix CI tests. It should be also a valid fix for 1.3.1.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
