### PR TITLE
Fix cron trait issue for release 1.3.x

### DIFF
--- a/pkg/trait/cron.go
+++ b/pkg/trait/cron.go
@@ -237,7 +237,7 @@ func (t *cronTrait) Apply(e *Environment) error {
 			e.ApplicationProperties = make(map[string]string)
 		}
 
-		e.ApplicationProperties["camel.main.duration-max-messages"] = "1"
+		e.ApplicationProperties["camel.main.duration-max-idle-seconds"] = "5"
 		e.ApplicationProperties["loader.interceptor.cron.overridable-components"] = t.Components
 		e.Interceptors = append(e.Interceptors, "cron")
 


### PR DESCRIPTION
<!-- Description -->

As described in

- https://github.com/apache/camel-k/issues/2439
- https://camel.zulipchat.com/#narrow/stream/257299-camel-k/topic/Cron.20and.20duration.20max.20messages


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
