### PR TITLE
Fix #2315: Add leader-election flag to Operator command

### DIFF
--- a/pkg/cmd/operator.go
+++ b/pkg/cmd/operator.go
@@ -39,6 +39,7 @@ func newCmdOperator() (*cobra.Command, *operatorCmdOptions) {
 
 	cmd.Flags().Int32("health-port", 8081, "The port of the health endpoint")
 	cmd.Flags().Int32("monitoring-port", 8080, "The port of the metrics endpoint")
+	cmd.Flags().Bool("leader-election", true, "Use leader election")
 
 	return &cmd, &options
 }
@@ -46,8 +47,9 @@ func newCmdOperator() (*cobra.Command, *operatorCmdOptions) {
 type operatorCmdOptions struct {
 	HealthPort     int32 `mapstructure:"health-port"`
 	MonitoringPort int32 `mapstructure:"monitoring-port"`
+	LeaderElection bool  `mapstructure:"leader-election"`
 }
 
 func (o *operatorCmdOptions) run(_ *cobra.Command, _ []string) {
-	operator.Run(o.HealthPort, o.MonitoringPort)
+	operator.Run(o.HealthPort, o.MonitoringPort, o.LeaderElection)
 }

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -65,7 +65,7 @@ func printVersion() {
 }
 
 // Run starts the Camel K operator
-func Run(healthPort, monitoringPort int32) {
+func Run(healthPort, monitoringPort int32, leaderElection bool) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	flag.Parse()
@@ -101,8 +101,6 @@ func Run(healthPort, monitoringPort int32) {
 		exitOnError(err, "cannot check permissions for creating Events")
 		log.Info("Event broadcasting is disabled because of missing permissions to create Events")
 	}
-
-	leaderElection := true
 
 	operatorNamespace := platform.GetOperatorNamespace()
 	if operatorNamespace == "" {


### PR DESCRIPTION
<!-- Description -->

Fixes #2315, thanks !


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
