### PR TITLE
chore(build): Upgrade Go to version 1.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Cache modules

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:
@@ -193,7 +193,7 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.15.x
       - name: Get YAKS
         run: |
           export YAKS_VERSION=0.4.0-202104120032

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@v1
       with:

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Build Kamel
       run: |
         echo "Build project"

--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Get OpenShift Client (oc)
       run: |
         export OPENSHIFT_VERSION=v3.11.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Cache modules

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Set Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Set up operator-sdk
       run: |
         curl -L https://github.com/operator-framework/operator-sdk/releases/download/v1.3.0/operator-sdk_linux_amd64 -o operator-sdk

--- a/docs/modules/ROOT/pages/contributing/developers.adoc
+++ b/docs/modules/ROOT/pages/contributing/developers.adoc
@@ -11,7 +11,7 @@ Camel K is built on top of Kubernetes through *Custom Resource Definitions*.
 
 In order to build the project, you need to comply with the following requirements:
 
-* **Go version 1.13+**: needed to compile and test the project. Refer to the https://golang.org/[Go website] for the installation.
+* **Go version 1.15+**: needed to compile and test the project. Refer to the https://golang.org/[Go website] for the installation.
 * **GNU Make**: used to define composite build actions. This should be already installed or available as a package if you have a good OS (https://www.gnu.org/software/make/).
 
 The Camel K Java runtime (camel-k-runtime) requires:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/camel-k
 
-go 1.13
+go 1.15
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/pkg/apis/camel/go.mod
+++ b/pkg/apis/camel/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/camel-k/pkg/apis/camel
 
-go 1.13
+go 1.15
 
 require (
 	github.com/stretchr/testify v1.4.0

--- a/pkg/client/camel/go.mod
+++ b/pkg/client/camel/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/camel-k/pkg/client/camel
 
-go 1.13
+go 1.15
 
 require (
 	github.com/apache/camel-k/pkg/apis/camel v0.0.0

--- a/pkg/kamelet/repository/go.mod
+++ b/pkg/kamelet/repository/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/camel-k/pkg/kamelet/repository
 
-go 1.13
+go 1.15
 
 require (
 	github.com/apache/camel-k/pkg/apis/camel v0.0.0


### PR DESCRIPTION
Newer dependency versions start requiring more recent Go versions.

**Release Note**
```release-note
chore(build): Upgrade Go to version 1.15
```
