### PR TITLE
fix: Consider ObjectMeta field for deep derivative comparison before patching

### DIFF
--- a/pkg/trait/deployer.go
+++ b/pkg/trait/deployer.go
@@ -95,9 +95,10 @@ func (t *deployerTrait) Apply(e *Environment) error {
 					return err
 				}
 
-				if !patch.SpecEqualDeepDerivative(object, resource) {
-					// If both objects have a "Spec" field and it contains all expected fields
-					// (plus optional others), then avoid patching
+				// If both objects have "ObjectMeta" and "Spec" fields and they contain all the expected fields
+				// (plus optional others), then avoid patching.
+				if !patch.ObjectMetaEqualDeepDerivative(object, resource) ||
+					!patch.SpecEqualDeepDerivative(object, resource) {
 
 					p, err := patch.PositiveMergePatch(object, resource)
 					if err != nil {

--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -91,6 +91,25 @@ func removeNilValues(v reflect.Value, parent reflect.Value) {
 	}
 }
 
+func ObjectMetaEqualDeepDerivative(object runtime.Object, expected runtime.Object) (res bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			res = false
+		}
+	}()
+
+	if expected == nil {
+		return true
+	} else if object == nil {
+		return false
+	}
+
+	objectMeta := reflect.ValueOf(object).Elem().FieldByName("ObjectMeta").Interface()
+	expectedMeta := reflect.ValueOf(expected).Elem().FieldByName("ObjectMeta").Interface()
+
+	return equality.Semantic.DeepDerivative(expectedMeta, objectMeta)
+}
+
 func SpecEqualDeepDerivative(object runtime.Object, expected runtime.Object) (res bool) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Existing comparison for deep derivative equality of the `Spec` field is not enough and breaks logic based on metadata, mainly annotations and labels, like garbage collection.

**Release Note**
```release-note
fix: Consider ObjectMeta field for deep derivative comparison before patching
```
