### PR TITLE
refactor(example): error handler using a real Kafka topic

### DIFF
--- a/examples/kafka/sasl_ssl/README.md
+++ b/examples/kafka/sasl_ssl/README.md
@@ -2,13 +2,40 @@
 
 This example shows how Camel K can be used to connect to a generic Kafka broker using SASL SSL authentication mechanism. Edit the `application` properties file with the proper values to be able to authenticate a Kafka Broker and use any Topic.
 
+## Prerequisite
+
+You have a Kafka broker available on the cluster, or anywhere else accessible from the cluster. You will need to edit the `application.properties` file setting a "kafka broker", a "SASL username" and a "SASL password". 
+
+## Secret Configuration
+
 For convenience create a secret to contain the sensitive properties in the `application.properties` file:
 
 ```
 kubectl create secret generic kafka-props --from-file application.properties
 ```
 
-Finally run this sample using the command:
+## Run a producer
+
+At this stage, run a producer integration to fill the topic with a message, every 10 seconds:
+
+```
+kamel run --secret kafka-props SaslSSLKafkaProducer.java --dev
+```
+
+The producer will create a new message every 10 seconds, push into the topic and log some information.
+
+```
+[2] 2021-05-06 08:48:11,854 INFO  [FromTimer2Kafka] (Camel (camel-1) thread #1 - KafkaProducer[test]) Message correctly sent to the topic!
+[2] 2021-05-06 08:48:11,854 INFO  [FromTimer2Kafka] (Camel (camel-1) thread #3 - KafkaProducer[test]) Message correctly sent to the topic!
+[2] 2021-05-06 08:48:11,973 INFO  [FromTimer2Kafka] (Camel (camel-1) thread #5 - KafkaProducer[test]) Message correctly sent to the topic!
+[2] 2021-05-06 08:48:12,970 INFO  [FromTimer2Kafka] (Camel (camel-1) thread #7 - KafkaProducer[test]) Message correctly sent to the topic!
+[2] 2021-05-06 08:48:13,970 INFO  [FromTimer2Kafka] (Camel (camel-1) thread #9 - KafkaProducer[test]) Message correctly sent to the topic!
+```
+
+
+## Run a consumer
+
+Now, open another shell and run the consumer integration using the command:
 
 ```
 kamel run --secret kafka-props SaslSSLKafkaConsumer.java --dev
@@ -17,7 +44,8 @@ kamel run --secret kafka-props SaslSSLKafkaConsumer.java --dev
 A consumer will start logging the events found in the Topic:
 
 ```
-[1] 2021-04-29 08:57:16,894 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #1096
-[1] 2021-04-29 08:57:18,995 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #1097
-[1] 2021-04-29 08:57:20,879 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #1098
+[1] 2021-05-06 08:51:08,991 INFO  [FromKafka2Log] (Camel (camel-1) thread #0 - KafkaConsumer[test]) Message #8
+[1] 2021-05-06 08:51:10,065 INFO  [FromKafka2Log] (Camel (camel-1) thread #0 - KafkaConsumer[test]) Message #9
+[1] 2021-05-06 08:51:10,991 INFO  [FromKafka2Log] (Camel (camel-1) thread #0 - KafkaConsumer[test]) Message #10
+[1] 2021-05-06 08:51:11,991 INFO  [FromKafka2Log] (Camel (camel-1) thread #0 - KafkaConsumer[test]) Message #11
 ```

--- a/examples/kafka/sasl_ssl/README.md
+++ b/examples/kafka/sasl_ssl/README.md
@@ -1,0 +1,23 @@
+# Kafka Camel K SASL SSL example
+
+This example shows how Camel K can be used to connect to a generic Kafka broker using SASL SSL authentication mechanism. Edit the `application` properties file with the proper values to be able to authenticate a Kafka Broker and use any Topic.
+
+For convenience create a secret to contain the sensitive properties in the `application.properties` file:
+
+```
+kubectl create secret generic kafka-props --from-file application.properties
+```
+
+Finally run this sample using the command:
+
+```
+kamel run --secret kafka-props SaslSSLKafkaConsumer.java --dev
+```
+
+A consumer will start logging the events found in the Topic:
+
+```
+[1] 2021-04-29 08:57:16,894 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #1096
+[1] 2021-04-29 08:57:18,995 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #1097
+[1] 2021-04-29 08:57:20,879 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #1098
+```

--- a/examples/kafka/sasl_ssl/SaslSSLKafkaConsumer.java
+++ b/examples/kafka/sasl_ssl/SaslSSLKafkaConsumer.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// kubectl create secret generic kafka-props --from-file application.properties
+// kamel run --secret kafka-props SaslSSLKafkaConsumer.java --dev
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class SaslSSLKafkaConsumer extends RouteBuilder {
+  @Override
+  public void configure() throws Exception {
+	log.info("About to start route: Kafka Server -> Log ");
+	from("kafka:{{consumer.topic}}")
+             .routeId("FromKafka")
+             .log("${body}");
+  }
+}

--- a/examples/kafka/sasl_ssl/SaslSSLKafkaProducer.java
+++ b/examples/kafka/sasl_ssl/SaslSSLKafkaProducer.java
@@ -15,16 +15,20 @@
  * limitations under the License.
  */
 
-// kamel run --secret kafka-props SaslSSLKafkaConsumer.java --dev
+// kubectl create secret generic kafka-props --from-file application.properties
+// kamel run --secret kafka-props SaslSSLKafkaProducer.java --dev
 
 import org.apache.camel.builder.RouteBuilder;
 
-public class SaslSSLKafkaConsumer extends RouteBuilder {
+public class SaslSSLKafkaProducer extends RouteBuilder {
   @Override
   public void configure() throws Exception {
-	log.info("About to start route: Kafka -> Log ");
-	from("kafka:{{consumer.topic}}")
-    .routeId("FromKafka2Log")
-    .log("${body}");
+  log.info("About to start route: Timer -> Kafka ");
+  from("timer:foo")
+    .routeId("FromTimer2Kafka")
+    .setBody()
+      .simple("Message #${exchangeProperty.CamelTimerCounter}")
+	  .to("kafka:{{producer.topic}}")
+    .log("Message correctly sent to the topic!");
   }
 }

--- a/examples/kafka/sasl_ssl/application.properties
+++ b/examples/kafka/sasl_ssl/application.properties
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Kafka config
+camel.component.kafka.brokers = *********************.kafka.my-cloud.service.com:443
+camel.component.kafka.security-protocol = SASL_SSL
+
+camel.component.kafka.sasl-mechanism = PLAIN
+camel.component.kafka.sasl-jaas-config=org.apache.kafka.common.security.plain.PlainLoginModule required username=*** password=***;
+
+consumer.topic = my-first-test

--- a/examples/kafka/sasl_ssl/application.properties
+++ b/examples/kafka/sasl_ssl/application.properties
@@ -16,10 +16,11 @@
 # under the License.
 
 # Kafka config
-camel.component.kafka.brokers = *********************.kafka.my-cloud.service.com:443
+camel.component.kafka.brokers = ********.kafka.mycloud.com:443
 camel.component.kafka.security-protocol = SASL_SSL
 
 camel.component.kafka.sasl-mechanism = PLAIN
 camel.component.kafka.sasl-jaas-config=org.apache.kafka.common.security.plain.PlainLoginModule required username=*** password=***;
 
-consumer.topic = my-first-test
+consumer.topic = test
+producer.topic = test

--- a/examples/kamelets/error-handler/error-handler.kamelet.yaml
+++ b/examples/kamelets/error-handler/error-handler.kamelet.yaml
@@ -21,20 +21,53 @@ metadata:
   name: error-handler
 spec:
   definition:
-    title: "Error Log Sink"
-    description: "Error logger channel"
+    title: "DLC and Log"
+    description: "Push an event to a kafka topic and log an error message"
     required:
-      - message
+      - kafka-brokers
+      - kafka-topic
+      - kafka-service-account-id
+      - kafka-service-account-secret
+      - log-message
     properties:
-      message:
+      kafka-brokers:
+        title: Kafka Brokers
+        description: the bootstrap server
+        type: string
+        example: "xyz-ins--rplssqfz-yyyyyyy-crojg.bf2.kafka.my-clud-service.com:443"    
+      kafka-topic:
+        title: Kafka Topic
+        description: the DLC topic
+        type: string
+        example: "my-dlc"    
+      kafka-service-account-id:
+        title: Service Account ID
+        description: the SA to use
+        type: string
+        example: "srvc-acct-xxxxxx-519b-453f-9f68-yyyyyyyyy"    
+      kafka-service-account-secret:
+        title: Service Account Secret
+        description: the SA secrete to use
+        type: string
+        example: "xxxxxxxxx-46c7-4c6c-a753-yyyyyyyyyyyyyyy"                
+      log-message:
         title: Message
-        description: The message to log
+        description: A message warning to log
         type: string
         example: "error while checking the source"    
   flow:
     from:
       uri: kamelet:source
       steps:
+      # First step: send to the DLC for future processing
+      - to:
+          uri: kafka:{{kafka-topic}}
+          parameters:
+            brokers: "{{kafka-brokers}}"
+            security-protocol: SASL_SSL
+            sasl-mechanism: PLAIN
+            sasl-jaas-config: "org.apache.kafka.common.security.plain.PlainLoginModule required username={{kafka-service-account-id}} password={{kafka-service-account-secret}};"
+      # Log an error message to notify about the failure
       - set-body:
-          constant: "{{message}}"
+          constant: "{{log-message}} - worry not, the event is stored in the DLC"
       - to: "log:error-sink"  

--- a/examples/kamelets/error-handler/kamelet-binding-error-handler.yaml
+++ b/examples/kamelets/error-handler/kamelet-binding-error-handler.yaml
@@ -30,16 +30,7 @@ spec:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1
       name: log-sink
-  errorHandler:   
-#    log:
-#      parameters:
-#        maximumRedeliveries: 3
-#        redeliveryDelay: 2000      
-#    ref: "something"
-#    bean:
-#      type: "org.apache.camel.builder.DeadLetterChannelBuilder"
-#      properties:
-#        deadLetterUri: log:error
+  errorHandler:
     dead-letter-channel:
       endpoint:
         ref:
@@ -47,8 +38,12 @@ spec:
           apiVersion: camel.apache.org/v1alpha1
           name: error-handler
         properties:
-          message: "ERROR!"
+          log-message: "ERROR!"
+          kafka-brokers: ***
+          kafka-topic: my-first-test
+          kafka-service-account-id: ***
+          kafka-service-account-secret: ***
       parameters:
-        maximumRedeliveries: 3
+        maximumRedeliveries: 1
         redeliveryDelay: 2000    
     

--- a/examples/kamelets/error-handler/readme.md
+++ b/examples/kamelets/error-handler/readme.md
@@ -1,5 +1,5 @@
 # Kamelets Binding Error Handler example
-This example shows how to create a simple _source_ `Kamelet` which sends periodically events (and certain failures). The events are consumed by a log _sink_ in a `KameletBinding`. With the support of the `ErrorHandler` we will be able to redirect all errors to a `Dead Letter Channel` _error-handler_ `Kamelet`.
+This example shows how to create a simple _source_ `Kamelet` which sends periodically events (and certain failures). The events are consumed by a log _sink_ in a `KameletBinding`. With the support of the `ErrorHandler` we will be able to redirect all errors to a `Dead Letter Channel` _error-handler_ `Kamelet` whose goal is to store the events in a `Kafka` topic and provide a nice log notifying us about the error happened.
 
 ## Incremental ID Source Kamelet
 First of all, you must install the _incremental-id-source_ Kamelet defined in `incremental-id-source.kamelet.yaml` file. This source will emit events every second with an autoincrement counter that will be forced to fail when the number 0 is caught. With this trick, we will simulate possible event faults.
@@ -27,11 +27,51 @@ log-sink                Ready
 incremental-id-source   Ready
 ```
 ## Error handler Kamelet
-We finally install an error handler as specified in `error-handler.kamelet.yaml` file. This is a simple logger, but you can use any endpoint to collect and store the failing events.
+We finally install an error handler as specified in `error-handler.kamelet.yaml` file. Let's have a look at how it is configured:
+
+```
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: error-handler
+spec:
+  definition:
+    ...
+    properties:
+      kafka-brokers:
+        ...  
+      kafka-topic:
+        ...
+      kafka-service-account-id:
+        ...  
+      kafka-service-account-secret:
+        ...              
+      log-message:
+        ...    
+  flow:
+    from:
+      uri: kamelet:source
+      steps:
+      # First step: send to the DLC for future processing
+      - to:
+          uri: kafka:{{kafka-topic}}
+          parameters:
+            brokers: "{{kafka-brokers}}"
+            security-protocol: SASL_SSL
+            sasl-mechanism: PLAIN
+            sasl-jaas-config: "org.apache.kafka.common.security.plain.PlainLoginModule required username={{kafka-service-account-id}} password={{kafka-service-account-secret}};"
+      # Log an error message to notify about the failure
+      - set-body:
+          constant: "{{log-message}} - worry not, the event is stored in the DLC"
+      - to: "log:error-sink"
+```
+
+We first send the errored event to a kafka topic, and then, we send a simple notification message to output, just to let the user know that some issue happened. Let's apply it:
+
 ```
 $ kubectl apply -f error-handler.kamelet.yaml
 ```
-You can check the newly created `kamelet` checking the list of kamelets available:
+You can check the newly created `kamelet` listing the kamelets available:
 ```
 $ kubectl get kamelets
 
@@ -41,7 +81,7 @@ log-sink                Ready
 incremental-id-source   Ready
 ```
 ## Error Handler Kamelet Binding
-We can create a `KameletBinding` which is started by the _incremental-id-source_ `Kamelet` and log events to _log-sink_ `Kamelet`. As this will sporadically fail, we can configure an _errorHandler_ with the _error-handler_ `Kamelet` as **Dead Letter Channel**. We want to configure also some redelivery policies. We can declare it as in `kamelet-binding-error-handler.yaml` file:
+We can now create a `KameletBinding` which is started by the _incremental-id-source_ `Kamelet` and log events to _log-sink_ `Kamelet`. As this will sporadically fail, we can configure an _errorHandler_ with the _error-handler_ `Kamelet` as **Dead Letter Channel**. We want to configure also some redelivery policies (1 retry, with a 2000 milliseconds delay). We can declare it as in `kamelet-binding-error-handler.yaml` file:
 ```
 ...
   errorHandler:
@@ -54,7 +94,7 @@ We can create a `KameletBinding` which is started by the _incremental-id-source_
         properties:
           message: "ERROR!"
       parameters:
-        maximumRedeliveries: 3
+        maximumRedeliveries: 1
         redeliveryDelay: 2000
 ```
 Execute the following command to start the `Integration`:
@@ -63,9 +103,25 @@ kubectl apply -f kamelet-binding-error-handler.yaml
 ```
 As soon as the `Integration` starts, it will log the events on the `ok` log channel and errors on the `error` log channel:
 ```
-[1] 2021-04-21 13:03:43,773 INFO  [sink] (Camel (camel-1) thread #0 - timer://tick) Exchange[ExchangePattern: InOnly, BodyType: String, Body: Producing message #8]
-[1] 2021-04-21 13:03:44,774 INFO  [sink] (Camel (camel-1) thread #0 - timer://tick) Exchange[ExchangePattern: InOnly, BodyType: String, Body: Producing message #9]
-[1] 2021-04-21 13:03:45,898 INFO  [error-sink] (Camel (camel-1) thread #0 - timer://tick) Exchange[ExchangePattern: InOnly, BodyType: String, Body: ERROR!]
-[1] 2021-04-21 13:09:46,775 INFO  [sink] (Camel (camel-1) thread #0 - timer://tick) Exchange[ExchangePattern: InOnly, BodyType: String, Body: Producing message #11]
+[1] 2021-04-29 08:35:08,875 INFO  [sink] (Camel (camel-1) thread #0 - timer://tick) Exchange[ExchangePattern: InOnly, BodyType: String, Body: Producing message #49]
+[1] 2021-04-29 08:35:11,878 INFO  [sink] (Camel (camel-1) thread #0 - timer://tick) Exchange[ExchangePattern: InOnly, BodyType: String, Body: Producing message #51]
+[1] 2021-04-29 08:35:12,088 INFO  [error-sink] (Camel (camel-1) thread #9 - KafkaProducer[my-first-test]) Exchange[ExchangePattern: InOnly, BodyType: String, Body: ERROR! - worry not, the event is stored in the DLC]
+[1] 2021-04-29 08:35:12,877 INFO  [sink] (Camel (camel-1) thread #0 - timer://tick) Exchange[ExchangePattern: InOnly, BodyType: String, Body: Producing message #52]
 ```
-This example is useful to guide you through the configuration of an error handler. In a production environment you will likely configure the error handler `Kamelet` pointing to a persistent queue.
+
+### Recover the errors from DLC
+
+If you're curious to know what was going on in the DLC side, you can use the example you found in [kafka sasl ssl consumer](../kafka/sasl_ssl/):
+
+´´´
+kamel run --secret kafka-props SaslSSLKafkaConsumer.java --dev
+...
+[1] 2021-04-29 08:57:08,636 INFO  [org.apa.kaf.com.uti.AppInfoParser] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Kafka commitId: 448719dc99a19793
+[1] 2021-04-29 08:57:08,636 INFO  [org.apa.kaf.com.uti.AppInfoParser] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Kafka startTimeMs: 1619686628635
+[1] 2021-04-29 08:57:08,637 INFO  [org.apa.cam.com.kaf.KafkaConsumer] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Subscribing my-first-test-Thread 0 to topic my-first-test
+...
+[1] 2021-04-29 08:35:02,894 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #40
+[1] 2021-04-29 08:35:12,995 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #50
+[1] 2021-04-29 08:35:22,879 INFO  [FromKafka] (Camel (camel-1) thread #0 - KafkaConsumer[my-first-test]) Producing message #60
+...
+´´´


### PR DESCRIPTION
Improved the error handler example. Using now a Kafka topic as DLC and using an external consumer to watch failing events.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Example: error handler dead letter channel using a Kafka topic
```
