### PR TITLE
[Examples] Use correct folder in resource-secret-route example

### DIFF
--- a/examples/user-config/resource-secret-route.groovy
+++ b/examples/user-config/resource-secret-route.groovy
@@ -23,5 +23,5 @@
 // kamel run --resource secret:my-sec resource-secret-route.groovy --dev
 //
 
-from('file:/etc/camel/my-sec/?fileName=my-secret-key&noop=true&idempotent=false')
+from('file:/etc/camel/resources/my-sec/?fileName=my-secret-key&noop=true&idempotent=false')
     .log('resource file content is: ${body}')


### PR DESCRIPTION
<!-- Description -->
Use correct folder in resource-secret-route example



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
