### PR TITLE
chore(ci): upgrade Knative versions in CI to latest possible

### DIFF
--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -94,10 +94,10 @@ jobs:
         # Prerequisites
         sudo pip install yq
 
-        export SERVING_VERSION=v0.16.0
-        export EVENTING_VERSION=v0.16.2
-        export KOURIER_VERSION=v0.16.0
-        export SOURCES_VERSION=v0.16.0
+        export SERVING_VERSION=v0.23.1
+        export EVENTING_VERSION=v0.17.9
+        export KOURIER_VERSION=v0.23.0
+        export SOURCES_VERSION=v0.17.8
 
         # Serving
         kubectl apply --filename https://github.com/knative/serving/releases/download/$SERVING_VERSION/serving-crds.yaml
@@ -218,10 +218,10 @@ jobs:
           # Prerequisites
           sudo pip install yq
 
-          export SERVING_VERSION=v0.16.0
-          export EVENTING_VERSION=v0.16.2
-          export KOURIER_VERSION=v0.16.0
-          export SOURCES_VERSION=v0.16.0
+          export SERVING_VERSION=v0.23.1
+          export EVENTING_VERSION=v0.17.9
+          export KOURIER_VERSION=v0.23.0
+          export SOURCES_VERSION=v0.17.8
 
           # Serving
           kubectl apply --filename https://github.com/knative/serving/releases/download/$SERVING_VERSION/serving-crds.yaml


### PR DESCRIPTION
Due to #2195 and #2343, eventing is still required to stay lower than v0.18.0.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
