### PR TITLE
Provide more information when the build fails

### DIFF
--- a/pkg/controller/build/schedule_routine.go
+++ b/pkg/controller/build/schedule_routine.go
@@ -20,6 +20,7 @@ package build
 import (
 	"context"
 	"fmt"
+	"github.com/apache/camel-k/pkg/util/log"
 	"io/ioutil"
 	"os"
 	"path"
@@ -158,6 +159,11 @@ func (action *scheduleRoutineAction) runBuild(ctx context.Context, build *v1.Bui
 		}
 
 		if lastTask || taskFailed {
+			if taskFailed {
+				log.Errorf(nil, "Unable to complete the build: %s", status.Error)
+			}
+
+
 			// Spare a redundant update
 			break
 		}
@@ -165,6 +171,7 @@ func (action *scheduleRoutineAction) runBuild(ctx context.Context, build *v1.Bui
 		// Update the Build status
 		err := action.updateBuildStatus(ctx, build, status)
 		if err != nil {
+			log.Errorf(nil, "Unable to update build status: %s", status.Error)
 			status.Failed(err)
 			break
 		}


### PR DESCRIPTION
<!-- Description -->
Fix GH issue #2306


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Integration build error absent on the operator logs
```