### PR TITLE
Fix #2271: add support for beans in kamelets

### DIFF
--- a/config/crd/bases/camel.apache.org_kamelets.yaml
+++ b/config/crd/bases/camel.apache.org_kamelets.yaml
@@ -214,8 +214,7 @@ spec:
                   type: string
                 type: array
               flow:
-                description: Flow is an unstructured object representing a Camel Flow
-                  in YAML/JSON DSL
+                description: 'Deprecated: use template'
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               sources:
@@ -262,6 +261,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              template:
+                description: Template is an unstructured object representing a Kamelet
+                  template in YAML/JSON DSL
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               types:
                 additionalProperties:
                   properties:

--- a/deploy/olm-catalog/camel-k-dev/1.5.0-snapshot/camel.apache.org_kamelets.yaml
+++ b/deploy/olm-catalog/camel-k-dev/1.5.0-snapshot/camel.apache.org_kamelets.yaml
@@ -214,8 +214,7 @@ spec:
                   type: string
                 type: array
               flow:
-                description: Flow is an unstructured object representing a Camel Flow
-                  in YAML/JSON DSL
+                description: 'Deprecated: use template'
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               sources:
@@ -262,6 +261,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              template:
+                description: Template is an unstructured object representing a Kamelet
+                  template in YAML/JSON DSL
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               types:
                 additionalProperties:
                   properties:

--- a/e2e/knative/knative_platform_test.go
+++ b/e2e/knative/knative_platform_test.go
@@ -33,7 +33,7 @@ import (
 
 	. "github.com/apache/camel-k/e2e/support"
 	"github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util/flow"
+	"github.com/apache/camel-k/pkg/util/dsl"
 	"github.com/apache/camel-k/pkg/util/knative"
 )
 
@@ -57,10 +57,10 @@ func TestKnativePlatform(t *testing.T) {
 			// Change something in the integration to produce a redeploy
 			Expect(UpdateIntegration(ns, "yaml", func(it *v1.Integration) {
 				it.Spec.Profile = ""
-				content, err := flow.ToYamlDSL(it.Spec.Flows)
+				content, err := dsl.ToYamlDSL(it.Spec.Flows)
 				assert.NoError(t, err)
 				newData := strings.ReplaceAll(string(content), "string!", "string!!!")
-				newFlows, err := flow.FromYamlDSLString(newData)
+				newFlows, err := dsl.FromYamlDSLString(newData)
 				assert.NoError(t, err)
 				it.Spec.Flows = newFlows
 			})).To(Succeed())

--- a/e2e/yaks/common/kamelet-beans/beans-source.kamelet.yaml
+++ b/e2e/yaks/common/kamelet-beans/beans-source.kamelet.yaml
@@ -1,0 +1,36 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: beans-source
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  template:
+    beans:
+    - name: myBean
+      type: "#class:java.util.Date"
+      properties:
+        time: 0
+    from:
+      uri: timer:tick
+      steps:
+        - set-body:
+            simple: "Bean time is ${bean:{{myBean}}?method=getTime}!"
+        - to: "kamelet:sink"

--- a/e2e/yaks/common/kamelet-beans/kamelet.feature
+++ b/e2e/yaks/common/kamelet-beans/kamelet.feature
@@ -1,0 +1,15 @@
+Feature: Kamelets can declare local beans
+
+  Background:
+    Given Disable auto removal of Kamelet resources
+    Given Disable auto removal of Kubernetes resources
+    Given Camel-K resource polling configuration
+      | maxAttempts          | 40   |
+      | delayBetweenAttempts | 3000 |
+
+  Scenario: Kamelets templates can use beans
+    Given bind Kamelet beans-source to uri log:info
+    When create KameletBinding binding
+    Then KameletBinding binding should be available
+    Then Camel-K integration binding should be running
+    Then Camel-K integration binding should print Bean time is 0!

--- a/e2e/yaks/common/kamelet-beans/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-beans/yaks-config.yaml
@@ -1,0 +1,26 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+config:
+  namespace:
+    temporary: true
+pre:
+- name: installation
+  run: |
+    kamel install -n $YAKS_NAMESPACE
+
+    kubectl apply -f beans-source.kamelet.yaml -n $YAKS_NAMESPACE

--- a/helm/camel-k/crds/crd-kamelet.yaml
+++ b/helm/camel-k/crds/crd-kamelet.yaml
@@ -214,8 +214,7 @@ spec:
                   type: string
                 type: array
               flow:
-                description: Flow is an unstructured object representing a Camel Flow
-                  in YAML/JSON DSL
+                description: 'Deprecated: use template'
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               sources:
@@ -262,6 +261,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              template:
+                description: Template is an unstructured object representing a Kamelet
+                  template in YAML/JSON DSL
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               types:
                 additionalProperties:
                   properties:

--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -175,6 +175,11 @@ type Flow struct {
 	RawMessage `json:",inline"`
 }
 
+// Template is an unstructured object representing a Kamelet template in YAML/JSON DSL
+type Template struct {
+	RawMessage `json:",inline"`
+}
+
 // RuntimeProvider --
 type RuntimeProvider string
 

--- a/pkg/apis/camel/v1alpha1/kamelet_types.go
+++ b/pkg/apis/camel/v1alpha1/kamelet_types.go
@@ -43,8 +43,10 @@ var (
 
 // KameletSpec defines the desired state of Kamelet
 type KameletSpec struct {
-	Definition    *JSONSchemaProps            `json:"definition,omitempty"`
-	Sources       []camelv1.SourceSpec        `json:"sources,omitempty"`
+	Definition *JSONSchemaProps     `json:"definition,omitempty"`
+	Sources    []camelv1.SourceSpec `json:"sources,omitempty"`
+	Template   *camelv1.Template    `json:"template,omitempty"`
+	// Deprecated: use template
 	Flow          *camelv1.Flow               `json:"flow,omitempty"`
 	Authorization *AuthorizationSpec          `json:"authorization,omitempty"`
 	Types         map[EventSlot]EventTypeSpec `json:"types,omitempty"`
@@ -108,6 +110,8 @@ const (
 	KameletConditionReasonInvalidName string = "InvalidName"
 	// KameletConditionReasonInvalidProperty --
 	KameletConditionReasonInvalidProperty string = "InvalidProperty"
+	// KameletConditionReasonInvalidTemplate --
+	KameletConditionReasonInvalidTemplate string = "InvalidTemplate"
 )
 
 type KameletPhase string

--- a/pkg/apis/camel/v1alpha1/kamelet_types_support.go
+++ b/pkg/apis/camel/v1alpha1/kamelet_types_support.go
@@ -192,6 +192,16 @@ func ValidKameletProperties(kamelet *Kamelet) bool {
 	return true
 }
 
+func ValidKameletTemplate(kamelet *Kamelet) bool {
+	if kamelet == nil {
+		return true
+	}
+	if kamelet.Spec.Template != nil && kamelet.Spec.Flow != nil {
+		return false
+	}
+	return true
+}
+
 // NewKamelet creates a new kamelet
 func NewKamelet(namespace string, name string) Kamelet {
 	return Kamelet{

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -47,7 +47,7 @@ import (
 	"github.com/apache/camel-k/pkg/client"
 	"github.com/apache/camel-k/pkg/trait"
 	"github.com/apache/camel-k/pkg/util"
-	"github.com/apache/camel-k/pkg/util/flow"
+	"github.com/apache/camel-k/pkg/util/dsl"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	k8slog "github.com/apache/camel-k/pkg/util/kubernetes/log"
 	"github.com/apache/camel-k/pkg/util/sync"
@@ -523,7 +523,7 @@ func (o *runCmdOptions) updateIntegrationCode(c client.Client, sources []string,
 
 	for _, source := range resolvedSources {
 		if o.UseFlows && !o.Compression && (strings.HasSuffix(source.Name, ".yaml") || strings.HasSuffix(source.Name, ".yml")) {
-			flows, err := flow.FromYamlDSLString(source.Content)
+			flows, err := dsl.FromYamlDSLString(source.Content)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kamelet/initialize.go
+++ b/pkg/kamelet/initialize.go
@@ -49,6 +49,15 @@ func Initialize(kamelet *v1alpha1.Kamelet) (*v1alpha1.Kamelet, error) {
 			fmt.Sprintf("Kamelet property %q is reserved and cannot be part of the schema", v1alpha1.KameletIDProperty),
 		)
 	}
+	if !v1alpha1.ValidKameletTemplate(kamelet) {
+		ok = false
+		target.Status.SetCondition(
+			v1alpha1.KameletConditionReady,
+			corev1.ConditionFalse,
+			v1alpha1.KameletConditionReasonInvalidTemplate,
+			`Kamelet can only specify one of "flow" or "template"`,
+		)
+	}
 
 	if !ok {
 		target.Status.Phase = v1alpha1.KameletPhaseError

--- a/pkg/trait/init.go
+++ b/pkg/trait/init.go
@@ -24,7 +24,7 @@ import (
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/util"
-	"github.com/apache/camel-k/pkg/util/flow"
+	"github.com/apache/camel-k/pkg/util/dsl"
 )
 
 const flowsInternalSourceName = "camel-k-embedded-flow.yaml"
@@ -53,7 +53,7 @@ func (t *initTrait) Apply(e *Environment) error {
 
 		// Flows need to be turned into a generated source
 		if len(e.Integration.Spec.Flows) > 0 {
-			content, err := flow.ToYamlDSL(e.Integration.Spec.Flows)
+			content, err := dsl.ToYamlDSL(e.Integration.Spec.Flows)
 			if err != nil {
 				return err
 			}

--- a/pkg/trait/kamelets.go
+++ b/pkg/trait/kamelets.go
@@ -33,7 +33,7 @@ import (
 	"github.com/apache/camel-k/pkg/platform"
 	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/digest"
-	"github.com/apache/camel-k/pkg/util/flow"
+	"github.com/apache/camel-k/pkg/util/dsl"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -260,16 +260,17 @@ func (t *kameletsTrait) configureApplicationProperties(e *Environment) error {
 func (t *kameletsTrait) addKameletAsSource(e *Environment, kamelet *v1alpha1.Kamelet) error {
 	sources := make([]v1.SourceSpec, 0)
 
-	if kamelet.Spec.Flow != nil {
-
-		flowData, err := flow.ToYamlDSL([]v1.Flow{*kamelet.Spec.Flow})
+	if kamelet.Spec.Template != nil || kamelet.Spec.Flow != nil {
+		template := kamelet.Spec.Template
+		if template == nil {
+			// Backward compatibility with Kamelets using flow
+			template = &v1.Template{
+				RawMessage: kamelet.Spec.Flow.RawMessage,
+			}
+		}
+		flowData, err := dsl.TemplateToYamlDSL(*template, kamelet.Name)
 		if err != nil {
 			return err
-		}
-
-		propertyNames := make([]string, 0, len(kamelet.Status.Properties))
-		for _, p := range kamelet.Status.Properties {
-			propertyNames = append(propertyNames, p.Name)
 		}
 
 		flowSource := v1.SourceSpec{
@@ -277,11 +278,9 @@ func (t *kameletsTrait) addKameletAsSource(e *Environment, kamelet *v1alpha1.Kam
 				Name:    fmt.Sprintf("%s.yaml", kamelet.Name),
 				Content: string(flowData),
 			},
-			Language:      v1.LanguageYaml,
-			Type:          v1.SourceTypeTemplate,
-			PropertyNames: propertyNames,
+			Language: v1.LanguageYaml,
 		}
-		flowSource, err = integrationSourceFromKameletSource(e, kamelet, flowSource, fmt.Sprintf("%s-kamelet-%s-flow", e.Integration.Name, kamelet.Name))
+		flowSource, err = integrationSourceFromKameletSource(e, kamelet, flowSource, fmt.Sprintf("%s-kamelet-%s-template", e.Integration.Name, kamelet.Name))
 		if err != nil {
 			return err
 		}
@@ -296,11 +295,7 @@ func (t *kameletsTrait) addKameletAsSource(e *Environment, kamelet *v1alpha1.Kam
 		sources = append(sources, intSource)
 	}
 
-	kameletCounter := 0
 	for _, source := range sources {
-		if source.Type == v1.SourceTypeTemplate {
-			kameletCounter++
-		}
 		replaced := false
 		for idx, existing := range e.Integration.Status.GeneratedSources {
 			if existing.Name == source.Name {
@@ -311,10 +306,6 @@ func (t *kameletsTrait) addKameletAsSource(e *Environment, kamelet *v1alpha1.Kam
 		if !replaced {
 			e.Integration.Status.GeneratedSources = append(e.Integration.Status.GeneratedSources, source)
 		}
-	}
-
-	if kameletCounter > 1 {
-		return fmt.Errorf(`kamelet %s contains %d sources of type "kamelet": at most one is allowed`, kamelet.Name, kameletCounter)
 	}
 
 	return nil

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -34,7 +34,7 @@ import (
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/defaults"
-	"github.com/apache/camel-k/pkg/util/flow"
+	"github.com/apache/camel-k/pkg/util/dsl"
 )
 
 // ComputeForIntegration a digest of the fields that are relevant for the deployment
@@ -74,7 +74,7 @@ func ComputeForIntegration(integration *v1.Integration) (string, error) {
 
 	// Integration flows
 	if len(integration.Spec.Flows) > 0 {
-		flows, err := flow.ToYamlDSL(integration.Spec.Flows)
+		flows, err := dsl.ToYamlDSL(integration.Spec.Flows)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/util/dsl/flow.go
+++ b/pkg/util/dsl/flow.go
@@ -1,0 +1,76 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dsl
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	yaml2 "gopkg.in/yaml.v2"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+)
+
+// FromYamlDSLString creates a slice of flows from a Camel YAML DSL string
+func FromYamlDSLString(flowsString string) ([]v1.Flow, error) {
+	return FromYamlDSL(bytes.NewReader([]byte(flowsString)))
+}
+
+// FromYamlDSL creates a slice of flows from a Camel YAML DSL stream
+func FromYamlDSL(reader io.Reader) ([]v1.Flow, error) {
+	buffered, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	var flows []v1.Flow
+	// Using the Kubernetes decoder to turn them into JSON before unmarshal.
+	// This avoids having map[interface{}]interface{} objects which are not JSON compatible.
+	jsonData, err := yaml.ToJSON(buffered)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(jsonData, &flows); err != nil {
+		return nil, err
+	}
+	return flows, err
+}
+
+// ToYamlDSL converts a flow into its Camel YAML DSL equivalent
+func ToYamlDSL(flows []v1.Flow) ([]byte, error) {
+	data, err := json.Marshal(&flows)
+	if err != nil {
+		return nil, err
+	}
+	jsondata := make([]map[string]interface{}, 0)
+	err = json.Unmarshal(data, &jsondata)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling json: %v", err)
+	}
+	yamldata, err := yaml2.Marshal(&jsondata)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling to yaml: %v", err)
+	}
+
+	return yamldata, nil
+}

--- a/pkg/util/dsl/flow_test.go
+++ b/pkg/util/dsl/flow_test.go
@@ -1,0 +1,53 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dsl
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadWriteYaml(t *testing.T) {
+	// yaml in conventional form as marshalled by the go runtime
+	yaml := `- from:
+    steps:
+    - to: log:info
+    uri: timer:tick
+`
+
+	yamlReader := bytes.NewReader([]byte(yaml))
+	flows, err := FromYamlDSL(yamlReader)
+	assert.NoError(t, err)
+	assert.NotNil(t, flows)
+	assert.Len(t, flows, 1)
+
+	flow := map[string]interface{}{}
+	err = json.Unmarshal(flows[0].RawMessage, &flow)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, flow["from"])
+	assert.Nil(t, flow["xx"])
+
+	data, err := ToYamlDSL(flows)
+	assert.NoError(t, err)
+	assert.NotNil(t, data)
+	assert.Equal(t, yaml, string(data))
+}


### PR DESCRIPTION
<!-- Description -->

Fix #2271

Tests will fail unless we:
- Upgrade to Camel 3.10.0
- Add fix https://github.com/apache/camel-quarkus/pull/2750 in Camel Quarkus


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Kamelets support local beans
```
