### PR TITLE
feat(cli): add sub command kamel kamelet for get and delete #2312

### DIFF
--- a/pkg/apis/camel/v1alpha1/kamelet_types.go
+++ b/pkg/apis/camel/v1alpha1/kamelet_types.go
@@ -25,7 +25,15 @@ import (
 )
 
 const (
-	AnnotationIcon = "camel.apache.org/kamelet.icon"
+	AnnotationIcon       = "camel.apache.org/kamelet.icon"
+	KameletBundledLabel  = "camel.apache.org/kamelet.bundled"
+	KameletReadOnlyLabel = "camel.apache.org/kamelet.readonly"
+	KameletTypeLabel     = "camel.apache.org/kamelet.type"
+	KameletGroupLabel    = "camel.apache.org/kamelet.group"
+
+	KameletTypeSink   = "sink"
+	KameletTypeSource = "source"
+	KameletTypeAction = "action"
 )
 
 var (

--- a/pkg/cmd/kamelet.go
+++ b/pkg/cmd/kamelet.go
@@ -1,0 +1,35 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newCmdKamelet(rootCmdOptions *RootCmdOptions) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "kamelet",
+		Short: "Configure a Kamelet",
+		Long:  `Configure a Kamelet.`,
+	}
+
+	cmd.AddCommand(cmdOnly(newKameletGetCmd(rootCmdOptions)))
+	cmd.AddCommand(cmdOnly(newKameletDeleteCmd(rootCmdOptions)))
+
+	return &cmd
+}

--- a/pkg/cmd/kamelet_delete.go
+++ b/pkg/cmd/kamelet_delete.go
@@ -1,0 +1,146 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+)
+
+func newKameletDeleteCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kameletDeleteCommandOptions) {
+	options := kameletDeleteCommandOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		Use:     "delete <name>",
+		Short:   "Delete a Kamelet",
+		Long:    `Delete a Kamelet.`,
+		PreRunE: decode(&options),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.validate(args); err != nil {
+				return err
+			}
+			if err := options.run(args); err != nil {
+				fmt.Println(err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("all", false, "Delete all Kamelets")
+
+	return &cmd, &options
+}
+
+type kameletDeleteCommandOptions struct {
+	*RootCmdOptions
+	All bool `mapstructure:"all"`
+}
+
+func (command *kameletDeleteCommandOptions) validate(args []string) error {
+	if command.All && len(args) > 0 {
+		return errors.New("invalid combination: both all flag and named kamelets are set")
+	}
+	if !command.All && len(args) == 0 {
+		return errors.New("invalid combination: neither all flag nor named kamelets are set")
+	}
+
+	return nil
+}
+
+func (command *kameletDeleteCommandOptions) run(args []string) error {
+	names := args
+
+	c, err := command.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	if command.All {
+		klList := v1alpha1.NewKameletList()
+		if err := c.List(command.Context, &klList, k8sclient.InNamespace(command.Namespace)); err != nil {
+			return err
+		}
+		names = make([]string, 0, len(klList.Items))
+		for _, kl := range klList.Items {
+			// only include non-bundled, non-readonly kamelets
+			if kl.Labels[v1alpha1.KameletBundledLabel] != "true" && kl.Labels[v1alpha1.KameletReadOnlyLabel] != "true" {
+				names = append(names, kl.Name)
+			}
+		}
+	}
+
+	for _, name := range names {
+		if err := command.delete(name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (command *kameletDeleteCommandOptions) delete(name string) error {
+	c, err := command.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	kl := v1alpha1.NewKamelet(command.Namespace, name)
+	key := k8sclient.ObjectKey{
+		Namespace: command.Namespace,
+		Name:      name,
+	}
+	err = c.Get(command.Context, key, &kl)
+	if err != nil {
+		if k8errors.IsNotFound(err) {
+			return fmt.Errorf("no kamelet found with name \"%s\"", name)
+		} else {
+			return err
+		}
+	}
+
+	// check that it is not a bundled nor read-only one which is supposed to belong to platform
+	// thus not managed by the end user
+	if kl.Labels[v1alpha1.KameletBundledLabel] == "true" || kl.Labels[v1alpha1.KameletReadOnlyLabel] == "true" {
+		// skip platform Kamelets while deleting all Kamelets
+		if command.All {
+			return nil
+		}
+		return fmt.Errorf("kamelet \"%s\" is not editable", name)
+	}
+
+	err = c.Delete(command.Context, &kl)
+	if err != nil {
+		if k8errors.IsNotFound(err) {
+			return fmt.Errorf("no kamelet found with name \"%s\"", name)
+		} else {
+			return fmt.Errorf("error deleting kamelet \"%s\", %s", name, err)
+		}
+	}
+	fmt.Printf("kamelet \"%s\" has been deleted\n", name)
+	return nil
+}

--- a/pkg/cmd/kamelet_get.go
+++ b/pkg/cmd/kamelet_get.go
@@ -1,0 +1,139 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+)
+
+func newKameletGetCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kameletGetCommandOptions) {
+	options := kameletGetCommandOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		Use:     "get",
+		Short:   "Get defined Kamelet",
+		Long:    `Get defined Kamelet.`,
+		PreRunE: decode(&options),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.validate(cmd, args); err != nil {
+				return err
+			}
+			if err := options.run(cmd); err != nil {
+				fmt.Println(err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("sink", false, "Show only sink Kamelets")
+	cmd.Flags().Bool("source", false, "Show only source Kamelets")
+	cmd.Flags().Bool("action", false, "Show only action Kamelets")
+	cmd.Flags().String("group", "", "Filters Kamelets by group")
+	cmd.Flags().Bool("bundled", true, "Includes bundled Kamelets")
+	cmd.Flags().Bool("read-only", true, "Includes read-only Kamelets")
+
+	return &cmd, &options
+}
+
+type kameletGetCommandOptions struct {
+	*RootCmdOptions
+	Sink     bool   `mapstructure:"sink"`
+	Source   bool   `mapstructure:"source"`
+	Action   bool   `mapstructure:"action"`
+	Group    string `mapstructure:"group"`
+	Bundled  bool   `mapstructure:"bundled"`
+	ReadOnly bool   `mapstructure:"read-only"`
+}
+
+func (command *kameletGetCommandOptions) validate(cmd *cobra.Command, args []string) error {
+	count := 0
+	for _, b := range []bool{command.Sink, command.Source, command.Action} {
+		if b {
+			count++
+		}
+	}
+
+	if count > 1 {
+		return errors.New("invalid combination: flags --sink, --source, and --action are mutually exclusive")
+	}
+	return nil
+}
+
+func (command *kameletGetCommandOptions) run(cmd *cobra.Command) error {
+	c, err := command.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	klList := v1alpha1.NewKameletList()
+	if err := c.List(command.Context, &klList, k8sclient.InNamespace(command.Namespace)); err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 1, '\t', 0)
+	fmt.Fprintln(w, "NAME\tPHASE\tTYPE\tGROUP\tBUNDLED\tREAD ONLY\tTITLE")
+	for _, kl := range klList.Items {
+		klType := kl.Labels[v1alpha1.KameletTypeLabel]
+		group := kl.Annotations[v1alpha1.KameletGroupLabel]
+		bundled := kl.Labels[v1alpha1.KameletBundledLabel]
+		readOnly := kl.Labels[v1alpha1.KameletReadOnlyLabel]
+
+		if command.Sink && klType != v1alpha1.KameletTypeSink {
+			continue
+		}
+		if command.Source && klType != v1alpha1.KameletTypeSource {
+			continue
+		}
+		if command.Action && klType != v1alpha1.KameletTypeAction {
+			continue
+		}
+		if command.Group != "" && !strings.EqualFold(command.Group, group) {
+			continue
+		}
+		if !command.Bundled && bundled == "true" {
+			continue
+		}
+		if !command.ReadOnly && readOnly == "true" {
+			continue
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			kl.Name,
+			string(kl.Status.Phase),
+			klType,
+			group,
+			bundled,
+			readOnly,
+			kl.Spec.Definition.Title)
+	}
+	w.Flush()
+
+	return nil
+}

--- a/pkg/cmd/kit_delete.go
+++ b/pkg/cmd/kit_delete.go
@@ -35,7 +35,7 @@ func newKitDeleteCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kitDelete
 	}
 
 	cmd := cobra.Command{
-		Use:     "delete",
+		Use:     "delete <name>",
 		Short:   "Delete an Integration Kit",
 		Long:    `Delete an Integration Kit.`,
 		PreRunE: decode(&options),

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -148,6 +148,7 @@ func addKamelSubcommands(cmd *cobra.Command, options *RootCmdOptions) {
 	cmd.AddCommand(cmdOnly(newCmdDump(options)))
 	cmd.AddCommand(newCmdLocal(options))
 	cmd.AddCommand(cmdOnly(newCmdBind(options)))
+	cmd.AddCommand(newCmdKamelet(options))
 }
 
 func addHelpSubCommands(cmd *cobra.Command, options *RootCmdOptions) error {

--- a/pkg/install/kamelets.go
+++ b/pkg/install/kamelets.go
@@ -37,8 +37,6 @@ import (
 
 const kameletDirEnv = "KAMELET_CATALOG_DIR"
 const defaultKameletDir = "/kamelets/"
-const kameletBundledLabel = "camel.apache.org/kamelet.bundled"
-const kameletReadOnlyLabel = "camel.apache.org/kamelet.readonly"
 
 // KameletCatalog installs the bundled KameletCatalog into one namespace
 func KameletCatalog(ctx context.Context, c client.Client, namespace string) error {
@@ -93,8 +91,8 @@ func KameletCatalog(ctx context.Context, c client.Client, namespace string) erro
 				if k.GetLabels() == nil {
 					k.SetLabels(make(map[string]string))
 				}
-				k.GetLabels()[kameletBundledLabel] = "true"
-				k.GetLabels()[kameletReadOnlyLabel] = "true"
+				k.GetLabels()[v1alpha1.KameletBundledLabel] = "true"
+				k.GetLabels()[v1alpha1.KameletReadOnlyLabel] = "true"
 
 				err := ObjectOrCollect(ctx, c, namespace, nil, true, k)
 


### PR DESCRIPTION
This adds a feature-rich `kamel kamelet` sub command with `get` and `delete` supports.

```
$ ./kamel kamelet get -h
Get defined Kamelet.

Usage:
  kamel kamelet get [flags]

Flags:
      --action         Show only action Kamelets
      --bundled        Includes bundled Kamelets (default true)
      --group string   Filters Kamelets by group
  -h, --help           help for get
      --read-only      Includes read-only Kamelets (default true)
      --sink           Show only sink Kamelets
      --source         Show only source Kamelets
...
```

```
$ ./kamel kamelet delete -h
Delete a Kamelet.

Usage:
  kamel kamelet delete <name> [flags]

Flags:
      --all    Delete all Kamelets
  -h, --help   help for delete
...
```

`kamel kamelet get` output would look like this:
```
$ ./kamel kamelet get
NAME				PHASE	TYPE	GROUP			BUNDLED	READ ONLY	TITLE
aws-ddb-streams-source		Ready	source	AWS DynamoDB Streams	true	true		AWS DynamoDB Streams Source
aws-kinesis-firehose-sink	Ready	sink	AWS Kinesis Firehose	true	true		AWS Kinesis Firehose Sink
aws-kinesis-sink		Ready	sink	AWS Kinesis		true	true		AWS Kinesis Sink
aws-kinesis-source		Ready	source	AWS Kinesis		true	true		AWS Kinesis Source
aws-lambda-sink			Ready	sink	AWS Lambda		true	true		AWS Lambda Sink
aws-s3-sink			Ready	sink	AWS S3			true	true		AWS S3 Sink
aws-s3-source			Ready	source	AWS S3			true	true		AWS S3 Source
aws-sns-fifo-sink		Ready	sink	AWS SNS			true	true		AWS SNS FIFO Sink
aws-sns-sink			Ready	sink	AWS SNS			true	true		AWS SNS Sink
aws-sqs-batch-sink		Ready	sink	AWS SQS			true	true		AWS SQS Batch Sink
aws-sqs-fifo-sink		Ready	sink	AWS SQS			true	true		AWS SQS FIFO Sink
aws-sqs-sink			Ready	sink	AWS SQS			true	true		AWS SQS Sink
aws-sqs-source			Ready	source	AWS SQS			true	true		AWS SQS Source
...
```