### PR TITLE
Doc: generated API

### DIFF
--- a/docs/modules/ROOT/nav-end.adoc
+++ b/docs/modules/ROOT/nav-end.adoc
@@ -15,6 +15,7 @@
 ** xref:architecture/runtime.adoc[Runtime]
 ** xref:architecture/traits.adoc[Traits]
 ** xref:architecture/sources.adoc[Sources]
+* xref:apis/camel.adoc[API]
 * xref:uninstalling.adoc[Uninstalling]
 * xref:contributing/developers.adoc[Contributing]
 ** xref:contributing/local-development.adoc[Local development]

--- a/docs/modules/ROOT/pages/apis/camel.adoc
+++ b/docs/modules/ROOT/pages/apis/camel.adoc
@@ -1,0 +1,3 @@
+++++
+include::crds-html.adoc[]
+++++

--- a/docs/modules/ROOT/pages/apis/crds-html.adoc
+++ b/docs/modules/ROOT/pages/apis/crds-html.adoc
@@ -1,0 +1,6504 @@
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#camel.apache.org%2fv1">camel.apache.org/v1</a>
+</li>
+<li>
+<a href="#camel.apache.org%2fv1alpha1">camel.apache.org/v1alpha1</a>
+</li>
+</ul>
+<h2 id="camel.apache.org/v1">camel.apache.org/v1</h2>
+<p>
+<p>Package v1 contains API Schema definitions for the camel v1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#camel.apache.org/v1.Build">Build</a>
+</li><li>
+<a href="#camel.apache.org/v1.CamelCatalog">CamelCatalog</a>
+</li><li>
+<a href="#camel.apache.org/v1.Integration">Integration</a>
+</li><li>
+<a href="#camel.apache.org/v1.IntegrationKit">IntegrationKit</a>
+</li><li>
+<a href="#camel.apache.org/v1.IntegrationPlatform">IntegrationPlatform</a>
+</li></ul>
+<h3 id="camel.apache.org/v1.Build">Build
+</h3>
+<p>
+<p>Build is the Schema for the builds API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+camel.apache.org/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Build</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#camel.apache.org/v1.BuildSpec">
+BuildSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>tasks</code></br>
+<em>
+<a href="#camel.apache.org/v1.Task">
+[]Task
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#camel.apache.org/v1.BuildStatus">
+BuildStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.CamelCatalog">CamelCatalog
+</h3>
+<p>
+<p>CamelCatalog is the Schema for the camelcatalogs API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+camel.apache.org/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>CamelCatalog</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelCatalogStatus">
+CamelCatalogStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelCatalogSpec">
+CamelCatalogSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>runtime</code></br>
+<em>
+<a href="#camel.apache.org/v1.RuntimeSpec">
+RuntimeSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>artifacts</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelArtifact">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.CamelArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>loaders</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelLoader">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.CamelLoader
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.Integration">Integration
+</h3>
+<p>
+<p>Integration is the Schema for the integrations API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+camel.apache.org/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Integration</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationSpec">
+IntegrationSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sources</code></br>
+<em>
+<a href="#camel.apache.org/v1.SourceSpec">
+[]SourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>flows</code></br>
+<em>
+<a href="#camel.apache.org/v1.Flow">
+[]Flow
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#camel.apache.org/v1.ResourceSpec">
+[]ResourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>kit</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Deprecated: use the IntegrationKit field</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>integrationKit</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>profile</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitProfile">
+TraitProfile
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>traits</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitSpec">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.TraitSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#camel.apache.org/v1.PodSpecTemplate">
+PodSpecTemplate
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#camel.apache.org/v1.ConfigurationSpec">
+[]ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>repositories</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationStatus">
+IntegrationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationKit">IntegrationKit
+</h3>
+<p>
+<p>IntegrationKit is the Schema for the integrationkits API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+camel.apache.org/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>IntegrationKit</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationKitSpec">
+IntegrationKitSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>profile</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitProfile">
+TraitProfile
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>traits</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitSpec">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.TraitSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#camel.apache.org/v1.ConfigurationSpec">
+[]ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>repositories</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationKitStatus">
+IntegrationKitStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationPlatform">IntegrationPlatform
+</h3>
+<p>
+<p>IntegrationPlatform is the Schema for the integrationplatforms API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+camel.apache.org/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>IntegrationPlatform</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">
+IntegrationPlatformSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>cluster</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformCluster">
+IntegrationPlatformCluster
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>profile</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitProfile">
+TraitProfile
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>build</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildSpec">
+IntegrationPlatformBuildSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformResourcesSpec">
+IntegrationPlatformResourcesSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>traits</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitSpec">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.TraitSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#camel.apache.org/v1.ConfigurationSpec">
+[]ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>kamelet</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformKameletSpec">
+IntegrationPlatformKameletSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformStatus">
+IntegrationPlatformStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.Artifact">Artifact
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuildStatus">BuildStatus</a>, 
+<a href="#camel.apache.org/v1.IntegrationKitStatus">IntegrationKitStatus</a>)
+</p>
+<p>
+<p>Artifact &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>location</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>target</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>checksum</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.BaseTask">BaseTask
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuildahTask">BuildahTask</a>, 
+<a href="#camel.apache.org/v1.BuilderTask">BuilderTask</a>, 
+<a href="#camel.apache.org/v1.KanikoTask">KanikoTask</a>, 
+<a href="#camel.apache.org/v1.S2iTask">S2iTask</a>, 
+<a href="#camel.apache.org/v1.SpectrumTask">SpectrumTask</a>)
+</p>
+<p>
+<p>BaseTask &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.BuildCondition">BuildCondition
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuildStatus">BuildStatus</a>)
+</p>
+<p>
+<p>BuildCondition describes the state of a resource at a certain point.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#camel.apache.org/v1.BuildConditionType">
+BuildConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Type of integration condition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the condition, one of True, False, Unknown.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastUpdateTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>The last time this condition was updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastTransitionTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>Last time the condition transitioned from one status to another.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The reason for the condition&rsquo;s last transition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>A human readable message indicating details about the transition.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.BuildConditionType">BuildConditionType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuildCondition">BuildCondition</a>)
+</p>
+<p>
+<p>BuildConditionType &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.BuildPhase">BuildPhase
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuildStatus">BuildStatus</a>)
+</p>
+<p>
+<p>BuildPhase &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.BuildSpec">BuildSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Build">Build</a>)
+</p>
+<p>
+<p>BuildSpec defines the desired state of Build</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>tasks</code></br>
+<em>
+<a href="#camel.apache.org/v1.Task">
+[]Task
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.BuildStatus">BuildStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Build">Build</a>)
+</p>
+<p>
+<p>BuildStatus defines the observed state of Build</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#camel.apache.org/v1.BuildPhase">
+BuildPhase
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>digest</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>baseImage</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>artifacts</code></br>
+<em>
+<a href="#camel.apache.org/v1.Artifact">
+[]Artifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>error</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>failure</code></br>
+<em>
+<a href="#camel.apache.org/v1.Failure">
+Failure
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>startedAt</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>platform</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="#camel.apache.org/v1.BuildCondition">
+[]BuildCondition
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>duration</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Change to Duration / ISO 8601 when CRD uses OpenAPI spec v3
+<a href="https://github.com/OAI/OpenAPI-Specification/issues/845">https://github.com/OAI/OpenAPI-Specification/issues/845</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.BuildahTask">BuildahTask
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Task">Task</a>)
+</p>
+<p>
+<p>BuildahTask &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>BaseTask</code></br>
+<em>
+<a href="#camel.apache.org/v1.BaseTask">
+BaseTask
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BaseTask</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>PublishTask</code></br>
+<em>
+<a href="#camel.apache.org/v1.PublishTask">
+PublishTask
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>PublishTask</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>verbose</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpProxySecret</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.BuilderTask">BuilderTask
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Task">Task</a>)
+</p>
+<p>
+<p>BuilderTask &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>BaseTask</code></br>
+<em>
+<a href="#camel.apache.org/v1.BaseTask">
+BaseTask
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BaseTask</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>baseImage</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtime</code></br>
+<em>
+<a href="#camel.apache.org/v1.RuntimeSpec">
+RuntimeSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sources</code></br>
+<em>
+<a href="#camel.apache.org/v1.SourceSpec">
+[]SourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#camel.apache.org/v1.ResourceSpec">
+[]ResourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>maven</code></br>
+<em>
+<a href="#camel.apache.org/v1.MavenSpec">
+MavenSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildDir</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#duration-v1-meta">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.CamelArtifact">CamelArtifact
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelCatalogSpec">CamelCatalogSpec</a>)
+</p>
+<p>
+<p>CamelArtifact &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>CamelArtifactDependency</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelArtifactDependency">
+CamelArtifactDependency
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>CamelArtifactDependency</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schemes</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelScheme">
+[]CamelScheme
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>languages</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dataformats</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelArtifactDependency">
+[]CamelArtifactDependency
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>javaTypes</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.CamelArtifactDependency">CamelArtifactDependency
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelArtifact">CamelArtifact</a>, 
+<a href="#camel.apache.org/v1.CamelSchemeScope">CamelSchemeScope</a>)
+</p>
+<p>
+<p>CamelArtifactDependency represent a maven&rsquo;s dependency</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>MavenArtifact</code></br>
+<em>
+<a href="#camel.apache.org/v1.MavenArtifact">
+MavenArtifact
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>MavenArtifact</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>exclusions</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelArtifactExclusion">
+[]CamelArtifactExclusion
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.CamelArtifactExclusion">CamelArtifactExclusion
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelArtifactDependency">CamelArtifactDependency</a>)
+</p>
+<p>
+<p>CamelArtifactExclusion &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>groupId</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>artifactId</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.CamelCatalogSpec">CamelCatalogSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelCatalog">CamelCatalog</a>)
+</p>
+<p>
+<p>CamelCatalogSpec defines the desired state of CamelCatalog</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>runtime</code></br>
+<em>
+<a href="#camel.apache.org/v1.RuntimeSpec">
+RuntimeSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>artifacts</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelArtifact">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.CamelArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>loaders</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelLoader">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.CamelLoader
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.CamelCatalogStatus">CamelCatalogStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelCatalog">CamelCatalog</a>)
+</p>
+<p>
+<p>CamelCatalogStatus defines the observed state of CamelCatalog</p>
+</p>
+<h3 id="camel.apache.org/v1.CamelLoader">CamelLoader
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelCatalogSpec">CamelCatalogSpec</a>)
+</p>
+<p>
+<p>CamelLoader &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>MavenArtifact</code></br>
+<em>
+<a href="#camel.apache.org/v1.MavenArtifact">
+MavenArtifact
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>MavenArtifact</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>languages</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+<a href="#camel.apache.org/v1.MavenArtifact">
+[]MavenArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.CamelScheme">CamelScheme
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelArtifact">CamelArtifact</a>)
+</p>
+<p>
+<p>CamelScheme &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>passive</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>http</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>consumer</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelSchemeScope">
+CamelSchemeScope
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>producer</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelSchemeScope">
+CamelSchemeScope
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.CamelSchemeScope">CamelSchemeScope
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelScheme">CamelScheme</a>)
+</p>
+<p>
+<p>CamelSchemeScope contains scoped information about a scheme</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+<a href="#camel.apache.org/v1.CamelArtifactDependency">
+[]CamelArtifactDependency
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.Capability">Capability
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.RuntimeSpec">RuntimeSpec</a>)
+</p>
+<p>
+<p>Capability &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+<a href="#camel.apache.org/v1.MavenArtifact">
+[]MavenArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.Configurable">Configurable
+</h3>
+<p>
+<p>Configurable &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.ConfigurationSpec">ConfigurationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKitSpec">IntegrationKitSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">IntegrationPlatformSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationSpec">IntegrationSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationStatus">IntegrationStatus</a>)
+</p>
+<p>
+<p>ConfigurationSpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.DataSpec">DataSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.ResourceSpec">ResourceSpec</a>, 
+<a href="#camel.apache.org/v1.SourceSpec">SourceSpec</a>)
+</p>
+<p>
+<p>DataSpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>content</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>rawContent</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>contentRef</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>contentKey</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>contentType</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>compression</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.Failure">Failure
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuildStatus">BuildStatus</a>, 
+<a href="#camel.apache.org/v1.IntegrationKitStatus">IntegrationKitStatus</a>, 
+<a href="#camel.apache.org/v1.IntegrationStatus">IntegrationStatus</a>)
+</p>
+<p>
+<p>Failure &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>time</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>recovery</code></br>
+<em>
+<a href="#camel.apache.org/v1.FailureRecovery">
+FailureRecovery
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.FailureRecovery">FailureRecovery
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Failure">Failure</a>)
+</p>
+<p>
+<p>FailureRecovery &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>attempt</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>attemptMax</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>attemptTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.Flow">Flow
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationSpec">IntegrationSpec</a>, 
+<a href="#camel.apache.org/v1alpha1.KameletSpec">KameletSpec</a>)
+</p>
+<p>
+<p>Flow is an unstructured object representing a Camel Flow in YAML/JSON DSL</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>RawMessage</code></br>
+<em>
+<a href="#camel.apache.org/v1.RawMessage">
+RawMessage
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>RawMessage</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationCondition">IntegrationCondition
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationStatus">IntegrationStatus</a>)
+</p>
+<p>
+<p>IntegrationCondition describes the state of a resource at a certain point.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationConditionType">
+IntegrationConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Type of integration condition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the condition, one of True, False, Unknown.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastUpdateTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>The last time this condition was updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastTransitionTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>Last time the condition transitioned from one status to another.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>firstTruthyTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>First time the condition status transitioned to True.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The reason for the condition&rsquo;s last transition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>A human readable message indicating details about the transition.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationConditionType">IntegrationConditionType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationCondition">IntegrationCondition</a>)
+</p>
+<p>
+<p>IntegrationConditionType &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationKitCondition">IntegrationKitCondition
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKitStatus">IntegrationKitStatus</a>)
+</p>
+<p>
+<p>IntegrationKitCondition describes the state of a resource at a certain point.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationKitConditionType">
+IntegrationKitConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Type of integration condition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the condition, one of True, False, Unknown.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastUpdateTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>The last time this condition was updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastTransitionTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>Last time the condition transitioned from one status to another.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The reason for the condition&rsquo;s last transition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>A human readable message indicating details about the transition.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationKitConditionType">IntegrationKitConditionType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKitCondition">IntegrationKitCondition</a>)
+</p>
+<p>
+<p>IntegrationKitConditionType &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationKitPhase">IntegrationKitPhase
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKitStatus">IntegrationKitStatus</a>)
+</p>
+<p>
+<p>IntegrationKitPhase &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationKitSpec">IntegrationKitSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKit">IntegrationKit</a>)
+</p>
+<p>
+<p>IntegrationKitSpec defines the desired state of IntegrationKit</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>profile</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitProfile">
+TraitProfile
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>traits</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitSpec">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.TraitSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#camel.apache.org/v1.ConfigurationSpec">
+[]ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>repositories</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationKitStatus">IntegrationKitStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKit">IntegrationKit</a>)
+</p>
+<p>
+<p>IntegrationKitStatus defines the observed state of IntegrationKit</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationKitPhase">
+IntegrationKitPhase
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>baseImage</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>digest</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>artifacts</code></br>
+<em>
+<a href="#camel.apache.org/v1.Artifact">
+[]Artifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>failure</code></br>
+<em>
+<a href="#camel.apache.org/v1.Failure">
+Failure
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtimeVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtimeProvider</code></br>
+<em>
+<a href="#camel.apache.org/v1.RuntimeProvider">
+RuntimeProvider
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>platform</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationKitCondition">
+[]IntegrationKitCondition
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>version</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationPhase">IntegrationPhase
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationStatus">IntegrationStatus</a>)
+</p>
+<p>
+<p>IntegrationPhase &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationPlatformBuildPublishStrategy">IntegrationPlatformBuildPublishStrategy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildSpec">IntegrationPlatformBuildSpec</a>)
+</p>
+<p>
+<p>IntegrationPlatformBuildPublishStrategy enumerates all implemented publish strategies</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationPlatformBuildSpec">IntegrationPlatformBuildSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">IntegrationPlatformSpec</a>)
+</p>
+<p>
+<p>IntegrationPlatformBuildSpec contains platform related build information</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>buildStrategy</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildStrategy">
+IntegrationPlatformBuildStrategy
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>publishStrategy</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildPublishStrategy">
+IntegrationPlatformBuildPublishStrategy
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtimeVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtimeProvider</code></br>
+<em>
+<a href="#camel.apache.org/v1.RuntimeProvider">
+RuntimeProvider
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>baseImage</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>registry</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformRegistrySpec">
+IntegrationPlatformRegistrySpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#duration-v1-meta">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>persistentVolumeClaim</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>maven</code></br>
+<em>
+<a href="#camel.apache.org/v1.MavenSpec">
+MavenSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpProxySecret</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>kanikoBuildCache</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationPlatformBuildStrategy">IntegrationPlatformBuildStrategy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildSpec">IntegrationPlatformBuildSpec</a>)
+</p>
+<p>
+<p>IntegrationPlatformBuildStrategy enumerates all implemented build strategies</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationPlatformCluster">IntegrationPlatformCluster
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">IntegrationPlatformSpec</a>)
+</p>
+<p>
+<p>IntegrationPlatformCluster is the kind of orchestration cluster the platform is installed into</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationPlatformCondition">IntegrationPlatformCondition
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformStatus">IntegrationPlatformStatus</a>)
+</p>
+<p>
+<p>IntegrationPlatformCondition describes the state of a resource at a certain point.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformConditionType">
+IntegrationPlatformConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Type of integration condition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the condition, one of True, False, Unknown.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastUpdateTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>The last time this condition was updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastTransitionTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>Last time the condition transitioned from one status to another.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The reason for the condition&rsquo;s last transition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>A human readable message indicating details about the transition.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationPlatformConditionType">IntegrationPlatformConditionType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformCondition">IntegrationPlatformCondition</a>)
+</p>
+<p>
+<p>IntegrationPlatformConditionType &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationPlatformKameletRepositorySpec">IntegrationPlatformKameletRepositorySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformKameletSpec">IntegrationPlatformKameletSpec</a>)
+</p>
+<p>
+<p>IntegrationPlatformKameletRepositorySpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationPlatformKameletSpec">IntegrationPlatformKameletSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">IntegrationPlatformSpec</a>)
+</p>
+<p>
+<p>IntegrationPlatformKameletSpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>repositories</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformKameletRepositorySpec">
+[]IntegrationPlatformKameletRepositorySpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationPlatformPhase">IntegrationPlatformPhase
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformStatus">IntegrationPlatformStatus</a>)
+</p>
+<p>
+<p>IntegrationPlatformPhase &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationPlatformRegistrySpec">IntegrationPlatformRegistrySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildSpec">IntegrationPlatformBuildSpec</a>, 
+<a href="#camel.apache.org/v1.PublishTask">PublishTask</a>)
+</p>
+<p>
+<p>IntegrationPlatformRegistrySpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>insecure</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>secret</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ca</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>organization</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationPlatformResourcesSpec">IntegrationPlatformResourcesSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">IntegrationPlatformSpec</a>)
+</p>
+<p>
+<p>IntegrationPlatformResourcesSpec contains platform related resources</p>
+</p>
+<h3 id="camel.apache.org/v1.IntegrationPlatformSpec">IntegrationPlatformSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatform">IntegrationPlatform</a>, 
+<a href="#camel.apache.org/v1.IntegrationPlatformStatus">IntegrationPlatformStatus</a>)
+</p>
+<p>
+<p>IntegrationPlatformSpec defines the desired state of IntegrationPlatform</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cluster</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformCluster">
+IntegrationPlatformCluster
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>profile</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitProfile">
+TraitProfile
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>build</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildSpec">
+IntegrationPlatformBuildSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformResourcesSpec">
+IntegrationPlatformResourcesSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>traits</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitSpec">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.TraitSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#camel.apache.org/v1.ConfigurationSpec">
+[]ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>kamelet</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformKameletSpec">
+IntegrationPlatformKameletSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationPlatformStatus">IntegrationPlatformStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationPlatform">IntegrationPlatform</a>)
+</p>
+<p>
+<p>IntegrationPlatformStatus defines the observed state of IntegrationPlatform</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>IntegrationPlatformSpec</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">
+IntegrationPlatformSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>IntegrationPlatformSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformPhase">
+IntegrationPlatformPhase
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformCondition">
+[]IntegrationPlatformCondition
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>version</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationSpec">IntegrationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Integration">Integration</a>, 
+<a href="#camel.apache.org/v1alpha1.KameletBindingSpec">KameletBindingSpec</a>)
+</p>
+<p>
+<p>IntegrationSpec defines the desired state of Integration</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sources</code></br>
+<em>
+<a href="#camel.apache.org/v1.SourceSpec">
+[]SourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>flows</code></br>
+<em>
+<a href="#camel.apache.org/v1.Flow">
+[]Flow
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#camel.apache.org/v1.ResourceSpec">
+[]ResourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>kit</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Deprecated: use the IntegrationKit field</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>integrationKit</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>profile</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitProfile">
+TraitProfile
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>traits</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitSpec">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.TraitSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#camel.apache.org/v1.PodSpecTemplate">
+PodSpecTemplate
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#camel.apache.org/v1.ConfigurationSpec">
+[]ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>repositories</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.IntegrationStatus">IntegrationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Integration">Integration</a>)
+</p>
+<p>
+<p>IntegrationStatus defines the observed state of Integration</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPhase">
+IntegrationPhase
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>digest</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>profile</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitProfile">
+TraitProfile
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>kit</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Deprecated: use the IntegrationKit field</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>integrationKit</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>platform</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>generatedSources</code></br>
+<em>
+<a href="#camel.apache.org/v1.SourceSpec">
+[]SourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>generatedResources</code></br>
+<em>
+<a href="#camel.apache.org/v1.ResourceSpec">
+[]ResourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>failure</code></br>
+<em>
+<a href="#camel.apache.org/v1.Failure">
+Failure
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtimeVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtimeProvider</code></br>
+<em>
+<a href="#camel.apache.org/v1.RuntimeProvider">
+RuntimeProvider
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#camel.apache.org/v1.ConfigurationSpec">
+[]ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationCondition">
+[]IntegrationCondition
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>version</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capabilities</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastInitTimestamp</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>The timestamp representing the last time when this integration was initialized.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.KanikoTask">KanikoTask
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Task">Task</a>)
+</p>
+<p>
+<p>KanikoTask &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>BaseTask</code></br>
+<em>
+<a href="#camel.apache.org/v1.BaseTask">
+BaseTask
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BaseTask</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>PublishTask</code></br>
+<em>
+<a href="#camel.apache.org/v1.PublishTask">
+PublishTask
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>PublishTask</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>verbose</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpProxySecret</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>cache</code></br>
+<em>
+<a href="#camel.apache.org/v1.KanikoTaskCache">
+KanikoTaskCache
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.KanikoTaskCache">KanikoTaskCache
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.KanikoTask">KanikoTask</a>)
+</p>
+<p>
+<p>KanikoTaskCache</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enabled</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>persistentVolumeClaim</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.Language">Language
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.SourceSpec">SourceSpec</a>)
+</p>
+<p>
+<p>Language &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.MavenArtifact">MavenArtifact
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.CamelArtifactDependency">CamelArtifactDependency</a>, 
+<a href="#camel.apache.org/v1.CamelLoader">CamelLoader</a>, 
+<a href="#camel.apache.org/v1.Capability">Capability</a>, 
+<a href="#camel.apache.org/v1.RuntimeSpec">RuntimeSpec</a>)
+</p>
+<p>
+<p>MavenArtifact &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>groupId</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>artifactId</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>version</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.MavenSpec">MavenSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuilderTask">BuilderTask</a>, 
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildSpec">IntegrationPlatformBuildSpec</a>)
+</p>
+<p>
+<p>MavenSpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>localRepository</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>settings</code></br>
+<em>
+<a href="#camel.apache.org/v1.ValueSource">
+ValueSource
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>caSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>The Secret name and key, containing the CA certificate(s) used to connect
+to remote Maven repositories.
+It can contain X.509 certificates, and PKCS#7 formatted certificate chains.
+A JKS formatted keystore is automatically created to store the CA certificate(s),
+and configured to be used as a trusted certificate(s) by the Maven commands.
+Note that the root CA certificates are also imported into the created keystore.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#duration-v1-meta">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.PlatformInjectable">PlatformInjectable
+</h3>
+<p>
+<p>PlatformInjectable &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.PodSpec">PodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.PodSpecTemplate">PodSpecTemplate</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>initContainers</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ephemeralContainers</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#ephemeralcontainer-v1-core">
+[]Kubernetes core/v1.EphemeralContainer
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>restartPolicy</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#restartpolicy-v1-core">
+Kubernetes core/v1.RestartPolicy
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationGracePeriodSeconds</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>activeDeadlineSeconds</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dnsPolicy</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>topologySpreadConstraints</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#topologyspreadconstraint-v1-core">
+[]Kubernetes core/v1.TopologySpreadConstraint
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.PodSpecTemplate">PodSpecTemplate
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationSpec">IntegrationSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#camel.apache.org/v1.PodSpec">
+PodSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>initContainers</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ephemeralContainers</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#ephemeralcontainer-v1-core">
+[]Kubernetes core/v1.EphemeralContainer
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>restartPolicy</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#restartpolicy-v1-core">
+Kubernetes core/v1.RestartPolicy
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationGracePeriodSeconds</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>activeDeadlineSeconds</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dnsPolicy</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>topologySpreadConstraints</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#topologyspreadconstraint-v1-core">
+[]Kubernetes core/v1.TopologySpreadConstraint
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.PublishTask">PublishTask
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuildahTask">BuildahTask</a>, 
+<a href="#camel.apache.org/v1.KanikoTask">KanikoTask</a>, 
+<a href="#camel.apache.org/v1.SpectrumTask">SpectrumTask</a>)
+</p>
+<p>
+<p>PublishTask &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>contextDir</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>baseImage</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>registry</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationPlatformRegistrySpec">
+IntegrationPlatformRegistrySpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.RawMessage">RawMessage
+(<code>[]byte</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.BeanProperties">BeanProperties</a>, 
+<a href="#camel.apache.org/v1alpha1.EndpointProperties">EndpointProperties</a>, 
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerParameters">ErrorHandlerParameters</a>, 
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerRef">ErrorHandlerRef</a>, 
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerSpec">ErrorHandlerSpec</a>, 
+<a href="#camel.apache.org/v1.Flow">Flow</a>, 
+<a href="#camel.apache.org/v1.TraitConfiguration">TraitConfiguration</a>)
+</p>
+<p>
+<p>RawMessage is a raw encoded JSON value.
+It implements Marshaler and Unmarshaler and can
+be used to delay JSON decoding or precompute a JSON encoding.</p>
+</p>
+<h3 id="camel.apache.org/v1.ResourceCondition">ResourceCondition
+</h3>
+<p>
+<p>ResourceCondition is a common type for all conditions</p>
+</p>
+<h3 id="camel.apache.org/v1.ResourceSpec">ResourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuilderTask">BuilderTask</a>, 
+<a href="#camel.apache.org/v1.IntegrationSpec">IntegrationSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationStatus">IntegrationStatus</a>)
+</p>
+<p>
+<p>ResourceSpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>DataSpec</code></br>
+<em>
+<a href="#camel.apache.org/v1.DataSpec">
+DataSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>DataSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#camel.apache.org/v1.ResourceType">
+ResourceType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>mountPath</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.ResourceType">ResourceType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.ResourceSpec">ResourceSpec</a>)
+</p>
+<p>
+<p>ResourceType &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.RuntimeProvider">RuntimeProvider
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKitStatus">IntegrationKitStatus</a>, 
+<a href="#camel.apache.org/v1.IntegrationPlatformBuildSpec">IntegrationPlatformBuildSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationStatus">IntegrationStatus</a>, 
+<a href="#camel.apache.org/v1.RuntimeSpec">RuntimeSpec</a>)
+</p>
+<p>
+<p>RuntimeProvider &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1.RuntimeSpec">RuntimeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuilderTask">BuilderTask</a>, 
+<a href="#camel.apache.org/v1.CamelCatalogSpec">CamelCatalogSpec</a>)
+</p>
+<p>
+<p>RuntimeSpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>version</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>provider</code></br>
+<em>
+<a href="#camel.apache.org/v1.RuntimeProvider">
+RuntimeProvider
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>applicationClass</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+<a href="#camel.apache.org/v1.MavenArtifact">
+[]MavenArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capabilities</code></br>
+<em>
+<a href="#camel.apache.org/v1.Capability">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1.Capability
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.S2iTask">S2iTask
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Task">Task</a>)
+</p>
+<p>
+<p>S2iTask &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>BaseTask</code></br>
+<em>
+<a href="#camel.apache.org/v1.BaseTask">
+BaseTask
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BaseTask</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>contextDir</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>tag</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.SourceSpec">SourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuilderTask">BuilderTask</a>, 
+<a href="#camel.apache.org/v1.IntegrationSpec">IntegrationSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationStatus">IntegrationStatus</a>, 
+<a href="#camel.apache.org/v1alpha1.KameletSpec">KameletSpec</a>)
+</p>
+<p>
+<p>SourceSpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>DataSpec</code></br>
+<em>
+<a href="#camel.apache.org/v1.DataSpec">
+DataSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>DataSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>language</code></br>
+<em>
+<a href="#camel.apache.org/v1.Language">
+Language
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>loader</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Loader is an optional id of the org.apache.camel.k.RoutesLoader that will
+interpret this source at runtime</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>interceptors</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Interceptors are optional identifiers the org.apache.camel.k.RoutesLoader
+uses to pre/post process sources</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#camel.apache.org/v1.SourceType">
+SourceType
+</a>
+</em>
+</td>
+<td>
+<p>Type defines the kind of source described by this object</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>property-names</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>List of property names defined in the source (e.g. if type is &ldquo;template&rdquo;)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.SourceType">SourceType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.SourceSpec">SourceSpec</a>)
+</p>
+<p>
+</p>
+<h3 id="camel.apache.org/v1.SpectrumTask">SpectrumTask
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.Task">Task</a>)
+</p>
+<p>
+<p>SpectrumTask &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>BaseTask</code></br>
+<em>
+<a href="#camel.apache.org/v1.BaseTask">
+BaseTask
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BaseTask</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>PublishTask</code></br>
+<em>
+<a href="#camel.apache.org/v1.PublishTask">
+PublishTask
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>PublishTask</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.Task">Task
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.BuildSpec">BuildSpec</a>)
+</p>
+<p>
+<p>Task &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>builder</code></br>
+<em>
+<a href="#camel.apache.org/v1.BuilderTask">
+BuilderTask
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildah</code></br>
+<em>
+<a href="#camel.apache.org/v1.BuildahTask">
+BuildahTask
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>kaniko</code></br>
+<em>
+<a href="#camel.apache.org/v1.KanikoTask">
+KanikoTask
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>spectrum</code></br>
+<em>
+<a href="#camel.apache.org/v1.SpectrumTask">
+SpectrumTask
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>s2i</code></br>
+<em>
+<a href="#camel.apache.org/v1.S2iTask">
+S2iTask
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.TraitConfiguration">TraitConfiguration
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.TraitSpec">TraitSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>RawMessage</code></br>
+<em>
+<a href="#camel.apache.org/v1.RawMessage">
+RawMessage
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>RawMessage</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.TraitProfile">TraitProfile
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKitSpec">IntegrationKitSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">IntegrationPlatformSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationSpec">IntegrationSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationStatus">IntegrationStatus</a>)
+</p>
+<p>
+<p>TraitProfile represents lists of traits that are enabled for the specific installation/integration</p>
+</p>
+<h3 id="camel.apache.org/v1.TraitSpec">TraitSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.IntegrationKitSpec">IntegrationKitSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationPlatformSpec">IntegrationPlatformSpec</a>, 
+<a href="#camel.apache.org/v1.IntegrationSpec">IntegrationSpec</a>)
+</p>
+<p>
+<p>A TraitSpec contains the configuration of a trait</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#camel.apache.org/v1.TraitConfiguration">
+TraitConfiguration
+</a>
+</em>
+</td>
+<td>
+<p>TraitConfiguration &ndash;</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1.ValueSource">ValueSource
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1.MavenSpec">MavenSpec</a>)
+</p>
+<p>
+<p>ValueSource &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>configMapKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#configmapkeyselector-v1-core">
+Kubernetes core/v1.ConfigMapKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>Selects a key of a ConfigMap.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>Selects a key of a secret.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="camel.apache.org/v1alpha1">camel.apache.org/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the camel v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#camel.apache.org/v1alpha1.Kamelet">Kamelet</a>
+</li><li>
+<a href="#camel.apache.org/v1alpha1.KameletBinding">KameletBinding</a>
+</li></ul>
+<h3 id="camel.apache.org/v1alpha1.Kamelet">Kamelet
+</h3>
+<p>
+<p>Kamelet is the Schema for the kamelets API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+camel.apache.org/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Kamelet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletSpec">
+KameletSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>definition</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProps">
+JSONSchemaProps
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sources</code></br>
+<em>
+<a href="#camel.apache.org/v1.SourceSpec">
+[]SourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>flow</code></br>
+<em>
+<a href="#camel.apache.org/v1.Flow">
+Flow
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>authorization</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.AuthorizationSpec">
+AuthorizationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>types</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.EventTypeSpec">
+map[github.com/apache/camel-k/pkg/apis/camel/v1alpha1.EventSlot]github.com/apache/camel-k/pkg/apis/camel/v1alpha1.EventTypeSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletStatus">
+KameletStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.KameletBinding">KameletBinding
+</h3>
+<p>
+<p>KameletBinding is the Schema for the kamelets binding API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+camel.apache.org/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>KameletBinding</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingSpec">
+KameletBindingSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>integration</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationSpec">
+IntegrationSpec
+</a>
+</em>
+</td>
+<td>
+<p>Integration is an optional integration used to specify custom parameters</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">
+Endpoint
+</a>
+</em>
+</td>
+<td>
+<p>Source is the starting point of the integration defined by this binding</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">
+Endpoint
+</a>
+</em>
+</td>
+<td>
+<p>Sink is the destination of the integration defined by this binding</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>errorHandler</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerSpec">
+ErrorHandlerSpec
+</a>
+</em>
+</td>
+<td>
+<p>ErrorHandler is an optional handler called upon an error occuring in the integration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">
+[]Endpoint
+</a>
+</em>
+</td>
+<td>
+<p>Steps contains an optional list of intermediate steps that are executed between the Source and the Sink</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingStatus">
+KameletBindingStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.AuthorizationSpec">AuthorizationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletSpec">KameletSpec</a>)
+</p>
+<p>
+<p>AuthorizationSpec is TODO (oauth information)</p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.BeanProperties">BeanProperties
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerBean">ErrorHandlerBean</a>)
+</p>
+<p>
+<p>BeanProperties represent an unstructured object properties to be set on a bean</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>RawMessage</code></br>
+<em>
+<a href="#camel.apache.org/v1.RawMessage">
+RawMessage
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.Endpoint">Endpoint
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerDeadLetterChannel">ErrorHandlerDeadLetterChannel</a>, 
+<a href="#camel.apache.org/v1alpha1.KameletBindingSpec">KameletBindingSpec</a>)
+</p>
+<p>
+<p>Endpoint represents a source/sink external entity</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ref</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Ref can be used to declare a Kubernetes resource as source/sink endpoint</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>uri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>URI can alternatively be used to specify the (Camel) endpoint explicitly</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.EndpointProperties">
+EndpointProperties
+</a>
+</em>
+</td>
+<td>
+<p>Properties are a key value representation of endpoint properties</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>types</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.EventTypeSpec">
+map[github.com/apache/camel-k/pkg/apis/camel/v1alpha1.EventSlot]github.com/apache/camel-k/pkg/apis/camel/v1alpha1.EventTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>Types defines the schema of the data produced/consumed by the endpoint</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.EndpointProperties">EndpointProperties
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">Endpoint</a>)
+</p>
+<p>
+<p>EndpointProperties is a key/value struct represented as JSON raw to allow numeric/boolean values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>RawMessage</code></br>
+<em>
+<a href="#camel.apache.org/v1.RawMessage">
+RawMessage
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>RawMessage</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.EndpointType">EndpointType
+(<code>string</code> alias)</p></h3>
+<p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandler">ErrorHandler
+</h3>
+<p>
+<p>ErrorHandler is a generic interface that represent any type of error handler specification</p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandlerBean">ErrorHandlerBean
+</h3>
+<p>
+<p>ErrorHandlerBean represents a bean error handler type</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ErrorHandlerNone</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerNone">
+ErrorHandlerNone
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.BeanProperties">
+BeanProperties
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandlerDeadLetterChannel">ErrorHandlerDeadLetterChannel
+</h3>
+<p>
+<p>ErrorHandlerDeadLetterChannel represents a dead letter channel error handler type</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ErrorHandlerLog</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerLog">
+ErrorHandlerLog
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>endpoint</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">
+Endpoint
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandlerLog">ErrorHandlerLog
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerDeadLetterChannel">ErrorHandlerDeadLetterChannel</a>)
+</p>
+<p>
+<p>ErrorHandlerLog represent a default (log) error handler type</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ErrorHandlerNone</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerNone">
+ErrorHandlerNone
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>parameters</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerParameters">
+ErrorHandlerParameters
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandlerNone">ErrorHandlerNone
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerBean">ErrorHandlerBean</a>, 
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerLog">ErrorHandlerLog</a>)
+</p>
+<p>
+<p>ErrorHandlerNone &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>baseErrorHandler</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.baseErrorHandler">
+baseErrorHandler
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandlerParameters">ErrorHandlerParameters
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerLog">ErrorHandlerLog</a>)
+</p>
+<p>
+<p>ErrorHandlerParameters represent an unstructured object for error handler parameters</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>RawMessage</code></br>
+<em>
+<a href="#camel.apache.org/v1.RawMessage">
+RawMessage
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandlerRef">ErrorHandlerRef
+</h3>
+<p>
+<p>ErrorHandlerRef represents a reference to an error handler builder available in the registry</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>baseErrorHandler</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.baseErrorHandler">
+baseErrorHandler
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>RawMessage</code></br>
+<em>
+<a href="#camel.apache.org/v1.RawMessage">
+RawMessage
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandlerSpec">ErrorHandlerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingSpec">KameletBindingSpec</a>)
+</p>
+<p>
+<p>ErrorHandlerSpec represents an unstructured object for an error handler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>RawMessage</code></br>
+<em>
+<a href="#camel.apache.org/v1.RawMessage">
+RawMessage
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.ErrorHandlerType">ErrorHandlerType
+(<code>string</code> alias)</p></h3>
+<p>
+<p>ErrorHandlerType &ndash;</p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.EventSlot">EventSlot
+(<code>string</code> alias)</p></h3>
+<p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.EventTypeSpec">EventTypeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">Endpoint</a>, 
+<a href="#camel.apache.org/v1alpha1.KameletSpec">KameletSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>mediaType</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>schema</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProps">
+JSONSchemaProps
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.ExternalDocumentation">ExternalDocumentation
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProps">JSONSchemaProps</a>)
+</p>
+<p>
+<p>ExternalDocumentation allows referencing an external resource for extended documentation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>description</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>url</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.JSON">JSON
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProp">JSONSchemaProp</a>, 
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProps">JSONSchemaProps</a>)
+</p>
+<p>
+<p>JSON represents any valid JSON value.
+These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>RawMessage</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.RawMessage">
+RawMessage
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>RawMessage</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.JSONSchemaProp">JSONSchemaProp
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProps">JSONSchemaProps</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>format</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:</p>
+<ul>
+<li>bsonobjectid: a bson object ID, i.e. a 24 characters hex string</li>
+<li>uri: an URI as parsed by Golang net/url.ParseRequestURI</li>
+<li>email: an email address as parsed by Golang net/mail.ParseAddress</li>
+<li>hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034].</li>
+<li>ipv4: an IPv4 IP as parsed by Golang net.ParseIP</li>
+<li>ipv6: an IPv6 IP as parsed by Golang net.ParseIP</li>
+<li>cidr: a CIDR as parsed by Golang net.ParseCIDR</li>
+<li>mac: a MAC address as parsed by Golang net.ParseMAC</li>
+<li>uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$</li>
+<li>uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$</li>
+<li>uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$</li>
+<li>uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$</li>
+<li>isbn: an ISBN10 or ISBN13 number string like &ldquo;0321751043&rdquo; or &ldquo;978-0321751041&rdquo;</li>
+<li>isbn10: an ISBN10 number string like &ldquo;0321751043&rdquo;</li>
+<li>isbn13: an ISBN13 number string like &ldquo;978-0321751041&rdquo;</li>
+<li>creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})$ with any non digit characters mixed in</li>
+<li>ssn: a U.S. social security number following the regex ^\d{3}[- ]?\d{2}[- ]?\d{4}$</li>
+<li>hexcolor: an hexadecimal color code like &ldquo;#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$</li>
+<li>rgbcolor: an RGB color code like rgb like &ldquo;rgb(255,255,2559&rdquo;</li>
+<li>byte: base64 encoded binary data</li>
+<li>password: any kind of string</li>
+<li>date: a date string like &ldquo;2006-01-02&rdquo; as defined by full-date in RFC3339</li>
+<li>duration: a duration string like &ldquo;22 ns&rdquo; as parsed by Golang time.ParseDuration or compatible with Scala duration format</li>
+<li>datetime: a date time string like &ldquo;2014-12-15T19:30:20.000Z&rdquo; as defined by date-time in RFC3339.</li>
+</ul>
+</td>
+</tr>
+<tr>
+<td>
+<code>title</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>default</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSON">
+JSON
+</a>
+</em>
+</td>
+<td>
+<p>default is a default value for undefined object fields.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maximum</code></br>
+<em>
+encoding/json.Number
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>exclusiveMaximum</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>minimum</code></br>
+<em>
+encoding/json.Number
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>exclusiveMinimum</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxLength</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>minLength</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>pattern</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxItems</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>minItems</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>uniqueItems</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxProperties</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>minProperties</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>multipleOf</code></br>
+<em>
+encoding/json.Number
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>enum</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSON">
+[]JSON
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>example</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSON">
+JSON
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nullable</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>x-descriptors</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>The list of descriptors that determine which UI components to use on different views</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.JSONSchemaProps">JSONSchemaProps
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.EventTypeSpec">EventTypeSpec</a>, 
+<a href="#camel.apache.org/v1alpha1.KameletSpec">KameletSpec</a>)
+</p>
+<p>
+<p>JSONSchemaProps is a JSON-Schema following Specification Draft 4 (<a href="http://json-schema.org/">http://json-schema.org/</a>).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>title</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProp">
+map[string]github.com/apache/camel-k/pkg/apis/camel/v1alpha1.JSONSchemaProp
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>required</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>example</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSON">
+JSON
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>externalDocs</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.ExternalDocumentation">
+ExternalDocumentation
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>$schema</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaURL">
+JSONSchemaURL
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.JSONSchemaURL">JSONSchemaURL
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProps">JSONSchemaProps</a>)
+</p>
+<p>
+<p>JSONSchemaURL represents a schema url.</p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.KameletBindingCondition">KameletBindingCondition
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingStatus">KameletBindingStatus</a>)
+</p>
+<p>
+<p>KameletBindingCondition describes the state of a resource at a certain point.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingConditionType">
+KameletBindingConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Type of kameletBinding condition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the condition, one of True, False, Unknown.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastUpdateTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>The last time this condition was updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastTransitionTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>Last time the condition transitioned from one status to another.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The reason for the condition&rsquo;s last transition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>A human readable message indicating details about the transition.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.KameletBindingConditionType">KameletBindingConditionType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingCondition">KameletBindingCondition</a>)
+</p>
+<p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.KameletBindingPhase">KameletBindingPhase
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingStatus">KameletBindingStatus</a>)
+</p>
+<p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.KameletBindingSpec">KameletBindingSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletBinding">KameletBinding</a>)
+</p>
+<p>
+<p>KameletBindingSpec &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>integration</code></br>
+<em>
+<a href="#camel.apache.org/v1.IntegrationSpec">
+IntegrationSpec
+</a>
+</em>
+</td>
+<td>
+<p>Integration is an optional integration used to specify custom parameters</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">
+Endpoint
+</a>
+</em>
+</td>
+<td>
+<p>Source is the starting point of the integration defined by this binding</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">
+Endpoint
+</a>
+</em>
+</td>
+<td>
+<p>Sink is the destination of the integration defined by this binding</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>errorHandler</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.ErrorHandlerSpec">
+ErrorHandlerSpec
+</a>
+</em>
+</td>
+<td>
+<p>ErrorHandler is an optional handler called upon an error occuring in the integration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.Endpoint">
+[]Endpoint
+</a>
+</em>
+</td>
+<td>
+<p>Steps contains an optional list of intermediate steps that are executed between the Source and the Sink</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.KameletBindingStatus">KameletBindingStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletBinding">KameletBinding</a>)
+</p>
+<p>
+<p>KameletBindingStatus &ndash;</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingPhase">
+KameletBindingPhase
+</a>
+</em>
+</td>
+<td>
+<p>Phase &ndash;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletBindingCondition">
+[]KameletBindingCondition
+</a>
+</em>
+</td>
+<td>
+<p>Conditions &ndash;</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.KameletCondition">KameletCondition
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletStatus">KameletStatus</a>)
+</p>
+<p>
+<p>KameletCondition describes the state of a resource at a certain point.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletConditionType">
+KameletConditionType
+</a>
+</em>
+</td>
+<td>
+<p>Type of kamelet condition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the condition, one of True, False, Unknown.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastUpdateTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>The last time this condition was updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastTransitionTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>Last time the condition transitioned from one status to another.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The reason for the condition&rsquo;s last transition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>A human readable message indicating details about the transition.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.KameletConditionType">KameletConditionType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletCondition">KameletCondition</a>)
+</p>
+<p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.KameletPhase">KameletPhase
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletStatus">KameletStatus</a>)
+</p>
+<p>
+</p>
+<h3 id="camel.apache.org/v1alpha1.KameletProperty">KameletProperty
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.KameletStatus">KameletStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>default</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.KameletSpec">KameletSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.Kamelet">Kamelet</a>)
+</p>
+<p>
+<p>KameletSpec defines the desired state of Kamelet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>definition</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.JSONSchemaProps">
+JSONSchemaProps
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sources</code></br>
+<em>
+<a href="#camel.apache.org/v1.SourceSpec">
+[]SourceSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>flow</code></br>
+<em>
+<a href="#camel.apache.org/v1.Flow">
+Flow
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>authorization</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.AuthorizationSpec">
+AuthorizationSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>types</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.EventTypeSpec">
+map[github.com/apache/camel-k/pkg/apis/camel/v1alpha1.EventSlot]github.com/apache/camel-k/pkg/apis/camel/v1alpha1.EventTypeSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>dependencies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.KameletStatus">KameletStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.Kamelet">Kamelet</a>)
+</p>
+<p>
+<p>KameletStatus defines the observed state of Kamelet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>phase</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletPhase">
+KameletPhase
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletCondition">
+[]KameletCondition
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code></br>
+<em>
+<a href="#camel.apache.org/v1alpha1.KameletProperty">
+[]KameletProperty
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="camel.apache.org/v1alpha1.RawMessage">RawMessage
+(<code>[]byte</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#camel.apache.org/v1alpha1.JSON">JSON</a>)
+</p>
+<p>
+<p>RawMessage is a raw encoded JSON value.
+It implements Marshaler and Unmarshaler and can
+be used to delay JSON decoding or precompute a JSON encoding.</p>
+</p>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>
+on git commit <code>bd0a199c</code>.
+</em></p>

--- a/script/gen_crd/gen-crd-api-config.json
+++ b/script/gen_crd/gen-crd-api-config.json
@@ -1,0 +1,20 @@
+{
+    "hideMemberFields": [
+        "TypeMeta"
+    ],
+    "hideTypePatterns": [
+        "ParseError$",
+        "List$"
+    ],
+    "externalPackages": [
+        {
+            "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+        }
+    ],
+    "typeDisplayNamePrefixOverrides": {
+        "k8s.io/api/": "Kubernetes ",
+        "k8s.io/apimachinery/pkg/apis/": "Kubernetes "
+    },
+    "markdownDisabled": false
+}

--- a/script/gen_crd/gen_crd_api.sh
+++ b/script/gen_crd/gen_crd_api.sh
@@ -16,13 +16,22 @@
 # limitations under the License.
 
 location=$(dirname $0)
-rootdir=$location/..
+rootdir=$location/../..
 
-echo "Generating API documentation..."
-$location/gen_crd/gen_crd_api.sh
-echo "Generating API documentation... done!"
+echo "Downloading gen-crd-api-reference-docs binary..."
+TMPFILE=`mktemp`
+TMPDIR=`mktemp -d`
+PWD=`pwd`
+wget -q --show-progress https://github.com/ahmetb/gen-crd-api-reference-docs/releases/download/v0.1.5/gen-crd-api-reference-docs_linux_amd64.tar.gz -O $TMPFILE
+tar -C $TMPDIR -xf $TMPFILE
 
-echo "Generating traits documentation..."
-cd $rootdir
-go run ./cmd/util/doc-gen --input-dirs ./pkg/trait --input-dirs ./addons/master --input-dirs ./addons/threescale --input-dirs ./addons/tracing
-echo "Generating traits documentation... done!"
+echo "Generating CRD API documentation..."
+$TMPDIR/gen-crd-api-reference-docs \
+    -config $location/gen-crd-api-config.json \
+    -template-dir $location/template \
+    -api-dir "github.com/apache/camel-k/pkg/apis/camel" \
+    -out-file $rootdir/docs/modules/ROOT/pages/apis/crds-html.adoc
+
+echo "Cleaning the gen-crd-api-reference-docs binary..."
+rm $TMPFILE
+rm -rf $TMPDIR

--- a/script/gen_crd/template/members.tpl
+++ b/script/gen_crd/template/members.tpl
@@ -1,0 +1,48 @@
+{{ define "members" }}
+
+{{ range .Members }}
+{{ if not (hiddenMember .)}}
+<tr>
+    <td>
+        <code>{{ fieldName . }}</code></br>
+        <em>
+            {{ if linkForType .Type }}
+                <a href="{{ linkForType .Type}}">
+                    {{ typeDisplayName .Type }}
+                </a>
+            {{ else }}
+                {{ typeDisplayName .Type }}
+            {{ end }}
+        </em>
+    </td>
+    <td>
+        {{ if fieldEmbedded . }}
+            <p>
+                (Members of <code>{{ fieldName . }}</code> are embedded into this type.)
+            </p>
+        {{ end}}
+
+        {{ if isOptionalMember .}}
+            <em>(Optional)</em>
+        {{ end }}
+
+        {{ safe (renderComments .CommentLines) }}
+
+    {{ if and (eq (.Type.Name.Name) "ObjectMeta") }}
+        Refer to the Kubernetes API documentation for the fields of the
+        <code>metadata</code> field.
+    {{ end }}
+
+    {{ if or (eq (fieldName .) "spec") }}
+        <br/>
+        <br/>
+        <table>
+            {{ template "members" .Type }}
+        </table>
+    {{ end }}
+    </td>
+</tr>
+{{ end }}
+{{ end }}
+
+{{ end }}

--- a/script/gen_crd/template/pkg.tpl
+++ b/script/gen_crd/template/pkg.tpl
@@ -1,0 +1,49 @@
+{{ define "packages" }}
+
+{{ with .packages}}
+<p>Packages:</p>
+<ul>
+    {{ range . }}
+    <li>
+        <a href="#{{- packageAnchorID . -}}">{{ packageDisplayName . }}</a>
+    </li>
+    {{ end }}
+</ul>
+{{ end}}
+
+{{ range .packages }}
+    <h2 id="{{- packageAnchorID . -}}">
+        {{- packageDisplayName . -}}
+    </h2>
+
+    {{ with (index .GoPackages 0 )}}
+        {{ with .DocComments }}
+        <p>
+            {{ safe (renderComments .) }}
+        </p>
+        {{ end }}
+    {{ end }}
+
+    Resource Types:
+    <ul>
+    {{- range (visibleTypes (sortedTypes .Types)) -}}
+        {{ if isExportedType . -}}
+        <li>
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+        </li>
+        {{- end }}
+    {{- end -}}
+    </ul>
+
+    {{ range (visibleTypes (sortedTypes .Types))}}
+        {{ template "type" .  }}
+    {{ end }}
+    <hr/>
+{{ end }}
+
+<p><em>
+    Generated with <code>gen-crd-api-reference-docs</code>
+    {{ with .gitCommit }} on git commit <code>{{ . }}</code>{{end}}.
+</em></p>
+
+{{ end }}

--- a/script/gen_crd/template/type.tpl
+++ b/script/gen_crd/template/type.tpl
@@ -1,0 +1,58 @@
+{{ define "type" }}
+
+<h3 id="{{ anchorIDForType . }}">
+    {{- .Name.Name }}
+    {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias)</p>{{ end -}}
+</h3>
+{{ with (typeReferences .) }}
+    <p>
+        (<em>Appears on:</em>
+        {{- $prev := "" -}}
+        {{- range . -}}
+            {{- if $prev -}}, {{ end -}}
+            {{ $prev = . }}
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+        {{- end -}}
+        )
+    </p>
+{{ end }}
+
+
+<p>
+    {{ safe (renderComments .CommentLines) }}
+</p>
+
+{{ if .Members }}
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{ if isExportedType . }}
+        <tr>
+            <td>
+                <code>apiVersion</code></br>
+                string</td>
+            <td>
+                <code>
+                    {{apiGroup .}}
+                </code>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>kind</code></br>
+                string
+            </td>
+            <td><code>{{.Name.Name}}</code></td>
+        </tr>
+        {{ end }}
+        {{ template "members" .}}
+    </tbody>
+</table>
+{{ end }}
+
+{{ end }}


### PR DESCRIPTION
<!-- Description -->
With this PR we introduce a new script which is in charge to generate an html single page with the definition of the API. We use the project https://github.com/ahmetb/gen-crd-api-reference-docs by temporary downloading the binary needed to run the generation.

I've changed the `generate-doc` procedure to include the execution of this script that will update the API definition file as expected by the documentation

We include that file in a document that will be exposed in the documentation. 

Close #1137 

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Doc: generated API
```
