### PR TITLE
fix(cli): stop printing <nil> at the end of kamel describe output

### DIFF
--- a/pkg/cmd/describe_integration.go
+++ b/pkg/cmd/describe_integration.go
@@ -85,7 +85,11 @@ func (command *describeIntegrationCommandOptions) run(args []string) error {
 	}
 
 	if err := c.Get(command.Context, key, &ctx); err == nil {
-		fmt.Print(command.describeIntegration(ctx))
+		if desc, err := command.describeIntegration(ctx); err == nil {
+			fmt.Print(desc)
+		} else {
+			fmt.Println(err)
+		}
 	} else {
 		fmt.Printf("Integration '%s' does not exist.\n", args[0])
 	}

--- a/pkg/cmd/describe_kamelet.go
+++ b/pkg/cmd/describe_kamelet.go
@@ -81,7 +81,11 @@ func (command *describeKameletCommandOptions) run(args []string) error {
 	}
 
 	if err := c.Get(command.Context, kameletKey, &kamelet); err == nil {
-		fmt.Print(command.describeKamelet(kamelet))
+		if desc, err := command.describeKamelet(kamelet); err == nil {
+			fmt.Print(desc)
+		} else {
+			fmt.Println(err)
+		}
 	} else {
 		fmt.Printf("Kamelet '%s' does not exist.\n", args[0])
 	}

--- a/pkg/cmd/describe_kit.go
+++ b/pkg/cmd/describe_kit.go
@@ -80,7 +80,11 @@ func (command *describeKitCommandOptions) run(args []string) error {
 	}
 
 	if err := c.Get(command.Context, kitKey, &kit); err == nil {
-		fmt.Print(command.describeIntegrationKit(kit))
+		if desc, err := command.describeIntegrationKit(kit); err == nil {
+			fmt.Print(desc)
+		} else {
+			fmt.Println(err)
+		}
 	} else {
 		fmt.Printf("IntegrationKit '%s' does not exist.\n", args[0])
 	}

--- a/pkg/cmd/describe_platform.go
+++ b/pkg/cmd/describe_platform.go
@@ -80,7 +80,11 @@ func (command *describePlatformCommandOptions) run(args []string) error {
 	}
 
 	if err := c.Get(command.Context, platformKey, &platform); err == nil {
-		fmt.Print(command.describeIntegrationPlatform(platform))
+		if desc, err := command.describeIntegrationPlatform(platform); err == nil {
+			fmt.Print(desc)
+		} else {
+			fmt.Println(err)
+		}
 	} else {
 		fmt.Printf("IntegrationPlatform '%s' does not exist.\n", args[0])
 	}


### PR DESCRIPTION
Before:
```
$ kamel describe platform camel-k
Name:                camel-k
Namespace:           test
Labels:              app=camel-k
Creation Timestamp:  Tue, 01 Jun 2021 15:48:58 +0900
Phase:               Ready
Version:             1.5.0-SNAPSHOT
Base Image:          adoptopenjdk/openjdk11:slim
Runtime Version:     1.7.0
Local Repository:    /tmp/artifacts/m2
Publish Strategy:    Spectrum
<nil>
```
After:
```
$ ./kamel describe ip camel-k
Name:                camel-k
Namespace:           test
Labels:              app=camel-k
Creation Timestamp:  Tue, 01 Jun 2021 15:48:58 +0900
Phase:               Ready
Version:             1.5.0-SNAPSHOT
Base Image:          adoptopenjdk/openjdk11:slim
Runtime Version:     1.7.0
Local Repository:    /tmp/artifacts/m2
Publish Strategy:    Spectrum
```