### PR TITLE
chore(s2i): Set owner reference for BuildConfig and ImageStream resources

### DIFF
--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -61,7 +61,6 @@ jobs:
 
         echo "Final status:"
         df -h
-        sudo mount --make-shared /
     - name: Set up JDK 11
       uses: AdoptOpenJDK/install-jdk@v1
       with:

--- a/pkg/builder/s2i.go
+++ b/pkg/builder/s2i.go
@@ -29,9 +29,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/json"
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -54,7 +56,7 @@ var _ Task = &s2iTask{}
 func (t *s2iTask) Do(ctx context.Context) v1.BuildStatus {
 	status := v1.BuildStatus{}
 
-	bc := buildv1.BuildConfig{
+	bc := &buildv1.BuildConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: buildv1.GroupVersion.String(),
 			Kind:       "BuildConfig",
@@ -82,17 +84,28 @@ func (t *s2iTask) Do(ctx context.Context) v1.BuildStatus {
 		},
 	}
 
-	err := t.c.Delete(ctx, &bc)
+	err := t.c.Delete(ctx, bc)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return status.Failed(errors.Wrap(err, "cannot delete build config"))
 	}
 
-	err = t.c.Create(ctx, &bc)
+	// Set the build controller as owner reference
+	owner := t.getControllerReference()
+	if owner == nil {
+		// Default to the Build if no controller reference is present
+		owner = t.build
+	}
+
+	if err := ctrlutil.SetOwnerReference(owner, bc, t.c.GetScheme()); err != nil {
+		return status.Failed(errors.Wrapf(err, "cannot set owner reference on BuildConfig: %s", bc.Name))
+	}
+
+	err = t.c.Create(ctx, bc)
 	if err != nil {
 		return status.Failed(errors.Wrap(err, "cannot create build config"))
 	}
 
-	is := imagev1.ImageStream{
+	is := &imagev1.ImageStream{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: imagev1.GroupVersion.String(),
 			Kind:       "ImageStream",
@@ -109,12 +122,16 @@ func (t *s2iTask) Do(ctx context.Context) v1.BuildStatus {
 		},
 	}
 
-	err = t.c.Delete(ctx, &is)
+	err = t.c.Delete(ctx, is)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return status.Failed(errors.Wrap(err, "cannot delete image stream"))
 	}
 
-	err = t.c.Create(ctx, &is)
+	if err := ctrlutil.SetOwnerReference(owner, is, t.c.GetScheme()); err != nil {
+		return status.Failed(errors.Wrapf(err, "cannot set owner reference on ImageStream: %s", is.Name))
+	}
+
+	err = t.c.Create(ctx, is)
 	if err != nil {
 		return status.Failed(errors.Wrap(err, "cannot create image stream"))
 	}
@@ -185,7 +202,7 @@ func (t *s2iTask) Do(ctx context.Context) v1.BuildStatus {
 		return status.Failed(err)
 	}
 
-	err = t.c.Get(ctx, ctrl.ObjectKeyFromObject(&is), &is)
+	err = t.c.Get(ctx, ctrl.ObjectKeyFromObject(is), is)
 	if err != nil {
 		return status.Failed(err)
 	}
@@ -197,4 +214,21 @@ func (t *s2iTask) Do(ctx context.Context) v1.BuildStatus {
 	status.Image = is.Status.DockerImageRepository + ":" + t.task.Tag
 
 	return status
+}
+
+func (t *s2iTask) getControllerReference() metav1.Object {
+	var owner metav1.Object
+	for _, ref := range t.build.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			o := &unstructured.Unstructured{}
+			o.SetNamespace(t.build.Namespace)
+			o.SetName(ref.Name)
+			o.SetUID(ref.UID)
+			o.SetAPIVersion(ref.APIVersion)
+			o.SetKind(ref.Kind)
+			owner = o
+			break
+		}
+	}
+	return owner
 }


### PR DESCRIPTION
This enables proper garbage collection of build resources created by the S2I strategy. 

**Release Note**
```release-note
chore(s2i): Set owner reference for BuildConfig and ImageStream resources
```
