### PR TITLE
Fix #2165: allow configuring traits via annotations

### DIFF
--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const TraitAnnotationPrefix = "trait.camel.apache.org/"
+
 // ConfigurationSpec --
 type ConfigurationSpec struct {
 	Type  string `json:"type"`

--- a/pkg/controller/kameletbinding/common.go
+++ b/pkg/controller/kameletbinding/common.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"github.com/apache/camel-k/pkg/client"
 	"github.com/apache/camel-k/pkg/platform"
+	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/bindings"
 	"github.com/apache/camel-k/pkg/util/knative"
 	"github.com/pkg/errors"
@@ -39,8 +40,10 @@ func createIntegrationFor(ctx context.Context, c client.Client, kameletbinding *
 	blockOwnerDeletion := true
 	it := v1.Integration{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: kameletbinding.Namespace,
-			Name:      kameletbinding.Name,
+			Namespace:   kameletbinding.Namespace,
+			Name:        kameletbinding.Name,
+			Annotations: util.CopyMap(kameletbinding.Annotations),
+			Labels:      util.CopyMap(kameletbinding.Labels),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         kameletbinding.APIVersion,

--- a/pkg/trait/trait_catalog.go
+++ b/pkg/trait/trait_catalog.go
@@ -19,7 +19,6 @@ package trait
 
 import (
 	"context"
-	"encoding/json"
 	"reflect"
 	"sort"
 	"strings"
@@ -153,49 +152,6 @@ func (c *Catalog) GetTrait(id string) Trait {
 		}
 	}
 	return nil
-}
-
-func (c *Catalog) configure(env *Environment) error {
-	if env.Platform != nil && env.Platform.Status.Traits != nil {
-		if err := c.configureTraits(env.Platform.Status.Traits); err != nil {
-			return err
-		}
-	}
-	if env.IntegrationKit != nil && env.IntegrationKit.Spec.Traits != nil {
-		if err := c.configureTraits(env.IntegrationKit.Spec.Traits); err != nil {
-			return err
-		}
-	}
-	if env.Integration != nil && env.Integration.Spec.Traits != nil {
-		if err := c.configureTraits(env.Integration.Spec.Traits); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (c *Catalog) configureTraits(traits map[string]v1.TraitSpec) error {
-	for id, traitSpec := range traits {
-		catTrait := c.GetTrait(id)
-		if catTrait != nil {
-			trait := traitSpec
-			if err := decodeTraitSpec(&trait, catTrait); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func decodeTraitSpec(in *v1.TraitSpec, target interface{}) error {
-	data, err := json.Marshal(&in.Configuration)
-	if err != nil {
-		return err
-	}
-
-	return json.Unmarshal(data, &target)
 }
 
 // ComputeTraitsProperties returns all key/value configuration properties that can be used to configure traits

--- a/pkg/trait/trait_configure.go
+++ b/pkg/trait/trait_configure.go
@@ -1,0 +1,156 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trait
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+)
+
+func (c *Catalog) configure(env *Environment) error {
+	if env.Platform != nil {
+		if env.Platform.Status.Traits != nil {
+			if err := c.configureTraits(env.Platform.Status.Traits); err != nil {
+				return err
+			}
+		}
+		if err := c.configureTraitsFromAnnotations(env.Platform.Annotations); err != nil {
+			return err
+		}
+	}
+	if env.IntegrationKit != nil {
+		if env.IntegrationKit.Spec.Traits != nil {
+			if err := c.configureTraits(env.IntegrationKit.Spec.Traits); err != nil {
+				return err
+			}
+		}
+		if err := c.configureTraitsFromAnnotations(env.IntegrationKit.Annotations); err != nil {
+			return err
+		}
+	}
+	if env.Integration != nil {
+		if env.Integration.Spec.Traits != nil {
+			if err := c.configureTraits(env.Integration.Spec.Traits); err != nil {
+				return err
+			}
+		}
+		if err := c.configureTraitsFromAnnotations(env.Integration.Annotations); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Catalog) configureTraits(traits map[string]v1.TraitSpec) error {
+	for id, traitSpec := range traits {
+		catTrait := c.GetTrait(id)
+		if catTrait != nil {
+			trait := traitSpec
+			if err := decodeTraitSpec(&trait, catTrait); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func decodeTraitSpec(in *v1.TraitSpec, target interface{}) error {
+	data, err := json.Marshal(&in.Configuration)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, &target)
+}
+
+func (c *Catalog) configureTraitsFromAnnotations(annotations map[string]string) error {
+	options := make(map[string]map[string]string, len(annotations))
+	for k, v := range annotations {
+		if strings.HasPrefix(k, v1.TraitAnnotationPrefix) {
+			configKey := strings.TrimPrefix(k, v1.TraitAnnotationPrefix)
+			if strings.Contains(configKey, ".") {
+				parts := strings.SplitN(configKey, ".", 2)
+				id := parts[0]
+				prop := parts[1]
+				if _, ok := options[id]; !ok {
+					options[id] = make(map[string]string)
+				}
+				options[id][prop] = v
+			} else {
+				return fmt.Errorf("wrong format for trait annotation %q: missing trait ID", k)
+			}
+		}
+	}
+	return c.configureFromOptions(options)
+}
+
+func (c *Catalog) configureFromOptions(traits map[string]map[string]string) error {
+	for id, config := range traits {
+		t := c.GetTrait(id)
+		if t != nil {
+			err := configureTrait(id, config, t)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func configureTrait(id string, config map[string]string, trait interface{}) error {
+	md := mapstructure.Metadata{}
+
+	var valueConverter mapstructure.DecodeHookFuncKind = func(sourceKind reflect.Kind, targetKind reflect.Kind, data interface{}) (interface{}, error) {
+		// Allow JSON encoded arrays to set slices
+		if sourceKind == reflect.String && targetKind == reflect.Slice {
+			if v, ok := data.(string); ok && strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]") {
+				var value interface{}
+				if err := json.Unmarshal([]byte(v), &value); err != nil {
+					return nil, errors.Wrap(err, "could not decode JSON array for configuring trait property")
+				}
+				return value, nil
+			}
+		}
+		return data, nil
+	}
+
+	decoder, err := mapstructure.NewDecoder(
+		&mapstructure.DecoderConfig{
+			Metadata:         &md,
+			DecodeHook:       valueConverter,
+			WeaklyTypedInput: true,
+			TagName:          "property",
+			Result:           &trait,
+			ErrorUnused:      true,
+		},
+	)
+
+	if err != nil {
+		return errors.Wrapf(err, "error while decoding trait configuration from annotations on trait %q", id)
+	}
+
+	return decoder.Decode(config)
+}

--- a/pkg/trait/trait_configure_test.go
+++ b/pkg/trait/trait_configure_test.go
@@ -1,0 +1,149 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trait
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/util/test"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTraitConfigurationFromAnnotations(t *testing.T) {
+	env := Environment{
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"trait.camel.apache.org/cron.concurrency-policy":    "annotated-policy",
+					"trait.camel.apache.org/environment.container-meta": "true",
+				},
+			},
+			Spec: v1.IntegrationSpec{
+				Profile: v1.TraitProfileKubernetes,
+				Traits: map[string]v1.TraitSpec{
+					"cron": test.TraitSpecFromMap(t, map[string]interface{}{
+						"fallback":          true,
+						"concurrencyPolicy": "mypolicy",
+					}),
+				},
+			},
+		},
+	}
+	c := NewCatalog(context.Background(), nil)
+	assert.NoError(t, c.configure(&env))
+	assert.True(t, *c.GetTrait("cron").(*cronTrait).Fallback)
+	assert.Equal(t, "annotated-policy", c.GetTrait("cron").(*cronTrait).ConcurrencyPolicy)
+	assert.True(t, *c.GetTrait("environment").(*environmentTrait).ContainerMeta)
+}
+
+func TestFailOnWrongTraitAnnotations(t *testing.T) {
+	env := Environment{
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"trait.camel.apache.org/cron.missing-property": "the-value",
+				},
+			},
+			Spec: v1.IntegrationSpec{
+				Profile: v1.TraitProfileKubernetes,
+			},
+		},
+	}
+	c := NewCatalog(context.Background(), nil)
+	assert.Error(t, c.configure(&env))
+}
+
+func TestTraitConfigurationOverrideRulesFromAnnotations(t *testing.T) {
+	env := Environment{
+		Platform: &v1.IntegrationPlatform{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"trait.camel.apache.org/cron.components": "cmp2",
+					"trait.camel.apache.org/cron.schedule":   "schedule2",
+				},
+			},
+			Spec: v1.IntegrationPlatformSpec{
+				Traits: map[string]v1.TraitSpec{
+					"cron": test.TraitSpecFromMap(t, map[string]interface{}{
+						"components": "cmp1",
+						"schedule":   "schedule1",
+					}),
+				},
+			},
+		},
+		IntegrationKit: &v1.IntegrationKit{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"trait.camel.apache.org/cron.components":         "cmp4",
+					"trait.camel.apache.org/cron.concurrency-policy": "policy2",
+				},
+			},
+			Spec: v1.IntegrationKitSpec{
+				Traits: map[string]v1.TraitSpec{
+					"cron": test.TraitSpecFromMap(t, map[string]interface{}{
+						"components":        "cmp3",
+						"concurrencyPolicy": "policy1",
+					}),
+				},
+			},
+		},
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"trait.camel.apache.org/cron.concurrency-policy": "policy4",
+				},
+			},
+			Spec: v1.IntegrationSpec{
+				Profile: v1.TraitProfileKubernetes,
+				Traits: map[string]v1.TraitSpec{
+					"cron": test.TraitSpecFromMap(t, map[string]interface{}{
+						"concurrencyPolicy": "policy3",
+					}),
+				},
+			},
+		},
+	}
+	c := NewCatalog(context.Background(), nil)
+	assert.NoError(t, c.configure(&env))
+	assert.Equal(t, "schedule2", c.GetTrait("cron").(*cronTrait).Schedule)
+	assert.Equal(t, "cmp4", c.GetTrait("cron").(*cronTrait).Components)
+	assert.Equal(t, "policy4", c.GetTrait("cron").(*cronTrait).ConcurrencyPolicy)
+}
+
+func TestTraitListConfigurationFromAnnotations(t *testing.T) {
+	env := Environment{
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"trait.camel.apache.org/jolokia.options":                  `["opt1", "opt2"]`,
+					"trait.camel.apache.org/service-binding.service-bindings": `Binding:xxx`, // lenient
+				},
+			},
+			Spec: v1.IntegrationSpec{
+				Profile: v1.TraitProfileKubernetes,
+			},
+		},
+	}
+	c := NewCatalog(context.Background(), nil)
+	assert.NoError(t, c.configure(&env))
+	assert.Equal(t, []string{"opt1", "opt2"}, c.GetTrait("jolokia").(*jolokiaTrait).Options)
+	assert.Equal(t, []string{"Binding:xxx"}, c.GetTrait("service-binding").(*serviceBindingTrait).ServiceBindings)
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -349,6 +349,18 @@ func SortedStringMapKeys(m map[string]string) []string {
 	return res
 }
 
+// CopyMap clones a map of strings
+func CopyMap(source map[string]string) map[string]string {
+	if source == nil {
+		return nil
+	}
+	dest := make(map[string]string, len(source))
+	for k, v := range source {
+		dest[k] = v
+	}
+	return dest
+}
+
 // DependenciesToJSON --
 func DependenciesToJSON(list []string) ([]byte, error) {
 	jsondata := map[string]interface{}{}


### PR DESCRIPTION
<!-- Description -->

Fix #2165


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Integrations can also be configured using trait.camel.apache.org/trait-id.trait-prop annotations
```
