### PR TITLE
Backport fix for #2035: invalid YAML should not make the operator panic

### DIFF
--- a/pkg/util/source/inspector_yaml_test.go
+++ b/pkg/util/source/inspector_yaml_test.go
@@ -96,7 +96,7 @@ func TestYAMLDependencies(t *testing.T) {
 			name:   "invalid",
 			source: YAMLInvalid,
 			dependencies: []string{
-				`mvn:org.apache.camel.k:camel-k-knative-consumer`,
+				`mvn:org.apache.camel.k/camel-k-knative-consumer`,
 			},
 		},
 	}

--- a/pkg/util/source/inspector_yaml_test.go
+++ b/pkg/util/source/inspector_yaml_test.go
@@ -61,6 +61,13 @@ const YAMLRouteTransformer = `
           uri: knative:endpoint/service
 `
 
+const YAMLInvalid = `
+- from:
+    uri: knative:endpoint/default
+    steps:
+      - "log:out"
+`
+
 func TestYAMLDependencies(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -84,6 +91,13 @@ func TestYAMLDependencies(t *testing.T) {
 			name:         "transformer",
 			source:       YAMLRouteTransformer,
 			dependencies: []string{`mvn:org.apache.camel.k/camel-k-knative-producer`, `mvn:org.apache.camel.k/camel-k-knative-consumer`},
+		},
+		{
+			name:   "invalid",
+			source: YAMLInvalid,
+			dependencies: []string{
+				`mvn:org.apache.camel.k:camel-k-knative-consumer`,
+			},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
<!-- Description -->

Fix  #2035


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
