### PR TITLE
chore(e2e): Assert upgraded integration Pod uses new version Kit

### DIFF
--- a/e2e/support/util/dump.go
+++ b/e2e/support/util/dump.go
@@ -35,7 +35,6 @@ import (
 
 // Dump prints all information about the given namespace to debug errors
 func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
-
 	t.Logf("-------------------- start dumping namespace %s --------------------\n", ns)
 
 	camelClient, err := versioned.NewForConfig(c.GetConfig())
@@ -82,6 +81,19 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 			return err
 		}
 		t.Logf("---\n%s\n---\n", string(pdata))
+	}
+
+	builds, err := camelClient.CamelV1().Builds(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	t.Logf("Found %d Builds:\n", len(builds.Items))
+	for _, build := range builds.Items {
+		data, err := kubernetes.ToYAML(&build)
+		if err != nil {
+			return err
+		}
+		t.Logf("---\n%s\n---\n", string(data))
 	}
 
 	cms, err := c.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
This covers the case where the new version Build fails, and the current integration Pod still runs the older Deployment ReplicaSet Pod.

**Release Note**
```release-note
NONE
```
