### PR TITLE
chore(cmd): skip operator compatibility warning

### DIFF
--- a/pkg/cmd/operator.go
+++ b/pkg/cmd/operator.go
@@ -23,9 +23,10 @@ import (
 	"github.com/apache/camel-k/pkg/cmd/operator"
 )
 
+const operatorCommand = "operator"
+
 func newCmdOperator() (*cobra.Command, *operatorCmdOptions) {
-	options := operatorCmdOptions{
-	}
+	options := operatorCmdOptions{}
 
 	cmd := cobra.Command{
 		Use:     "operator",

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -189,10 +189,10 @@ func (command *RootCmdOptions) preRun(cmd *cobra.Command, _ []string) error {
 		// Check that the Kamel CLI matches that of the operator.
 		// The check relies on the version reported in the IntegrationPlatform status,
 		// which requires the operator is running and the IntegrationPlatform resource
-		// reconciled. Hence the compatibility check is skipped for the install command.
+		// reconciled. Hence the compatibility check is skipped for the install and the operator command.
 		// Furthermore, there can be any incompatibilities, as the install command deploys
 		// the operator version it's compatible with.
-		if cmd.Use != installCommand {
+		if cmd.Use != installCommand && cmd.Use != operatorCommand {
 			checkAndShowCompatibilityWarning(command.Context, c, command.Namespace)
 		}
 	}


### PR DESCRIPTION
Fix #2051

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
