### PR TITLE
fix(cli): Use apiextensions.k8s.io/v1 to uninstall CRDs

### DIFF
--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -269,7 +269,7 @@ func (o *uninstallCmdOptions) uninstallNamespaceResources(ctx context.Context, c
 }
 
 func (o *uninstallCmdOptions) uninstallCrd(ctx context.Context, c kubernetes.Interface) error {
-	restClient, err := customclient.GetClientFor(c, "apiextensions.k8s.io", "v1beta1")
+	restClient, err := customclient.GetClientFor(c, "apiextensions.k8s.io", "v1")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #2168.

**Release Note**
```release-note
fix(cli): Use apiextensions.k8s.io/v1 to uninstall CRDs
```
