### PR TITLE
fix: Integrations are re-built on operator upgrade

### DIFF
--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -130,8 +130,8 @@ func ComputeForIntegration(integration *v1.Integration) (string, error) {
 // Produces a digest that can be used as docker image tag
 func ComputeForIntegrationKit(kit *v1.IntegrationKit) (string, error) {
 	hash := sha256.New()
-	// Operator version is relevant
-	if _, err := hash.Write([]byte(defaults.Version)); err != nil {
+	// Kit version is relevant
+	if _, err := hash.Write([]byte(kit.Status.Version)); err != nil {
 		return "", err
 	}
 

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -40,8 +40,8 @@ import (
 // Produces a digest that can be used as docker image tag
 func ComputeForIntegration(integration *v1.Integration) (string, error) {
 	hash := sha256.New()
-	// Operator version is relevant
-	if _, err := hash.Write([]byte(defaults.Version)); err != nil {
+	// Integration version is relevant
+	if _, err := hash.Write([]byte(integration.Status.Version)); err != nil {
 		return "", err
 	}
 	// Integration Kit is relevant
@@ -241,7 +241,6 @@ func sortedTraitSpecMapKeys(m map[string]v1.TraitSpec) []string {
 	return res
 }
 
-// ComputeSHA1 ---
 func ComputeSHA1(elem ...string) (string, error) {
 	file := path.Join(elem...)
 


### PR DESCRIPTION
Fixes #2162.

**Release Note**
```release-note
fix: Integrations are re-built on operator upgrade
```
