### PR TITLE
fix(cli): resource path with quotes and spaces

### DIFF
--- a/pkg/cmd/run_help_test.go
+++ b/pkg/cmd/run_help_test.go
@@ -62,6 +62,7 @@ func TestParseConfigOptionAllParams(t *testing.T) {
 	sec4 := "secret:sec"
 	file1 := "file:/path/to/my-file.txt@/tmp/file.txt"
 	file2 := "file:/path/to/my-file.txt"
+	file3 := "file:/path to/my-file.txt"
 
 	parsedCm1, err := ParseConfigOption(cm1)
 	assert.Nil(t, err)
@@ -132,6 +133,13 @@ func TestParseConfigOptionAllParams(t *testing.T) {
 	assert.Equal(t, "/path/to/my-file.txt", parsedFile2.Name())
 	assert.Equal(t, "", parsedFile2.Key())
 	assert.Equal(t, "", parsedFile2.DestinationPath())
+
+	parsedFile3, err := ParseConfigOption(file3)
+	assert.Nil(t, err)
+	assert.Equal(t, "file", parsedFile3.Type())
+	assert.Equal(t, "/path to/my-file.txt", parsedFile3.Name())
+	assert.Equal(t, "", parsedFile3.Key())
+	assert.Equal(t, "", parsedFile3.DestinationPath())
 }
 
 func TestFilterFileLocation(t *testing.T) {


### PR DESCRIPTION
Closes #2417

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
