### PR TITLE
chore(cli): Update CRDs when force installing cluster resources

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -233,14 +233,14 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 				fmt.Fprintln(cobraCmd.OutOrStdout(), "OLM resources are already available: skipping installation")
 			}
 
-			if err = install.WaitForAllCRDInstallation(o.Context, clientProvider, 90*time.Second); err != nil {
+			if err = install.WaitForAllCrdInstallation(o.Context, clientProvider, 90*time.Second); err != nil {
 				return err
 			}
 		}
 	}
 
 	if !o.SkipClusterSetup && !installViaOLM {
-		err := install.SetupClusterWideResourcesOrCollect(o.Context, clientProvider, collection, o.ClusterType)
+		err := install.SetupClusterWideResourcesOrCollect(o.Context, clientProvider, collection, o.ClusterType, o.Force)
 		if err != nil && k8serrors.IsForbidden(err) {
 			fmt.Fprintln(cobraCmd.OutOrStdout(), "Current user is not authorized to create cluster-wide objects like custom resource definitions or cluster roles: ", err)
 


### PR DESCRIPTION
This enables updating the CRDs when installing a newer version of Camel K via the CLI.

This also fixes upgrade e2e test when new changes are introduced in the CRDs.

**Release Note**
```release-note
chore(cli): Update CRDs when force installing cluster resources
```
