### PR TITLE
[Backport 1.4.x] fix(cmd): run file system stat errors

### DIFF
--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -513,3 +513,10 @@ func TestRunTextCompressedResource(t *testing.T) {
 	assert.Equal(t, "text/plain", textResourceSpec.ContentType)
 	assert.True(t, textResourceSpec.Compression)
 }
+
+func TestIsLocalFileAndExists(t *testing.T) {
+	value, err := isLocalAndFileExists("/root/test")
+	// must not panic because a permission error
+	assert.NotNil(t, err)
+	assert.False(t, value)
+}

--- a/pkg/cmd/util_content.go
+++ b/pkg/cmd/util_content.go
@@ -30,7 +30,12 @@ func loadRawContent(source string) ([]byte, string, error) {
 	var content []byte
 	var err error
 
-	if isLocalAndFileExists(source) {
+	ok, err := isLocalAndFileExists(source)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if ok {
 		content, err = ioutil.ReadFile(source)
 	} else {
 		u, err := url.Parse(source)

--- a/pkg/cmd/util_sources.go
+++ b/pkg/cmd/util_sources.go
@@ -65,7 +65,12 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 	sources := make([]Source, 0, len(locations))
 
 	for _, location := range locations {
-		if isLocalAndFileExists(location) {
+		ok, err := isLocalAndFileExists(location)
+		if err != nil {
+			return sources, err
+		}
+
+		if ok {
 			answer, err := ResolveLocalSource(location, compress)
 			if err != nil {
 				return sources, err


### PR DESCRIPTION
* Introducing a check to make sure that we don't panic if any kind of filesystem error but file not found is reported
* Adding a unit test to check a permission error on /root won't panic

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cmd): run file system stat errors
```
