### PR TITLE
fix: Unrecognized configuration from quarkus-logging-json

### DIFF
--- a/pkg/trait/logging.go
+++ b/pkg/trait/logging.go
@@ -29,7 +29,7 @@ const (
 	envVarQuarkusLogConsoleFormat          = "QUARKUS_LOG_CONSOLE_FORMAT"
 	envVarQuarkusLogConsoleJson            = "QUARKUS_LOG_CONSOLE_JSON"
 	envVarQuarkusLogConsoleJsonPrettyPrint = "QUARKUS_LOG_CONSOLE_JSON_PRETTY_PRINT"
-	depQuarkusLoggingJson                  = "quarkus-logging-json"
+	depQuarkusLoggingJson                  = "mvn:io.quarkus:quarkus-logging-json"
 	defaultLogLevel                        = "INFO"
 )
 

--- a/pkg/trait/logging_test.go
+++ b/pkg/trait/logging_test.go
@@ -19,14 +19,17 @@ package trait
 
 import (
 	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/util/camel"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/apache/camel-k/pkg/util/test"
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func createLoggingTestEnv(t *testing.T, color bool, json bool, jsonPrettyPrint bool, logLevel string, logFormat string) *Environment {
@@ -82,7 +85,7 @@ func createLoggingTestEnv(t *testing.T, color bool, json bool, jsonPrettyPrint b
 }
 
 func createDefaultLoggingTestEnv(t *testing.T) *Environment {
-	return createLoggingTestEnv(t, true, false, false, defaultLogLevel, defaultLogFormat)
+	return createLoggingTestEnv(t, true, false, false, defaultLogLevel, "")
 }
 
 func NewLoggingTestCatalog() *Catalog {


### PR DESCRIPTION
This PR fixes the following warning messages, that Quarkus logs when the `quarkus-logging-json` extension is not present:

```
2021-06-28 10:13:50,787 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.log.console.json.pretty.print" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
2021-06-28 10:13:50,788 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.log.console.json" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```

More generally, this PR only appends environment variables related to Quarkus logging configuration when explicitly needed or provided by the user.

**Release Note**
```release-note
NONE
```
