### PR TITLE
doc: Improve Helm configuration section and architecture integration platform

### DIFF
--- a/docs/modules/ROOT/pages/architecture/cr/integration-platform.adoc
+++ b/docs/modules/ROOT/pages/architecture/cr/integration-platform.adoc
@@ -11,19 +11,21 @@ type IntegrationPlatform struct {
 }
 
 type IntegrationPlatformSpec struct {
-	Cluster       IntegrationPlatformCluster    // <3>
-	Profile       TraitProfile                  // <4>
-	Build         IntegrationPlatformBuildSpec  // <5>
-	Traits        map[string]TraitSpec          // <6>
-	Configuration []ConfigurationSpec           // <6>
+	Cluster       IntegrationPlatformCluster       // <3>
+	Profile       TraitProfile                     // <4>
+	Build         IntegrationPlatformBuildSpec     // <5>
+	Traits        map[string]TraitSpec             // <6>
+	Configuration []ConfigurationSpec              // <6>
+	Kamelet       []IntegrationPlatformKameletSpec // <7>
 }
 ----
 <1> The desired state
 <2> The status of the object at current time
 <3> The type of the Kubernetes Cluster (Kubernetes or OpenShift)
-<4> Configures the traits that have to be applied by default (Kubernetes, OpneShift, Knative)
-<5> Configuration options of the image build process such as the type of the builder (buildah, kanico, spectrum) and the maven repositories that have to be configured in order retrieve the artifacts needed by the integrations.
-<6> The traits and configuration options that have to be propagated to each integration.
+<4> Configures the traits that have to be applied by default (Kubernetes, OpenShift, Knative)
+<5> Configuration options of the image build process such as the type of the builder (buildah, kanico, spectrum), the container registry and the maven repositories that have to be configured in order retrieve the artifacts needed by the integrations.
+<6> The traits and configuration options (properties, secrets, configmaps) that have to be propagated to each integration.
+<7> Locations to look up Kamelet definitions
 
 [NOTE]
 ====

--- a/helm/camel-k/README.md
+++ b/helm/camel-k/README.md
@@ -69,21 +69,24 @@ The command removes all the Kubernetes resources installed.
 ## Configuration
 
 The following table lists the most commonly configured parameters of the
-CouchDB chart and their default values:
+Camel-K chart and their default values. The chart allows configuration of an `IntegrationPlatform` resource, which among others includes build properties and traits configuration. A full list of parameters can be found [in the operator specification][1].
 
-|           Parameter                |             Description                                     |                Default                 |
-|------------------------------------|-------------------------------------------------------------|----------------------------------------|
-| `platform.build.registry.address`  | The address of a container image registry to push images    |                                        |
-| `platform.build.registry.insecure` | Indicates if the registry is secured                        | true                                   |
-| `platform.cluster`                 | The kind of Kubernetes cluster (Kubernetes or OpenShift)    | `Kubernetes`                           |
-| `platform.profile`                 | The trait profile to use (Knative, Kubernetes or OpenShift) | auto                                   |
+|           Parameter                    |             Description                                                   |            Default             |
+|----------------------------------------|---------------------------------------------------------------------------|--------------------------------|
+| `platform.build.registry.address`      | The address of a container image registry to push images                  |                                |
+| `platform.build.registry.secret`       | A secret used to push/pull images to the Docker registry                  |                                |
+| `platform.build.registry.organization` | An organization on the Docker registry that can be used to publish images |                                |
+| `platform.build.registry.insecure`     | Indicates if the registry is not secured                                  | true                           |
+| `platform.cluster`                     | The kind of Kubernetes cluster (Kubernetes or OpenShift)                  | `Kubernetes`                   |
+| `platform.profile`                     | The trait profile to use (Knative, Kubernetes or OpenShift)               | auto                           |
 
 ## Contributing
 
 We'd like to hear your feedback and we love any kind of contribution!
 
-The main contact points for the Camel K project are the [GitHub repository][1]
-and the [Chat room][2].
+The main contact points for the Camel K project are the [GitHub repository][2]
+and the [Chat room][3].
 
-[1]: https://github.com/apache/camel-k
-[2]: https://camel.zulipchat.com
+[1]: https://camel.apache.org/camel-k/latest/architecture/cr/integration-platform.html
+[2]: https://github.com/apache/camel-k
+[3]: https://camel.zulipchat.com


### PR DESCRIPTION
Improve the Helm configuration section by mentioning additional [common](https://camel.apache.org/camel-k/latest/installation/registry/registry.html) parameters and link to the [integration platform](https://camel.apache.org/camel-k/latest/architecture/cr/integration-platform.html) page. Also slightly improved that page. Would it be a good idea to describe the possible configuration settings on the integration platform in more detail in the main [configuration section](https://camel.apache.org/camel-k/latest/configuration/configuration.html)?

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
