### PR TITLE
fix(cli): install error message

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -209,6 +209,8 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 					"You can either ask your administrator to provide permissions (preferred) or run the install command with the `--olm=false` flag.")
 				os.Exit(1)
 			}
+		} else {
+			fmt.Fprintln(cobraCmd.OutOrStdout(), "OLM is not available in the cluster. Fallback to regular installation.")
 		}
 
 		if installViaOLM {


### PR DESCRIPTION
Printing an error message telling the user OLM is not available if that was selected during installation

Fixes #2105

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
