### PR TITLE
Removed the deprecated --logging-level option (issue #2000)

### DIFF
--- a/docs/modules/ROOT/pages/observability/integration-logging.adoc
+++ b/docs/modules/ROOT/pages/observability/integration-logging.adoc
@@ -1,0 +1,36 @@
+[[integration-logging]]
+= Camel K Integration Logging
+
+Starting with https://camel.apache.org/blog/2021/05/new-camel-k-logging-features/[Camel K 1.5], we introduced a new
+xref:traits:logging.adoc[logging trait] that simplifies access to the logging configuration available on the runtime.
+
+
+[[integration-logging-level]]
+== Logging Level
+
+To configure the log level, pass one of the supported log levels to the trait. For example:
+
+```
+--trait logging.level=DEBUG
+```
+
+
+[[integration-logging-format]]
+== Logging Format
+
+The format of the logging message can also be configured using one of the supported log format options from
+https://quarkus.io/guides/logging[Quarkus] (which provides the logging framework for Camel Quarkus which is leveraged by
+Camel K).
+
+A sample custom configuration would look like this:
+
+```
+--trait logging.format='%d{HH:mm:ss} %-5p (%t) %s%e%n'.
+```
+
+[[integration-logging-structured]]
+== Structured Logs in Json Format
+
+Like the operator, the integrations will use structured logs to facilitate collection and parsing. This can be turned on
+or off using the `--trait logging.json` trait. Subsequently, it can also be customized to output pretty json logs by
+setting the `logging.json.pretty-print` trait.

--- a/docs/modules/ROOT/pages/observability/logging.adoc
+++ b/docs/modules/ROOT/pages/observability/logging.adoc
@@ -1,0 +1,6 @@
+[[logging]]
+= Camel K Logging
+
+The Camel K logging has two major areas. The first one is related to the logging provided by the
+xref:observability/operator-logging.adoc[operator itself], whereas the second is related to the
+xref:observability/integration-logging.adoc[integrations] ran by Camel K.

--- a/docs/modules/ROOT/pages/observability/operator-logging.adoc
+++ b/docs/modules/ROOT/pages/observability/operator-logging.adoc
@@ -1,0 +1,16 @@
+[[logging]]
+= Camel K Operator Logging
+
+The Camel K Operator logging is mostly managed by the Kubernetes infrastructure, with some specific aspects managed by
+Camel K itself. The operator uses https://kubernetes.io/blog/2020/09/04/kubernetes-1-19-introducing-structured-logs/[structured logs]
+so that the logs are more easily parseable.
+
+This includes the output of components managed by the operator, such as the maven build, and the integration container build.
+For example, the maven build logs should be displayed like this:
+
+
+```
+{"level":"info","ts":1620393185.321101,"logger":"camel-k.maven.build","msg":"Downloading from repository-000: http://my.repository.com:8081/artifactory/fuse-brno/org/jboss/shrinkwrap/resolver/shrinkwrap-resolver-bom/2.2.4/shrinkwrap-resolver-bom-2.2.4.pom"}
+```
+
+There are some exceptions to this, though, and they are mostly related to running the operator for development purposes.

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -90,7 +90,6 @@ func newCmdRun(rootCmdOptions *RootCmdOptions) (*cobra.Command, *runCmdOptions) 
 	cmd.Flags().Bool("use-flows", true, "Write yaml sources as Flow objects in the integration custom resource")
 	cmd.Flags().String("profile", "", "Trait profile used for deployment")
 	cmd.Flags().StringArrayP("trait", "t", nil, "Configure a trait. E.g. \"-t service.enabled=false\"")
-	cmd.Flags().StringArray("logging-level", nil, "Configure the logging level. e.g. \"--logging-level org.apache.camel=DEBUG\"")
 	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml")
 	cmd.Flags().Bool("compression", false, "Enable storage of sources and resources as a compressed binary blobs")
 	cmd.Flags().StringArray("resource", nil, "Add a resource")
@@ -135,7 +134,6 @@ type runCmdOptions struct {
 	Secrets         []string `mapstructure:"secrets" yaml:",omitempty"`
 	Repositories    []string `mapstructure:"maven-repositories" yaml:",omitempty"`
 	Traits          []string `mapstructure:"traits" yaml:",omitempty"`
-	LoggingLevels   []string `mapstructure:"logging-levels" yaml:",omitempty"`
 	Volumes         []string `mapstructure:"volumes" yaml:",omitempty"`
 	EnvVars         []string `mapstructure:"envs" yaml:",omitempty"`
 	// Deprecated: PropertyFiles has been deprecated in 1.5
@@ -591,9 +589,6 @@ func (o *runCmdOptions) updateIntegrationCode(c client.Client, sources []string,
 				return nil, err
 			}
 		}
-	}
-	for _, item := range o.LoggingLevels {
-		integration.Spec.AddConfiguration("property", "logging.level."+item)
 	}
 	for _, item := range o.Configs {
 		if config, parseErr := ParseConfigOption(item); parseErr == nil {

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -154,18 +154,6 @@ func TestRunLabelWrongFormatFlag(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestRunLoggingLevelFlag(t *testing.T) {
-	runCmdOptions, rootCmd, _ := initializeRunCmdOptions(t)
-	_, err := test.ExecuteCommand(rootCmd, cmdRun,
-		"--logging-level", "lev1",
-		"--logging-level", "lev2",
-		integrationSource)
-	assert.Nil(t, err)
-	assert.Len(t, runCmdOptions.LoggingLevels, 2)
-	assert.Equal(t, "lev1", runCmdOptions.LoggingLevels[0])
-	assert.Equal(t, "lev2", runCmdOptions.LoggingLevels[1])
-}
-
 func TestRunLogsFlag(t *testing.T) {
 	runCmdOptions, rootCmd, _ := initializeRunCmdOptions(t)
 	_, err := test.ExecuteCommand(rootCmd, cmdRun, "--logs", integrationSource)


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```