### PR TITLE
Missing camel-k-kamelet-reify version while building kamelet binding

### DIFF
--- a/build/maven/pom-runtime.xml
+++ b/build/maven/pom-runtime.xml
@@ -123,6 +123,16 @@
             <artifactId>camel-k-cron-deployment</artifactId>
             <version>${runtime.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-kamelet-reify</artifactId>
+            <version>${runtime.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.k</groupId>
+            <artifactId>camel-k-kamelet-reify-deployment</artifactId>
+            <version>${runtime.version}</version>
+        </dependency>
 
         <!-- loaders -->
         <dependency>


### PR DESCRIPTION
Fix #2214 

**Release Note**
```release-note
NONE
```
