### PR TITLE
fix(cli): kamel uninstall should delete kamelets #2479

### DIFF
--- a/e2e/common/cli/uninstall_test.go
+++ b/e2e/common/cli/uninstall_test.go
@@ -42,6 +42,7 @@ func TestBasicUninstall(t *testing.T) {
 		Eventually(Configmap(ns, "camel-k-maven-settings")).Should(BeNil())
 		Eventually(ServiceAccount(ns, "camel-k-operator")).Should(BeNil())
 		Eventually(OperatorPod(ns)).Should(BeNil())
+		Eventually(Kamelet(ns)).Should(BeNil())
 	})
 }
 
@@ -98,5 +99,17 @@ func TestUninstallSkipIntegrationPlatform(t *testing.T) {
 		// NOTE: skip CRDs is also required in addition to skip integration platform
 		Expect(Kamel("uninstall", "-n", ns, "--skip-crd", "--skip-cluster-roles", "--skip-integration-platform").Execute()).To(Succeed())
 		Eventually(Platform(ns)).ShouldNot(BeNil())
+	})
+}
+
+func TestUninstallSkipKamelets(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		// a successful new installation
+		Expect(Kamel("install", "-n", ns).Execute()).To(Succeed())
+		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
+		Eventually(Kamelet(ns)).ShouldNot(BeNil())
+		// on uninstall it should remove everything except kamelets
+		Expect(Kamel("uninstall", "-n", ns, "--skip-crd", "--skip-cluster-roles", "--skip-kamelets").Execute()).To(Succeed())
+		Eventually(Kamelet(ns)).ShouldNot(BeNil())
 	})
 }

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -22,8 +22,8 @@ limitations under the License.
 package support
 
 import (
-	"bytes"
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -946,6 +946,20 @@ func ServiceAccount(ns, name string) func() *corev1.ServiceAccount {
 			ctrl.MatchingLabels{
 				"app": "camel-k",
 			})
+		if err != nil {
+			panic(err)
+		}
+		if len(lst.Items) == 0 {
+			return nil
+		}
+		return &lst.Items[0]
+	}
+}
+
+func Kamelet(ns string) func() *v1alpha1.Kamelet {
+	return func() *v1alpha1.Kamelet {
+		lst := v1alpha1.NewKameletList()
+		err := TestClient().List(TestContext, &lst, ctrl.InNamespace(ns))
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -274,7 +274,7 @@ func (o *uninstallCmdOptions) uninstallNamespaceResources(ctx context.Context, c
 		if err := o.uninstallKamelets(ctx, c); err != nil {
 			return err
 		}
-		fmt.Printf("Kamelets removed from namespace %s\n", o.Namespace)
+		fmt.Printf("Camel K platform Kamelets removed from namespace %s\n", o.Namespace)
 	}
 
 	return nil
@@ -479,9 +479,12 @@ func (o *uninstallCmdOptions) uninstallKamelets(ctx context.Context, c client.Cl
 	}
 
 	for _, kamelet := range kameletList.Items {
-		err := c.Delete(ctx, &kamelet)
-		if err != nil {
-			return err
+		// remove only platform Kamelets (use-defined Kamelets should be skipped)
+		if kamelet.Labels[v1alpha1.KameletBundledLabel] == "true" {
+			err := c.Delete(ctx, &kamelet)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Description -->

Fix #2479


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
`kamel uninstall` now also cleans up all kamelets defined in the same namespace.
```
