### PR TITLE
fix(#2514): Fix tar.gz changes the uid/gid of cwd

### DIFF
--- a/script/cross_compile.sh
+++ b/script/cross_compile.sh
@@ -53,7 +53,7 @@ cross_compile () {
 	cp ${location}/../LICENSE ${targetdir}/
 	cp ${location}/../NOTICE ${targetdir}/
 
-	pushd . && cd ${targetdir} && tar -zcvf ../../${label}.tar.gz . && popd
+	pushd . && cd ${targetdir} && tar -zcvf ../../${label}.tar.gz $(ls -A) && popd
 }
 
 cross_compile ${basename}-${version}-linux-64bit linux amd64


### PR DESCRIPTION
<!-- Description -->

Do not include "." in the tarball in order to avoid changing the current working directory when installing the tar.gz

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

Fixes #2514 

**Release Note**
```release-note
NONE
```
