### PR TITLE
fix: ensure Kaniko build strategy works with insecure registries

### DIFF
--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -342,9 +342,15 @@ func (t *builderTrait) kanikoTask(e *Environment) (*v1.ImageTask, error) {
 			return nil, err
 		}
 		mountRegistrySecret(e.Platform.Status.Build.Registry.Secret, secret, &volumes, &volumeMounts, &env)
-	} else if e.Platform.Status.Build.Registry.Insecure {
+	}
+
+	if e.Platform.Status.Build.Registry.Insecure {
 		args = append(args, "--insecure")
 		args = append(args, "--insecure-pull")
+
+		// We use these 2 flags to force Kaniko to try HTTP instead of HTTPS
+		args = append(args, "--skip-tls-verify")
+		args = append(args, "--skip-tls-verify-pull")
 	}
 
 	env = append(env, proxySecretEnvVars(e)...)


### PR DESCRIPTION
<!-- Description -->
Proposed fix for issue #2127



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix pushing to insecure registry when using Kaniko build strategy
```