### PR TITLE
Configure kubernetes to use structured log

### DIFF
--- a/e2e/common/operator_metrics_test.go
+++ b/e2e/common/operator_metrics_test.go
@@ -56,7 +56,7 @@ func TestMetrics(t *testing.T) {
 		pod := OperatorPod(ns)()
 		Expect(pod).NotTo(BeNil())
 
-		logs := StructuredLogs(ns, pod.Name, corev1.PodLogOptions{})
+		logs := StructuredLogs(ns, pod.Name, corev1.PodLogOptions{}, false)
 		Expect(logs).NotTo(BeEmpty())
 
 		response, err := TestClient().CoreV1().RESTClient().Get().
@@ -81,14 +81,19 @@ func TestMetrics(t *testing.T) {
 				AddStep(MatchFields(IgnoreExtras, Fields{
 					"LoggerName":  Equal("camel-k.controller.build"),
 					"Message":     Equal("Build state transition"),
-					"Phase":       Equal(string(v1.BuildPhasePending)),
+					"Phase":       MatchFields(IgnoreExtras,
+						Fields{
+							"Name": Equal(string(v1.BuildPhasePending)),
+						}),
 					"RequestName": Equal(build.Name),
 				}), LogEntryNoop).
 				AddStep(MatchFields(IgnoreExtras, Fields{
 					"LoggerName":  Equal("camel-k.controller.build"),
 					"Message":     Equal("Reconciling Build"),
 					"RequestName": Equal(build.Name),
-				}), func(l *LogEntry) { ts1 = l.Timestamp.Time }).
+				}), func(l *LogEntry) {
+					ts1 = l.Timestamp.Time
+				}).
 				AddStep(MatchFields(IgnoreExtras, Fields{
 					"LoggerName": Equal("camel-k.builder"),
 					"Message":    HavePrefix("resolved base image:"),
@@ -97,7 +102,9 @@ func TestMetrics(t *testing.T) {
 					"LoggerName":  Equal("camel-k.controller.build"),
 					"Message":     Equal("Reconciling Build"),
 					"RequestName": Equal(build.Name),
-				}), func(l *LogEntry) { ts2 = l.Timestamp.Time }).
+				}), func(l *LogEntry) {
+					ts2 = l.Timestamp.Time
+				}).
 				Walk()
 			Expect(err).To(BeNil())
 			Expect(ts1).NotTo(BeZero())
@@ -337,7 +344,10 @@ func TestMetrics(t *testing.T) {
 				AddStep(MatchFields(IgnoreExtras, Fields{
 					"LoggerName":  Equal("camel-k.controller.build"),
 					"Message":     Equal("Build state transition"),
-					"Phase":       Equal(string(v1.BuildPhasePending)),
+					"Phase":       MatchFields(IgnoreExtras,
+						Fields{
+							"Name": Equal(string(v1.BuildPhasePending)),
+					}),
 					"RequestName": Equal(build.Name),
 				}), func(l *LogEntry) { ts2 = l.Timestamp.Time }).
 				Walk()

--- a/e2e/common/structured_logs_test.go
+++ b/e2e/common/structured_logs_test.go
@@ -1,0 +1,58 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	. "github.com/onsi/gomega"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/apache/camel-k/e2e/support"
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+)
+
+func TestStructuredLogs(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		name := "java"
+		Expect(Kamel("install", "-n", ns).Execute()).To(Succeed())
+		Expect(Kamel("run", "-n", ns, "files/Java.java",
+			"-t", "logging.format=json").Execute()).To(Succeed())
+		Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+		Eventually(IntegrationCondition(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+
+		pod := OperatorPod(ns)()
+		Expect(pod).NotTo(BeNil())
+
+		logs := StructuredLogs(ns, pod.Name, corev1.PodLogOptions{}, false)
+		Expect(logs).NotTo(BeEmpty())
+
+		it := Integration(ns, name)()
+		Expect(it).NotTo(BeNil())
+		build := Build(ns, it.Status.IntegrationKit.Name)()
+		Expect(build).NotTo(BeNil())
+
+		// Clean up
+		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+	})
+}
+

--- a/e2e/support/util/structured_log.go
+++ b/e2e/support/util/structured_log.go
@@ -20,6 +20,7 @@ limitations under the License.
 package util
 
 import (
+	"encoding/json"
 	"math"
 	"strconv"
 	"time"
@@ -43,6 +44,27 @@ func (t *Time) UnmarshalJSON(s []byte) (err error) {
 	return nil
 }
 
+type Phase struct {
+	Name string
+}
+
+func (p *Phase) UnmarshalJSON(b []byte) error {
+	if b[0] != '"' {
+		var tmp int
+
+		json.Unmarshal(b, &tmp)
+		p.Name = strconv.Itoa(tmp)
+
+		return nil
+	}
+
+	if err := json.Unmarshal(b, &p.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type LogEntry struct {
 	// Zap
 	Level      zapcore.Level `json:"level,omitempty"`
@@ -57,7 +79,7 @@ type LogEntry struct {
 	// Camel K
 	Namespace string `json:"ns,omitempty"`
 	Name      string `json:"name,omitempty"`
-	Phase     string `json:"phase,omitempty"`
+	Phase     Phase `json:"phase,omitempty"`
 	PhaseFrom string `json:"phase-from,omitempty"`
 	PhaseTo   string `json:"phase-to,omitempty"`
 }

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"k8s.io/klog/v2"
 	"math/rand"
 	"os"
 	"runtime"
@@ -76,6 +77,8 @@ func Run(healthPort, monitoringPort int32) {
 	logf.SetLogger(zap.New(func(o *zap.Options) {
 		o.Development = false
 	}))
+
+	klog.SetLogger(log)
 
 	printVersion()
 


### PR DESCRIPTION
Also include an integration test to ensure no unstructured logs leak
from other parts of the code

This solves #2286

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Use structured logs for kubernetes messages
```