### PR TITLE
Normalize names

### DIFF
--- a/deploy/traits.yaml
+++ b/deploy/traits.yaml
@@ -530,9 +530,8 @@ traits:
   - name: filter-source-channels
     type: bool
     description: Enables filtering on events based on the header "ce-knativehistory".
-      Since this is an experimental headerthat can be removed in a future version
-      of Knative, filtering is enabled only when the integration islistening from
-      more than 1 channel.
+      Since this header has been removed in newer versions ofKnative, filtering is
+      disabled by default.
   - name: camel-source-compat
     type: bool
     description: Enables Knative CamelSource pre 0.15 compatibility fixes (will be
@@ -808,7 +807,7 @@ traits:
       property.
   - name: service-bindings
     type: '[]string'
-    description: List of Provisioned Services and ServiceBindings in the form KIND.VERSION.GROUP/NAME[/NAMESPACE]
+    description: List of Provisioned Services and ServiceBindings in the form [[apigroup/]version:]kind:[namespace/]name
 - name: service
   platform: false
   profiles:

--- a/docs/modules/ROOT/assets/attachments/schema/integration-schema.json
+++ b/docs/modules/ROOT/assets/attachments/schema/integration-schema.json
@@ -1257,6 +1257,9 @@
         },
         {
           "properties": {
+            "break-on-shutdown": {
+              "type": "string"
+            },
             "copy": {
               "type": "string"
             },
@@ -3129,7 +3132,7 @@
         "include": {
           "type": "string"
         },
-        "json-view": {
+        "json-view-type-name": {
           "type": "string"
         },
         "module-class-names": {
@@ -3272,7 +3275,7 @@
         "include": {
           "type": "string"
         },
-        "json-view": {
+        "json-view-type-name": {
           "type": "string"
         },
         "library": {
@@ -4500,15 +4503,22 @@
       ]
     },
     "org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition": {
-      "type": "object",
-      "properties": {
-        "id": {
+      "anyOf": [
+        {
           "type": "string"
         },
-        "ref": {
-          "type": "string"
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            }
+          }
         }
-      }
+      ]
     },
     "org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition": {
       "type": "object",

--- a/docs/modules/ROOT/assets/attachments/schema/kamelet-schema.json
+++ b/docs/modules/ROOT/assets/attachments/schema/kamelet-schema.json
@@ -1192,6 +1192,9 @@
         },
         {
           "properties": {
+            "break-on-shutdown": {
+              "type": "string"
+            },
             "copy": {
               "type": "string"
             },
@@ -3064,7 +3067,7 @@
         "include": {
           "type": "string"
         },
-        "json-view": {
+        "json-view-type-name": {
           "type": "string"
         },
         "module-class-names": {
@@ -3207,7 +3210,7 @@
         "include": {
           "type": "string"
         },
-        "json-view": {
+        "json-view-type-name": {
           "type": "string"
         },
         "library": {
@@ -4435,15 +4438,22 @@
       ]
     },
     "org.apache.camel.model.loadbalancer.CustomLoadBalancerDefinition": {
-      "type": "object",
-      "properties": {
-        "id": {
+      "anyOf": [
+        {
           "type": "string"
         },
-        "ref": {
-          "type": "string"
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            }
+          }
         }
-      }
+      ]
     },
     "org.apache.camel.model.loadbalancer.FailoverLoadBalancerDefinition": {
       "type": "object",

--- a/docs/modules/traits/pages/knative.adoc
+++ b/docs/modules/traits/pages/knative.adoc
@@ -66,9 +66,8 @@ Can contain simple event types or full Camel URIs (to use a specific broker).
 
 | knative.filter-source-channels
 | bool
-| Enables filtering on events based on the header "ce-knativehistory". Since this is an experimental header
-that can be removed in a future version of Knative, filtering is enabled only when the integration is
-listening from more than 1 channel.
+| Enables filtering on events based on the header "ce-knativehistory". Since this header has been removed in newer versions of
+Knative, filtering is disabled by default.
 
 | knative.camel-source-compat
 | bool

--- a/docs/modules/traits/pages/service-binding.adoc
+++ b/docs/modules/traits/pages/service-binding.adoc
@@ -28,7 +28,7 @@ The following configuration options are available:
 
 | service-binding.service-bindings
 | []string
-| List of Provisioned Services and ServiceBindings in the form KIND.VERSION.GROUP/NAME[/NAMESPACE]
+| List of Provisioned Services and ServiceBindings in the form [[apigroup/]version:]kind:[namespace/]name
 
 |===
 

--- a/pkg/cmd/completion_bash.go
+++ b/pkg/cmd/completion_bash.go
@@ -108,7 +108,7 @@ __kamel_kubectl_get_servicebinding() {
                version=$(echo ${resource} | cut -d'/' -f 3)
                group=$(echo ${resource} | cut -d'/' -f 2)
                kind=$(echo ${resource} | cut -d'/' -f 1)
-               services_list="${services_list} ${kind}.${version}.${group}/${name}"
+               services_list="${services_list} ${group}/${version}:${kind}:${name}"
             done
             COMPREPLY=( $( compgen -W "${services_list[*]}" -- "$cur" ) )
         fi

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -73,7 +73,7 @@ func newCmdRun(rootCmdOptions *RootCmdOptions) (*cobra.Command, *runCmdOptions) 
 	}
 
 	cmd.Flags().String("name", "", "The integration name")
-	cmd.Flags().StringArrayP("connect", "c", nil, "A ServiceBinding or Provisioned Service that the integration should bind to specified as KIND.VERSION.GROUP/NAME[/NAMESPACE]")
+	cmd.Flags().StringArrayP("connect", "c", nil, "A ServiceBinding or Provisioned Service that the integration should bind to, specified as [[apigroup/]version:]kind:[namespace/]name")
 	cmd.Flags().StringArrayP("dependency", "d", nil, "An external library that should be included. E.g. for Maven dependencies \"mvn:org.my/app:1.0\"")
 	cmd.Flags().BoolP("wait", "w", false, "Wait for the integration to be running")
 	cmd.Flags().StringP("kit", "k", "", "The kit used to run the integration")

--- a/pkg/trait/service_binding.go
+++ b/pkg/trait/service_binding.go
@@ -207,8 +207,11 @@ func (t *serviceBindingTrait) parseServiceBindings(e *Environment) ([]string, er
 		if err != nil {
 			return serviceBindings, err
 		}
+		if ref.Namespace == "" {
+			ref.Namespace = e.Integration.Namespace
+		}
 		if ref.Kind == "ServiceBinding" {
-			if ref.GroupVersionKind().String() != sb.GroupVersion.String() {
+			if ref.GroupVersionKind().GroupVersion().String() != sb.GroupVersion.String() {
 				return nil, fmt.Errorf("ServiceBinding: %q api version should be %q", s, sb.GroupVersion.String())
 			}
 			if ref.Namespace != e.Integration.Namespace {

--- a/pkg/util/reference/reference.go
+++ b/pkg/util/reference/reference.go
@@ -18,6 +18,7 @@ limitations under the License.
 package reference
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"unicode"
@@ -124,5 +125,20 @@ func (c *Converter) simpleDecodeString(str string) (corev1.ObjectReference, erro
 }
 
 func (c *Converter) ToString(ref corev1.ObjectReference) (string, error) {
-	return "", nil
+	if ref.Kind == "" {
+		return "", errors.New(`object reference is missing the "kind" field`)
+	}
+	if ref.Name == "" {
+		return "", errors.New(`object reference is missing the "name" field`)
+	}
+	res := ""
+	if ref.APIVersion != "" {
+		res += ref.APIVersion + ":"
+	}
+	res += ref.Kind + ":"
+	if ref.Namespace != "" {
+		res += ref.Namespace + "/"
+	}
+	res += ref.Name
+	return res, nil
 }

--- a/pkg/util/reference/reference.go
+++ b/pkg/util/reference/reference.go
@@ -1,0 +1,128 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reference
+
+import (
+	"fmt"
+	"regexp"
+	"unicode"
+
+	camelv1alpha1 "github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+const (
+	KameletPrefix = "kamelet:"
+)
+
+var (
+	simpleNameRegexp = regexp.MustCompile(`^(?:(?P<namespace>[a-z0-9-.]+)/)?(?P<name>[a-z0-9-.]+)$`)
+	fullNameRegexp   = regexp.MustCompile(`^(?:(?P<apiVersion>(?:[a-z0-9-.]+/)?(?:[a-z0-9-.]+)):)?(?P<kind>[A-Za-z0-9-.]+):(?:(?P<namespace>[a-z0-9-.]+)/)?(?P<name>[a-z0-9-.]+)$`)
+
+	templates = map[string]corev1.ObjectReference{
+		"kamelet": corev1.ObjectReference{
+			Kind:       "Kamelet",
+			APIVersion: camelv1alpha1.SchemeGroupVersion.String(),
+		},
+		"channel": corev1.ObjectReference{
+			Kind:       "Channel",
+			APIVersion: messagingv1.SchemeGroupVersion.String(),
+		},
+		"broker": corev1.ObjectReference{
+			Kind:       "Broker",
+			APIVersion: eventingv1.SchemeGroupVersion.String(),
+		},
+		"ksvc": corev1.ObjectReference{
+			Kind:       "Service",
+			APIVersion: servingv1.SchemeGroupVersion.String(),
+		},
+	}
+)
+
+type Converter struct {
+	defaultPrefix string
+}
+
+func NewConverter(defaultPrefix string) *Converter {
+	return &Converter{
+		defaultPrefix: defaultPrefix,
+	}
+}
+
+func (c *Converter) FromString(str string) (corev1.ObjectReference, error) {
+	ref, err := c.simpleDecodeString(str)
+	if err != nil {
+		return ref, err
+	}
+	c.expandReference(&ref)
+
+	if ref.Kind == "" || !unicode.IsUpper([]rune(ref.Kind)[0]) {
+		return corev1.ObjectReference{}, fmt.Errorf("invalid kind: %q", ref.Kind)
+	}
+	return ref, nil
+}
+
+func (c *Converter) expandReference(ref *corev1.ObjectReference) {
+	if template, ok := templates[ref.Kind]; ok {
+		if template.Kind != "" {
+			ref.Kind = template.Kind
+		}
+		if ref.APIVersion == "" && template.APIVersion != "" {
+			ref.APIVersion = template.APIVersion
+		}
+	}
+}
+
+func (c *Converter) simpleDecodeString(str string) (corev1.ObjectReference, error) {
+	fullName := str
+	if simpleNameRegexp.MatchString(str) {
+		fullName = c.defaultPrefix + str
+	}
+
+	if fullNameRegexp.MatchString(fullName) {
+		groupNames := fullNameRegexp.SubexpNames()
+		ref := corev1.ObjectReference{}
+		for _, match := range fullNameRegexp.FindAllStringSubmatch(fullName, -1) {
+			for idx, text := range match {
+				groupName := groupNames[idx]
+				switch groupName {
+				case "apiVersion":
+					ref.APIVersion = text
+				case "namespace":
+					ref.Namespace = text
+				case "kind":
+					ref.Kind = text
+				case "name":
+					ref.Name = text
+				}
+			}
+		}
+		return ref, nil
+	}
+	if c.defaultPrefix != "" {
+		return corev1.ObjectReference{}, fmt.Errorf(`name %q does not match either "[[apigroup/]version:]kind:[namespace/]name" or "[namespace/]name"`, str)
+	}
+	return corev1.ObjectReference{}, fmt.Errorf(`name %q does not match format "[[apigroup/]version:]kind:[namespace/]name"`, str)
+}
+
+func (c *Converter) ToString(ref corev1.ObjectReference) (string, error) {
+	return "", nil
+}

--- a/pkg/util/reference/reference_test.go
+++ b/pkg/util/reference/reference_test.go
@@ -1,0 +1,131 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reference
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestExpressions(t *testing.T) {
+	emptyPrefix := ""
+	tests := []struct {
+		defaultPrefix *string
+		name          string
+		error         bool
+		ref           corev1.ObjectReference
+	}{
+		{
+			name:  "lowercase:source",
+			error: true,
+		},
+		{
+			name:  "PostgreSQL/ns/name",
+			error: true,
+		},
+		{
+			defaultPrefix: &emptyPrefix,
+			name:          "source",
+			error:         true,
+		},
+		{
+			name: "source",
+			ref: corev1.ObjectReference{
+				Kind:       "Kamelet",
+				APIVersion: "camel.apache.org/v1alpha1",
+				Name:       "source",
+			},
+		},
+		{
+			name: "ns1/source",
+			ref: corev1.ObjectReference{
+				Kind:       "Kamelet",
+				APIVersion: "camel.apache.org/v1alpha1",
+				Namespace:  "ns1",
+				Name:       "source",
+			},
+		},
+		{
+			name: "ksvc:service",
+			ref: corev1.ObjectReference{
+				Kind:       "Service",
+				APIVersion: "serving.knative.dev/v1",
+				Name:       "service",
+			},
+		},
+		{
+			name: "channel:ns3/ch2",
+			ref: corev1.ObjectReference{
+				Kind:       "Channel",
+				APIVersion: "messaging.knative.dev/v1",
+				Namespace:  "ns3",
+				Name:       "ch2",
+			},
+		},
+		{
+			name: "broker:default",
+			ref: corev1.ObjectReference{
+				Kind:       "Broker",
+				APIVersion: "eventing.knative.dev/v1",
+				Name:       "default",
+			},
+		},
+		{
+			name: "PostgreSQL:ns1/db",
+			ref: corev1.ObjectReference{
+				Kind:      "PostgreSQL",
+				Namespace: "ns1",
+				Name:      "db",
+			},
+		},
+		{
+			name: "postgres.org/v1alpha1:PostgreSQL:ns1/db",
+			ref: corev1.ObjectReference{
+				APIVersion: "postgres.org/v1alpha1",
+				Kind:       "PostgreSQL",
+				Namespace:  "ns1",
+				Name:       "db",
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+
+			var converter *Converter
+			if tc.defaultPrefix != nil {
+				converter = NewConverter(*tc.defaultPrefix)
+			} else {
+				// Using kamelet: prefix by default in the tests
+				converter = NewConverter(KameletPrefix)
+			}
+
+			ref, err := converter.FromString(tc.name)
+			if tc.error {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.ref, ref)
+			}
+		})
+	}
+
+}

--- a/pkg/util/reference/reference_test.go
+++ b/pkg/util/reference/reference_test.go
@@ -32,6 +32,7 @@ func TestExpressions(t *testing.T) {
 		name          string
 		error         bool
 		ref           corev1.ObjectReference
+		stringRef     string
 	}{
 		{
 			name:  "lowercase:source",
@@ -53,6 +54,7 @@ func TestExpressions(t *testing.T) {
 				APIVersion: "camel.apache.org/v1alpha1",
 				Name:       "source",
 			},
+			stringRef: "camel.apache.org/v1alpha1:Kamelet:source",
 		},
 		{
 			name: "ns1/source",
@@ -62,6 +64,17 @@ func TestExpressions(t *testing.T) {
 				Namespace:  "ns1",
 				Name:       "source",
 			},
+			stringRef: "camel.apache.org/v1alpha1:Kamelet:ns1/source",
+		},
+		{
+			name: "v1:Secret:ns1/scr2",
+			ref: corev1.ObjectReference{
+				Kind:       "Secret",
+				APIVersion: "v1",
+				Namespace:  "ns1",
+				Name:       "scr2",
+			},
+			stringRef: "v1:Secret:ns1/scr2",
 		},
 		{
 			name: "ksvc:service",
@@ -70,6 +83,7 @@ func TestExpressions(t *testing.T) {
 				APIVersion: "serving.knative.dev/v1",
 				Name:       "service",
 			},
+			stringRef: "serving.knative.dev/v1:Service:service",
 		},
 		{
 			name: "channel:ns3/ch2",
@@ -79,6 +93,7 @@ func TestExpressions(t *testing.T) {
 				Namespace:  "ns3",
 				Name:       "ch2",
 			},
+			stringRef: "messaging.knative.dev/v1:Channel:ns3/ch2",
 		},
 		{
 			name: "broker:default",
@@ -87,6 +102,7 @@ func TestExpressions(t *testing.T) {
 				APIVersion: "eventing.knative.dev/v1",
 				Name:       "default",
 			},
+			stringRef: "eventing.knative.dev/v1:Broker:default",
 		},
 		{
 			name: "PostgreSQL:ns1/db",
@@ -95,6 +111,7 @@ func TestExpressions(t *testing.T) {
 				Namespace: "ns1",
 				Name:      "db",
 			},
+			stringRef: "PostgreSQL:ns1/db",
 		},
 		{
 			name: "postgres.org/v1alpha1:PostgreSQL:ns1/db",
@@ -104,6 +121,7 @@ func TestExpressions(t *testing.T) {
 				Namespace:  "ns1",
 				Name:       "db",
 			},
+			stringRef: "postgres.org/v1alpha1:PostgreSQL:ns1/db",
 		},
 	}
 
@@ -122,8 +140,12 @@ func TestExpressions(t *testing.T) {
 			if tc.error {
 				assert.Error(t, err)
 			} else {
+				asString, err2 := converter.ToString(ref)
+				assert.NoError(t, err2)
+
 				assert.NoError(t, err)
 				assert.Equal(t, tc.ref, ref)
+				assert.Equal(t, tc.stringRef, asString)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Description -->

Fix #2158

An attempt to normalize names according to `[[apigroup/]version:]kind:[namespace/]name` (which looks pretty good imo...)

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
