### PR TITLE
fix(trait): never fallback to client-side apply unless server-side apply is incombatible

### DIFF
--- a/pkg/util/test/client.go
+++ b/pkg/util/test/client.go
@@ -18,6 +18,7 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"strings"
 
 	"github.com/apache/camel-k/pkg/apis"
@@ -103,6 +104,11 @@ func (c *FakeClient) GetConfig() *rest.Config {
 
 func (c *FakeClient) GetCurrentNamespace(kubeConfig string) (string, error) {
 	return "", nil
+}
+
+// Patch mimicks patch for server-side apply and simply creates the obj
+func (c *FakeClient) Patch(ctx context.Context, obj controller.Object, patch controller.Patch, opts ...controller.PatchOption) error {
+	return c.Create(ctx, obj)
 }
 
 func (c *FakeClient) Discovery() discovery.DiscoveryInterface {


### PR DESCRIPTION
<!-- Description -->

It's convenient for debugging if we output log with error why SSA failed at deployer trait (other than incompatibility) before attempting to CSA so that we can know the direct reason why the operation failed.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
