### PR TITLE
Fix #1992: allow accessing Strimzi "kafkatopics" instead of "topics"

### DIFF
--- a/config/rbac/operator-role-olm.yaml
+++ b/config/rbac/operator-role-olm.yaml
@@ -237,7 +237,7 @@ rules:
 - apiGroups:
   - "kafka.strimzi.io"
   resources:
-  - topics
+  - kafkatopics
   - kafkas
   verbs:
   - get

--- a/config/rbac/operator-role-strimzi.yaml
+++ b/config/rbac/operator-role-strimzi.yaml
@@ -25,7 +25,7 @@ rules:
 - apiGroups:
   - "kafka.strimzi.io"
   resources:
-  - topics
+  - kafkatopics
   - kafkas
   verbs:
   - get

--- a/deploy/operator-role-olm.yaml
+++ b/deploy/operator-role-olm.yaml
@@ -248,7 +248,7 @@ rules:
 - apiGroups:
   - "kafka.strimzi.io"
   resources:
-  - topics
+  - kafkatopics
   - kafkas
   verbs:
   - get

--- a/deploy/operator-role-strimzi.yaml
+++ b/deploy/operator-role-strimzi.yaml
@@ -25,7 +25,7 @@ rules:
 - apiGroups:
   - "kafka.strimzi.io"
   resources:
-  - topics
+  - kafkatopics
   - kafkas
   verbs:
   - get

--- a/helm/camel-k/templates/operator-role.yaml
+++ b/helm/camel-k/templates/operator-role.yaml
@@ -239,7 +239,7 @@ rules:
 - apiGroups:
   - "kafka.strimzi.io"
   resources:
-  - topics
+  - kafkatopics
   - kafkas
   verbs:
   - get


### PR DESCRIPTION
<!-- Description -->

Fix #1992


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fixed bug to allow KameletBinding to pull/push data from Strimzi Kafka topics
```
