### PR TITLE
[e2e-tests] cli test (without kamel debug)

### DIFF
--- a/e2e/common/cli/delete_test.go
+++ b/e2e/common/cli/delete_test.go
@@ -1,0 +1,85 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/apache/camel-k/e2e/support"
+)
+
+func TestKamelCLIDelete(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		Expect(Kamel("install", "-n", ns).Execute()).To(Succeed())
+
+		t.Run("delete running integration", func(t *testing.T) {
+			Expect(Kamel("run", "-n", ns, "../files/yaml.yaml").Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Expect(Kamel("delete", "yaml", "-n", ns).Execute()).To(Succeed())
+			Eventually(Integration(ns, "yaml")).Should(BeNil())
+			Eventually(IntegrationPod(ns, "yaml")).Should(BeNil())
+		})
+
+		t.Run("delete building integration", func(t *testing.T) {
+			Expect(Kamel("run", "-n", ns, "../files/yaml.yaml").Execute()).To(Succeed())
+			Expect(Kamel("delete", "yaml", "-n", ns).Execute()).To(Succeed())
+			Eventually(Integration(ns, "yaml")).Should(BeNil())
+			Eventually(IntegrationPod(ns, "yaml")).Should(BeNil())
+		})
+
+		t.Run("delete integration from csv", func(t *testing.T) {
+			Expect(Kamel("run", "github:apache/camel-k/e2e/common/files/yaml.yaml", "-n", ns).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Expect(Kamel("delete", "yaml", "-n", ns).Execute()).To(Succeed())
+			Eventually(Integration(ns, "yaml")).Should(BeNil())
+			Eventually(IntegrationPod(ns, "yaml")).Should(BeNil())
+		})
+
+		t.Run("delete several integrations", func(t *testing.T) {
+			Expect(Kamel("run", "../files/yaml.yaml", "-n", ns).Execute()).To(Succeed())
+			Expect(Kamel("run", "../files/Java.java", "-n", ns).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Expect(Kamel("delete", "yaml", "-n", ns).Execute()).To(Succeed())
+			Eventually(Integration(ns, "yaml")).Should(BeNil())
+			Eventually(IntegrationPod(ns, "yaml")).Should(BeNil())
+			Expect(Kamel("delete", "java", "-n", ns).Execute()).To(Succeed())
+			Eventually(Integration(ns, "java")).Should(BeNil())
+			Eventually(IntegrationPod(ns, "java")).Should(BeNil())
+		})
+
+		t.Run("delete all integrations", func(t *testing.T) {
+			Expect(Kamel("run", "../files/yaml.yaml", "-n", ns).Execute()).To(Succeed())
+			Expect(Kamel("run", "../files/Java.java", "-n", ns).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+			Eventually(Integration(ns, "yaml")).Should(BeNil())
+			Eventually(IntegrationPod(ns, "yaml")).Should(BeNil())
+			Eventually(Integration(ns, "java")).Should(BeNil())
+			Eventually(IntegrationPod(ns, "java")).Should(BeNil())
+		})
+	})
+}

--- a/e2e/common/cli/get_test.go
+++ b/e2e/common/cli/get_test.go
@@ -1,0 +1,70 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/apache/camel-k/e2e/support"
+)
+
+func TestKamelCLIGet(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		Expect(Kamel("install", "-n", ns).Execute()).To(Succeed())
+
+		t.Run("get integration", func(t *testing.T) {
+			Expect(Kamel("run", "../files/yaml.yaml", "-n", ns).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			// regex is used for the compatibility of tests between OC and vanilla K8
+			// kamel get may have different output depending og the platform
+			kitName := Integration(ns, "yaml")().Status.Kit
+			regex := fmt.Sprintf("^NAME\tPHASE\tKIT\n\\s*yaml\tRunning\t(%s/%s|%s)", ns, kitName, kitName)
+			Expect(GetOutputString(Kamel("get", "-n", ns))).To(MatchRegexp(regex))
+
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("get several integrations", func(t *testing.T) {
+			Expect(Kamel("run", "../files/yaml.yaml", "-n", ns).Execute()).To(Succeed())
+			Expect(Kamel("run", "../files/Java.java", "-n", ns).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+			Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutMedium).Should(Equal(v1.PodRunning))
+
+			kitName1 := Integration(ns, "java")().Status.IntegrationKit.Name
+			kitName2 := Integration(ns, "yaml")().Status.IntegrationKit.Name
+			regex := fmt.Sprintf("^NAME\tPHASE\tKIT\n\\s*java\tRunning\t" +
+				"(%s/%s|%s)\n\\s*yaml\tRunning\t(%s/%s|%s)\n", ns, kitName1, kitName1, ns, kitName2, kitName2)
+			Expect(GetOutputString(Kamel("get", "-n", ns))).To(MatchRegexp(regex))
+
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("get no integrations" , func(t *testing.T) {
+			Expect(GetOutputString(Kamel("get", "-n", ns))).NotTo(ContainSubstring("Running"))
+			Expect(GetOutputString(Kamel("get", "-n", ns))).NotTo(ContainSubstring("Building Kit"))
+		})
+	})
+}

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -22,6 +22,7 @@ limitations under the License.
 package support
 
 import (
+	"bytes"
 	"bufio"
 	"context"
 	"encoding/json"
@@ -1260,4 +1261,22 @@ func NewTestNamespace(injectKnativeBroker bool) ctrl.Object {
 		}
 	}
 	return obj
+}
+
+func GetOutputString(command *cobra.Command) string {
+	var buf bytes.Buffer
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	command.SetOut(writer)
+	command.Execute()
+
+	writer.Close()
+	defer reader.Close()
+
+	buf.ReadFrom(reader)
+
+	return buf.String()
 }


### PR DESCRIPTION
This PR contains tests for `kamel get` and kamel `kamel delete` commands, it does not contain tests for the `kamel debug` command because there are some problems with concurrent execution of debug (see previous PR: https://github.com/apache/camel-k/pull/2126). Expect `kamel debug` test in the next release :)