### PR TITLE
fix: buildah to ensure it works with insecure registries

### DIFF
--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -270,7 +270,9 @@ func (t *builderTrait) buildahTask(e *Environment) (*v1.ImageTask, error) {
 			})
 		}
 		mountRegistrySecret(e.Platform.Status.Build.Registry.Secret, secret, &volumes, &volumeMounts, &env)
-	} else if e.Platform.Status.Build.Registry.Insecure {
+	}
+
+	if e.Platform.Status.Build.Registry.Insecure {
 		bud = append(bud[:2], append([]string{"--tls-verify=false"}, bud[2:]...)...)
 		push = append(push[:2], append([]string{"--tls-verify=false"}, push[2:]...)...)
 	}


### PR DESCRIPTION
<!-- Description -->
Fix issue #2137 by reprioritizing the insecure flag check


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix buildah strategy with mixed secure/insecure registries
```