### PR TITLE
Allow Probe Scheme to Be Customized

### DIFF
--- a/deploy/traits.yaml
+++ b/deploy/traits.yaml
@@ -129,6 +129,10 @@ traits:
   - name: probes-enabled
     type: bool
     description: ProbesEnabled enable/disable probes on the container (default `false`)
+  - name: liveness-scheme
+    type: string
+    description: Scheme to use when connecting. Defaults to HTTP. Applies to the liveness
+      probe.
   - name: liveness-initial-delay
     type: int32
     description: Number of seconds after the container has started before liveness
@@ -148,6 +152,10 @@ traits:
     type: int32
     description: Minimum consecutive failures for the probe to be considered failed
       after having succeeded.Applies to the liveness probe.
+  - name: readiness-scheme
+    type: string
+    description: Scheme to use when connecting. Defaults to HTTP. Applies to the readiness
+      probe.
   - name: readiness-initial-delay
     type: int32
     description: Number of seconds after the container has started before readiness

--- a/docs/modules/traits/pages/container.adoc
+++ b/docs/modules/traits/pages/container.adoc
@@ -81,6 +81,10 @@ The following configuration options are available:
 | bool
 | ProbesEnabled enable/disable probes on the container (default `false`)
 
+| container.liveness-scheme
+| string
+| Scheme to use when connecting. Defaults to HTTP. Applies to the liveness probe.
+
 | container.liveness-initial-delay
 | int32
 | Number of seconds after the container has started before liveness probes are initiated.
@@ -102,6 +106,10 @@ Applies to the liveness probe.
 | int32
 | Minimum consecutive failures for the probe to be considered failed after having succeeded.
 Applies to the liveness probe.
+
+| container.readiness-scheme
+| string
+| Scheme to use when connecting. Defaults to HTTP. Applies to the readiness probe.
 
 | container.readiness-initial-delay
 | int32

--- a/examples/traits/container/HttpsHealthChecks.java
+++ b/examples/traits/container/HttpsHealthChecks.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Generate a certificate for the integration (provide at least Country Name, can use defaults for rest)
+// openssl req -x509 -newkey rsa:4096 -keyout /tmp/integration-key.pem -out /tmp/integration-cert.pem -days 365 -nodes
+
+// Create a secret containing the generated certificate
+// kubectl create secret tls my-tls-secret --cert=/tmp/integration-cert.pem --key=/tmp/integration-key.pem
+
+// Run the integration
+/*
+kamel run \
+  --property quarkus.http.ssl.certificate.file=/etc/camel/conf.d/_secrets/my-tls-secret/tls.crt \
+  --property quarkus.http.ssl.certificate.key-file=/etc/camel/conf.d/_secrets/my-tls-secret/tls.key \
+  --config secret:my-tls-secret \
+  HttpsHealthChecks.java \
+  --trait container.port=8443 \
+  --trait container.probes-enabled=true \
+  --trait container.liveness-scheme=HTTPS \
+  --trait container.readiness-scheme=HTTPS
+*/
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class HttpsHealthChecks extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("timer:tick")
+            .setBody()
+            .constant("Hello Camel K!")
+            .to("log:info");
+    }
+}

--- a/examples/traits/container/README.md
+++ b/examples/traits/container/README.md
@@ -1,0 +1,3 @@
+# Camel K Container Trait
+
+In this section you will find examples about fine tuning your `Integration` using **Container** `trait` capability.


### PR DESCRIPTION
<!-- Description -->

Addresses https://github.com/apache/camel-k/issues/2513. This change allows the scheme used for the liveness and readiness probes to be overridden to HTTPS when needed. The approach taken was minimalistic.

Verified using this groovy script saved to /tmp/helloworld.groovy
```
from('timer:tick?period=3000')
  .setBody().constant('Hello world from Camel K')
  .to('log:info')
```
and an integration deployed with the following commands
```
openssl req -x509 -newkey rsa:4096 -keyout /tmp/integration-key.pem -out /tmp/integration-cert.pem -days 365 -nodes

kubectl create secret tls my-tls-secret --cert=/tmp/integration-cert.pem --key=/tmp/integration-key.pem

kamel run \
  --property quarkus.http.ssl.certificate.file=/etc/camel/conf.d/_secrets/my-tls-secret/tls.crt \
  --property quarkus.http.ssl.certificate.key-file=/etc/camel/conf.d/_secrets/my-tls-secret/tls.key \
  --config secret:my-tls-secret \
  /tmp/helloworld.groovy \
  --trait container.port=8443 \
  --trait container.probes-enabled=true \
  --trait container.liveness-scheme=HTTPS \
  --trait container.readiness-scheme=HTTPS
```

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Allow the scheme used for the liveness and readiness probes to be overridden
```
