### PR TITLE
fix: Add bindings.knative.dev/include label to SinkBinding sources

### DIFF
--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -31,6 +31,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	serving "knative.dev/serving/pkg/apis/serving/v1"
 
@@ -524,7 +526,7 @@ func (t *knativeTrait) configureSinkBinding(e *Environment, env *knativeapi.Came
 					return nil
 				}
 
-				controller := e.Resources.GetController(func(object runtime.Object) bool {
+				controller := e.Resources.GetController(func(object ctrl.Object) bool {
 					return true
 				})
 				if controller != nil && !reflect.ValueOf(controller).IsNil() {
@@ -542,7 +544,20 @@ func (t *knativeTrait) configureSinkBinding(e *Environment, env *knativeapi.Came
 						Name:       ref.Name,
 						APIVersion: ref.APIVersion,
 					}
+
+					// Add the SinkBinding in first position, to make sure it is created
+					// before the reference source, so that the SinkBinding webhook has
+					// all the information to perform injection.
 					e.Resources.AddFirst(knativeutil.CreateSinkBinding(source, target))
+
+					// Make sure the Eventing webhook will select the source resource,
+					// in order to inject the sink information.
+					// This is necessary for Knative environments, that are configured
+					// with SINK_BINDING_SELECTION_MODE=inclusion.
+					// See:
+					// - https://knative.dev/v0.20-docs/eventing/sources/sinkbinding/
+					// - https://github.com/knative/operator/blob/c60e62bb86ff318c44d1520927d2182659cfdeb5/docs/configuration.md#specsinkbindingselectionmode
+					controller.GetLabels()["bindings.knative.dev/include"] = "true"
 				}
 				return nil
 			})

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -513,7 +513,7 @@ func (t *knativeTrait) configureSinkBinding(e *Environment, env *knativeapi.Came
 		e.ApplicationProperties["camel.k.customizer.sinkbinding.kind"] = ref.Kind
 		e.ApplicationProperties["camel.k.customizer.sinkbinding.api-version"] = ref.APIVersion
 
-		if e.IntegrationInPhase(v1.IntegrationPhaseDeploying) {
+		if e.IntegrationInPhase(v1.IntegrationPhaseDeploying, v1.IntegrationPhaseRunning) {
 			e.PostStepProcessors = append(e.PostStepProcessors, func(e *Environment) error {
 				sinkBindingInjected := false
 				e.Resources.Visit(func(object runtime.Object) {

--- a/pkg/util/kubernetes/collection.go
+++ b/pkg/util/kubernetes/collection.go
@@ -382,7 +382,7 @@ func (c *Collection) VisitContainer(visitor func(container *corev1.Container)) {
 }
 
 // GetController returns the controller associated with the integration (e.g. Deployment, Knative Service or CronJob)
-func (c *Collection) GetController(filter func(object runtime.Object) bool) runtime.Object {
+func (c *Collection) GetController(filter func(object ctrl.Object) bool) ctrl.Object {
 	d := c.GetDeployment(func(deployment *appsv1.Deployment) bool {
 		return filter(deployment)
 	})
@@ -476,7 +476,6 @@ func (c *Collection) Remove(selector func(runtime.Object) bool) runtime.Object {
 	return nil
 }
 
-// VisitServiceMonitor ---
 func (c *Collection) VisitServiceMonitor(visitor func(*monitoringv1.ServiceMonitor)) {
 	c.Visit(func(res runtime.Object) {
 		if conv, ok := res.(*monitoringv1.ServiceMonitor); ok {
@@ -485,7 +484,6 @@ func (c *Collection) VisitServiceMonitor(visitor func(*monitoringv1.ServiceMonit
 	})
 }
 
-// GetServiceMonitor ---
 func (c *Collection) GetServiceMonitor(filter func(*monitoringv1.ServiceMonitor) bool) *monitoringv1.ServiceMonitor {
 	var retValue *monitoringv1.ServiceMonitor
 	c.VisitServiceMonitor(func(serviceMonitor *monitoringv1.ServiceMonitor) {


### PR DESCRIPTION
This PR makes sure the Eventing webhook will select the source resources, in order to inject the sink information.

This is necessary for Knative environments, that are configured with `SINK_BINDING_SELECTION_MODE=inclusion`. See:
- https://knative.dev/v0.20-docs/eventing/sources/sinkbinding/
- https://github.com/knative/operator/blob/c60e62bb86ff318c44d1520927d2182659cfdeb5/docs/configuration.md#specsinkbindingselectionmode

Fixes #2184.

**Release Note**
```release-note
fix: Add bindings.knative.dev/include label to SinkBinding sources
```
