### PR TITLE
Increase timeouts

### DIFF
--- a/e2e/yaks/common/kamelet-binding-autoload/kamelet-autoload-specific.feature
+++ b/e2e/yaks/common/kamelet-binding-autoload/kamelet-autoload-specific.feature
@@ -17,7 +17,7 @@ Feature: Camel K can load specific secrets for Kamelets
 
  Scenario: Verify specific binding
     Given HTTP server "stub-service-2"
-    And HTTP server timeout is 60000 ms
+    And HTTP server timeout is 600000 ms
     Then expect HTTP request body: specific
     And receive POST /specific
     And delete KameletBinding binding-specific

--- a/e2e/yaks/common/kamelet-binding-autoload/kamelet-autoload.feature
+++ b/e2e/yaks/common/kamelet-binding-autoload/kamelet-autoload.feature
@@ -15,7 +15,7 @@ Feature: Camel K can load default secrets for Kamelets
 
  Scenario: Verify default binding
     Given HTTP server "stub-service"
-    And HTTP server timeout is 60000 ms
+    And HTTP server timeout is 600000 ms
     Then expect HTTP request body: default
     And receive POST /default
     And delete KameletBinding binding


### PR DESCRIPTION
Increase test timeout in order to not fail on a slow infra.