### PR TITLE
Fix #1986: use properties instead of URL encoding for Kamelets in bin…

### DIFF
--- a/pkg/controller/kameletbinding/common.go
+++ b/pkg/controller/kameletbinding/common.go
@@ -20,6 +20,8 @@ package kameletbinding
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sort"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
@@ -87,6 +89,23 @@ func createIntegrationFor(ctx context.Context, c client.Client, kameletbinding *
 		}
 		for k, v := range to.Traits {
 			it.Spec.Traits[k] = v
+		}
+	}
+
+	if len(from.ApplicationProperties) > 0 || len(to.ApplicationProperties) > 0 {
+		propList := make([]string, 0, len(from.ApplicationProperties)+len(to.ApplicationProperties))
+		for k, v := range from.ApplicationProperties {
+			propList = append(propList, fmt.Sprintf("%s=%s", k, v))
+		}
+		for k, v := range to.ApplicationProperties {
+			propList = append(propList, fmt.Sprintf("%s=%s", k, v))
+		}
+		sort.Strings(propList)
+		for _, p := range propList {
+			it.Spec.Configuration = append(it.Spec.Configuration, v1.ConfigurationSpec{
+				Type:  "property",
+				Value: p,
+			})
 		}
 	}
 

--- a/pkg/util/bindings/api.go
+++ b/pkg/util/bindings/api.go
@@ -38,6 +38,8 @@ type Binding struct {
 	URI string
 	// Traits is a partial trait specification that should be merged into the integration
 	Traits map[string]v1.TraitSpec
+	// ApplicationProperties contain properties that should be set on the integration for the binding to work
+	ApplicationProperties map[string]string
 }
 
 // BindingProvider maps a KameletBinding endpoint into Camel K resources

--- a/pkg/util/bindings/bindings_test.go
+++ b/pkg/util/bindings/bindings_test.go
@@ -39,6 +39,7 @@ func TestBindings(t *testing.T) {
 		profile      camelv1.TraitProfile
 		uri          string
 		traits       map[string]camelv1.TraitSpec
+		props        map[string]string
 	}{
 		{
 			endpointType: v1alpha1.EndpointTypeSink,
@@ -113,6 +114,7 @@ func TestBindings(t *testing.T) {
 			uri: "knative:event/myeventtype?apiVersion=eventing.knative.dev%2Fv1beta1&kind=Broker",
 		},
 		{
+			endpointType: v1alpha1.EndpointTypeSource,
 			endpoint: v1alpha1.Endpoint{
 				Ref: &corev1.ObjectReference{
 					Kind:       "Kamelet",
@@ -120,9 +122,10 @@ func TestBindings(t *testing.T) {
 					Name:       "mykamelet",
 				},
 			},
-			uri: "kamelet:mykamelet",
+			uri: "kamelet:mykamelet/source",
 		},
 		{
+			endpointType: v1alpha1.EndpointTypeSink,
 			endpoint: v1alpha1.Endpoint{
 				Ref: &corev1.ObjectReference{
 					Kind:       "Kamelet",
@@ -134,7 +137,11 @@ func TestBindings(t *testing.T) {
 					"encodedkey?": "encoded=val",
 				}),
 			},
-			uri: "kamelet:mykamelet?encodedkey%3F=encoded%3Dval&mymessage=myval",
+			uri: "kamelet:mykamelet/sink",
+			props: map[string]string{
+				"camel.kamelet.mykamelet.sink.encodedkey?": "encoded=val",
+				"camel.kamelet.mykamelet.sink.mymessage":   "myval",
+			},
 		},
 		{
 			endpoint: v1alpha1.Endpoint{
@@ -148,7 +155,10 @@ func TestBindings(t *testing.T) {
 					"mymessage": "myval",
 				}),
 			},
-			uri: "kamelet:mykamelet/myid%3F?mymessage=myval",
+			uri: "kamelet:mykamelet/myid%3F",
+			props: map[string]string{
+				"camel.kamelet.mykamelet.myid?.mymessage": "myval",
+			},
 		},
 		{
 			endpointType: v1alpha1.EndpointTypeSink,
@@ -206,6 +216,7 @@ func TestBindings(t *testing.T) {
 			assert.NotNil(t, binding)
 			assert.Equal(t, tc.uri, binding.URI)
 			assert.Equal(t, tc.traits, binding.Traits)
+			assert.Equal(t, tc.props, binding.ApplicationProperties)
 		})
 	}
 }

--- a/script/gen_release_notes.sh
+++ b/script/gen_release_notes.sh
@@ -23,8 +23,8 @@ if [ "$#" -ne 2 ]; then
 fi
 
 location=$(dirname $0)
-last_tag=$1
-new_tag=$2
+last_tag=v$1
+new_tag=v$2
 
 echo "Generating release notes for version $new_tag starting from tag $last_tag"
 


### PR DESCRIPTION
…dings

<!-- Description -->

Fix #1986


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
KameletBinding can use special characters in Kamelet properties
```
