### PR TITLE
Backport #2041 to 1.3.x branch

### DIFF
--- a/pkg/trait/pdb.go
+++ b/pkg/trait/pdb.go
@@ -85,6 +85,10 @@ func (t *pdbTrait) Apply(e *Environment) error {
 
 func (t *pdbTrait) podDisruptionBudgetFor(integration *v1.Integration) *v1beta1.PodDisruptionBudget {
 	pdb := &v1beta1.PodDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "PodDisruptionBudget",
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      integration.Name,
 			Namespace: integration.Namespace,


### PR DESCRIPTION
Backport #2041 to 1.3.x branch.

TypeMeta may be required in some situations, like for logic that work with unstructured representation of resources.

/cc @mmelko 

**Release Note**
```release-note
fix(pdb): Add TypeMeta field to PodDisruptionBudget resource
```
