### PR TITLE
Forcelly set QUARKUS_LOG_CONSOLE_JSON to false if the trait is not provided (GH issue #2539)

### DIFF
--- a/pkg/trait/logging.go
+++ b/pkg/trait/logging.go
@@ -90,8 +90,12 @@ func (l loggingTrait) Apply(environment *Environment) error {
 		if util.IsTrue(l.JsonPrettyPrint) {
 			envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleJsonPrettyPrint, True)
 		}
-	} else if util.IsNilOrTrue(l.Color) {
-		envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleColor, True)
+	} else {
+		envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleJson, False)
+
+		if util.IsNilOrTrue(l.Color) {
+			envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleColor, True)
+		}
 	}
 
 	return nil

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -46,6 +46,7 @@ import (
 
 // True --
 const True = "true"
+const False = "false"
 
 var (
 	basePath                  = "/etc/camel"


### PR DESCRIPTION
<!-- Description -->
Ensures that QUARKUS_LOG_CONSOLE_JSON is set to false if the `logging.json` trait is not provided



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Ensures that QUARKUS_LOG_CONSOLE_JSON is set to false if the `logging.json` trait is not provided
```