### PR TITLE
fix: Correct Quarkus default health probe path

### DIFF
--- a/pkg/trait/container.go
+++ b/pkg/trait/container.go
@@ -40,7 +40,7 @@ const (
 	defaultContainerPort     = 8080
 	defaultContainerPortName = "http"
 	defaultServicePort       = 80
-	defaultProbePath         = "/health"
+	defaultProbePath         = "/q/health"
 	containerTraitID         = "container"
 )
 


### PR DESCRIPTION
**Release Note**
```release-note
fix: Correct Quarkus default health probe path
```
