### PR TITLE
Added support for displaying Maven logs in JSON

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -85,6 +85,8 @@ jobs:
       run: |
         echo "Build project"
         make build-kamel bundle-kamelets
+        echo "Preparing the maven overlay"
+        make maven-overlay
         echo "Adding maven artifacts to the image context"
         make PACKAGE_ARTIFACTS_STRATEGY=download package-artifacts
         echo "Copying binary file to docker dir"

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -130,6 +130,8 @@ jobs:
       run: |
         echo "Build project"
         make build-kamel bundle-kamelets
+        echo "Preparing the maven overlay"
+        make maven-overlay
         echo "Adding maven artifacts to the image context"
         make PACKAGE_ARTIFACTS_STRATEGY=download package-artifacts
         echo "Copying binary file to docker dir"
@@ -259,6 +261,8 @@ jobs:
         run: |
           echo "Build project"
           make build-kamel bundle-kamelets
+          echo "Preparing the maven overlay"
+          make maven-overlay
           echo "Adding maven artifacts to the image context"
           make PACKAGE_ARTIFACTS_STRATEGY=download package-artifacts
           echo "Copying binary file to docker dir"

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -85,6 +85,8 @@ jobs:
       run: |
         echo "Build project"
         make build-kamel bundle-kamelets
+        echo "Preparing the maven overlay"
+        make maven-overlay
         echo "Adding maven artifacts to the image context"
         make PACKAGE_ARTIFACTS_STRATEGY=download package-artifacts
         echo "Copying binary file to docker dir"

--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -148,6 +148,9 @@ jobs:
         echo "Build project"
         make build-kamel bundle-kamelets
 
+        echo "Preparing the maven overlay"
+        make maven-overlay
+
         echo "Adding maven artifacts to the image context"
         make PACKAGE_ARTIFACTS_STRATEGY=download package-artifacts
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -103,6 +103,8 @@ jobs:
       run: |
         echo "Build project"
         make build-kamel bundle-kamelets
+        echo "Preparing the maven overlay"
+        make maven-overlay
         echo "Adding maven artifacts to the image context"
         make PACKAGE_ARTIFACTS_STRATEGY=download package-artifacts
         echo "Copying binary file to docker dir"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,10 +24,15 @@ RUN mkdir -p /usr/share/maven \
     && echo "${SHA} /tmp/maven.tar.gz" | sha512sum -c - \
     && tar -xzC /usr/share/maven --strip-components=1 -f /tmp/maven.tar.gz \
     && rm -v /tmp/maven.tar.gz \
-    && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+    && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
+    && rm /usr/share/maven/lib/maven-slf4j-provider*
 
 ADD build/_maven_output /tmp/artifacts/m2
 ADD build/_kamelets /kamelets
+COPY build/_maven_overlay/ /usr/share/maven/lib/
+ADD build/logback.xml /usr/share/maven/conf/
+
+ENV MAVEN_OPTS="${MAVEN_OPTS} -Dlogback.configurationFile=/usr/share/maven/conf/logback.xml"
 
 USER 0
 

--- a/build/logback.xml
+++ b/build/logback.xml
@@ -1,0 +1,62 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <!--
+        This configuration tries to output the Maven build log in a way that is as close as possible the native k8s
+        log output format.
+        -->
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <logLevel>
+                    <fieldName>level</fieldName>
+                </logLevel>
+                <timestamp>
+                    <fieldName>ts</fieldName>
+                    <timeZone>UTC</timeZone>
+                </timestamp>
+                <loggerName>
+                    <fieldName>logger</fieldName>
+                </loggerName>
+                <message>
+                    <fieldName>msg</fieldName>
+                </message>
+                <callerData>
+                    <classFieldName>class</classFieldName>
+                </callerData>
+                <threadName>
+                    <fieldName>thread</fieldName>
+                </threadName>
+                <mdc/>
+                <arguments>
+                    <includeNonStructuredArguments>false</includeNonStructuredArguments>
+                </arguments>
+                <logstashMarkers/>
+                <stackTrace>
+                    <fieldName>stack</fieldName>
+                    <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                        <maxLength>4096</maxLength>
+                        <rootCauseFirst>false</rootCauseFirst>
+                    </throwableConverter>
+                </stackTrace>
+            </providers>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/script/Makefile
+++ b/script/Makefile
@@ -219,6 +219,7 @@ clean:
 	rm -f kamel
 	rm -f *.test
 	rm -rf build/_maven_output
+	rm -rf build/_maven_overlay
 	rm -rf build/_output
 	rm -rf camel-k-client-*.tar.gz
 	rm -rf camel-k-examples-*.tar.gz
@@ -237,7 +238,11 @@ lint-fix:
 check-licenses:
 	./script/check_licenses.sh
 
-images: bundle-kamelets test
+maven-overlay:
+	mkdir -p build/_maven_overlay
+	./script/maven_overlay.sh build/_maven_overlay
+
+images: bundle-kamelets test maven-overlay
 	mkdir -p build/_maven_output
 	mkdir -p build/_output/bin
 ifneq ($(shell uname -s 2>/dev/null || echo Unknown),Linux)
@@ -247,7 +252,7 @@ else
 endif
 	docker build -t $(IMAGE_NAME):$(VERSION) -f build/Dockerfile .
 
-images-dev: bundle-kamelets test package-artifacts
+images-dev: bundle-kamelets test package-artifacts maven-overlay
 	mkdir -p build/_maven_output
 	mkdir -p build/_output/bin
 ifneq ($(shell uname -s 2>/dev/null || echo Unknown),Linux)

--- a/script/maven_overlay.sh
+++ b/script/maven_overlay.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mvn dependency:get -Dartifact=ch.qos.logback:logback-core:1.2.3 -Ddest=$1
+mvn dependency:get -Dartifact=ch.qos.logback:logback-classic:1.2.3 -Ddest=$1
+mvn dependency:get -Dartifact=net.logstash.logback:logstash-logback-encoder:4.11 -Ddest=$1
+mvn dependency:get -Dartifact=com.fasterxml.jackson.core:jackson-annotations:2.9.10 -Ddest=$1
+mvn dependency:get -Dartifact=com.fasterxml.jackson.core:jackson-core:2.9.10 -Ddest=$1
+mvn dependency:get -Dartifact=com.fasterxml.jackson.core:jackson-databind:2.9.10.8 -Ddest=$1


### PR DESCRIPTION
This solves GH issue #1783


<!-- Description -->


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Added support for displaying Maven logs in JSON format
```