### PR TITLE
Check if the environment can produce structured Maven logs before parsing them

### DIFF
--- a/pkg/util/maven/maven.go
+++ b/pkg/util/maven/maven.go
@@ -183,11 +183,13 @@ func Run(ctx Context) error {
 
 		mavenLog, parseError := ParseLog(line)
 
-		if parseError != nil {
-			// Do not abort the build because parsing failed ... the build may have succeeded
-			Log.Error(parseError, "Unable to parse maven log")
-		} else {
+		if parseError == nil {
 			NormalizeLog(mavenLog)
+		} else {
+			// Why we are ignoring the parsing errors here: there are a few scenarios where this would likely occur.
+			// For example, if something outside of Maven outputs something (i.e.: the JDK, a misbehaved plugin,
+			// etc). The build may still have succeeded, though.
+			NonNormalizedLog(line)
 		}
 	}
 	Log.Debug("Finished parsing Maven output")

--- a/pkg/util/maven/maven_log.go
+++ b/pkg/util/maven/maven_log.go
@@ -43,6 +43,8 @@ const (
 	FATAL = "FATAL"
 )
 
+var mavenLogger = log.WithName("maven.build")
+
 func ParseLog(line string) (mavenLog MavenLog, error error) {
 	error = json.Unmarshal([]byte(line), &mavenLog)
 
@@ -50,14 +52,16 @@ func ParseLog(line string) (mavenLog MavenLog, error error) {
 }
 
 func NormalizeLog(mavenLog MavenLog) {
-	logger := log.WithName("maven.build")
-
 	switch mavenLog.Level {
 	case DEBUG, TRACE:
-		logger.Debug(mavenLog.Msg)
+		mavenLogger.Debug(mavenLog.Msg)
 	case INFO, WARN:
-		logger.Info(mavenLog.Msg)
+		mavenLogger.Info(mavenLog.Msg)
 	case ERROR, FATAL:
-		logger.Errorf(nil, mavenLog.Msg)
+		mavenLogger.Errorf(nil, mavenLog.Msg)
 	}
+}
+
+func NonNormalizedLog(rawLog string) {
+	mavenLogger.Info(rawLog)
 }


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```