### PR TITLE
fix(doc): broken links

### DIFF
--- a/docs/modules/ROOT/pages/apis/crds-html.adoc
+++ b/docs/modules/ROOT/pages/apis/crds-html.adoc
@@ -1,10 +1,10 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#camel.apache.org%2fv1">camel.apache.org/v1</a>
+<a href="#camel.apache.org/v1">camel.apache.org/v1</a>
 </li>
 <li>
-<a href="#camel.apache.org%2fv1alpha1">camel.apache.org/v1alpha1</a>
+<a href="#camel.apache.org/v1alpha1">camel.apache.org/v1alpha1</a>
 </li>
 </ul>
 <h2 id="camel.apache.org/v1">camel.apache.org/v1</h2>
@@ -5307,18 +5307,6 @@ ErrorHandlerParameters
 </tr>
 </thead>
 <tbody>
-<tr>
-<td>
-<code>baseErrorHandler</code></br>
-<em>
-<a href="#camel.apache.org/v1alpha1.baseErrorHandler">
-baseErrorHandler
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="camel.apache.org/v1alpha1.ErrorHandlerParameters">ErrorHandlerParameters
@@ -5365,18 +5353,6 @@ RawMessage
 </tr>
 </thead>
 <tbody>
-<tr>
-<td>
-<code>baseErrorHandler</code></br>
-<em>
-<a href="#camel.apache.org/v1alpha1.baseErrorHandler">
-baseErrorHandler
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
 <tr>
 <td>
 <code>RawMessage</code></br>
@@ -6500,5 +6476,5 @@ be used to delay JSON decoding or precompute a JSON encoding.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>bd0a199c</code>.
+on git commit <code>cca9858d</code>.
 </em></p>

--- a/script/gen_crd/gen-crd-api-config.json
+++ b/script/gen_crd/gen-crd-api-config.json
@@ -1,6 +1,7 @@
 {
     "hideMemberFields": [
-        "TypeMeta"
+        "TypeMeta",
+        "baseErrorHandler"
     ],
     "hideTypePatterns": [
         "ParseError$",

--- a/script/gen_crd/gen_crd_api.sh
+++ b/script/gen_crd/gen_crd_api.sh
@@ -32,6 +32,9 @@ $TMPDIR/gen-crd-api-reference-docs \
     -api-dir "github.com/apache/camel-k/pkg/apis/camel" \
     -out-file $rootdir/docs/modules/ROOT/pages/apis/crds-html.adoc
 
+# Workaround: https://github.com/ahmetb/gen-crd-api-reference-docs/issues/33
+sed -i -E "s/%2f/\//" $rootdir/docs/modules/ROOT/pages/apis/crds-html.adoc
+
 echo "Cleaning the gen-crd-api-reference-docs binary..."
 rm $TMPFILE
 rm -rf $TMPDIR


### PR DESCRIPTION
* Excluded a private struct so it's no longer linked in the gen docs
* Workaround an issue reported to convert urlencoded chars

Fixes #2280

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
