### PR TITLE
fix(cmd/run): windows scheme support

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -728,18 +728,6 @@ func (o *runCmdOptions) configureTraits(integration *v1.Integration, options []s
 	return nil
 }
 
-func isLocalAndFileExists(fileName string) (bool, error) {
-	info, err := os.Stat(fileName)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		// If it is a different error (ie, permission denied) we should report it back
-		return false, errors.Wrap(err, fmt.Sprintf("file system error while looking for %s", fileName))
-	}
-	return !info.IsDir(), nil
-}
-
 func addIntegrationProperties(props *properties.Properties, spec *v1.IntegrationSpec) error {
 	for _, k := range props.Keys() {
 		v, _ := props.Get(k)

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -565,13 +565,6 @@ func TestResolveJsonPodTemplate(t *testing.T) {
 	assert.Equal(t, 2, len(integrationSpec.PodTemplate.Spec.Containers))
 }
 
-func TestIsLocalFileAndExists(t *testing.T) {
-	value, err := isLocalAndFileExists("/root/test")
-	// must not panic because a permission error
-	assert.NotNil(t, err)
-	assert.False(t, value)
-}
-
 func TestExtractProperties_SingleKeyValue(t *testing.T) {
 	correctValues := []string{"key=val", "key = val", "key= val", " key   =  val"}
 	for _, val := range correctValues {

--- a/pkg/cmd/util_sources.go
+++ b/pkg/cmd/util_sources.go
@@ -84,7 +84,7 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 			}
 
 			switch {
-			case u.Scheme == "gist" || strings.HasPrefix(location, "https://gist.github.com/"):
+			case u.Scheme == gistScheme || strings.HasPrefix(location, "https://gist.github.com/"):
 				var tc *http.Client
 
 				if token, ok := os.LookupEnv("GITHUB_TOKEN"); ok {
@@ -133,7 +133,7 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 					}
 					sources = append(sources, answer)
 				}
-			case u.Scheme == "github":
+			case u.Scheme == githubScheme:
 				answer := Source{
 					Name:     path.Base(location),
 					Origin:   location,
@@ -149,7 +149,7 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 					return sources, err
 				}
 				sources = append(sources, answer)
-			case u.Scheme == "http":
+			case u.Scheme == httpScheme:
 				answer := Source{
 					Name:     path.Base(location),
 					Origin:   location,
@@ -165,7 +165,7 @@ func ResolveSources(ctx context.Context, locations []string, compress bool) ([]S
 					return sources, err
 				}
 				sources = append(sources, answer)
-			case u.Scheme == "https":
+			case u.Scheme == httpsScheme:
 				answer := Source{
 					Name:     path.Base(location),
 					Origin:   location,

--- a/pkg/cmd/util_test.go
+++ b/pkg/cmd/util_test.go
@@ -1,0 +1,65 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCorrectFileValuesButNotFound(t *testing.T) {
+	value1, err1 := isLocalAndFileExists("c:\\test")
+	value2, err2 := isLocalAndFileExists("path/to/file")
+
+	// they are all not found, but it must not panic
+	assert.Nil(t, err1)
+	assert.False(t, value1)
+	assert.Nil(t, err2)
+	assert.False(t, value2)
+}
+
+func TestPermissionDenied(t *testing.T) {
+	value, err := isLocalAndFileExists("/root/test")
+	// must not panic because a permission error
+	assert.NotNil(t, err)
+	assert.False(t, value)
+}
+
+func TestSupportedScheme(t *testing.T) {
+	gistValue, err1 := isLocalAndFileExists("gist:some/gist/resource")
+	githubValue, err2 := isLocalAndFileExists("github:some/github/resource")
+	httpValue, err3 := isLocalAndFileExists("http://some/http/resource")
+	httpsValue, err4 := isLocalAndFileExists("https://some/https/resource")
+
+	assert.Nil(t, err1)
+	assert.False(t, gistValue)
+	assert.Nil(t, err2)
+	assert.False(t, githubValue)
+	assert.Nil(t, err3)
+	assert.False(t, httpValue)
+	assert.Nil(t, err4)
+	assert.False(t, httpsValue)
+}
+
+func TestUnSupportedScheme(t *testing.T) {
+	value, err := isLocalAndFileExists("bad_scheme:some/bad/resource")
+	// must not report an error
+	assert.Nil(t, err)
+	assert.False(t, value)
+}


### PR DESCRIPTION
Introduced a check to verify if the source matches with a supported scheme.

Closes #2475

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cmd/run): windows scheme support
```
