### PR TITLE
feat(operator): NodeSelector install options

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -128,6 +128,7 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *installCmdO
 
 	// Pod settings
 	cmd.Flags().StringArrayP("toleration", "", nil, "Add a Toleration to the operator Pod")
+	cmd.Flags().StringArrayP("node-selector", "", nil, "Add a NodeSelector to the operator Pod")
 
 	// save
 	cmd.Flags().Bool("save", false, "Save the install parameters into the default kamel configuration file (kamel-config.yaml)")
@@ -175,6 +176,7 @@ type installCmdOptions struct {
 	Properties              []string `mapstructure:"properties"`
 	TraitProfile            string   `mapstructure:"trait-profile"`
 	Tolerations             []string `mapstructure:"tolerations"`
+	NodeSelectors           []string `mapstructure:"node-selectors"`
 	HTTPProxySecret         string   `mapstructure:"http-proxy-secret"`
 
 	registry         v1.IntegrationPlatformRegistrySpec
@@ -272,7 +274,8 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 					Enabled: o.Monitoring,
 					Port:    o.MonitoringPort,
 				},
-				Tolerations: o.Tolerations,
+				Tolerations:   o.Tolerations,
+				NodeSelectors: o.NodeSelectors,
 			}
 			err = install.OperatorOrCollect(o.Context, c, cfg, collection, o.Force)
 			if err != nil {

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -223,7 +223,7 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 		if installViaOLM {
 			fmt.Fprintln(cobraCmd.OutOrStdout(), "OLM is available in the cluster")
 			var installed bool
-			if installed, err = olm.Install(o.Context, olmClient, o.Namespace, o.Global, o.olmOptions, collection, o.Tolerations); err != nil {
+			if installed, err = olm.Install(o.Context, olmClient, o.Namespace, o.Global, o.olmOptions, collection, o.Tolerations, o.NodeSelectors); err != nil {
 				return err
 			}
 			if !installed {

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -55,6 +55,7 @@ type OperatorConfiguration struct {
 	Health                OperatorHealthConfiguration
 	Monitoring            OperatorMonitoringConfiguration
 	Tolerations           []string
+	NodeSelectors         []string
 }
 
 // OperatorHealthConfiguration --
@@ -95,6 +96,18 @@ func OperatorOrCollect(ctx context.Context, c client.Client, cfg OperatorConfigu
 						fmt.Println("Warning: could not parse the configured tolerations!")
 					}
 					d.Spec.Template.Spec.Tolerations = tolerations
+				}
+			}
+		}
+
+		if cfg.NodeSelectors != nil {
+			if d, ok := o.(*appsv1.Deployment); ok {
+				if d.Labels["camel.apache.org/component"] == "operator" {
+					nodeSelector, err := kubernetes.GetNodeSelectors(cfg.NodeSelectors)
+					if err != nil {
+						fmt.Println("Warning: could not parse the configured node selectors!")
+					}
+					d.Spec.Template.Spec.NodeSelector = nodeSelector
 				}
 			}
 		}

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -103,7 +103,7 @@ func OperatorOrCollect(ctx context.Context, c client.Client, cfg OperatorConfigu
 		if cfg.NodeSelectors != nil {
 			if d, ok := o.(*appsv1.Deployment); ok {
 				if d.Labels["camel.apache.org/component"] == "operator" {
-					nodeSelector, err := kubernetes.GetNodeSelectors(cfg.NodeSelectors)
+					nodeSelector, err := kubernetes.NewNodeSelectors(cfg.NodeSelectors)
 					if err != nil {
 						fmt.Println("Warning: could not parse the configured node selectors!")
 					}

--- a/pkg/util/kubernetes/core_factory_test.go
+++ b/pkg/util/kubernetes/core_factory_test.go
@@ -95,3 +95,42 @@ func TestValueTolerations(t *testing.T) {
 	assert.Equal(t, v1.TaintEffectNoSchedule, toleration[3].Effect)
 	assert.Equal(t, int64(120), *toleration[3].TolerationSeconds)
 }
+
+func TestValidNodeSelectors(t *testing.T) {
+	validNodeSelectors := [][]string{
+		{"key1=value"},
+		{"kubernetes.io/hostname=worker0"},
+		{"disktype=ssd"},
+		{"key=path-to-value"},
+		{"keyNum=123"},
+	}
+	for _, vds := range validNodeSelectors {
+		_, err := GetNodeSelectors(vds)
+		assert.Nil(t, err)
+	}
+}
+
+func TestInvalidNodeSelectors(t *testing.T) {
+	validNodeSelectors := [][]string{
+		{"key1"},
+		{"kubernetes.io@hostname=worker0"},
+		{"key=path/to/value"},
+	}
+	for _, vds := range validNodeSelectors {
+		_, err := GetNodeSelectors(vds)
+		assert.NotNil(t, err)
+	}
+}
+
+func TestValueNodeSelectors(t *testing.T) {
+	nodeSelectorsArray := []string{
+		"key=value",
+		"kubernetes.io/hostname=worker0",
+	}
+	nodeSelectors, err := GetNodeSelectors(nodeSelectorsArray)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(nodeSelectors))
+
+	assert.Equal(t, "value", nodeSelectors["key"])
+	assert.Equal(t, "worker0", nodeSelectors["kubernetes.io/hostname"])
+}

--- a/pkg/util/kubernetes/core_factory_test.go
+++ b/pkg/util/kubernetes/core_factory_test.go
@@ -1,0 +1,97 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestValidTolerations(t *testing.T) {
+	validTolerations := [][]string{
+		{"key=value:NoSchedule"},
+		{"key=value:NoExecute"},
+		{"key=value:PreferNoSchedule"},
+		{"key=value:NoSchedule:120"},
+		{"key=value:NoExecute:120"},
+		{"key=value:PreferNoSchedule:120"},
+		{"existKey:NoSchedule"},
+		{"existKey:NoExecute"},
+		{"existKey:PreferNoSchedule"},
+		{"existKey:NoSchedule:120"},
+		{"existKey:NoExecute:120"},
+		{"existKey:PreferNoSchedule:120"},
+	}
+	for _, vd := range validTolerations {
+		_, err := GetTolerations(vd)
+		assert.Nil(t, err)
+	}
+}
+
+func TestInvalidTolerations(t *testing.T) {
+	validTolerations := [][]string{
+		{"key-NoSchedule"},
+		{"key=value:Something"},
+		{"key@wrong=value:PreferNoSchedule"},
+		{"key=value%wrong:NoSchedule:120"},
+		{"existKey"},
+		{"existKey:"},
+		{"existKey:Something"},
+		{"existKey:PreferNoSchedule:something"},
+	}
+	for _, vd := range validTolerations {
+		_, err := GetTolerations(vd)
+		assert.NotNil(t, err)
+	}
+}
+
+func TestValueTolerations(t *testing.T) {
+	tolerations := []string{
+		"key=value:NoSchedule",
+		"key=value:NoExecute:120",
+		"existKey:PreferNoSchedule",
+		"existKey:NoSchedule:120",
+	}
+	toleration, err := GetTolerations(tolerations)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(toleration))
+
+	assert.Equal(t, "key", toleration[0].Key)
+	assert.Equal(t, v1.TolerationOpEqual, toleration[0].Operator)
+	assert.Equal(t, "value", toleration[0].Value)
+	assert.Equal(t, v1.TaintEffectNoSchedule, toleration[0].Effect)
+
+	assert.Equal(t, "key", toleration[1].Key)
+	assert.Equal(t, v1.TolerationOpEqual, toleration[1].Operator)
+	assert.Equal(t, "value", toleration[1].Value)
+	assert.Equal(t, v1.TaintEffectNoExecute, toleration[1].Effect)
+	assert.Equal(t, int64(120), *toleration[1].TolerationSeconds)
+
+	assert.Equal(t, "existKey", toleration[2].Key)
+	assert.Equal(t, v1.TolerationOpExists, toleration[2].Operator)
+	assert.Equal(t, "", toleration[2].Value)
+	assert.Equal(t, v1.TaintEffectPreferNoSchedule, toleration[2].Effect)
+
+	assert.Equal(t, "existKey", toleration[3].Key)
+	assert.Equal(t, v1.TolerationOpExists, toleration[3].Operator)
+	assert.Equal(t, "", toleration[3].Value)
+	assert.Equal(t, v1.TaintEffectNoSchedule, toleration[3].Effect)
+	assert.Equal(t, int64(120), *toleration[3].TolerationSeconds)
+}

--- a/pkg/util/kubernetes/factory.go
+++ b/pkg/util/kubernetes/factory.go
@@ -28,7 +28,7 @@ import (
 var validTaintRegexp = regexp.MustCompile(`^([\w\/_\-\.]+)(=)?([\w_\-\.]+)?:(NoSchedule|NoExecute|PreferNoSchedule):?(\d*)?$`)
 var validNodeSelectorRegexp = regexp.MustCompile(`^([\w\/_\-\.]+)=([\w_\-\.]+)$`)
 
-// GetTolerations build an array of Tolerations from an array of string
+// NewTolerations build an array of Tolerations from an array of string
 func NewTolerations(taints []string) ([]corev1.Toleration, error) {
 	tolerations := make([]corev1.Toleration, 0)
 	for _, t := range taints {
@@ -62,8 +62,8 @@ func NewTolerations(taints []string) ([]corev1.Toleration, error) {
 	return tolerations, nil
 }
 
-// GetNodeSelectors build a map of NodeSelectors from an array of string
-func GetNodeSelectors(nsArray []string) (map[string]string, error) {
+// NewNodeSelectors build a map of NodeSelectors from an array of string
+func NewNodeSelectors(nsArray []string) (map[string]string, error) {
 	nodeSelectors := make(map[string]string)
 	for _, ns := range nsArray {
 		if !validNodeSelectorRegexp.MatchString(ns) {

--- a/pkg/util/kubernetes/factory.go
+++ b/pkg/util/kubernetes/factory.go
@@ -26,6 +26,7 @@ import (
 )
 
 var validTaintRegexp = regexp.MustCompile(`^([\w\/_\-\.]+)(=)?([\w_\-\.]+)?:(NoSchedule|NoExecute|PreferNoSchedule):?(\d*)?$`)
+var validNodeSelectorRegexp = regexp.MustCompile(`^([\w\/_\-\.]+)=([\w_\-\.]+)$`)
 
 // GetTolerations build an array of Tolerations from an array of string
 func NewTolerations(taints []string) ([]corev1.Toleration, error) {
@@ -59,4 +60,18 @@ func NewTolerations(taints []string) ([]corev1.Toleration, error) {
 	}
 
 	return tolerations, nil
+}
+
+// GetNodeSelectors build a map of NodeSelectors from an array of string
+func GetNodeSelectors(nsArray []string) (map[string]string, error) {
+	nodeSelectors := make(map[string]string)
+	for _, ns := range nsArray {
+		if !validNodeSelectorRegexp.MatchString(ns) {
+			return nil, fmt.Errorf("could not match node selector %v", ns)
+		}
+		// Parse the regexp groups
+		groups := validNodeSelectorRegexp.FindStringSubmatch(ns)
+		nodeSelectors[groups[1]] = groups[2]
+	}
+	return nodeSelectors, nil
 }

--- a/pkg/util/kubernetes/factory_test.go
+++ b/pkg/util/kubernetes/factory_test.go
@@ -40,7 +40,7 @@ func TestValidTolerations(t *testing.T) {
 		{"existKey:PreferNoSchedule:120"},
 	}
 	for _, vd := range validTolerations {
-		_, err := GetTolerations(vd)
+		_, err := NewTolerations(vd)
 		assert.Nil(t, err)
 	}
 }
@@ -57,7 +57,7 @@ func TestInvalidTolerations(t *testing.T) {
 		{"existKey:PreferNoSchedule:something"},
 	}
 	for _, vd := range validTolerations {
-		_, err := GetTolerations(vd)
+		_, err := NewTolerations(vd)
 		assert.NotNil(t, err)
 	}
 }
@@ -69,7 +69,7 @@ func TestValueTolerations(t *testing.T) {
 		"existKey:PreferNoSchedule",
 		"existKey:NoSchedule:120",
 	}
-	toleration, err := GetTolerations(tolerations)
+	toleration, err := NewTolerations(tolerations)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(toleration))
 
@@ -105,7 +105,7 @@ func TestValidNodeSelectors(t *testing.T) {
 		{"keyNum=123"},
 	}
 	for _, vds := range validNodeSelectors {
-		_, err := GetNodeSelectors(vds)
+		_, err := NewNodeSelectors(vds)
 		assert.Nil(t, err)
 	}
 }
@@ -117,7 +117,7 @@ func TestInvalidNodeSelectors(t *testing.T) {
 		{"key=path/to/value"},
 	}
 	for _, vds := range validNodeSelectors {
-		_, err := GetNodeSelectors(vds)
+		_, err := NewNodeSelectors(vds)
 		assert.NotNil(t, err)
 	}
 }
@@ -127,7 +127,7 @@ func TestValueNodeSelectors(t *testing.T) {
 		"key=value",
 		"kubernetes.io/hostname=worker0",
 	}
-	nodeSelectors, err := GetNodeSelectors(nodeSelectorsArray)
+	nodeSelectors, err := NewNodeSelectors(nodeSelectorsArray)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(nodeSelectors))
 

--- a/pkg/util/olm/operator.go
+++ b/pkg/util/olm/operator.go
@@ -222,7 +222,7 @@ func maybeSetTolerations(sub *operatorsv1alpha1.Subscription, tolArray []string)
 
 func maybeSetNodeSelectors(sub *operatorsv1alpha1.Subscription, nsArray []string) error {
 	if nsArray != nil {
-		nodeSelectors, err := kubernetes.GetNodeSelectors(nsArray)
+		nodeSelectors, err := kubernetes.NewNodeSelectors(nsArray)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Description -->

With this PR we give the user the possibility to chose a `Node Selector` when installing the operator, both for regular and `olm` modes.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(operator): NodeSelector install options
```
