### PR TITLE
fix(cmd): run file system stat errors

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -379,7 +379,11 @@ func (o *runCmdOptions) syncIntegration(cmd *cobra.Command, c client.Client, sou
 	files = append(files, o.OpenAPIs...)
 
 	for _, s := range files {
-		if isLocalAndFileExists(s) {
+		ok, err := isLocalAndFileExists(s)
+		if err != nil {
+			return err
+		}
+		if ok {
 			changes, err := sync.File(o.Context, s)
 			if err != nil {
 				return err
@@ -688,12 +692,16 @@ func (o *runCmdOptions) configureTraits(integration *v1.Integration, options []s
 	return nil
 }
 
-func isLocalAndFileExists(fileName string) bool {
+func isLocalAndFileExists(fileName string) (bool, error) {
 	info, err := os.Stat(fileName)
-	if os.IsNotExist(err) {
-		return false
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		// If it is a different error (ie, permission denied) we should report it back
+		return false, errors.Wrap(err, fmt.Sprintf("file system error while looking for %s", fileName))
 	}
-	return !info.IsDir()
+	return !info.IsDir(), nil
 }
 
 func addPropertyFile(fileName string, spec *v1.IntegrationSpec) error {

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -532,7 +532,7 @@ volumes:
 `
 
 	integrationSpec := v1.IntegrationSpec{}
-	err := resolvePodTemplate(context.TODO(),templateText, &integrationSpec)
+	err := resolvePodTemplate(context.TODO(), templateText, &integrationSpec)
 	assert.Nil(t, err)
 	assert.NotNil(t, integrationSpec.PodTemplate)
 	assert.Equal(t, 1, len(integrationSpec.PodTemplate.Spec.Containers))
@@ -543,9 +543,16 @@ func TestResolveJsonPodTemplate(t *testing.T) {
 	integrationSpec := v1.IntegrationSpec{}
 	minifiedYamlTemplate := `{"containers": [{"name": "second"}, {"name": "integration", "env": [{"name": "CAMEL_K_DIGEST", "value": "new_value"}]}]}`
 
-	err := resolvePodTemplate(context.TODO(),minifiedYamlTemplate, &integrationSpec)
+	err := resolvePodTemplate(context.TODO(), minifiedYamlTemplate, &integrationSpec)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, integrationSpec.PodTemplate)
 	assert.Equal(t, 2, len(integrationSpec.PodTemplate.Spec.Containers))
+}
+
+func TestIsLocalFileAndExists(t *testing.T) {
+	value, err := isLocalAndFileExists("/root/test")
+	// must not panic because a permission error
+	assert.NotNil(t, err)
+	assert.False(t, value)
 }

--- a/pkg/cmd/util_content.go
+++ b/pkg/cmd/util_content.go
@@ -30,7 +30,12 @@ func loadRawContent(source string) ([]byte, string, error) {
 	var content []byte
 	var err error
 
-	if isLocalAndFileExists(source) {
+	ok, err := isLocalAndFileExists(source)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if ok {
 		content, err = ioutil.ReadFile(source)
 	} else {
 		u, err := url.Parse(source)

--- a/pkg/cmd/util_sources.go
+++ b/pkg/cmd/util_sources.go
@@ -65,7 +65,12 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 	sources := make([]Source, 0, len(locations))
 
 	for _, location := range locations {
-		if isLocalAndFileExists(location) {
+		ok, err := isLocalAndFileExists(location)
+		if err != nil {
+			return sources, err
+		}
+
+		if ok {
 			answer, err := ResolveLocalSource(location, compress)
 			if err != nil {
 				return sources, err


### PR DESCRIPTION
* Introducing a check to make sure that we don't panic if any kind of filesystem error but file not found is reported
* Adding a unit test to check a permission error on /root won't panic

Should fix #2239 
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cmd): run file system stat errors
```
