### PR TITLE
chore(ci): Cancel running workflows when PRs are updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,11 @@ on:
       - 'KEYS'
       - 'LICENSE'
       - 'NOTICE'
+
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -39,6 +39,10 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   builder-it:
     runs-on: ubuntu-20.04

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -39,6 +39,10 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -39,6 +39,10 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   kubernetes-it:
 

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -39,6 +39,10 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   local-it:
 

--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -39,6 +39,10 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: openshift-build

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -39,6 +39,10 @@ on:
       - 'LICENSE'
       - 'NOTICE'
 
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   upgrade:
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,11 @@ on:
     branches:
       - main
       - "release-*"
+
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Leverage GitHub Actions concurrency group to cancel any in progress workflows running for the same PR. This avoids wasting compute resources when PRs get updated, and free runners from running on obsolete changes. See:

https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/

**Release Note**
```release-note
NONE
```
