### PR TITLE
refactor(trait): affinity 

### DIFF
--- a/pkg/trait/affinity.go
+++ b/pkg/trait/affinity.go
@@ -75,21 +75,21 @@ func (t *affinityTrait) Configure(e *Environment) (bool, error) {
 func (t *affinityTrait) Apply(e *Environment) (err error) {
 	podSpec := e.GetIntegrationPodSpec()
 
-	if podSpec != nil {
-		if podSpec.Affinity == nil {
-			podSpec.Affinity = &corev1.Affinity{}
-		}
-		if err := t.addNodeAffinity(e, podSpec); err != nil {
-			return err
-		}
-		if err := t.addPodAffinity(e, podSpec); err != nil {
-			return err
-		}
-		if err := t.addPodAntiAffinity(e, podSpec); err != nil {
-			return err
-		}
+	if podSpec == nil {
+		return fmt.Errorf("could not find any integration deployment for %v", e.Integration.Name)
 	}
-
+	if podSpec.Affinity == nil {
+		podSpec.Affinity = &corev1.Affinity{}
+	}
+	if err := t.addNodeAffinity(e, podSpec); err != nil {
+		return err
+	}
+	if err := t.addPodAffinity(e, podSpec); err != nil {
+		return err
+	}
+	if err := t.addPodAntiAffinity(e, podSpec); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/trait/affinity_test.go
+++ b/pkg/trait/affinity_test.go
@@ -59,6 +59,15 @@ func TestConfigureDisabledAffinityTraitFails(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestApplyAffinityMissingDeployment(t *testing.T) {
+	tolerationTrait := createNominalAffinityTest()
+
+	environment := createNominalMissingDeploymentTraitTest()
+	err := tolerationTrait.Apply(environment)
+
+	assert.NotNil(t, err)
+}
+
 func TestApplyEmptyAffinityLabelsDoesSucceed(t *testing.T) {
 	affinityTrait := createNominalAffinityTest()
 

--- a/pkg/trait/toleration.go
+++ b/pkg/trait/toleration.go
@@ -73,14 +73,13 @@ func (t *tolerationTrait) Apply(e *Environment) (err error) {
 	}
 	podSpec := e.GetIntegrationPodSpec()
 
-	// Add the toleration
-	if podSpec != nil {
-		if podSpec.Tolerations == nil {
-			podSpec.Tolerations = make([]corev1.Toleration, 0)
-		}
-		podSpec.Tolerations = append(podSpec.Tolerations, tolerations...)
+	if podSpec == nil {
+		return fmt.Errorf("could not find any integration deployment for %v", e.Integration.Name)
 	}
-
+	if podSpec.Tolerations == nil {
+		podSpec.Tolerations = make([]corev1.Toleration, 0)
+	}
+	podSpec.Tolerations = append(podSpec.Tolerations, tolerations...)
 	return nil
 }
 

--- a/pkg/trait/toleration_test.go
+++ b/pkg/trait/toleration_test.go
@@ -47,6 +47,16 @@ func TestApplyTolerationTraitMalformedTaint(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestApplyPodTolerationMissingDeployment(t *testing.T) {
+	tolerationTrait := createNominalTolerationTrait()
+	tolerationTrait.Taints = append(tolerationTrait.Taints, "my-toleration=my-value:NoExecute")
+
+	environment := createNominalMissingDeploymentTraitTest()
+	err := tolerationTrait.Apply(environment)
+
+	assert.NotNil(t, err)
+}
+
 func TestApplyPodTolerationLabelsDefault(t *testing.T) {
 	tolerationTrait := createNominalTolerationTrait()
 	tolerationTrait.Taints = append(tolerationTrait.Taints, "my-toleration=my-value:NoExecute")

--- a/pkg/trait/trait_types_test.go
+++ b/pkg/trait/trait_types_test.go
@@ -1,0 +1,101 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trait
+
+import (
+	serving "knative.dev/serving/pkg/apis/serving/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/util/kubernetes"
+)
+
+func createNominalDeploymentTraitTest() (*Environment, *appsv1.Deployment) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "integration-name",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{},
+		},
+	}
+
+	environment := &Environment{
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "integration-name",
+			},
+			Status: v1.IntegrationStatus{
+				Phase: v1.IntegrationPhaseDeploying,
+			},
+		},
+		Resources: kubernetes.NewCollection(deployment),
+	}
+
+	return environment, deployment
+}
+
+func createNominalKnativeServiceTraitTest() (*Environment, *serving.Service) {
+	knativeService := &serving.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "integration-name",
+		},
+		Spec: serving.ServiceSpec{},
+	}
+
+	environment := &Environment{
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "integration-name",
+			},
+			Status: v1.IntegrationStatus{
+				Phase: v1.IntegrationPhaseDeploying,
+			},
+		},
+		Resources: kubernetes.NewCollection(knativeService),
+	}
+
+	return environment, knativeService
+}
+
+func createNominalCronJobTraitTest() (*Environment, *v1beta1.CronJob) {
+	cronJob := &v1beta1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "integration-name",
+		},
+		Spec: v1beta1.CronJobSpec{},
+	}
+
+	environment := &Environment{
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "integration-name",
+			},
+			Status: v1.IntegrationStatus{
+				Phase: v1.IntegrationPhaseDeploying,
+			},
+		},
+		Resources: kubernetes.NewCollection(cronJob),
+	}
+
+	return environment, cronJob
+}

--- a/pkg/trait/trait_types_test.go
+++ b/pkg/trait/trait_types_test.go
@@ -54,6 +54,22 @@ func createNominalDeploymentTraitTest() (*Environment, *appsv1.Deployment) {
 	return environment, deployment
 }
 
+func createNominalMissingDeploymentTraitTest() *Environment {
+	environment := &Environment{
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "integration-name",
+			},
+			Status: v1.IntegrationStatus{
+				Phase: v1.IntegrationPhaseDeploying,
+			},
+		},
+		Resources: kubernetes.NewCollection(),
+	}
+
+	return environment
+}
+
 func createNominalKnativeServiceTraitTest() (*Environment, *serving.Service) {
 	knativeService := &serving.Service{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Description -->
* Added a method to generalize visit strategy on all deployments
* Introduced the affinity trait for Knative and CronJob

Closes #2047
<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
refactor(trait): affinity trait for Knative and CronJob
```
