### PR TITLE
Support adjusting the log level for integrations

### DIFF
--- a/deploy/traits.yaml
+++ b/deploy/traits.yaml
@@ -576,6 +576,9 @@ traits:
   - name: color
     type: bool
     description: Colorize the log output
+  - name: level
+    type: string
+    description: Adjust the log level for the integrations (defaults to INFO)
   - name: json
     type: bool
     description: Output the log in json format

--- a/docs/modules/traits/pages/logging.adoc
+++ b/docs/modules/traits/pages/logging.adoc
@@ -29,6 +29,10 @@ The following configuration options are available:
 | bool
 | Colorize the log output
 
+| logging.level
+| string
+| Adjust the log level for the integrations (defaults to INFO)
+
 | logging.json
 | bool
 | Output the log in json format

--- a/pkg/trait/logging.go
+++ b/pkg/trait/logging.go
@@ -25,10 +25,12 @@ import (
 )
 
 const (
+	envVarQuarkusLogLevel                  = "QUARKUS_LOG_LEVEL"
 	envVarQuarkusLogConsoleColor           = "QUARKUS_LOG_CONSOLE_COLOR"
 	envVarQuarkusLogConsoleJson            = "QUARKUS_LOG_CONSOLE_JSON"
 	envVarQuarkusLogConsoleJsonPrettyPrint = "QUARKUS_LOG_CONSOLE_JSON_PRETTY_PRINT"
 	depQuarkusLoggingJson                  = "mvn:io.quarkus:quarkus-logging-json"
+	defaultLogLevel                        = "INFO"
 )
 
 // This trait is used to control logging options (such as color)
@@ -38,6 +40,8 @@ type loggingTrait struct {
 	BaseTrait `property:",squash"`
 	// Colorize the log output
 	Color *bool `property:"color" json:"color,omitempty"`
+	// Adjust the log level for the integrations (defaults to INFO)
+	Level string `property:"level" json:"level,omitempty"`
 	// Output the log in json format
 	Json *bool `property:"json" json:"json,omitempty"`
 	// Enable "pretty printing" of the json log
@@ -48,6 +52,7 @@ func newLoggingTraitTrait() Trait {
 	return &loggingTrait{
 		BaseTrait:       NewBaseTrait("logging", 800),
 		Color:           util.BoolP(true),
+		Level:           defaultLogLevel,
 		Json:            util.BoolP(false),
 		JsonPrettyPrint: util.BoolP(false),
 	}
@@ -76,6 +81,7 @@ func (l loggingTrait) Apply(environment *Environment) error {
 		return nil
 	}
 
+	envvar.SetVal(&environment.EnvVars, envVarQuarkusLogLevel, l.Level)
 	envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleJson, strconv.FormatBool(*l.Json))
 	envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleJsonPrettyPrint, strconv.FormatBool(*l.JsonPrettyPrint))
 

--- a/pkg/trait/logging_test.go
+++ b/pkg/trait/logging_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 )
 
-func createLoggingTestEnv(t *testing.T, color bool, json bool, jsonPrettyPrint bool) *Environment {
+func createLoggingTestEnv(t *testing.T, color bool, json bool, jsonPrettyPrint bool, logLevel string) *Environment {
 	c, err := camel.DefaultCatalog()
 	if err != nil {
 		panic(err)
@@ -54,6 +54,7 @@ func createLoggingTestEnv(t *testing.T, color bool, json bool, jsonPrettyPrint b
 						"color":             color,
 						"json":              json,
 						"json-pretty-print": jsonPrettyPrint,
+						"level":             logLevel,
 					}),
 				},
 			},
@@ -80,7 +81,7 @@ func createLoggingTestEnv(t *testing.T, color bool, json bool, jsonPrettyPrint b
 }
 
 func createDefaultLoggingTestEnv(t *testing.T) *Environment {
-	return createLoggingTestEnv(t, true, false, false)
+	return createLoggingTestEnv(t, true, false, false, defaultLogLevel)
 }
 
 func NewLoggingTestCatalog() *Catalog {
@@ -97,6 +98,7 @@ func TestEmptyLoggingTrait(t *testing.T) {
 	quarkusConsoleColor := false
 	jsonFormat := false
 	jsonPrettyPrint := false
+	logLevelIsInfo := false
 
 	for _, e := range env.EnvVars {
 		if e.Name == envVarQuarkusLogConsoleColor {
@@ -116,16 +118,23 @@ func TestEmptyLoggingTrait(t *testing.T) {
 				jsonPrettyPrint = true
 			}
 		}
+
+		if e.Name == envVarQuarkusLogLevel {
+			if e.Value == "INFO" {
+				logLevelIsInfo = true
+			}
+		}
 	}
 
 	assert.True(t, quarkusConsoleColor)
+	assert.True(t, logLevelIsInfo)
 	assert.False(t, jsonFormat)
 	assert.False(t, jsonPrettyPrint)
 	assert.NotEmpty(t, env.ExecutedTraits)
 }
 
 func TestJsonLoggingTrait(t *testing.T) {
-	env := createLoggingTestEnv(t, true, true, false)
+	env := createLoggingTestEnv(t, true, true, false, "TRACE")
 	err := NewLoggingTestCatalog().apply(env)
 
 	assert.Nil(t, err)
@@ -134,6 +143,7 @@ func TestJsonLoggingTrait(t *testing.T) {
 	quarkusConsoleColor := false
 	jsonFormat := true
 	jsonPrettyPrint := false
+	logLevelIsTrace := false
 
 	for _, e := range env.EnvVars {
 		if e.Name == envVarQuarkusLogConsoleColor {
@@ -153,10 +163,17 @@ func TestJsonLoggingTrait(t *testing.T) {
 				jsonPrettyPrint = true
 			}
 		}
+
+		if e.Name == envVarQuarkusLogLevel {
+			if e.Value == "TRACE" {
+				logLevelIsTrace = true
+			}
+		}
 	}
 
 	assert.False(t, quarkusConsoleColor)
 	assert.True(t, jsonFormat)
 	assert.False(t, jsonPrettyPrint)
+	assert.True(t, logLevelIsTrace)
 	assert.NotEmpty(t, env.ExecutedTraits)
 }


### PR DESCRIPTION
This solves issue #2000


<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Support adjusting the log level for integrations
```