### PR TITLE
feat(cmd): install resource requirements flag

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -129,7 +129,7 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *installCmdO
 	// Pod settings
 	cmd.Flags().StringArray("toleration", nil, "Add a Toleration to the operator Pod")
 	cmd.Flags().StringArray("node-selector", nil, "Add a NodeSelector to the operator Pod")
-	cmd.Flags().StringArray("resources-requirements", nil, "Define the resources requests and limits assigned to the operator Pod as <requestType.requestResource=value> (ie, limits.memory=256Mi)")
+	cmd.Flags().StringArray("operator-resources", nil, "Define the resources requests and limits assigned to the operator Pod as <requestType.requestResource=value> (ie, limits.memory=256Mi)")
 
 	// save
 	cmd.Flags().Bool("save", false, "Save the install parameters into the default kamel configuration file (kamel-config.yaml)")
@@ -179,7 +179,7 @@ type installCmdOptions struct {
 	Tolerations             []string `mapstructure:"tolerations"`
 	NodeSelectors           []string `mapstructure:"node-selectors"`
 	HTTPProxySecret         string   `mapstructure:"http-proxy-secret"`
-	ResourcesRequirements   []string `mapstructure:"resources-requirements"`
+	ResourcesRequirements   []string `mapstructure:"operator-resources"`
 
 	registry         v1.IntegrationPlatformRegistrySpec
 	registryAuth     registry.Auth

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -225,7 +225,8 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 		if installViaOLM {
 			fmt.Fprintln(cobraCmd.OutOrStdout(), "OLM is available in the cluster")
 			var installed bool
-			if installed, err = olm.Install(o.Context, olmClient, o.Namespace, o.Global, o.olmOptions, collection, o.Tolerations, o.NodeSelectors); err != nil {
+			if installed, err = olm.Install(o.Context, olmClient, o.Namespace, o.Global, o.olmOptions, collection,
+				o.Tolerations, o.NodeSelectors, o.ResourcesRequirements); err != nil {
 				return err
 			}
 			if !installed {

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -127,8 +127,9 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *installCmdO
 	cmd.Flags().Int("monitoring-port", 8080, "The port of the metrics endpoint")
 
 	// Pod settings
-	cmd.Flags().StringArrayP("toleration", "", nil, "Add a Toleration to the operator Pod")
-	cmd.Flags().StringArrayP("node-selector", "", nil, "Add a NodeSelector to the operator Pod")
+	cmd.Flags().StringArray("toleration", nil, "Add a Toleration to the operator Pod")
+	cmd.Flags().StringArray("node-selector", nil, "Add a NodeSelector to the operator Pod")
+	cmd.Flags().StringArray("resources-requirements", nil, "Define the resources requests and limits assigned to the operator Pod as <requestType.requestResource=value> (ie, limits.memory=256Mi)")
 
 	// save
 	cmd.Flags().Bool("save", false, "Save the install parameters into the default kamel configuration file (kamel-config.yaml)")
@@ -178,6 +179,7 @@ type installCmdOptions struct {
 	Tolerations             []string `mapstructure:"tolerations"`
 	NodeSelectors           []string `mapstructure:"node-selectors"`
 	HTTPProxySecret         string   `mapstructure:"http-proxy-secret"`
+	ResourcesRequirements   []string `mapstructure:"resources-requirements"`
 
 	registry         v1.IntegrationPlatformRegistrySpec
 	registryAuth     registry.Auth
@@ -274,8 +276,9 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 					Enabled: o.Monitoring,
 					Port:    o.MonitoringPort,
 				},
-				Tolerations:   o.Tolerations,
-				NodeSelectors: o.NodeSelectors,
+				Tolerations:           o.Tolerations,
+				NodeSelectors:         o.NodeSelectors,
+				ResourcesRequirements: o.ResourcesRequirements,
 			}
 			err = install.OperatorOrCollect(o.Context, c, cfg, collection, o.Force)
 			if err != nil {

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -56,6 +56,7 @@ type OperatorConfiguration struct {
 	Monitoring            OperatorMonitoringConfiguration
 	Tolerations           []string
 	NodeSelectors         []string
+	ResourcesRequirements []string
 }
 
 // OperatorHealthConfiguration --
@@ -96,6 +97,20 @@ func OperatorOrCollect(ctx context.Context, c client.Client, cfg OperatorConfigu
 						fmt.Println("Warning: could not parse the configured tolerations!")
 					}
 					d.Spec.Template.Spec.Tolerations = tolerations
+				}
+			}
+		}
+
+		if cfg.ResourcesRequirements != nil {
+			if d, ok := o.(*appsv1.Deployment); ok {
+				if d.Labels["camel.apache.org/component"] == "operator" {
+					resourceReq, err := kubernetes.GetResourceRequirements(cfg.ResourcesRequirements)
+					if err != nil {
+						fmt.Println("Warning: could not parse the configured resources requests!")
+					}
+					for i := 0; i < len(d.Spec.Template.Spec.Containers); i++ {
+						d.Spec.Template.Spec.Containers[i].Resources = resourceReq
+					}
 				}
 			}
 		}

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -104,7 +104,7 @@ func OperatorOrCollect(ctx context.Context, c client.Client, cfg OperatorConfigu
 		if cfg.ResourcesRequirements != nil {
 			if d, ok := o.(*appsv1.Deployment); ok {
 				if d.Labels["camel.apache.org/component"] == "operator" {
-					resourceReq, err := kubernetes.GetResourceRequirements(cfg.ResourcesRequirements)
+					resourceReq, err := kubernetes.NewResourceRequirements(cfg.ResourcesRequirements)
 					if err != nil {
 						fmt.Println("Warning: could not parse the configured resources requests!")
 					}

--- a/pkg/util/kubernetes/factory.go
+++ b/pkg/util/kubernetes/factory.go
@@ -78,9 +78,9 @@ func NewNodeSelectors(nsArray []string) (map[string]string, error) {
 	return nodeSelectors, nil
 }
 
-// GetResourceRequirements will build a CPU and memory requirements from an array of requests
+// NewResourceRequirements will build a CPU and memory requirements from an array of requests
 // matching <requestType.requestResource=value> (ie, limits.memory=256Mi)
-func GetResourceRequirements(reqs []string) (corev1.ResourceRequirements, error) {
+func NewResourceRequirements(reqs []string) (corev1.ResourceRequirements, error) {
 	resReq := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{},
 		Limits:   corev1.ResourceList{},

--- a/pkg/util/kubernetes/factory_test.go
+++ b/pkg/util/kubernetes/factory_test.go
@@ -139,7 +139,7 @@ func TestValueNodeSelectors(t *testing.T) {
 
 func TestAllResourceRequirements(t *testing.T) {
 	resReq := "limits.memory=256Mi,requests.memory=128Mi,limits.cpu=1000m,requests.cpu=500m"
-	resourceRequirements, err := GetResourceRequirements(strings.Split(resReq, ","))
+	resourceRequirements, err := NewResourceRequirements(strings.Split(resReq, ","))
 	assert.Nil(t, err)
 
 	assert.Equal(t, resource.MustParse("256Mi"), *resourceRequirements.Limits.Memory())
@@ -150,7 +150,7 @@ func TestAllResourceRequirements(t *testing.T) {
 
 func TestSomeResourceRequirements(t *testing.T) {
 	resReq := "limits.memory=128Mi,requests.cpu=500m"
-	resourceRequirements, err := GetResourceRequirements(strings.Split(resReq, ","))
+	resourceRequirements, err := NewResourceRequirements(strings.Split(resReq, ","))
 	assert.Nil(t, err)
 
 	assert.Equal(t, resource.MustParse("128Mi"), *resourceRequirements.Limits.Memory())
@@ -161,12 +161,12 @@ func TestSomeResourceRequirements(t *testing.T) {
 
 func TestErrorResourceRequirements(t *testing.T) {
 	resReq := "limits.memory=expectSomeError!"
-	_, err := GetResourceRequirements(strings.Split(resReq, ","))
+	_, err := NewResourceRequirements(strings.Split(resReq, ","))
 	assert.NotNil(t, err)
 }
 
 func TestMissingResourceRequirements(t *testing.T) {
 	resReq := ""
-	_, err := GetResourceRequirements(strings.Split(resReq, ","))
+	_, err := NewResourceRequirements(strings.Split(resReq, ","))
 	assert.NotNil(t, err)
 }

--- a/pkg/util/olm/operator.go
+++ b/pkg/util/olm/operator.go
@@ -238,12 +238,11 @@ func maybeSetNodeSelectors(sub *operatorsv1alpha1.Subscription, nsArray []string
 
 func maybeSetResourcesRequirements(sub *operatorsv1alpha1.Subscription, reqArray []string) error {
 	if reqArray != nil {
-		resourcesReq, err := kubernetes.GetResourceRequirements(reqArray)
+		resourcesReq, err := kubernetes.NewResourceRequirements(reqArray)
 		if err != nil {
 			return err
 		}
 		sub.Spec.Config.Resources = resourcesReq
-		fmt.Println("Setting resources to", sub.Spec.Config.Resources)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Description -->

Adding a flag to allow setting operator Pod resources as specified in https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

With this PR we can install the operator (both regular and OLM) specifing resources such as memory and CPU, ie:

```
kamel install --operator-resources limits.memory=256Mi --operator-resources limits.cpu=500m
```

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cmd): install operator resource requirements option
```
