### PR TITLE
fix: Resource name must be used instead of kind for SelfSubjectAccessReview request

### DIFF
--- a/pkg/controller/integration/integration_controller.go
+++ b/pkg/controller/integration/integration_controller.go
@@ -226,7 +226,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, c client.Client) error {
 		return err
 	} else if !ok {
 		log.Info("Service binding is disabled, install the Service Binding Operator if needed")
-	} else if ok, err := kubernetes.CheckPermission(context.TODO(), c, sb.SchemeGroupVersion.Group, "servicebindings", "", "", "create"); err != nil {
+	} else if ok, err := kubernetes.CheckPermission(context.TODO(), c, sb.SchemeGroupVersion.Group, "servicebindings", platform.GetOperatorWatchNamespace(), "", "create"); err != nil {
 		return err
 	} else if !ok {
 		log.Info("Service binding is disabled, the operator is not granted permission to create ServiceBindings!")

--- a/pkg/controller/integration/integration_controller.go
+++ b/pkg/controller/integration/integration_controller.go
@@ -222,12 +222,11 @@ func add(mgr manager.Manager, r reconcile.Reconciler, c client.Client) error {
 	}
 
 	// Check the ServiceBinding CRD is present
-	serviceBindingKind := reflect.TypeOf(sb.ServiceBinding{}).Name()
-	if ok, err := kubernetes.IsAPIResourceInstalled(c, sb.SchemeGroupVersion.String(), serviceBindingKind); err != nil {
+	if ok, err := kubernetes.IsAPIResourceInstalled(c, sb.SchemeGroupVersion.String(), reflect.TypeOf(sb.ServiceBinding{}).Name()); err != nil {
 		return err
 	} else if !ok {
 		log.Info("Service binding is disabled, install the Service Binding Operator if needed")
-	} else if ok, err := kubernetes.CheckPermission(context.TODO(), c, sb.SchemeGroupVersion.Group, serviceBindingKind, "", "", "create"); err != nil {
+	} else if ok, err := kubernetes.CheckPermission(context.TODO(), c, sb.SchemeGroupVersion.Group, "servicebindings", "", "", "create"); err != nil {
 		return err
 	} else if !ok {
 		log.Info("Service binding is disabled, the operator is not granted permission to create ServiceBindings!")

--- a/pkg/platform/operator.go
+++ b/pkg/platform/operator.go
@@ -67,6 +67,14 @@ func IsCurrentOperatorGlobal() bool {
 	return false
 }
 
+// GetOperatorWatchNamespace returns the namespace the operator watches
+func GetOperatorWatchNamespace() string {
+	if namespace, envSet := os.LookupEnv(operatorWatchNamespaceEnvVariable); envSet {
+		return namespace
+	}
+	return ""
+}
+
 // GetOperatorNamespace returns the namespace where the current operator is located (if set)
 func GetOperatorNamespace() string {
 	if podNamespace, envSet := os.LookupEnv(operatorNamespaceEnvVariable); envSet {


### PR DESCRIPTION
With the following `SAR.json` file:
```json
{
  "kind": "SelfSubjectAccessReview",
  "apiVersion": "authorization.k8s.io/v1",
  "spec": {
    "resourceAttributes": {
      "namespace": "camel-k",
      "verb": "create",
      "group": "operators.coreos.com",
      "resource": "ServiceBinding"
    }
  }
}
```
The following request fails:

```console
$ curl -H "Authorization: Bearer `oc whoami -t`" --data "@SAR.json" -H "Content-Type: application/json" -H "Impersonate-User: viewer" -k `oc whoami --show-server=true`/apis/authorization.k8s.io/v1/selfsubjectaccessreviews
{
  "kind": "SelfSubjectAccessReview",
  "apiVersion": "authorization.k8s.io/v1",
  "metadata": {
    "creationTimestamp": null,
    "managedFields": [
      {
        "manager": "curl",
        "operation": "Update",
        "apiVersion": "authorization.k8s.io/v1",
        "time": "2021-02-10T16:15:19Z",
        "fieldsType": "FieldsV1",
        "fieldsV1": {"f:spec":{"f:resourceAttributes":{".":{},"f:group":{},"f:namespace":{},"f:resource":{},"f:verb":{}}}}
      }
    ]
  },
  "spec": {
    "resourceAttributes": {
      "namespace": "camel-k",
      "verb": "create",
      "group": "operators.coreos.com",
      "resource": "ServiceBinding"
    }
  },
  "status": {
    "allowed": false
  }
}% 
```
While the user `viewer` is granted permission to create:

```console
$ kubectl auth can-i create servicebindings --as viewer
yes
```

**Release Note**
```release-note
NONE
```
