### PR TITLE
Fix alternative image test

### DIFF
--- a/e2e/common/install_test.go
+++ b/e2e/common/install_test.go
@@ -38,7 +38,7 @@ func TestBasicInstallation(t *testing.T) {
 
 func TestAlternativeImageInstallation(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
-		Expect(Kamel("install", "-n", ns, "--operator-image", "x/y:latest").Execute()).To(Succeed())
+		Expect(Kamel("install", "-n", ns, "--olm=false", "--operator-image", "x/y:latest").Execute()).To(Succeed())
 		Eventually(OperatorImage(ns)).Should(Equal("x/y:latest"))
 	})
 }


### PR DESCRIPTION
Disable OLM when using `--operator-image` option