### PR TITLE
#2358: Possible to skip configuring of registry when installing via cli

### DIFF
--- a/e2e/common/cli/install_test.go
+++ b/e2e/common/cli/install_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/apache/camel-k/e2e/support"
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 )
 
 func TestBasicInstallation(t *testing.T) {
@@ -58,5 +59,19 @@ func TestMavenRepositoryInstallation(t *testing.T) {
 		Eventually(func() string {
 			return Configmap(ns, "camel-k-maven-settings")().Data["settings.xml"]
 		}).Should(ContainSubstring("https://my.repo.org/public/"))
+	})
+}
+
+/*
+ * Expert mode where user does not want a registry configured
+ * so the Platform will have an empty Registry structure
+ */
+func TestSkipRegistryInstallation(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		Expect(Kamel("install", "-n", ns, "--skip-registry-setup").Execute()).To(Succeed())
+		Eventually(Platform(ns)).ShouldNot(BeNil())
+		Eventually(func() v1.IntegrationPlatformRegistrySpec {
+			return Platform(ns)().Spec.Build.Registry
+		}, TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformRegistrySpec{}))
 	})
 }

--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -314,6 +314,13 @@ func TestInstallSkipOperatorSetupFlag(t *testing.T) {
 	assert.Equal(t, true, installCmdOptions.SkipOperatorSetup)
 }
 
+func TestInstallSkipRegistrySetupFlag(t *testing.T) {
+	installCmdOptions, rootCmd, _ := initializeInstallCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdInstall, "--skip-registry-setup")
+	assert.Nil(t, err)
+	assert.Equal(t, true, installCmdOptions.SkipRegistrySetup)
+}
+
 func TestInstallTraitProfileFlag(t *testing.T) {
 	installCmdOptions, rootCmd, _ := initializeInstallCmdOptions(t)
 	_, err := test.ExecuteCommand(rootCmd, cmdInstall, "--trait-profile", "someString")

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -410,7 +410,7 @@ func installServiceBindings(ctx context.Context, c client.Client, namespace stri
 
 // PlatformOrCollect --
 // nolint: lll
-func PlatformOrCollect(ctx context.Context, c client.Client, clusterType string, namespace string, registry v1.IntegrationPlatformRegistrySpec, collection *kubernetes.Collection) (*v1.IntegrationPlatform, error) {
+func PlatformOrCollect(ctx context.Context, c client.Client, clusterType string, namespace string, skipRegistrySetup bool, registry v1.IntegrationPlatformRegistrySpec, collection *kubernetes.Collection) (*v1.IntegrationPlatform, error) {
 	isOpenShift, err := isOpenShift(c, clusterType)
 	if err != nil {
 		return nil, err
@@ -421,7 +421,7 @@ func PlatformOrCollect(ctx context.Context, c client.Client, clusterType string,
 	}
 	pl := platformObject.(*v1.IntegrationPlatform)
 
-	if !isOpenShift {
+	if !isOpenShift && !skipRegistrySetup {
 		pl.Spec.Build.Registry = registry
 
 		// Kubernetes only (Minikube)

--- a/script/Makefile
+++ b/script/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 VERSIONFILE := pkg/util/defaults/defaults.go
-VERSION := 1.5.0-SNAPSHOT
+VERSION ?= 1.5.0-SNAPSHOT
 OPERATOR_VERSION := $(subst -SNAPSHOT,,$(VERSION))
 LAST_RELEASED_VERSION := 1.4.1
 RUNTIME_VERSION := 1.8.0
@@ -23,7 +23,7 @@ KANIKO_VERSION := 0.17.1
 INSTALL_DEFAULT_KAMELETS := true
 BASE_IMAGE := adoptopenjdk/openjdk11:slim
 LOCAL_REPOSITORY := /tmp/artifacts/m2
-IMAGE_NAME := docker.io/apache/camel-k
+IMAGE_NAME ?= docker.io/apache/camel-k
 METADATA_IMAGE_NAME := $(IMAGE_NAME)-metadata
 RELEASE_GIT_REMOTE := upstream
 GIT_COMMIT := $(shell git rev-list -1 HEAD)


### PR DESCRIPTION
* install.go
 * Use of --skip-registry-setup switch will bypass all configuration in
   relation to the registry and leave a blank structure in the newly
   installed platform

* Includes tests

* Makefile
 * Makes the IMAGE_NAME and VERSION overrideable on the cli

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
