### PR TITLE
fix(dsl): The fromF DSL should be parsed during HTTP endpoint discovery

### DIFF
--- a/pkg/util/source/inspector.go
+++ b/pkg/util/source/inspector.go
@@ -34,7 +34,9 @@ const (
 
 var (
 	singleQuotedFrom        = regexp.MustCompile(`from\s*\(\s*'([a-zA-Z0-9-]+:[^']+)'`)
+	singleQuotedFromF       = regexp.MustCompile(`fromF\s*\(\s*'([a-zA-Z0-9-]+:[^']+)'`)
 	doubleQuotedFrom        = regexp.MustCompile(`from\s*\(\s*"([a-zA-Z0-9-]+:[^"]+)"`)
+	doubleQuotedFromF       = regexp.MustCompile(`fromF\s*\(\s*"([a-zA-Z0-9-]+:[^"]+)"`)
 	singleQuotedTo          = regexp.MustCompile(`\.to\s*\(\s*'([a-zA-Z0-9-]+:[^']+)'`)
 	singleQuotedToD         = regexp.MustCompile(`\.toD\s*\(\s*'([a-zA-Z0-9-]+:[^']+)'`)
 	singleQuotedToF         = regexp.MustCompile(`\.toF\s*\(\s*'([a-zA-Z0-9-]+:[^']+)'`)

--- a/pkg/util/source/inspector_groovy.go
+++ b/pkg/util/source/inspector_groovy.go
@@ -22,17 +22,17 @@ import (
 	"github.com/apache/camel-k/pkg/util"
 )
 
-// GroovyInspector --
 type GroovyInspector struct {
 	baseInspector
 }
 
-// Extract --
 func (i GroovyInspector) Extract(source v1.SourceSpec, meta *Metadata) error {
 	from := util.FindAllDistinctStringSubmatch(
 		source.Content,
 		singleQuotedFrom,
 		doubleQuotedFrom,
+		singleQuotedFromF,
+		doubleQuotedFromF,
 	)
 	to := util.FindAllDistinctStringSubmatch(
 		source.Content,

--- a/pkg/util/source/inspector_java_script.go
+++ b/pkg/util/source/inspector_java_script.go
@@ -22,17 +22,17 @@ import (
 	"github.com/apache/camel-k/pkg/util"
 )
 
-// JavaScriptInspector --
 type JavaScriptInspector struct {
 	baseInspector
 }
 
-// Extract --
 func (i JavaScriptInspector) Extract(source v1.SourceSpec, meta *Metadata) error {
 	from := util.FindAllDistinctStringSubmatch(
 		source.Content,
 		singleQuotedFrom,
 		doubleQuotedFrom,
+		singleQuotedFromF,
+		doubleQuotedFromF,
 	)
 	to := util.FindAllDistinctStringSubmatch(
 		source.Content,

--- a/pkg/util/source/inspector_java_source.go
+++ b/pkg/util/source/inspector_java_source.go
@@ -22,16 +22,15 @@ import (
 	"github.com/apache/camel-k/pkg/util"
 )
 
-// JavaSourceInspector --
 type JavaSourceInspector struct {
 	baseInspector
 }
 
-// Extract --
 func (i JavaSourceInspector) Extract(source v1.SourceSpec, meta *Metadata) error {
 	from := util.FindAllDistinctStringSubmatch(
 		source.Content,
 		doubleQuotedFrom,
+		doubleQuotedFromF,
 	)
 	to := util.FindAllDistinctStringSubmatch(
 		source.Content,

--- a/pkg/util/source/inspector_kotlin.go
+++ b/pkg/util/source/inspector_kotlin.go
@@ -22,16 +22,15 @@ import (
 	"github.com/apache/camel-k/pkg/util"
 )
 
-// KotlinInspector --
 type KotlinInspector struct {
 	baseInspector
 }
 
-// Extract --
 func (i KotlinInspector) Extract(source v1.SourceSpec, meta *Metadata) error {
 	from := util.FindAllDistinctStringSubmatch(
 		source.Content,
 		doubleQuotedFrom,
+		doubleQuotedFromF,
 	)
 	to := util.FindAllDistinctStringSubmatch(
 		source.Content,


### PR DESCRIPTION
Fixes #2210.

**Release Note**
```release-note
fix(dsl): The fromF DSL should be parsed during HTTP endpoint discovery
```
