### PR TITLE
fix: Add embedded kamelets directory check back

### DIFF
--- a/pkg/install/kamelets.go
+++ b/pkg/install/kamelets.go
@@ -22,24 +22,29 @@ import (
 	"path"
 	"strings"
 
-	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
-	"github.com/apache/camel-k/pkg/client"
-	"github.com/apache/camel-k/pkg/resources"
-	"github.com/apache/camel-k/pkg/util/defaults"
-	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/pkg/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/client"
+	"github.com/apache/camel-k/pkg/resources"
+	"github.com/apache/camel-k/pkg/util/defaults"
+	"github.com/apache/camel-k/pkg/util/kubernetes"
 )
 
 const kameletDir = "/kamelets/"
 const kameletBundledLabel = "camel.apache.org/kamelet.bundled"
 const kameletReadOnlyLabel = "camel.apache.org/kamelet.readonly"
 
-// KameletCatalog installs the bundlet KameletCatalog into one namespace
+// KameletCatalog installs the bundled KameletCatalog into one namespace
 func KameletCatalog(ctx context.Context, c client.Client, namespace string) error {
+	if !resources.DirExists(kameletDir) {
+		return nil
+	}
+
 	for _, res := range resources.Resources(kameletDir) {
 		if !strings.HasSuffix(res, ".yaml") && !strings.HasSuffix(res, ".yml") {
 			continue


### PR DESCRIPTION
This fixes the following error message when the operator starts:

```
{"level":"error","ts":1613030254.0653336,"logger":"camel-k","msg":"error while listing resource files","dir":"/kamelets/","error":"open /kamelets: file does not exist","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tgithub.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/apache/camel-k/pkg/util/log.Logger.Error\n\tgithub.com/apache/camel-k/pkg/util/log/log.go:75\ngithub.com/apache/camel-k/pkg/util/log.Error\n\tgithub.com/apache/camel-k/pkg/util/log/log.go:216\ngithub.com/apache/camel-k/pkg/resources.Resources\n\tgithub.com/apache/camel-k/pkg/resources/resources_support.go:105\ngithub.com/apache/camel-k/pkg/install.KameletCatalog\n\tgithub.com/apache/camel-k/pkg/install/kamelets.go:43\ngithub.com/apache/camel-k/pkg/install.OperatorStartupOptionalTools\n\tgithub.com/apache/camel-k/pkg/install/optional.go:59\ngithub.com/apache/camel-k/pkg/cmd/operator.Run\n\tgithub.com/apache/camel-k/pkg/cmd/operator/operator.go:156\ngithub.com/apache/camel-k/pkg/cmd.(*operatorCmdOptions).run\n\tgithub.com/apache/camel-k/pkg/cmd/operator.go:51\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.0.0/command.go:846\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.0.0/command.go:950\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.0.0/command.go:887\nmain.main\n\tcommand-line-arguments/main.go:48\nruntime.main\n\truntime/proc.go:204"}
```

Which is a side-effect of #1978.

**Release Note**
```release-note
NONE
```
