### PR TITLE
chore(e2e): allow e2e to use nexus mirror to speed up testing #2387

### DIFF
--- a/docs/modules/ROOT/pages/contributing/developers.adoc
+++ b/docs/modules/ROOT/pages/contributing/developers.adoc
@@ -87,27 +87,11 @@ make STAGING_IMAGE_NAME='docker.io/myrepo/camel-k' images-push-staging
 Unit tests are executed automatically as part of the build. They use the standard go testing framework.
 
 Integration tests (aimed at ensuring that the code integrates correctly with Kubernetes and OpenShift), need special care.
-
-The **convention** used in this repo is to name tests `xxx_test.go`.
 Integration tests are all in the https://github.com/apache/camel-k/tree/main/e2e[/e2e] dir.
 
-Since both names end with `_test.go`, both would be executed by go during the build, so you need to put a special **build tag** to mark
-integration tests. An integration test should start with the following line:
+For more detail on integration testing, refer to the following documentation:
 
-[source]
-----
-// +build integration
-----
-
-Look into the https://github.com/apache/camel-k/tree/main/e2e[/e2e] directory for examples of integration tests.
-
-Before running an integration test, you need to be connected to a Kubernetes/OpenShift namespace.
-After you log in into your cluster, you can run the following command to execute **all** integration tests:
-
-[source]
-----
-make test-integration
-----
+- xref:contributing/e2e.adoc[End To End local integration test]
 
 [[running]]
 == Running

--- a/docs/modules/ROOT/pages/contributing/e2e.adoc
+++ b/docs/modules/ROOT/pages/contributing/e2e.adoc
@@ -2,24 +2,41 @@
 
 Camel K has a suite of integration test that will run on every Pull Request. You can contribute by adding an integration test to cover any new feature introduced (or increment the coverage with features still untested).
 
+Since both unit test and integration test names end with `_test.go`, both would be executed by go during the build, so you need to put a special **build tag** to mark
+integration tests. An integration test should start with the following line:
+
+[source]
+----
+// +build integration
+----
+
+Look into the https://github.com/apache/camel-k/tree/main/e2e[/e2e] directory for examples of integration tests.
+
+Before running an integration test, you need to be connected to a Kubernetes/OpenShift namespace.
+After you log in into your cluster, you can run the following command to execute **all** integration tests:
+
+[source]
+----
+make test-integration
+----
+
 The test script will take care to install the operators needed in a random namespace, execute all expected tests and clean themselves. Cleaning may not be performed if the execution of tests fails or the test process is interrupted. In that case you can look for any namespace similar to `test-29ed8147-c9fc-4c04-9c29-744eaf4750c6` and remove manually.
 
-In order to run the test locally you will have to be connected to a kubernetes cluster and execute:
-
-----
-make test
-----
+[[testing-operator]]
+== Testing Operator under development
 
 You probably want to test your changes on camel-k `operator` locally after some development. You will need to make the operator docker image available to your cluster registry before launching the tests. We have a script that will take care of that.
 
 First, you must connect and point to the `docker daemon`. If you're on a local environment such as `minikube`, it will be as simple as executing
 
+[source]
 ----
 eval $(minikube -p minikube docker-env)
 ----
 
 For other cluster types you may check the specific documentation. As soon as you're connected to the `docker daemon` you can build images via:
 
+[source]
 ----
 make images
 ----
@@ -28,6 +45,25 @@ The script will take care to build the operator docker image and push to the und
 
 You can also execute the following script, if by any chance you have some change applied to the `camel-k-runtime`:
 
+[source]
 ----
 make images-dev
+----
+
+[[using-nexus]]
+== Using Nexus repository mirror with E2E testing
+
+To speed up integration testing locally, you may use a https://github.com/sonatype/docker-nexus3[Nexus Repository Manager] for Maven repository mirror.
+
+You can set the environment variable `TEST_ENABLE_NEXUS=true` to enable the usage of Nexus mirror in e2e testing. If `TEST_ENABLE_NEXUS` is set, e2e tests will try to discover an Nexus instance as `nexus` service in `nexus` namespace and if it is found they will use it as the Maven repository mirror for the `camel-k` platform under test.
+
+[source]
+----
+TEST_ENABLE_NEXUS=true make test-integration
+----
+
+To set up a Nexus instance in your cluster, run the following command:
+[source]
+----
+kubectl apply -f e2e/support/files/nexus.yaml
 ----

--- a/e2e/knative/kamelet_test.go
+++ b/e2e/knative/kamelet_test.go
@@ -55,5 +55,6 @@ func TestKameletChange(t *testing.T) {
 		Eventually(IntegrationPodPhase(ns, "timer-binding"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
 		Eventually(IntegrationCondition(ns, "timer-binding", camelv1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(v1.ConditionTrue))
 		Eventually(IntegrationLogs(ns, "display"), TestTimeoutShort).Should(ContainSubstring("message is Hi"))
+		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/support/files/nexus.yaml
+++ b/e2e/support/files/nexus.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nexus
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nexus
+  namespace: nexus
+spec:
+  selector:
+    app: nexus
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8081
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nexus
+  namespace: nexus
+spec:
+  selector:
+    matchLabels:
+      app: nexus
+  template:
+    metadata:
+      labels:
+        app: nexus
+    spec:
+      containers:
+        - name: nexus
+          image: sonatype/nexus3
+          ports:
+            - containerPort: 8081
+              name: 8081-tcp
+          livenessProbe:
+            httpGet:
+              path: /service/rest/v1/status
+              port: 8081
+            initialDelaySeconds: 90
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /service/rest/v1/status
+              port: 8081
+            initialDelaySeconds: 90
+            periodSeconds: 3
+          volumeMounts:
+            - name: nexus-data
+              mountPath: /nexus-data
+      volumes:
+        - name: nexus-data
+          emptyDir: {}

--- a/e2e/support/test_nexus_hooks.go
+++ b/e2e/support/test_nexus_hooks.go
@@ -1,0 +1,66 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package support
+
+import (
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	nexusNamespace   = "nexus"
+	nexusService     = "nexus"
+	nexusMavenMirror = "http://nexus.nexus/repository/maven-public/@id=nexus@mirrorOf=central"
+)
+
+func init() {
+	// Nexus repository mirror is disabled by default for E2E testing
+	nexus := os.Getenv("TEST_ENABLE_NEXUS")
+	if nexus == "true" {
+		svcChecked := false
+		svcExists := true
+		KamelHooks = append(KamelHooks, func(args []string) []string {
+			if len(args) > 0 && args[0] == "install" {
+				// Enable mirror only if nexus service exists
+				if !svcChecked {
+					svc := corev1.Service{}
+					key := ctrl.ObjectKey{
+						Namespace: nexusNamespace,
+						Name:      nexusService,
+					}
+
+					if err := TestClient().Get(TestContext, key, &svc); err != nil {
+						svcExists = false
+					}
+					svcChecked = true
+				}
+				if svcExists {
+					args = append(args, fmt.Sprintf("--maven-repository=%s", nexusMavenMirror))
+				}
+			}
+			return args
+		})
+	}
+}


### PR DESCRIPTION
<!-- Description -->

This time the pull req introduces a opt-in env var `TEST_ENABLE_NEXUS` to allow you to use nexus mirror during e2e testing. This doesn't affect existing workflow. Only developers who want to use nexus during local e2e testing can use this env var to enable it.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
