### PR TITLE
fix(ci): Upgrade Kubernetes to version 1.21.1

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -76,6 +76,7 @@ jobs:
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
+        version: v0.11.0
         node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
     - name: Info
       run: |

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
-        node_image: kindest/node:v1.20.2
+        node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
     - name: Info
       run: |
         kubectl cluster-info

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -74,6 +74,7 @@ jobs:
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
+        version: v0.11.0
         node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
     - name: Info
       run: |
@@ -200,6 +201,7 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v1
         with:
+          version: v0.11.0
           node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
       - name: Info
         run: |

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
-        node_image: kindest/node:v1.20.2
+        node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
     - name: Info
       run: |
         kubectl version
@@ -200,7 +200,7 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v1
         with:
-          node_image: kindest/node:v1.20.2
+          node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
       - name: Info
         run: |
           kubectl version

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -76,6 +76,7 @@ jobs:
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
+        version: v0.11.0
         node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
     - name: Info
       run: |

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
-        node_image: kindest/node:v1.20.2
+        node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
     - name: Info
       run: |
         kubectl cluster-info

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
-        node_image: kindest/node:v1.20.2
+        node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
     - name: Info
       run: |
         kubectl cluster-info

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -82,6 +82,7 @@ jobs:
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
+        version: v0.11.0
         node_image: kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
     - name: Info
       run: |


### PR DESCRIPTION
Picks up kubernetes/kubernetes#97998, that fixes pods termination kubernetes/kubernetes#97288.

Fixes #2250.

**Release Note**
```release-note
NONE
```
