### PR TITLE
Fix #2441: parse parameters in YAML DSL

### DIFF
--- a/e2e/common/cron_test.go
+++ b/e2e/common/cron_test.go
@@ -44,6 +44,14 @@ func TestRunCronExample(t *testing.T) {
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
+		t.Run("cron-yaml", func(t *testing.T) {
+			Expect(Kamel("run", "-n", ns, "files/cron-yaml.yaml").Execute()).To(Succeed())
+			Eventually(IntegrationCronJob(ns, "cron-yaml"), TestTimeoutMedium).ShouldNot(BeNil())
+			Eventually(IntegrationCondition(ns, "cron-yaml", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, "cron-yaml"), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+
 		t.Run("cron-timer", func(t *testing.T) {
 			Expect(Kamel("run", "-n", ns, "files/cron-timer.groovy").Execute()).To(Succeed())
 			Eventually(IntegrationCronJob(ns, "cron-timer"), TestTimeoutMedium).ShouldNot(BeNil())

--- a/e2e/common/files/cron-yaml.yaml
+++ b/e2e/common/files/cron-yaml.yaml
@@ -1,0 +1,31 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- from:
+    uri: "cron:tab"
+    parameters:
+      schedule: "* * * * ?"
+    steps:
+      - set-header:
+          name: "m"
+          constant: "string!"
+      - set-body:
+          simple: "Magic${header.m}"
+      - to:
+          uri: "log:info"
+          parameters:
+            show-all: "false"


### PR DESCRIPTION
<!-- Description -->

Fix #2441


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Parameters in YAML DSL are correctly processed by the operator
```
