### PR TITLE
Fix #2237: add flag to disable installation of default kamelets

### DIFF
--- a/pkg/controller/integrationplatform/create.go
+++ b/pkg/controller/integrationplatform/create.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	"github.com/apache/camel-k/pkg/resources"
+	"github.com/apache/camel-k/pkg/util/defaults"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/install"
@@ -52,9 +53,11 @@ func (action *createAction) Handle(ctx context.Context, platform *v1.Integration
 		}
 	}
 
-	// Kamelet Catalog installed on platform reconciliation for cases where users install a global operator
-	if err := install.KameletCatalog(ctx, action.client, platform.Namespace); err != nil {
-		return nil, err
+	if defaults.InstallDefaultKamelets() {
+		// Kamelet Catalog installed on platform reconciliation for cases where users install a global operator
+		if err := install.KameletCatalog(ctx, action.client, platform.Namespace); err != nil {
+			return nil, err
+		}
 	}
 
 	platform.Status.Phase = v1.IntegrationPlatformPhaseReady

--- a/pkg/install/optional.go
+++ b/pkg/install/optional.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/apache/camel-k/pkg/util/defaults"
 	"github.com/go-logr/logr"
 
 	"github.com/apache/camel-k/pkg/client"
@@ -46,9 +47,13 @@ func OperatorStartupOptionalTools(ctx context.Context, c client.Client, namespac
 	}
 
 	if kameletNamespace != "" {
-		if err := KameletCatalog(ctx, c, kameletNamespace); err != nil {
-			log.Info("Cannot install bundled Kamelet Catalog: skipping.")
-			log.V(8).Info("Error while installing bundled Kamelet Catalog", "error", err)
+		if defaults.InstallDefaultKamelets() {
+			if err := KameletCatalog(ctx, c, kameletNamespace); err != nil {
+				log.Info("Cannot install bundled Kamelet Catalog: skipping.")
+				log.V(8).Info("Error while installing bundled Kamelet Catalog", "error", err)
+			}
+		} else {
+			log.Info("Kamelet Catalog installation is disabled")
 		}
 
 		if globalOperator {

--- a/pkg/util/defaults/defaults.go
+++ b/pkg/util/defaults/defaults.go
@@ -42,4 +42,7 @@ const (
 
 	// ImageName --
 	ImageName = "docker.io/apache/camel-k"
+
+	// installDefaultKamelets --
+	installDefaultKamelets = true
 )

--- a/pkg/util/defaults/defaults_support.go
+++ b/pkg/util/defaults/defaults_support.go
@@ -17,12 +17,28 @@ limitations under the License.
 
 package defaults
 
-import "os"
+import (
+	"os"
+	"strconv"
 
-var baseImageOverrideEnvs = []string{"BASE_IMAGE", "RELATED_IMAGE_BASE"}
+	"github.com/apache/camel-k/pkg/util/log"
+)
 
 func BaseImage() string {
-	return envOrDefault(baseImage, baseImageOverrideEnvs...)
+	return envOrDefault(baseImage, "KAMEL_BASE_IMAGE", "RELATED_IMAGE_BASE")
+}
+
+func InstallDefaultKamelets() bool {
+	return boolEnvOrDefault(installDefaultKamelets, "KAMEL_INSTALL_DEFAULT_KAMELETS")
+}
+
+func boolEnvOrDefault(def bool, envs ...string) bool {
+	strVal := envOrDefault(strconv.FormatBool(def), envs...)
+	res, err := strconv.ParseBool(strVal)
+	if err != nil {
+		log.Error(err, "cannot parse boolean property", "property", def, "value", strVal)
+	}
+	return res
 }
 
 func envOrDefault(def string, envs ...string) string {

--- a/pkg/util/defaults/defaults_test.go
+++ b/pkg/util/defaults/defaults_test.go
@@ -19,6 +19,7 @@ package defaults
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,5 +35,17 @@ func TestOverriddenBaseImage(t *testing.T) {
 	overriddenImage := "xxx"
 	assert.NoError(t, os.Setenv(env, overriddenImage))
 	assert.Equal(t, overriddenImage, BaseImage())
+	assert.NoError(t, os.Setenv(env, oldEnvVal))
+}
+
+func TestOverriddenInstallDefaultKamelets(t *testing.T) {
+	env := "KAMEL_INSTALL_DEFAULT_KAMELETS"
+	oldEnvVal := os.Getenv(env)
+	assert.NoError(t, os.Setenv(env, strconv.FormatBool(false)))
+	assert.False(t, InstallDefaultKamelets())
+	assert.NoError(t, os.Setenv(env, strconv.FormatBool(true)))
+	assert.True(t, InstallDefaultKamelets())
+	assert.NoError(t, os.Setenv(env, "wrongval"))
+	assert.False(t, InstallDefaultKamelets())
 	assert.NoError(t, os.Setenv(env, oldEnvVal))
 }

--- a/script/Makefile
+++ b/script/Makefile
@@ -20,6 +20,7 @@ LAST_RELEASED_VERSION := 1.4.0
 RUNTIME_VERSION := 1.7.0
 BUILDAH_VERSION := 1.14.0
 KANIKO_VERSION := 0.17.1
+INSTALL_DEFAULT_KAMELETS := true
 BASE_IMAGE := adoptopenjdk/openjdk11:slim
 LOCAL_REPOSITORY := /tmp/artifacts/m2
 IMAGE_NAME := docker.io/apache/camel-k
@@ -116,6 +117,9 @@ codegen:
 	@echo "" >> $(VERSIONFILE)
 	@echo "  // ImageName -- " >> $(VERSIONFILE)
 	@echo "  ImageName = \"$(IMAGE_NAME)\"" >> $(VERSIONFILE)
+	@echo "" >> $(VERSIONFILE)
+	@echo "  // installDefaultKamelets -- " >> $(VERSIONFILE)
+	@echo "  installDefaultKamelets = $(INSTALL_DEFAULT_KAMELETS)" >> $(VERSIONFILE)
 	@echo ")" >> $(VERSIONFILE)
 	@echo "" >> $(VERSIONFILE)
 	gofmt -w pkg/util/defaults/defaults.go


### PR DESCRIPTION
<!-- Description -->

Fix #2237


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
