### PR TITLE
issue2230- fix for run-from-github page

### DIFF
--- a/docs/modules/ROOT/pages/running/run-from-github.adoc
+++ b/docs/modules/ROOT/pages/running/run-from-github.adoc
@@ -16,14 +16,14 @@ As example, running the following command
 
 [source]
 ----
-kamel run github:apache/camel-k/examples/Sample.java
+kamel run github:apache/camel-k/examples/languages/Sample.java
 ----
 
 is equivalent to:
 
 [source]
 ----
-kamel run https://raw.githubusercontent.com/apache/camel-k/master/examples/Sample.java
+kamel run https://raw.githubusercontent.com/apache/camel-k/master/examples/languages/Sample.java
 ----
 
 but does not require to type the full GitHub RAW URL.


### PR DESCRIPTION
Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>

<!-- Description -->

Discovered a problem in the run-from-github page of docs with the github path. Documented in https://github.com/apache/camel-k/issues/2230


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
