### PR TITLE
Fix knative subscriptions and triggers

### DIFF
--- a/e2e/knative/knative_test.go
+++ b/e2e/knative/knative_test.go
@@ -95,29 +95,26 @@ func TestRunChannelComboGetToPost(t *testing.T) {
 	})
 }
 
-/*
-// FIXME: uncomment when https://github.com/apache/camel-k-runtime/issues/69 is resolved
 func TestRunMultiChannelChain(t *testing.T) {
-	withNewTestNamespace(t, func(ns string) {
-		Expect(createKnativeChannel(ns, "messages")()).To(Succeed())
-		Expect(createKnativeChannel(ns, "words")()).To(Succeed())
-		Expect(kamel("install", "-n", ns, "--trait-profile", "knative").Execute()).To(Succeed())
-		Expect(kamel("run", "-n", ns, "files/knativemultihop3.groovy").Execute()).To(Succeed())
-		Expect(kamel("run", "-n", ns, "files/knativemultihop2.groovy").Execute()).To(Succeed())
-		Expect(kamel("run", "-n", ns, "files/knativemultihop1.groovy").Execute()).To(Succeed())
-		Eventually(integrationPodPhase(ns, "knativemultihop3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		Eventually(integrationPodPhase(ns, "knativemultihop2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		Eventually(integrationPodPhase(ns, "knativemultihop1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		Eventually(integrationLogs(ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From messages: message`))
-		Eventually(integrationLogs(ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: word`))
-		Eventually(integrationLogs(ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: transformed message`))
-		Eventually(integrationLogs(ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: word`))
-		Eventually(integrationLogs(ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From words: message`))
-		Eventually(integrationLogs(ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: transformed message`))
-		Expect(kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+	WithNewTestNamespace(t, func(ns string) {
+		Expect(CreateKnativeChannelv1Beta1(ns, "messages")()).To(Succeed())
+		Expect(CreateKnativeChannelv1Beta1(ns, "words")()).To(Succeed())
+		Expect(Kamel("install", "-n", ns, "--trait-profile", "knative").Execute()).To(Succeed())
+		Expect(Kamel("run", "-n", ns, "files/knativemultihop3.groovy").Execute()).To(Succeed())
+		Expect(Kamel("run", "-n", ns, "files/knativemultihop2.groovy").Execute()).To(Succeed())
+		Expect(Kamel("run", "-n", ns, "files/knativemultihop1.groovy").Execute()).To(Succeed())
+		Eventually(IntegrationPodPhase(ns, "knativemultihop3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		Eventually(IntegrationPodPhase(ns, "knativemultihop2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		Eventually(IntegrationPodPhase(ns, "knativemultihop1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		Eventually(IntegrationLogs(ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From messages: message`))
+		Eventually(IntegrationLogs(ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: word`))
+		Eventually(IntegrationLogs(ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: transformed message`))
+		Eventually(IntegrationLogs(ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: word`))
+		Eventually(IntegrationLogs(ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From words: message`))
+		Eventually(IntegrationLogs(ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: transformed message`))
+		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }
-*/
 
 func TestRunBroker(t *testing.T) {
 	WithNewTestNamespaceWithKnativeBroker(t, func(ns string) {

--- a/pkg/apis/camel/v1/knative/types.go
+++ b/pkg/apis/camel/v1/knative/types.go
@@ -40,6 +40,7 @@ type CamelServiceDefinition struct {
 	// Deprecated: use URL instead
 	Port     *int              `json:"port,omitempty"`
 	URL      string            `json:"url,omitempty"`
+	Path     string            `json:"path,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
@@ -75,8 +76,6 @@ func (s CamelServiceType) ResourceDescription(subject string) string {
 
 // Meta Options
 const (
-	CamelMetaServicePath = "service.path"
-
 	CamelMetaKnativeKind       = "knative.kind"
 	CamelMetaKnativeAPIVersion = "knative.apiVersion"
 	CamelMetaKnativeReply      = "knative.reply"

--- a/pkg/trait/knative_test.go
+++ b/pkg/trait/knative_test.go
@@ -250,7 +250,7 @@ func TestKnativeEnvConfigurationFromSource(t *testing.T) {
 	assert.NotNil(t, channel)
 	assert.Equal(t, "false", channel.Metadata[knativeapi.CamelMetaKnativeReply])
 
-	broker := ne.FindService("default", knativeapi.CamelEndpointKindSource, knativeapi.CamelServiceTypeEvent, "", "")
+	broker := ne.FindService("evt.type", knativeapi.CamelEndpointKindSource, knativeapi.CamelServiceTypeEvent, "", "")
 	assert.NotNil(t, broker)
 	assert.Equal(t, "false", broker.Metadata[knativeapi.CamelMetaKnativeReply])
 }

--- a/pkg/util/knative/knative.go
+++ b/pkg/util/knative/knative.go
@@ -45,7 +45,7 @@ import (
 )
 
 // CreateSubscription ---
-func CreateSubscription(channelReference corev1.ObjectReference, serviceName string) *messaging.Subscription {
+func CreateSubscription(channelReference corev1.ObjectReference, serviceName string, path string) *messaging.Subscription {
 	return &messaging.Subscription{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: messaging.SchemeGroupVersion.String(),
@@ -66,6 +66,9 @@ func CreateSubscription(channelReference corev1.ObjectReference, serviceName str
 					APIVersion: serving.SchemeGroupVersion.String(),
 					Kind:       "Service",
 					Name:       serviceName,
+				},
+				URI: &apis.URL{
+					Path: path,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Description -->

Fix #1840
Fix #2109

This changes the way triggers and subscriptions are created in Knative, by adding a path segment to them that allows us to distinguish where the request comes from.

Missing:
- [x] E2E tests


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Integrations can receive events from multiple channels (distinguishing the source)
Integrations are allowed to receive all events from a broker
```
