### PR TITLE
Fix #2035: invalid YAML should not make the operator panic

### DIFF
--- a/pkg/util/source/inspector_yaml_test.go
+++ b/pkg/util/source/inspector_yaml_test.go
@@ -62,6 +62,13 @@ const YAMLRouteTransformer = `
           uri: knative:endpoint/service
 `
 
+const YAMLInvalid = `
+- from:
+    uri: knative:endpoint/default
+    steps:
+      - "log:out"
+`
+
 func TestYAMLDependencies(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -86,6 +93,13 @@ func TestYAMLDependencies(t *testing.T) {
 			source: YAMLRouteTransformer,
 			dependencies: []string{
 				`mvn:org.apache.camel.k:camel-k-knative-producer`,
+				`mvn:org.apache.camel.k:camel-k-knative-consumer`,
+			},
+		},
+		{
+			name:   "invalid",
+			source: YAMLInvalid,
+			dependencies: []string{
 				`mvn:org.apache.camel.k:camel-k-knative-consumer`,
 			},
 		},


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Invalid YAML does not make the operator panic
```
