### PR TITLE
fix: only assume secure pull if the main registry and the base image registry are different

### DIFF
--- a/pkg/builder/spectrum/publisher.go
+++ b/pkg/builder/spectrum/publisher.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/apache/camel-k/pkg/builder"
 	"github.com/apache/camel-k/pkg/platform"
@@ -62,9 +63,15 @@ func publisher(ctx *builder.Context) error {
 	}
 
 	pullInsecure := pl.Status.Build.Registry.Insecure // incremental build case
-	if ctx.BaseImage == pl.Status.Build.BaseImage {
-		// Assuming the base image is always secure (we should add a flag)
-		pullInsecure = false
+
+	log.Debugf("Registry address: %s", pl.Status.Build.Registry.Address)
+	log.Debugf("Base image: %s", ctx.BaseImage)
+
+	if !strings.HasPrefix(ctx.BaseImage, pl.Status.Build.Registry.Address) {
+		if pullInsecure {
+			log.Info("Assuming secure pull because the registry for the base image and the main registry are different")
+			pullInsecure = false
+		}
 	}
 
 	registryConfigDir := ""


### PR DESCRIPTION
<!-- Description -->
Proposed fix for issue #2122


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix incorrectly assuming secure pull if the base image registry and main registry are the same
```