### PR TITLE
test: Operator upgrade e2e tests

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -109,6 +109,7 @@ jobs:
         export KAMEL_INSTALL_OLM=false
 
         # Configure test options
+        export KAMEL_K_TEST_RELEASE_VERSION=$(make get-last-released-version)
         export KAMEL_K_TEST_OPERATOR_CURRENT_IMAGE=$KIND_REGISTRY/apache/camel-k:$(make get-version)
 
         # Then run integration tests

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Run IT
       run: |
         # Use the last released Kamel CLI
-        KAMEL_BIN=kamel
+        export KAMEL_BIN=/usr/local/bin/kamel
 
         # Configure install options
         export KAMEL_INSTALL_BUILD_PUBLISH_STRATEGY=Spectrum

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,115 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: upgrade
+
+on:
+  pull_request:
+    branches:
+      - master
+      - "release-*"
+    paths-ignore:
+      - '**.adoc'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
+    branches:
+      - master
+      - "release-*"
+    paths-ignore:
+      - '**.adoc'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cleanup
+      run: |
+        ls -lart
+        echo "Initial status:"
+        df -h
+
+        echo "Cleaning up resources:"
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+
+        echo "Final status:"
+        df -h
+    - name: Set up JDK 11
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: "11"
+    - name: Set Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13.x
+    - name: Kubernetes KinD Cluster
+      uses: container-tools/kind-action@v1
+      with:
+        node_image: kindest/node:v1.20.2
+    - name: Info
+      run: |
+        kubectl cluster-info
+        kubectl describe nodes
+    - name: Get Kamel CLI
+      run: |
+        export KAMEL_VERSION=$(make get-last-released-version)
+        curl -L https://github.com/apache/camel-k/releases/download/v${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz -o kamel.tar.gz
+        tar -zxf kamel.tar.gz
+        sudo mv kamel /usr/local/bin/
+    - name: Build Operator
+      run: |
+        echo "Build project"
+        make build-kamel bundle-kamelets
+        echo "Adding maven artifacts to the image context"
+        make PACKAGE_ARTIFACTS_STRATEGY=download package-artifacts
+        echo "Copying binary file to docker dir"
+        mkdir -p ./build/_output/bin
+        cp ./kamel ./build/_output/bin/
+        echo "Building the images"
+        export LOCAL_IMAGE=$KIND_REGISTRY/apache/camel-k:$(make get-version)
+        docker build -t "${LOCAL_IMAGE}" -f build/Dockerfile .
+        docker push ${LOCAL_IMAGE}
+    - name: Run IT
+      run: |
+        # Use the last released Kamel CLI
+        KAMEL_BIN=kamel
+
+        # Configure install options
+        export KAMEL_INSTALL_BUILD_PUBLISH_STRATEGY=Spectrum
+        export KAMEL_INSTALL_MAVEN_REPOSITORIES=$(make get-staging-repo)
+        export KAMEL_INSTALL_REGISTRY=$KIND_REGISTRY
+        export KAMEL_INSTALL_REGISTRY_INSECURE=true
+
+        # TODO: Install OLM and cover upgrade managed by OLM
+        export KAMEL_INSTALL_OLM=false
+
+        # Configure test options
+        export KAMEL_K_TEST_OPERATOR_CURRENT_IMAGE=$KIND_REGISTRY/apache/camel-k:$(make get-version)
+
+        # Then run integration tests
+        make test-upgrade

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -93,6 +93,15 @@ func TestClient() client.Client {
 	return testClient
 }
 
+func SyncClient() client.Client {
+	var err error
+	testClient, err = NewTestClient()
+	if err != nil {
+		panic(err)
+	}
+	return testClient
+}
+
 // KamelHooks contains hooks useful to add option to kamel commands at runtime
 var KamelHooks []func([]string) []string
 
@@ -550,15 +559,6 @@ func IntegrationKit(ns string, name string) func() string {
 	}
 }
 
-func SetIntegrationVersion(ns string, name string, version string) error {
-	it := Integration(ns, name)()
-	if it == nil {
-		return fmt.Errorf("no integration named %s found", name)
-	}
-	it.Status.Version = version
-	return TestClient().Status().Update(TestContext, it)
-}
-
 func UpdateIntegration(ns string, name string, upd func(it *v1.Integration)) error {
 	it := Integration(ns, name)()
 	if it == nil {
@@ -594,17 +594,6 @@ func KitsWithVersion(ns string, version string) func() int {
 		}
 		return count
 	}
-}
-
-func SetAllKitsVersion(ns string, version string) error {
-	for _, k := range Kits(ns)() {
-		kit := k
-		kit.Status.Version = version
-		if err := TestClient().Status().Update(TestContext, &kit); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func OperatorImage(ns string) func() string {

--- a/e2e/support/util/dump.go
+++ b/e2e/support/util/dump.go
@@ -25,11 +25,12 @@ import (
 	"fmt"
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/apache/camel-k/pkg/client"
 	"github.com/apache/camel-k/pkg/client/camel/clientset/versioned"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Dump prints all information about the given namespace to debug errors
@@ -95,6 +96,20 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 			return err
 		}
 		t.Logf("---\n%s\n---\n", string(pdata))
+	}
+
+	deployments, err := c.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	t.Logf("Found %d deployments:\n", len(iks.Items))
+	for _, deployment := range deployments.Items {
+		ref := deployment
+		data, err := kubernetes.ToYAML(&ref)
+		if err != nil {
+			return err
+		}
+		t.Logf("---\n%s\n---\n", string(data))
 	}
 
 	lst, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})

--- a/e2e/upgrade/files/yaml.yaml
+++ b/e2e/upgrade/files/yaml.yaml
@@ -1,0 +1,28 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- from:
+    uri: "timer:yaml"
+    parameters:
+      period: "5000"
+    steps:
+      - set-header:
+          name: "m"
+          constant: "string!"
+      - set-body:
+          simple: "Magic${header.m}"
+      - to: "log:info"

--- a/e2e/upgrade/upgrade_operator_test.go
+++ b/e2e/upgrade/upgrade_operator_test.go
@@ -1,0 +1,92 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+
+	. "github.com/apache/camel-k/e2e/support"
+	camelv1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/util/defaults"
+)
+
+func TestOperatorUpgrade(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		version, ok := os.LookupEnv("KAMEL_VERSION")
+		Expect(ok).To(BeTrue())
+
+		image, ok := os.LookupEnv("KAMEL_K_TEST_OPERATOR_CURRENT_IMAGE")
+		Expect(ok).To(BeTrue())
+
+		Expect(Kamel("install", "--cluster-setup").Execute()).To(Succeed())
+		Expect(Kamel("install", "-n", ns).Execute()).To(Succeed())
+		Eventually(PlatformVersion(ns)).Should(Equal(version))
+
+		// Run the Integration
+		name := "yaml"
+		Expect(Kamel("run", "-n", ns, "files/yaml.yaml").Execute()).To(Succeed())
+		Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+		Eventually(IntegrationCondition(ns, name, camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
+		// Check the Integration version
+		Eventually(IntegrationVersion(ns, "yaml")).Should(Equal(version))
+		kit := IntegrationKit(ns, "yaml")()
+
+		// Clear the KAMEL_BIN environment variable so that the current version is used from now on
+		Expect(os.Setenv("KAMEL_BIN", "")).To(Succeed())
+
+		// Upgrade the operator by installing the current version
+		// FIXME: it seems forcing the installation does not re-install the CRDs
+		Expect(Kamel("install", "--cluster-setup", "--force").Execute()).To(Succeed())
+		Expect(Kamel("install", "-n", ns, "--force", "--operator-image", image).Execute()).To(Succeed())
+
+		Eventually(OperatorImage(ns)).Should(Equal(image))
+		Eventually(OperatorPodPhase(ns)).Should(Equal(v1.PodRunning))
+		Eventually(PlatformVersion(ns)).Should(Equal(defaults.Version))
+
+		// Check the Integration hasn't been upgraded
+		Consistently(IntegrationVersion(ns, "yaml"), 3*time.Second).Should(Equal(version))
+
+		// Force the Integration upgrade
+		Expect(Kamel("rebuild", "yaml", "-n", ns).Execute()).To(Succeed())
+
+		// Check the Integration version change
+		Eventually(IntegrationVersion(ns, "yaml")).Should(Equal(defaults.Version))
+		// Check the previous kit is not garbage collected
+		Eventually(KitsWithVersion(ns, version)).Should(Equal(1))
+		// Check a new kit is created with the current version
+		Eventually(KitsWithVersion(ns, defaults.Version)).Should(Equal(1))
+		// Check the Integration uses the new kit
+		Eventually(IntegrationKit(ns, "yaml"), TestTimeoutMedium).ShouldNot(Equal(kit))
+		// Check the Integration runs correctly
+		Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+		Eventually(IntegrationCondition(ns, name, camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
+
+		// Clean up
+		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+	})
+}

--- a/e2e/upgrade/upgrade_operator_test.go
+++ b/e2e/upgrade/upgrade_operator_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestOperatorUpgrade(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
-		version, ok := os.LookupEnv("KAMEL_VERSION")
+		version, ok := os.LookupEnv("KAMEL_K_TEST_RELEASE_VERSION")
 		Expect(ok).To(BeTrue())
 
 		image, ok := os.LookupEnv("KAMEL_K_TEST_OPERATOR_CURRENT_IMAGE")

--- a/e2e/upgrade/upgrade_operator_test.go
+++ b/e2e/upgrade/upgrade_operator_test.go
@@ -45,7 +45,11 @@ func TestOperatorUpgrade(t *testing.T) {
 
 		Expect(Kamel("install", "--cluster-setup").Execute()).To(Succeed())
 		Expect(Kamel("install", "-n", ns).Execute()).To(Succeed())
-		Eventually(PlatformVersion(ns)).Should(Equal(version))
+
+		// Check the operator pod is running
+		Eventually(OperatorPodPhase(ns), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+		// Check the IntegrationPlatform has been reconciled
+		Eventually(PlatformVersion(ns), TestTimeoutMedium).Should(Equal(version))
 
 		// Run the Integration
 		name := "yaml"
@@ -64,9 +68,12 @@ func TestOperatorUpgrade(t *testing.T) {
 		Expect(Kamel("install", "--cluster-setup", "--force").Execute()).To(Succeed())
 		Expect(Kamel("install", "-n", ns, "--force", "--operator-image", image).Execute()).To(Succeed())
 
+		// Check the operator image is the current built one
 		Eventually(OperatorImage(ns)).Should(Equal(image))
-		Eventually(OperatorPodPhase(ns)).Should(Equal(v1.PodRunning))
-		Eventually(PlatformVersion(ns)).Should(Equal(defaults.Version))
+		// Check the operator pod is running
+		Eventually(OperatorPodPhase(ns), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+		// Check the IntegrationPlatform has been reconciled
+		Eventually(PlatformVersion(ns), TestTimeoutMedium).Should(Equal(defaults.Version))
 
 		// Check the Integration hasn't been upgraded
 		Consistently(IntegrationVersion(ns, "yaml"), 3*time.Second).Should(Equal(version))

--- a/e2e/upgrade/upgrade_operator_test.go
+++ b/e2e/upgrade/upgrade_operator_test.go
@@ -48,6 +48,10 @@ func TestOperatorUpgrade(t *testing.T) {
 
 		// Check the operator pod is running
 		Eventually(OperatorPodPhase(ns), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+
+		// Refresh the test client to account for the newly installed CRDs
+		SyncClient()
+
 		// Check the IntegrationPlatform has been reconciled
 		Eventually(PlatformVersion(ns), TestTimeoutMedium).Should(Equal(version))
 

--- a/script/Makefile
+++ b/script/Makefile
@@ -173,6 +173,10 @@ test-kamel-cli: build
 	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" go test -timeout 60m -v ./e2e/common/cli -tags=integration
 	#go test -timeout 60m -v ./e2e/common/cli -tags=integration
 
+test-upgrade: build
+	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" \
+	go test -timeout 60m -v ./e2e/upgrade -tags=integration
+
 build-kamel:
 # Ensure the binary is statically linked when building on Linux due to ABI changes in newer glibc 2.32, otherwise
 # it would not run on older versions. See https://github.com/apache/camel-k/pull/2141#issuecomment-800990117
@@ -260,6 +264,9 @@ images-push-staging:
 
 get-version:
 	@echo $(VERSION)
+
+get-last-released-version:
+	@echo $(LAST_RELEASED_VERSION)
 
 set-version:
 	./script/set_version.sh $(VERSION) $(IMAGE_NAME)


### PR DESCRIPTION
~~The upgrade tests are currently expected to fail because of #2162.~~

This PR introduces a new GH Actions workflow dedicated to upgrade e2e tests. It will be improved, by installing OLM, so that OLM-managed upgrade scenarii will be covered as well.

The next steps are:
- Setup OLM
- Build and push the current OLM bundle
- Build and push the index image with `opm`
- Add tests to cover Camel K upgrade from the last release version to the current version

**Release Note**
```release-note
test: Operator upgrade e2e tests
```
