### PR TITLE
Add scaffold for Kamelet via kamel init

### DIFF
--- a/deploy/templates/kamelet.tmpl
+++ b/deploy/templates/kamelet.tmpl
@@ -1,0 +1,39 @@
+# camel-k: language=kamelet
+
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: {{ .Name }}
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Timer"
+    description: "Produces periodic events with a custom payload"
+    required:
+      - message
+    properties:
+      period:
+        title: Period
+        description: The time interval between two events
+        type: integer
+        default: 1000
+      message:
+        title: Message
+        description: The message to generate
+        type: string
+  types:
+    out:
+      mediaType: application/json
+      schema:
+        id: text.camel.apache.org
+        type: string
+  flow:
+    from:
+      uri: timer:tick
+      parameters:
+        period: {{`"{{period}}"`}}
+      steps:
+        - set-body:
+            constant: {{`"{{message}}"`}}
+        - to: "kamelet:sink"

--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -230,6 +230,8 @@ const (
 	LanguageKotlin Language = "kts"
 	// LanguageYaml --
 	LanguageYaml Language = "yaml"
+	// LanguageKamelet --
+	LanguageKamelet Language = "kamelet"
 )
 
 // Languages is the list of all supported languages
@@ -240,4 +242,5 @@ var Languages = []Language{
 	LanguageXML,
 	LanguageKotlin,
 	LanguageYaml,
+	LanguageKamelet,
 }

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -108,6 +108,10 @@ func (o *initCmdOptions) writeFromTemplate(language v1.Language, fileName string
 }
 
 func (o *initCmdOptions) extractLanguage(fileName string) *v1.Language {
+	if strings.HasSuffix(fileName, ".kamelet.yaml") {
+		language := v1.LanguageKamelet
+		return &language
+	}
 	for _, l := range v1.Languages {
 		if strings.HasSuffix(fileName, fmt.Sprintf(".%s", string(l))) {
 			return &l


### PR DESCRIPTION
<!-- Description -->

Closes #1983 

```shell
$ ./kamel init example.kamelet.yaml
$ cat example.kamelet.yaml
# camel-k: language=kamelet

apiVersion: camel.apache.org/v1alpha1
kind: Kamelet
metadata:
  name: example
  labels:
    camel.apache.org/kamelet.type: "source"
spec:
  definition:
    title: "Timer"
    description: "Produces periodic events with a custom payload"
    required:
      - message
    properties:
      period:
        title: Period
        description: The time interval between two events
        type: integer
        default: 1000
      message:
        title: Message
        description: The message to generate
        type: string
  types:
    out:
      mediaType: application/json
      schema:
        id: text.camel.apache.org
        type: string
  flow:
    from:
      uri: timer:tick
      parameters:
        period: "{{period}}"
      steps:
        - set-body:
            constant: "{{message}}"
        - to: "kamelet:sink"
```


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Add scaffold for Kamelet via kamel init
```
