### PR TITLE
feat(cmd/run): --config option flag

### DIFF
--- a/docs/modules/ROOT/pages/cli/modeline.adoc
+++ b/docs/modules/ROOT/pages/cli/modeline.adoc
@@ -67,7 +67,10 @@ The following is a partial list of useful options:
 |Option | Description
 
 |build-property
-|Add a build time property or properties file (syntax, my-key=my-value \| file:/path/to/my-conf.properties)"
+|Add a build time property or properties file (syntax: _[my-key=my-value\|file:/path/to/my-conf.properties]_
+
+|config
+|Add runtime configuration from a Configmap, a Secret or a file (syntax: _[configmap\|secret\|file]:name)_
 
 |dependency
 |An external library that should be included, e.g. for Maven dependencies `dependency=mvn:org.my:app:1.0`
@@ -88,7 +91,7 @@ The following is a partial list of useful options:
 |Trait profile used for deployment
 
 |property
-|Add a runtime property or properties file (syntax, my-key=my-value \| file:/path/to/my-conf.properties)
+|Add a runtime property or properties file (syntax: _[my-key=my-value\|file:/path/to/my-conf.properties]_)
 
 |resource
 |Add a resource

--- a/e2e/common/cli/offline_commands_test.go
+++ b/e2e/common/cli/offline_commands_test.go
@@ -31,11 +31,11 @@ import (
 )
 
 func TestKamelVersionWorksOffline(t *testing.T) {
-	assert.Nil(t, Kamel("version", "--config", "non-existent-kubeconfig-file").Execute())
+	assert.Nil(t, Kamel("version", "--kube-config", "non-existent-kubeconfig-file").Execute())
 }
 
 func TestKamelHelpTraitWorksOffline(t *testing.T) {
-	traitCmd := Kamel("help", "trait", "--all", "--config", "non-existent-kubeconfig-file")
+	traitCmd := Kamel("help", "trait", "--all", "--kube-config", "non-existent-kubeconfig-file")
 	traitCmd.SetOut(ioutil.Discard)
 	assert.Nil(t, traitCmd.Execute())
 }
@@ -47,9 +47,9 @@ func TestKamelHelpOptionWorksOffline(t *testing.T) {
 }
 
 func TestKamelCompletionWorksOffline(t *testing.T) {
-	bashCmd := Kamel("completion", "bash", "--config", "non-existent-kubeconfig-file")
+	bashCmd := Kamel("completion", "bash", "--kube-config", "non-existent-kubeconfig-file")
 	bashCmd.SetOut(ioutil.Discard)
-	zshCmd := Kamel("completion", "zsh", "--config", "non-existent-kubeconfig-file")
+	zshCmd := Kamel("completion", "zsh", "--kube-config", "non-existent-kubeconfig-file")
 	zshCmd.SetOut(ioutil.Discard)
 	assert.Nil(t, bashCmd.Execute())
 	assert.Nil(t, zshCmd.Execute())

--- a/e2e/common/config/config_test.go
+++ b/e2e/common/config/config_test.go
@@ -65,7 +65,7 @@ func TestRunConfigExamples(t *testing.T) {
 			cmData["my-configmap-key"] = "my-configmap-content"
 			NewPlainTextConfigmap(ns, "my-cm", cmData)
 
-			Expect(Kamel("run", "-n", ns, "./files/configmap-route.groovy", "--configmap", "my-cm").Execute()).To(Succeed())
+			Expect(Kamel("run", "-n", ns, "./files/configmap-route.groovy", "--config", "configmap:my-cm").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, "configmap-route"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
 			Eventually(IntegrationCondition(ns, "configmap-route", camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
 			Eventually(IntegrationLogs(ns, "configmap-route"), TestTimeoutShort).Should(ContainSubstring(cmData["my-configmap-key"]))
@@ -80,10 +80,20 @@ func TestRunConfigExamples(t *testing.T) {
 			secData["my-secret-key"] = "very top secret"
 			NewPlainTextSecret(ns, "my-sec", secData)
 
-			Expect(Kamel("run", "-n", ns, "./files/secret-route.groovy", "--secret", "my-sec").Execute()).To(Succeed())
+			Expect(Kamel("run", "-n", ns, "./files/secret-route.groovy", "--config", "secret:my-sec").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, "secret-route"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
 			Eventually(IntegrationCondition(ns, "secret-route", camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
 			Eventually(IntegrationLogs(ns, "secret-route"), TestTimeoutShort).Should(ContainSubstring(secData["my-secret-key"]))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+
+		// File Configuration
+
+		t.Run("Plain text configuration file", func(t *testing.T) {
+			Expect(Kamel("run", "-n", ns, "./files/config-file-route.groovy", "--config", "file:./files/resources-data.txt").Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "config-file-route"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(IntegrationCondition(ns, "config-file-route", camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, "config-file-route"), TestTimeoutShort).Should(ContainSubstring("the file body"))
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 

--- a/e2e/common/config/files/config-file-route.groovy
+++ b/e2e/common/config/files/config-file-route.groovy
@@ -18,8 +18,11 @@
 
 //
 // To run this integrations use:
-// kamel run --resource resources-data.txt resources-route.groovy --dev
+// kamel run --config file:resources-data.txt resources-route.groovy --dev
 //
 
-from('file:/etc/camel/resources/?fileName=resources-data.txt&noop=true&idempotent=false')
+from('timer:resources')
+    .routeId('resources')
+    .setBody()
+        .simple("resource:classpath:resources-data.txt")
     .log('resource file content is: ${body}')

--- a/e2e/common/config/files/configmap-route.groovy
+++ b/e2e/common/config/files/configmap-route.groovy
@@ -20,7 +20,7 @@
 // To run this integrations use:
 //
 // kubectl create configmap my-cm --from-literal=my-configmap-key="configmap content"
-// kamel run --configmap my-cm configmap-route.groovy --dev
+// kamel run --config configmap:my-cm configmap-route.groovy --dev
 //
 
 from('timer:configmap')

--- a/e2e/common/config/files/property-file-route.groovy
+++ b/e2e/common/config/files/property-file-route.groovy
@@ -19,7 +19,7 @@
 //
 // To run this integrations use:
 //
-// kamel run --property-file my.properties property-file-route.groovy --dev
+// kamel run --property file:my.properties property-file-route.groovy --dev
 //
 
 from('timer:property-file')

--- a/e2e/common/config/files/secret-route.groovy
+++ b/e2e/common/config/files/secret-route.groovy
@@ -20,7 +20,7 @@
 // To run this integrations use:
 //
 // kubectl create secret generic my-sec --from-literal=my-secret-key="very top secret"
-// kamel run --secret my-sec secret-route.groovy --dev
+// kamel run --config secret:my-sec secret-route.groovy --dev
 //
 
 from('timer:secret')

--- a/examples/modeline/modeline-config-file-route.groovy
+++ b/examples/modeline/modeline-config-file-route.groovy
@@ -1,0 +1,30 @@
+// camel-k: language=groovy
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// To run this integrations use:
+// kamel run modeline-config-file-route.groovy --dev
+//
+
+// camel-k: config=file:resources-data.txt
+
+from('timer:resources')
+    .routeId('resources')
+    .setBody()
+        .simple("resource:classpath:resources-data.txt")
+    .log('resource file content is: ${body}')

--- a/examples/modeline/modeline-secret-route.groovy
+++ b/examples/modeline/modeline-secret-route.groovy
@@ -1,0 +1,32 @@
+// camel-k: language=groovy
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// To run this integrations use:
+//
+// kubectl create secret generic my-sec --from-literal=my-secret-key="very top secret"
+// kamel run secret-route.groovy --dev
+//
+
+// camel-k: config=secret:my-sec
+
+from('timer:secret')
+    .routeId('secret')
+    .setBody()
+        .simple("resource:classpath:my-secret-key")
+    .log('secret content is: ${body}')

--- a/examples/modeline/resources-data.txt
+++ b/examples/modeline/resources-data.txt
@@ -1,0 +1,1 @@
+the file body

--- a/examples/user-config/config-file-route.groovy
+++ b/examples/user-config/config-file-route.groovy
@@ -18,8 +18,11 @@
 
 //
 // To run this integrations use:
-// kamel run --resource resources-data.txt resources-route.groovy --dev
+// kamel run --config file:resources-data.txt resources-route.groovy --dev
 //
 
-from('file:/etc/camel/resources/?fileName=resources-data.txt&noop=true&idempotent=false')
+from('timer:resources')
+    .routeId('resources')
+    .setBody()
+        .simple("resource:classpath:resources-data.txt")
     .log('resource file content is: ${body}')

--- a/examples/user-config/configmap-route.groovy
+++ b/examples/user-config/configmap-route.groovy
@@ -20,7 +20,7 @@
 // To run this integrations use:
 //
 // kubectl create configmap my-cm --from-literal=my-configmap-key="configmap content"
-// kamel run --configmap my-cm configmap-route.groovy --dev
+// kamel run --config configmap:my-cm configmap-route.groovy --dev
 //
 
 from('timer:configmap')

--- a/examples/user-config/secret-route.groovy
+++ b/examples/user-config/secret-route.groovy
@@ -20,7 +20,7 @@
 // To run this integrations use:
 //
 // kubectl create secret generic my-sec --from-literal=my-secret-key="very top secret"
-// kamel run --secret my-sec secret-route.groovy --dev
+// kamel run --config secret:my-sec secret-route.groovy --dev
 //
 
 from('timer:secret')

--- a/pkg/cmd/modeline.go
+++ b/pkg/cmd/modeline.go
@@ -53,7 +53,6 @@ var (
 	// file options must be considered relative to the source files they belong to
 	fileOptions = map[string]bool{
 		"resource":      true,
-		"config":        true,
 		"open-api":      true,
 		"property-file": true,
 	}

--- a/pkg/cmd/modeline.go
+++ b/pkg/cmd/modeline.go
@@ -53,6 +53,7 @@ var (
 	// file options must be considered relative to the source files they belong to
 	fileOptions = map[string]bool{
 		"resource":      true,
+		"kube-client":   true,
 		"open-api":      true,
 		"property-file": true,
 	}

--- a/pkg/cmd/modeline_test.go
+++ b/pkg/cmd/modeline_test.go
@@ -203,6 +203,57 @@ func TestModelineRunBuildPropertyFiles(t *testing.T) {
 	assert.Equal(t, []string{"run", fileName, "--build-property=file:application.properties"}, flags)
 }
 
+func TestModelineRunConfigSecret(t *testing.T) {
+	dir, err := ioutil.TempDir("", "camel-k-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	subDir := path.Join(dir, "sub")
+	err = os.Mkdir(subDir, 0777)
+	assert.NoError(t, err)
+
+	file := `
+		// camel-k: config=secret:my-secret
+	`
+	fileName := path.Join(subDir, "simple.groovy")
+	err = ioutil.WriteFile(fileName, []byte(file), 0777)
+	assert.NoError(t, err)
+
+	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
+	assert.NoError(t, err)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, []string{"run", fileName, "--config=secret:my-secret"}, flags)
+}
+
+func TestModelineRunConfigFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "camel-k-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	subDir := path.Join(dir, "sub")
+	err = os.Mkdir(subDir, 0777)
+	assert.NoError(t, err)
+
+	file := `
+		// camel-k: config=file:application.properties
+	`
+	fileName := path.Join(subDir, "simple.groovy")
+	err = ioutil.WriteFile(fileName, []byte(file), 0777)
+	assert.NoError(t, err)
+
+	propFile := `
+		a=b
+	`
+	propFileName := path.Join(dir, "application.properties")
+	err = ioutil.WriteFile(propFileName, []byte(propFile), 0777)
+	assert.NoError(t, err)
+
+	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
+	assert.NoError(t, err)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, []string{"run", fileName, "--config=file:application.properties"}, flags)
+}
+
 func TestModelineInspectSimple(t *testing.T) {
 	dir, err := ioutil.TempDir("", "camel-k-test-")
 	assert.NoError(t, err)

--- a/pkg/cmd/modeline_test.go
+++ b/pkg/cmd/modeline_test.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -142,14 +143,14 @@ func TestModelineRunPropertyFiles(t *testing.T) {
 	propFile := `
 		a=b
 	`
-	propFileName := path.Join(dir, "application.properties")
+	propFileName := path.Join(subDir, "application.properties")
 	err = ioutil.WriteFile(propFileName, []byte(propFile), 0777)
 	assert.NoError(t, err)
 
 	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
 	assert.NoError(t, err)
 	assert.NotNil(t, cmd)
-	assert.Equal(t, []string{"run", fileName, "--property=file:application.properties"}, flags)
+	assert.Equal(t, []string{"run", fileName, fmt.Sprintf("--property=file:%s", propFileName)}, flags)
 }
 
 func TestModelineRunBuildProperty(t *testing.T) {
@@ -193,14 +194,36 @@ func TestModelineRunBuildPropertyFiles(t *testing.T) {
 	propFile := `
 		a=b
 	`
-	propFileName := path.Join(dir, "application.properties")
+	propFileName := path.Join(subDir, "application.properties")
 	err = ioutil.WriteFile(propFileName, []byte(propFile), 0777)
 	assert.NoError(t, err)
 
 	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
 	assert.NoError(t, err)
 	assert.NotNil(t, cmd)
-	assert.Equal(t, []string{"run", fileName, "--build-property=file:application.properties"}, flags)
+	assert.Equal(t, []string{"run", fileName, fmt.Sprintf("--build-property=file:%s", propFileName)}, flags)
+}
+
+func TestModelineRunConfigConfigmap(t *testing.T) {
+	dir, err := ioutil.TempDir("", "camel-k-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	subDir := path.Join(dir, "sub")
+	err = os.Mkdir(subDir, 0777)
+	assert.NoError(t, err)
+
+	file := `
+		// camel-k: config=configmap:my-cm
+	`
+	fileName := path.Join(subDir, "simple.groovy")
+	err = ioutil.WriteFile(fileName, []byte(file), 0777)
+	assert.NoError(t, err)
+
+	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
+	assert.NoError(t, err)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, []string{"run", fileName, "--config=configmap:my-cm"}, flags)
 }
 
 func TestModelineRunConfigSecret(t *testing.T) {
@@ -244,14 +267,14 @@ func TestModelineRunConfigFile(t *testing.T) {
 	propFile := `
 		a=b
 	`
-	propFileName := path.Join(dir, "application.properties")
+	propFileName := path.Join(subDir, "application.properties")
 	err = ioutil.WriteFile(propFileName, []byte(propFile), 0777)
 	assert.NoError(t, err)
 
 	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
 	assert.NoError(t, err)
 	assert.NotNil(t, cmd)
-	assert.Equal(t, []string{"run", fileName, "--config=file:application.properties"}, flags)
+	assert.Equal(t, []string{"run", fileName, fmt.Sprintf("--config=file:%s", propFileName)}, flags)
 }
 
 func TestModelineInspectSimple(t *testing.T) {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -84,7 +84,7 @@ func kamelPreAddCommandInit(options *RootCmdOptions) *cobra.Command {
 		SilenceUsage:           true,
 	}
 
-	cmd.PersistentFlags().StringVar(&options.KubeConfig, "config", os.Getenv("KUBECONFIG"), "Path to the config file to use for CLI requests")
+	cmd.PersistentFlags().StringVar(&options.KubeConfig, "kube-config", os.Getenv("KUBECONFIG"), "Path to the kube config file to use for CLI requests")
 	cmd.PersistentFlags().StringVarP(&options.Namespace, "namespace", "n", "", "Namespace to use for all operations")
 
 	return &cmd

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -597,10 +597,8 @@ func (o *runCmdOptions) updateIntegrationCode(c client.Client, sources []string,
 	}
 	for _, item := range o.Configs {
 		if config, parseErr := ParseConfigOption(item); parseErr == nil {
-			if config.ConfigType == ConfigOptionTypeFile {
-				addResource(config.Value, &integration.Spec, o.Compression, v1.ResourceTypeData)
-			} else {
-				integration.Spec.AddConfiguration(string(config.ConfigType), config.Value)
+			if applyConfigOptionErr := ApplyConfigOption(config, &integration.Spec, c, namespace, o.Compression); applyConfigOptionErr != nil {
+				return nil, applyConfigOptionErr
 			}
 		} else {
 			return nil, parseErr

--- a/pkg/cmd/run_help.go
+++ b/pkg/cmd/run_help.go
@@ -1,0 +1,71 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// RunConfigOption represents a config option
+type RunConfigOption struct {
+	ConfigType configOptionType
+	Value      string
+}
+
+type configOptionType string
+
+const (
+	// ConfigOptionTypeConfigmap --
+	ConfigOptionTypeConfigmap configOptionType = "configmap"
+	// ConfigOptionTypeSecret --
+	ConfigOptionTypeSecret configOptionType = "secret"
+	// ConfigOptionTypeFile --
+	ConfigOptionTypeFile configOptionType = "file"
+)
+
+var validConfigRegexp = regexp.MustCompile(`^(configmap|secret|file)\:([\w\.\-\_\:\/]+)$`)
+
+func newRunConfigOption(configType configOptionType, value string) *RunConfigOption {
+	return &RunConfigOption{
+		ConfigType: configType,
+		Value:      value,
+	}
+}
+
+// ParseConfigOption will parse and return a runConfigOption
+func ParseConfigOption(item string) (*RunConfigOption, error) {
+	if !validConfigRegexp.MatchString(item) {
+		return nil, fmt.Errorf("could not match configuration %s, must match %v regular expression", item, validConfigRegexp)
+	}
+	// Parse the regexp groups
+	groups := validConfigRegexp.FindStringSubmatch(item)
+	var cot configOptionType
+	switch groups[1] {
+	case "configmap":
+		cot = ConfigOptionTypeConfigmap
+	case "secret":
+		cot = ConfigOptionTypeSecret
+	case "file":
+		cot = ConfigOptionTypeFile
+	default:
+		// Should never reach this
+		return nil, fmt.Errorf("invalid config option type %s", groups[1])
+	}
+	return newRunConfigOption(cot, groups[2]), nil
+}

--- a/pkg/cmd/run_help_test.go
+++ b/pkg/cmd/run_help_test.go
@@ -1,0 +1,46 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseConfigOption(t *testing.T) {
+	validConfigMap := "configmap:my-config_map"
+	validSecret := "secret:my-secret"
+	validFile := "file:/tmp/my-file.txt"
+	notValid := "someprotocol:wrong"
+
+	configmap, err := ParseConfigOption(validConfigMap)
+	assert.Nil(t, err)
+	assert.Equal(t, ConfigOptionTypeConfigmap, configmap.ConfigType)
+	assert.Equal(t, "my-config_map", configmap.Value)
+	secret, err := ParseConfigOption(validSecret)
+	assert.Nil(t, err)
+	assert.Equal(t, ConfigOptionTypeSecret, secret.ConfigType)
+	assert.Equal(t, "my-secret", secret.Value)
+	file, err := ParseConfigOption(validFile)
+	assert.Nil(t, err)
+	assert.Equal(t, ConfigOptionTypeFile, file.ConfigType)
+	assert.Equal(t, "/tmp/my-file.txt", file.Value)
+	_, err = ParseConfigOption(notValid)
+	assert.NotNil(t, err)
+}

--- a/pkg/cmd/util_content.go
+++ b/pkg/cmd/util_content.go
@@ -51,7 +51,7 @@ func loadRawContent(source string) ([]byte, string, error) {
 		case "https":
 			content, err = loadContentHTTP(u)
 		default:
-			return nil, "", fmt.Errorf("unsupported scheme %s", u.Scheme)
+			return nil, "", fmt.Errorf("missing file or unsupported scheme %s", u.Scheme)
 		}
 	}
 

--- a/pkg/util/kubernetes/lookup.go
+++ b/pkg/util/kubernetes/lookup.go
@@ -1,0 +1,76 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/apache/camel-k/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// LookupConfigmap will look for any k8s Configmap with a given name in a given namespace
+func LookupConfigmap(ctx context.Context, c client.Client, ns string, name string) *corev1.ConfigMap {
+	cm := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+	key := ctrl.ObjectKey{
+		Namespace: ns,
+		Name:      name,
+	}
+	if err := c.Get(ctx, key, &cm); err != nil && k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return nil
+	}
+	return &cm
+}
+
+// LookupSecret will look for any k8s Secret with a given name in a given namespace
+func LookupSecret(ctx context.Context, c client.Client, ns string, name string) *corev1.Secret {
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+	key := ctrl.ObjectKey{
+		Namespace: ns,
+		Name:      name,
+	}
+	if err := c.Get(ctx, key, &secret); err != nil && k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return nil
+	}
+	return &secret
+}


### PR DESCRIPTION
<!-- Description -->

With this PR we are:

* Introducing `--config [configmap|secret|file]:name` run option flag
* Deprecating `--configmap` and `--secret` run option flag
* Changing `--config` global flag with `--kube-config`
* Supporting modeline for `--config`

The goal is to provide a unique `config` flag to manage all different kind of configuration as explained in #2003. This flag eventually differs from `resource` as it is meant to only provide configuration files that will be evaluated by the `Integration` runtime.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cmd/run): --config option flag
```
