### PR TITLE
Move bool pointer functions to trait package and use them throughout the traits

### DIFF
--- a/addons/tracing/tracing.go
+++ b/addons/tracing/tracing.go
@@ -76,11 +76,11 @@ func NewTracingTrait() trait.Trait {
 }
 
 func (t *tracingTrait) Configure(e *trait.Environment) (bool, error) {
-	if t.Enabled == nil || !*t.Enabled {
+	if trait.IsNilOrFalse(t.Enabled) {
 		return false, nil
 	}
 
-	if t.Auto == nil || *t.Auto {
+	if trait.IsNilOrTrue(t.Auto) {
 		if t.Endpoint == "" {
 			for _, locator := range discovery.TracingLocators {
 				endpoint, err := locator.FindEndpoint(e.C, t.Client, t.L, e)

--- a/addons/tracing/tracing_test.go
+++ b/addons/tracing/tracing_test.go
@@ -30,8 +30,7 @@ import (
 func TestTracingTraitOnQuarkus(t *testing.T) {
 	e := createEnvironment(t, camel.QuarkusCatalog)
 	tracing := NewTracingTrait()
-	enabled := true
-	tracing.(*tracingTrait).Enabled = &enabled
+	tracing.(*tracingTrait).Enabled = trait.BoolP(true)
 	tracing.(*tracingTrait).Endpoint = "http://endpoint3"
 	ok, err := tracing.Configure(e)
 	assert.Nil(t, err)

--- a/pkg/trait/affinity.go
+++ b/pkg/trait/affinity.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util"
 )
 
 // Allows constraining which nodes the integration pod(s) are eligible to be scheduled on, based on labels on the node,
@@ -55,17 +54,17 @@ type affinityTrait struct {
 func newAffinityTrait() Trait {
 	return &affinityTrait{
 		BaseTrait:       NewBaseTrait("affinity", 1300),
-		PodAffinity:     util.BoolP(false),
-		PodAntiAffinity: util.BoolP(false),
+		PodAffinity:     BoolP(false),
+		PodAntiAffinity: BoolP(false),
 	}
 }
 
 func (t *affinityTrait) Configure(e *Environment) (bool, error) {
-	if util.IsNilOrFalse(t.Enabled) {
+	if IsNilOrFalse(t.Enabled) {
 		return false, nil
 	}
 
-	if util.IsTrue(t.PodAffinity) && util.IsTrue(t.PodAntiAffinity) {
+	if IsTrue(t.PodAffinity) && IsTrue(t.PodAntiAffinity) {
 		return false, fmt.Errorf("both pod affinity and pod anti-affinity can't be set simultaneously")
 	}
 
@@ -132,7 +131,7 @@ func (t *affinityTrait) addNodeAffinity(_ *Environment, podSpec *corev1.PodSpec)
 }
 
 func (t *affinityTrait) addPodAffinity(e *Environment, podSpec *corev1.PodSpec) error {
-	if util.IsNilOrFalse(t.PodAffinity) && len(t.PodAffinityLabels) == 0 {
+	if IsNilOrFalse(t.PodAffinity) && len(t.PodAffinityLabels) == 0 {
 		return nil
 	}
 
@@ -157,7 +156,7 @@ func (t *affinityTrait) addPodAffinity(e *Environment, podSpec *corev1.PodSpec) 
 		}
 	}
 
-	if util.IsTrue(t.PodAffinity) {
+	if IsTrue(t.PodAffinity) {
 		labelSelectorRequirements = append(labelSelectorRequirements, metav1.LabelSelectorRequirement{
 			Key:      v1.IntegrationLabel,
 			Operator: metav1.LabelSelectorOpIn,
@@ -183,7 +182,7 @@ func (t *affinityTrait) addPodAffinity(e *Environment, podSpec *corev1.PodSpec) 
 }
 
 func (t *affinityTrait) addPodAntiAffinity(e *Environment, podSpec *corev1.PodSpec) error {
-	if util.IsNilOrFalse(t.PodAntiAffinity) && len(t.PodAntiAffinityLabels) == 0 {
+	if IsNilOrFalse(t.PodAntiAffinity) && len(t.PodAntiAffinityLabels) == 0 {
 		return nil
 	}
 
@@ -208,7 +207,7 @@ func (t *affinityTrait) addPodAntiAffinity(e *Environment, podSpec *corev1.PodSp
 		}
 	}
 
-	if util.IsTrue(t.PodAntiAffinity) {
+	if IsTrue(t.PodAntiAffinity) {
 		labelSelectorRequirements = append(labelSelectorRequirements, metav1.LabelSelectorRequirement{
 			Key:      v1.IntegrationLabel,
 			Operator: metav1.LabelSelectorOpIn,

--- a/pkg/trait/affinity_test.go
+++ b/pkg/trait/affinity_test.go
@@ -50,7 +50,7 @@ func TestConfigureAffinityTraitWithConflictingAffinitiesFails(t *testing.T) {
 
 func TestConfigureDisabledAffinityTraitFails(t *testing.T) {
 	affinityTrait := createNominalAffinityTest()
-	affinityTrait.Enabled = new(bool)
+	affinityTrait.Enabled = BoolP(false)
 	environment, _ := createNominalDeploymentTraitTest()
 	configured, err := affinityTrait.Configure(environment)
 
@@ -181,8 +181,7 @@ func testApplyPodAffinityLabelsDoesSucceed(t *testing.T, trait *affinityTrait, e
 
 func createNominalAffinityTest() *affinityTrait {
 	trait := newAffinityTrait().(*affinityTrait)
-	enabled := true
-	trait.Enabled = &enabled
+	trait.Enabled = BoolP(true)
 
 	return trait
 }

--- a/pkg/trait/affinity_test.go
+++ b/pkg/trait/affinity_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util"
 )
 
 func TestConfigureAffinityTraitDoesSucceed(t *testing.T) {
@@ -41,8 +40,8 @@ func TestConfigureAffinityTraitDoesSucceed(t *testing.T) {
 func TestConfigureAffinityTraitWithConflictingAffinitiesFails(t *testing.T) {
 	affinityTrait := createNominalAffinityTest()
 	environment, _ := createNominalDeploymentTraitTest()
-	affinityTrait.PodAffinity = util.BoolP(true)
-	affinityTrait.PodAntiAffinity = util.BoolP(true)
+	affinityTrait.PodAffinity = BoolP(true)
+	affinityTrait.PodAntiAffinity = BoolP(true)
 	configured, err := affinityTrait.Configure(environment)
 
 	assert.False(t, configured)
@@ -117,7 +116,7 @@ func testApplyNodeAffinityLabelsDoesSucceed(t *testing.T, trait *affinityTrait, 
 
 func TestApplyPodAntiAffinityLabelsDoesSucceed(t *testing.T) {
 	affinityTrait := createNominalAffinityTest()
-	affinityTrait.PodAntiAffinity = util.BoolP(true)
+	affinityTrait.PodAntiAffinity = BoolP(true)
 	affinityTrait.PodAntiAffinityLabels = []string{"criteria != value"}
 
 	environment, deployment := createNominalDeploymentTraitTest()
@@ -150,7 +149,7 @@ func testApplyPodAntiAffinityLabelsDoesSucceed(t *testing.T, trait *affinityTrai
 
 func TestApplyPodAffinityLabelsDoesSucceed(t *testing.T) {
 	affinityTrait := createNominalAffinityTest()
-	affinityTrait.PodAffinity = util.BoolP(true)
+	affinityTrait.PodAffinity = BoolP(true)
 	affinityTrait.PodAffinityLabels = []string{"!criteria"}
 
 	environment, deployment := createNominalDeploymentTraitTest()

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -58,7 +58,7 @@ func (t *builderTrait) InfluencesKit() bool {
 }
 
 func (t *builderTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/camel"
 	"github.com/apache/camel-k/pkg/util/defaults"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
@@ -165,7 +164,7 @@ func TestMavenPropertyBuilderTrait(t *testing.T) {
 
 func createNominalBuilderTraitTest() *builderTrait {
 	builderTrait := newBuilderTrait().(*builderTrait)
-	builderTrait.Enabled = util.BoolP(true)
+	builderTrait.Enabled = BoolP(true)
 
 	return builderTrait
 }

--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -45,7 +45,7 @@ func newCamelTrait() Trait {
 }
 
 func (t *camelTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, errors.New("trait camel cannot be disabled")
 	}
 

--- a/pkg/trait/camel_test.go
+++ b/pkg/trait/camel_test.go
@@ -40,7 +40,7 @@ func TestConfigureEnabledCamelTraitSucceeds(t *testing.T) {
 
 func TestConfigureDisabledCamelTraitFails(t *testing.T) {
 	trait, environment := createNominalCamelTest()
-	trait.Enabled = new(bool)
+	trait.Enabled = BoolP(false)
 
 	configured, err := trait.Configure(environment)
 	assert.NotNil(t, err)
@@ -72,8 +72,7 @@ func createNominalCamelTest() (*camelTrait, *Environment) {
 	client, _ := test.NewFakeClient()
 
 	trait := newCamelTrait().(*camelTrait)
-	enabled := true
-	trait.Enabled = &enabled
+	trait.Enabled = BoolP(true)
 
 	environment := &Environment{
 		CamelCatalog: &camel.RuntimeCatalog{

--- a/pkg/trait/container.go
+++ b/pkg/trait/container.go
@@ -125,7 +125,7 @@ func newContainerTrait() Trait {
 }
 
 func (t *containerTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 
@@ -232,7 +232,7 @@ func (t *containerTrait) configureContainer(e *Environment) error {
 
 	t.configureResources(e, &container)
 
-	if t.Expose != nil && *t.Expose {
+	if IsTrue(t.Expose) {
 		t.configureService(e, &container)
 	}
 	t.configureCapabilities(e)

--- a/pkg/trait/container.go
+++ b/pkg/trait/container.go
@@ -118,7 +118,7 @@ func newContainerTrait() Trait {
 		ServicePort:     defaultServicePort,
 		ServicePortName: defaultContainerPortName,
 		Name:            defaultContainerName,
-		ProbesEnabled:   util.BoolP(false),
+		ProbesEnabled:   BoolP(false),
 		LivenessScheme:  string(corev1.URISchemeHTTP),
 		ReadinessScheme: string(corev1.URISchemeHTTP),
 	}
@@ -133,7 +133,7 @@ func (t *containerTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if util.IsNilOrTrue(t.Auto) {
+	if IsNilOrTrue(t.Auto) {
 		if t.Expose == nil {
 			e := e.Resources.GetServiceForIntegration(e.Integration) != nil
 			t.Expose = &e
@@ -192,7 +192,7 @@ func (t *containerTrait) configureDependencies(e *Environment) error {
 			e.Resources.Add(&kit)
 			e.Integration.SetIntegrationKit(&kit)
 		}
-		if util.IsTrue(t.ProbesEnabled) {
+		if IsTrue(t.ProbesEnabled) {
 			if capability, ok := e.CamelCatalog.Runtime.Capabilities[v1.CapabilityHealth]; ok {
 				for _, dependency := range capability.Dependencies {
 					util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, dependency.GetDependencyID())
@@ -243,7 +243,7 @@ func (t *containerTrait) configureContainer(e *Environment) error {
 	}
 	// Deployment
 	if err := e.Resources.VisitDeploymentE(func(deployment *appsv1.Deployment) error {
-		if util.IsTrue(t.ProbesEnabled) && portName == defaultContainerPortName {
+		if IsTrue(t.ProbesEnabled) && portName == defaultContainerPortName {
 			t.configureProbes(&container, t.Port, defaultProbePath)
 		}
 
@@ -270,7 +270,7 @@ func (t *containerTrait) configureContainer(e *Environment) error {
 
 	// Knative Service
 	if err := e.Resources.VisitKnativeServiceE(func(service *serving.Service) error {
-		if util.IsTrue(t.ProbesEnabled) && portName == defaultContainerPortName {
+		if IsTrue(t.ProbesEnabled) && portName == defaultContainerPortName {
 			// don't set the port on Knative service as it is not allowed.
 			t.configureProbes(&container, 0, defaultProbePath)
 		}
@@ -309,7 +309,7 @@ func (t *containerTrait) configureContainer(e *Environment) error {
 
 	// CronJob
 	if err := e.Resources.VisitCronJobE(func(cron *v1beta1.CronJob) error {
-		if util.IsTrue(t.ProbesEnabled) && portName == defaultContainerPortName {
+		if IsTrue(t.ProbesEnabled) && portName == defaultContainerPortName {
 			t.configureProbes(&container, t.Port, defaultProbePath)
 		}
 

--- a/pkg/trait/container_probes_test.go
+++ b/pkg/trait/container_probes_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/camel"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 )
@@ -59,7 +58,7 @@ func newTestProbesEnv(t *testing.T, provider v1.RuntimeProvider) Environment {
 
 func newTestContainerTrait() *containerTrait {
 	tr := newContainerTrait().(*containerTrait)
-	tr.ProbesEnabled = util.BoolP(true)
+	tr.ProbesEnabled = BoolP(true)
 
 	return tr
 }

--- a/pkg/trait/container_probes_test.go
+++ b/pkg/trait/container_probes_test.go
@@ -85,10 +85,8 @@ func TestProbesOnDeployment(t *testing.T) {
 	env.Integration.Status.Phase = v1.IntegrationPhaseDeploying
 	env.Resources.Add(&target)
 
-	expose := true
-
 	ctr := newTestContainerTrait()
-	ctr.Expose = &expose
+	ctr.Expose = BoolP(true)
 	ctr.LivenessTimeout = 1234
 
 	err := ctr.Apply(&env)
@@ -112,10 +110,8 @@ func TestProbesOnDeploymentWithCustomScheme(t *testing.T) {
 	env.Integration.Status.Phase = v1.IntegrationPhaseDeploying
 	env.Resources.Add(&target)
 
-	expose := true
-
 	ctr := newTestContainerTrait()
-	ctr.Expose = &expose
+	ctr.Expose = BoolP(true)
 	ctr.LivenessTimeout = 1234
 	ctr.LivenessScheme = "HTTPS"
 	ctr.ReadinessScheme = "HTTPS"
@@ -158,10 +154,8 @@ func TestProbesOnKnativeService(t *testing.T) {
 	env.Integration.Status.Phase = v1.IntegrationPhaseDeploying
 	env.Resources.Add(&target)
 
-	expose := true
-
 	ctr := newTestContainerTrait()
-	ctr.Expose = &expose
+	ctr.Expose = BoolP(true)
 	ctr.LivenessTimeout = 1234
 
 	err := ctr.Apply(&env)

--- a/pkg/trait/dependencies.go
+++ b/pkg/trait/dependencies.go
@@ -41,7 +41,7 @@ func newDependenciesTrait() Trait {
 }
 
 func (t *dependenciesTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/deployer.go
+++ b/pkg/trait/deployer.go
@@ -170,7 +170,7 @@ func isIncompatibleServerError(err error) bool {
 }
 
 func (t *deployerTrait) SelectControllerStrategy(e *Environment) (*ControllerStrategy, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return nil, nil
 	}
 	if t.Kind != "" {

--- a/pkg/trait/deployment.go
+++ b/pkg/trait/deployment.go
@@ -44,7 +44,7 @@ func newDeploymentTrait() Trait {
 }
 
 func (t *deploymentTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		e.Integration.Status.SetCondition(
 			v1.IntegrationConditionDeploymentAvailable,
 			corev1.ConditionFalse,
@@ -86,7 +86,7 @@ func (t *deploymentTrait) Configure(e *Environment) (bool, error) {
 }
 
 func (t *deploymentTrait) SelectControllerStrategy(e *Environment) (*ControllerStrategy, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return nil, nil
 	}
 	deploymentStrategy := ControllerStrategyDeployment

--- a/pkg/trait/deployment_test.go
+++ b/pkg/trait/deployment_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestConfigureDisabledDeploymentTraitDoesNotSucceed(t *testing.T) {
 	deploymentTrait, environment := createNominalDeploymentTest()
-	deploymentTrait.Enabled = new(bool)
+	deploymentTrait.Enabled = BoolP(false)
 
 	configured, err := deploymentTrait.Configure(environment)
 
@@ -145,8 +145,7 @@ func TestApplyDeploymentTraitWhileRunningIntegrationDoesSucceed(t *testing.T) {
 
 func createNominalDeploymentTest() (*deploymentTrait, *Environment) {
 	trait := newDeploymentTrait().(*deploymentTrait)
-	enabled := true
-	trait.Enabled = &enabled
+	trait.Enabled = BoolP(true)
 	trait.Client, _ = test.NewFakeClient(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "integration-name",

--- a/pkg/trait/environment.go
+++ b/pkg/trait/environment.go
@@ -19,7 +19,6 @@ package trait
 
 import (
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/defaults"
 	"github.com/apache/camel-k/pkg/util/envvar"
 )
@@ -54,7 +53,7 @@ const (
 func newEnvironmentTrait() Trait {
 	return &environmentTrait{
 		BaseTrait:     NewBaseTrait("environment", 800),
-		ContainerMeta: util.BoolP(true),
+		ContainerMeta: BoolP(true),
 	}
 }
 
@@ -75,7 +74,7 @@ func (t *environmentTrait) Apply(e *Environment) error {
 	envvar.SetVal(&e.EnvVars, envVarMountPathConfigMaps, configConfigmapsMountPath)
 	envvar.SetVal(&e.EnvVars, envVarMountPathSecrets, configSecretsMountPath)
 
-	if util.IsNilOrTrue(t.ContainerMeta) {
+	if IsNilOrTrue(t.ContainerMeta) {
 		envvar.SetValFrom(&e.EnvVars, envVarNamespace, "metadata.namespace")
 		envvar.SetValFrom(&e.EnvVars, envVarPodName, "metadata.name")
 	}

--- a/pkg/trait/environment.go
+++ b/pkg/trait/environment.go
@@ -58,7 +58,7 @@ func newEnvironmentTrait() Trait {
 }
 
 func (t *environmentTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled == nil || *t.Enabled {
+	if IsNilOrTrue(t.Enabled) {
 		return e.IntegrationInPhase(v1.IntegrationPhaseDeploying, v1.IntegrationPhaseRunning), nil
 	}
 

--- a/pkg/trait/error_handler.go
+++ b/pkg/trait/error_handler.go
@@ -44,7 +44,7 @@ func (t *errorHandlerTrait) IsPlatformTrait() bool {
 }
 
 func (t *errorHandlerTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/gc.go
+++ b/pkg/trait/gc.go
@@ -73,7 +73,7 @@ func newGarbageCollectorTrait() Trait {
 }
 
 func (t *garbageCollectorTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/gc_test.go
+++ b/pkg/trait/gc_test.go
@@ -37,7 +37,7 @@ func TestConfigureGarbageCollectorTraitDoesSucceed(t *testing.T) {
 
 func TestConfigureDisabledGarbageCollectorTraitDoesNotSucceed(t *testing.T) {
 	gcTrait, environment := createNominalGarbageCollectorTest()
-	gcTrait.Enabled = new(bool)
+	gcTrait.Enabled = BoolP(false)
 
 	configured, err := gcTrait.Configure(environment)
 
@@ -68,8 +68,7 @@ func TestApplyGarbageCollectorTraitDuringInitializationPhaseSkipPostActions(t *t
 
 func createNominalGarbageCollectorTest() (*garbageCollectorTrait, *Environment) {
 	trait := newGarbageCollectorTrait().(*garbageCollectorTrait)
-	enabled := true
-	trait.Enabled = &enabled
+	trait.Enabled = BoolP(true)
 
 	environment := &Environment{
 		Catalog: NewCatalog(context.TODO(), nil),

--- a/pkg/trait/ingress.go
+++ b/pkg/trait/ingress.go
@@ -57,7 +57,7 @@ func (t *ingressTrait) IsAllowedInProfile(profile v1.TraitProfile) bool {
 }
 
 func (t *ingressTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		e.Integration.Status.SetCondition(
 			v1.IntegrationConditionExposureAvailable,
 			corev1.ConditionFalse,
@@ -71,7 +71,7 @@ func (t *ingressTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if t.Auto == nil || *t.Auto {
+	if IsNilOrTrue(t.Auto) {
 		hasService := e.Resources.GetUserServiceForIntegration(e.Integration) != nil
 		hasHost := t.Host != ""
 		enabled := hasService && hasHost

--- a/pkg/trait/ingress_test.go
+++ b/pkg/trait/ingress_test.go
@@ -43,7 +43,7 @@ func TestConfigureIngressTraitDoesSucceed(t *testing.T) {
 
 func TestConfigureDisabledIngressTraitDoesNotSucceed(t *testing.T) {
 	ingressTrait, environment := createNominalIngressTest()
-	ingressTrait.Enabled = new(bool)
+	ingressTrait.Enabled = BoolP(false)
 
 	configured, err := ingressTrait.Configure(environment)
 
@@ -67,8 +67,7 @@ func TestConfigureIngressTraitInWrongPhaseDoesNotSucceed(t *testing.T) {
 
 func TestConfigureAutoIngressTraitWithoutUserServiceDoesNotSucceed(t *testing.T) {
 	ingressTrait, environment := createNominalIngressTest()
-	auto := true
-	ingressTrait.Auto = &auto
+	ingressTrait.Auto = BoolP(true)
 	environment.Resources = kubernetes.NewCollection()
 
 	configured, err := ingressTrait.Configure(environment)
@@ -156,9 +155,8 @@ func TestApplyIngressTraitDoesSucceed(t *testing.T) {
 
 func createNominalIngressTest() (*ingressTrait, *Environment) {
 	trait := newIngressTrait().(*ingressTrait)
-	enabled := true
-	trait.Enabled = &enabled
-	trait.Auto = new(bool)
+	trait.Enabled = BoolP(true)
+	trait.Auto = BoolP(false)
 	trait.Host = "hostname"
 
 	environment := &Environment{

--- a/pkg/trait/init.go
+++ b/pkg/trait/init.go
@@ -41,7 +41,7 @@ func newInitTrait() Trait {
 }
 
 func (t *initTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, errors.New("trait init cannot be disabled")
 	}
 

--- a/pkg/trait/istio.go
+++ b/pkg/trait/istio.go
@@ -52,7 +52,7 @@ func newIstioTrait() Trait {
 }
 
 func (t *istioTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && *t.Enabled {
+	if IsTrue(t.Enabled) {
 		return e.IntegrationInPhase(v1.IntegrationPhaseDeploying, v1.IntegrationPhaseRunning), nil
 	}
 

--- a/pkg/trait/jolokia.go
+++ b/pkg/trait/jolokia.go
@@ -75,7 +75,7 @@ func newJolokiaTrait() Trait {
 }
 
 func (t *jolokiaTrait) Configure(e *Environment) (bool, error) {
-	return t.Enabled != nil && *t.Enabled && e.IntegrationInPhase(
+	return IsTrue(t.Enabled) && e.IntegrationInPhase(
 		v1.IntegrationPhaseInitialization,
 		v1.IntegrationPhaseDeploying,
 		v1.IntegrationPhaseRunning,

--- a/pkg/trait/jolokia_test.go
+++ b/pkg/trait/jolokia_test.go
@@ -208,7 +208,7 @@ func TestSetDefaultBoolJolokiaOptionShouldSucceed(t *testing.T) {
 func TestSetDefaultBoolJolokiaOptionShouldNotOverrideExistingValue(t *testing.T) {
 	trait := newJolokiaTrait().(*jolokiaTrait)
 	options := map[string]string{}
-	option := new(bool)
+	option := BoolP(false)
 
 	trait.setDefaultJolokiaOption(options, &option, "key", true)
 
@@ -251,7 +251,7 @@ func TestAddBoolPointerOptionToJolokiaOptions(t *testing.T) {
 	trait := newJolokiaTrait().(*jolokiaTrait)
 	options := map[string]string{}
 
-	trait.addToJolokiaOptions(options, "key", new(bool))
+	trait.addToJolokiaOptions(options, "key", BoolP(false))
 
 	assert.Len(t, options, 1)
 	assert.Equal(t, "false", options["key"])
@@ -268,8 +268,7 @@ func TestAddWrongTypeOptionToJolokiaOptionsDoesNothing(t *testing.T) {
 
 func createNominalJolokiaTest() (*jolokiaTrait, *Environment) {
 	trait := newJolokiaTrait().(*jolokiaTrait)
-	enabled := true
-	trait.Enabled = &enabled
+	trait.Enabled = BoolP(true)
 
 	environment := &Environment{
 		Catalog: NewCatalog(context.TODO(), nil),

--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -62,7 +62,7 @@ func newJvmTrait() Trait {
 	return &jvmTrait{
 		BaseTrait:    NewBaseTrait("jvm", 2000),
 		DebugAddress: "*:5005",
-		PrintCommand: util.BoolP(true),
+		PrintCommand: BoolP(true),
 	}
 }
 
@@ -132,9 +132,9 @@ func (t *jvmTrait) Apply(e *Environment) error {
 	args := container.Args
 
 	// Remote debugging
-	if util.IsTrue(t.Debug) {
+	if IsTrue(t.Debug) {
 		suspend := "n"
-		if util.IsTrue(t.DebugSuspend) {
+		if IsTrue(t.DebugSuspend) {
 			suspend = "y"
 		}
 		args = append(args,
@@ -184,7 +184,7 @@ func (t *jvmTrait) Apply(e *Environment) error {
 	args = append(args, "-cp", strings.Join(items, ":"))
 	args = append(args, e.CamelCatalog.Runtime.ApplicationClass)
 
-	if util.IsNilOrTrue(t.PrintCommand) {
+	if IsNilOrTrue(t.PrintCommand) {
 		args = append([]string{"exec", "java"}, args...)
 		container.Command = []string{"/bin/sh", "-c"}
 		cmd := strings.Join(args, " ")

--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -67,7 +67,7 @@ func newJvmTrait() Trait {
 }
 
 func (t *jvmTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/jvm_test.go
+++ b/pkg/trait/jvm_test.go
@@ -35,7 +35,6 @@ import (
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/builder"
-	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/camel"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/apache/camel-k/pkg/util/test"
@@ -148,8 +147,8 @@ func TestApplyJvmTraitWithKNativeResource(t *testing.T) {
 
 func TestApplyJvmTraitWithDebugEnabled(t *testing.T) {
 	trait, environment := createNominalJvmTest(v1.IntegrationKitTypePlatform)
-	trait.Debug = util.BoolP(true)
-	trait.DebugSuspend = util.BoolP(true)
+	trait.Debug = BoolP(true)
+	trait.DebugSuspend = BoolP(true)
 
 	d := appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{
@@ -257,8 +256,8 @@ func createNominalJvmTest(kitType string) (*jvmTrait, *Environment) {
 	client, _ := test.NewFakeClient()
 
 	trait := newJvmTrait().(*jvmTrait)
-	trait.Enabled = util.BoolP(true)
-	trait.PrintCommand = util.BoolP(false)
+	trait.Enabled = BoolP(true)
+	trait.PrintCommand = BoolP(false)
 	trait.Ctx = context.TODO()
 	trait.Client = client
 

--- a/pkg/trait/jvm_test.go
+++ b/pkg/trait/jvm_test.go
@@ -68,7 +68,7 @@ func TestConfigureJvmTraitInWrongIntegrationKitPhaseDoesNotSucceed(t *testing.T)
 
 func TestConfigureJvmDisabledTraitDoesNotSucceed(t *testing.T) {
 	trait, environment := createNominalJvmTest(v1.IntegrationKitTypePlatform)
-	trait.Enabled = new(bool)
+	trait.Enabled = BoolP(false)
 
 	configured, err := trait.Configure(environment)
 	assert.Nil(t, err)

--- a/pkg/trait/kamelets.go
+++ b/pkg/trait/kamelets.go
@@ -20,11 +20,12 @@ package trait
 import (
 	"errors"
 	"fmt"
-	"github.com/apache/camel-k/pkg/util/source"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/apache/camel-k/pkg/util/source"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
@@ -87,7 +88,7 @@ func (t *kameletsTrait) IsPlatformTrait() bool {
 }
 
 func (t *kameletsTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 
@@ -95,7 +96,7 @@ func (t *kameletsTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if t.Auto == nil || *t.Auto {
+	if IsNilOrTrue(t.Auto) {
 		var kamelets []string
 		if t.List == "" {
 			sources, err := kubernetes.ResolveIntegrationSources(e.C, e.Client, e.Integration, e.Resources)

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -193,8 +193,7 @@ func (t *knativeTrait) Configure(e *Environment) (bool, error) {
 		}
 		if t.FilterSourceChannels == nil {
 			// Filtering is no longer used by default
-			filter := false
-			t.FilterSourceChannels = &filter
+			t.FilterSourceChannels = BoolP(false)
 		}
 		if t.SinkBinding == nil {
 			allowed := t.isSinkBindingAllowed(e)

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -104,7 +104,7 @@ func (t *knativeTrait) IsAllowedInProfile(profile v1.TraitProfile) bool {
 }
 
 func (t *knativeTrait) Configure(e *Environment) (bool, error) {
-	if util.IsFalse(t.Enabled) {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 
@@ -112,7 +112,7 @@ func (t *knativeTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if util.IsNilOrTrue(t.Auto) {
+	if IsNilOrTrue(t.Auto) {
 		if len(t.ChannelSources) == 0 {
 			items := make([]string, 0)
 			sources, err := kubernetes.ResolveIntegrationSources(e.C, e.Client, e.Integration, e.Resources)
@@ -206,7 +206,7 @@ func (t *knativeTrait) Configure(e *Environment) (bool, error) {
 }
 
 func (t *knativeTrait) Apply(e *Environment) error {
-	if util.IsTrue(t.SinkBinding) {
+	if IsTrue(t.SinkBinding) {
 		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel.k:camel-k-knative")
 	}
 
@@ -264,7 +264,7 @@ func (t *knativeTrait) configureChannels(e *Environment, env *knativeapi.CamelEn
 				knativeapi.CamelMetaKnativeKind:       ref.Kind,
 				knativeapi.CamelMetaKnativeReply:      "false",
 			}
-			if util.IsTrue(t.FilterSourceChannels) {
+			if IsTrue(t.FilterSourceChannels) {
 				meta[knativeapi.CamelMetaFilterPrefix+knativeHistoryHeader] = loc.Host
 			}
 			svc := knativeapi.CamelServiceDefinition{
@@ -285,7 +285,7 @@ func (t *knativeTrait) configureChannels(e *Environment, env *knativeapi.CamelEn
 		return err
 	}
 
-	if util.IsNilOrFalse(t.SinkBinding) {
+	if IsNilOrFalse(t.SinkBinding) {
 		// Sinks
 		err = t.ifServiceMissingDo(e, env, t.ChannelSinks, knativeapi.CamelServiceTypeChannel, knativeapi.CamelEndpointKindSink,
 			func(ref *corev1.ObjectReference, serviceURI string, urlProvider func() (*url.URL, error)) error {
@@ -345,7 +345,7 @@ func (t *knativeTrait) configureEndpoints(e *Environment, env *knativeapi.CamelE
 	}
 
 	// Sinks
-	if util.IsNilOrFalse(t.SinkBinding) {
+	if IsNilOrFalse(t.SinkBinding) {
 		err := t.ifServiceMissingDo(e, env, t.EndpointSinks, knativeapi.CamelServiceTypeEndpoint, knativeapi.CamelEndpointKindSink,
 			func(ref *corev1.ObjectReference, serviceURI string, urlProvider func() (*url.URL, error)) error {
 				loc, err := urlProvider()
@@ -403,7 +403,7 @@ func (t *knativeTrait) configureEvents(e *Environment, env *knativeapi.CamelEnvi
 	}
 
 	// Sinks
-	if util.IsNilOrFalse(t.SinkBinding) {
+	if IsNilOrFalse(t.SinkBinding) {
 		err = t.ifServiceMissingDo(e, env, t.EventSinks, knativeapi.CamelServiceTypeEvent, knativeapi.CamelEndpointKindSink,
 			func(ref *corev1.ObjectReference, serviceURI string, urlProvider func() (*url.URL, error)) error {
 				loc, err := urlProvider()
@@ -444,7 +444,7 @@ func (t *knativeTrait) isSinkBindingAllowed(e *Environment) bool {
 }
 
 func (t *knativeTrait) configureSinkBinding(e *Environment, env *knativeapi.CamelEnvironment) error {
-	if util.IsNilOrFalse(t.SinkBinding) {
+	if IsNilOrFalse(t.SinkBinding) {
 		return nil
 	}
 	var serviceType knativeapi.CamelServiceType

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -91,7 +91,7 @@ func (t *knativeServiceTrait) IsAllowedInProfile(profile v1.TraitProfile) bool {
 }
 
 func (t *knativeServiceTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		e.Integration.Status.SetCondition(
 			v1.IntegrationConditionKnativeServiceAvailable,
 			corev1.ConditionFalse,
@@ -139,7 +139,7 @@ func (t *knativeServiceTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if t.Auto == nil || *t.Auto {
+	if IsNilOrTrue(t.Auto) {
 		// Check the right value for minScale, as not all services are allowed to scale down to 0
 		if t.MinScale == nil {
 			sources, err := kubernetes.ResolveIntegrationSources(t.Ctx, t.Client, e.Integration, e.Resources)

--- a/pkg/trait/logging.go
+++ b/pkg/trait/logging.go
@@ -59,7 +59,7 @@ func newLoggingTraitTrait() Trait {
 }
 
 func (l loggingTrait) Configure(environment *Environment) (bool, error) {
-	if util.IsFalse(l.Enabled) {
+	if IsFalse(l.Enabled) {
 		return false, nil
 	}
 
@@ -69,7 +69,7 @@ func (l loggingTrait) Configure(environment *Environment) (bool, error) {
 
 func (l loggingTrait) Apply(environment *Environment) error {
 	if environment.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
-		if util.IsTrue(l.Json) {
+		if IsTrue(l.Json) {
 			if environment.Integration.Status.Dependencies == nil {
 				environment.Integration.Status.Dependencies = make([]string, 0)
 			}
@@ -85,15 +85,15 @@ func (l loggingTrait) Apply(environment *Environment) error {
 		envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleFormat, l.Format)
 	}
 
-	if util.IsTrue(l.Json) {
+	if IsTrue(l.Json) {
 		envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleJson, True)
-		if util.IsTrue(l.JsonPrettyPrint) {
+		if IsTrue(l.JsonPrettyPrint) {
 			envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleJsonPrettyPrint, True)
 		}
 	} else {
 		envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleJson, False)
 
-		if util.IsNilOrTrue(l.Color) {
+		if IsNilOrTrue(l.Color) {
 			envvar.SetVal(&environment.EnvVars, envVarQuarkusLogConsoleColor, True)
 		}
 	}

--- a/pkg/trait/openapi.go
+++ b/pkg/trait/openapi.go
@@ -64,7 +64,7 @@ func (t *openAPITrait) IsPlatformTrait() bool {
 }
 
 func (t *openAPITrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/owner.go
+++ b/pkg/trait/owner.go
@@ -44,7 +44,7 @@ func newOwnerTrait() Trait {
 }
 
 func (t *ownerTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/pdb.go
+++ b/pkg/trait/pdb.go
@@ -49,7 +49,7 @@ func newPdbTrait() Trait {
 }
 
 func (t *pdbTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled == nil || !*t.Enabled {
+	if IsNilOrFalse(t.Enabled) {
 		return false, nil
 	}
 
@@ -86,7 +86,7 @@ func (t *pdbTrait) Apply(e *Environment) error {
 func (t *pdbTrait) podDisruptionBudgetFor(integration *v1.Integration) *v1beta1.PodDisruptionBudget {
 	pdb := &v1beta1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
-			Kind: "PodDisruptionBudget",
+			Kind:       "PodDisruptionBudget",
 			APIVersion: v1beta1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/trait/pdb_test.go
+++ b/pkg/trait/pdb_test.go
@@ -94,8 +94,7 @@ func findPdb(resources *kubernetes.Collection) *v1beta1.PodDisruptionBudget {
 
 func createPdbTest() (*pdbTrait, *Environment, *appsv1.Deployment) {
 	trait := newPdbTrait().(*pdbTrait)
-	enabled := true
-	trait.Enabled = &enabled
+	trait.Enabled = BoolP(true)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/trait/platform.go
+++ b/pkg/trait/platform.go
@@ -48,7 +48,7 @@ func newPlatformTrait() Trait {
 }
 
 func (t *platformTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 
@@ -56,7 +56,7 @@ func (t *platformTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if t.Auto == nil || !*t.Auto {
+	if IsNilOrFalse(t.Auto) {
 		if e.Platform == nil {
 			if t.CreateDefault == nil {
 				// Calculate if the platform should be automatically created when missing.
@@ -102,13 +102,13 @@ func (t *platformTrait) Apply(e *Environment) error {
 func (t *platformTrait) getOrCreatePlatform(e *Environment) (*v1.IntegrationPlatform, error) {
 	pl, err := platform.GetOrFind(t.Ctx, t.Client, e.Integration.Namespace, e.Integration.Status.Platform, false)
 	if err != nil && k8serrors.IsNotFound(err) {
-		if t.CreateDefault != nil && *t.CreateDefault {
+		if IsTrue(t.CreateDefault) {
 			platformName := e.Integration.Status.Platform
 			if platformName == "" {
 				platformName = platform.DefaultPlatformName
 			}
 			namespace := e.Integration.Namespace
-			if t.Global != nil && *t.Global {
+			if IsTrue(t.Global) {
 				operatorNamespace := platform.GetOperatorNamespace()
 				if operatorNamespace != "" {
 					namespace = operatorNamespace

--- a/pkg/trait/platform_test.go
+++ b/pkg/trait/platform_test.go
@@ -57,8 +57,7 @@ func TestPlatformTraitChangeStatus(t *testing.T) {
 			}
 
 			trait := newPlatformTrait().(*platformTrait)
-			createPlatform := false
-			trait.CreateDefault = &createPlatform
+			trait.CreateDefault = BoolP(false)
 
 			var err error
 			trait.Client, err = test.NewFakeClient()
@@ -92,8 +91,7 @@ func TestPlatformTraitCreatesDefaultPlatform(t *testing.T) {
 	}
 
 	trait := newPlatformTrait().(*platformTrait)
-	createPlatform := true
-	trait.CreateDefault = &createPlatform
+	trait.CreateDefault = BoolP(true)
 
 	var err error
 	trait.Client, err = test.NewFakeClient()
@@ -149,8 +147,7 @@ func TestPlatformTraitExisting(t *testing.T) {
 			}
 
 			trait := newPlatformTrait().(*platformTrait)
-			createPlatform := true
-			trait.CreateDefault = &createPlatform
+			trait.CreateDefault = BoolP(true)
 
 			var err error
 			existingPlatform := v1.NewIntegrationPlatform("ns1", "existing")

--- a/pkg/trait/pod.go
+++ b/pkg/trait/pod.go
@@ -50,7 +50,7 @@ func newPodTrait() Trait {
 }
 
 func (t *podTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/pod_test.go
+++ b/pkg/trait/pod_test.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 )
 
@@ -73,7 +72,7 @@ func TestChangeEnvVariables(t *testing.T) {
 
 func createPodTest(podSpecTemplate string) (*podTrait, *Environment, *appsv1.Deployment) {
 	trait := newPodTrait().(*podTrait)
-	trait.Enabled = util.BoolP(true)
+	trait.Enabled = BoolP(true)
 
 	var podSpec v1.PodSpec
 	if podSpecTemplate != "" {

--- a/pkg/trait/prometheus.go
+++ b/pkg/trait/prometheus.go
@@ -52,7 +52,7 @@ type prometheusTrait struct {
 func newPrometheusTrait() Trait {
 	return &prometheusTrait{
 		BaseTrait:  NewBaseTrait("prometheus", 1900),
-		PodMonitor: util.BoolP(true),
+		PodMonitor: BoolP(true),
 	}
 }
 
@@ -102,7 +102,7 @@ func (t *prometheusTrait) Apply(e *Environment) (err error) {
 	condition.Message = fmt.Sprintf("%s(%d)", container.Name, containerPort.ContainerPort)
 
 	// Add the PodMonitor resource
-	if util.IsTrue(t.PodMonitor) {
+	if IsTrue(t.PodMonitor) {
 		portName := containerPort.Name
 		// Knative defaults to naming the userland container port "user-port".
 		// Let's rely on that default, granted it is not officially part of the Knative

--- a/pkg/trait/prometheus.go
+++ b/pkg/trait/prometheus.go
@@ -57,7 +57,7 @@ func newPrometheusTrait() Trait {
 }
 
 func (t *prometheusTrait) Configure(e *Environment) (bool, error) {
-	return t.Enabled != nil && *t.Enabled && e.IntegrationInPhase(
+	return IsTrue(t.Enabled) && e.IntegrationInPhase(
 		v1.IntegrationPhaseInitialization,
 		v1.IntegrationPhaseDeploying,
 		v1.IntegrationPhaseRunning,

--- a/pkg/trait/pull_secret.go
+++ b/pkg/trait/pull_secret.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/platform"
-	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/apache/camel-k/pkg/util/openshift"
 	"github.com/pkg/errors"
@@ -61,7 +60,7 @@ func newPullSecretTrait() Trait {
 }
 
 func (t *pullSecretTrait) Configure(e *Environment) (bool, error) {
-	if util.IsFalse(t.Enabled) {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 
@@ -69,7 +68,7 @@ func (t *pullSecretTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if util.IsNilOrTrue(t.Auto) {
+	if IsNilOrTrue(t.Auto) {
 		if t.SecretName == "" {
 			secret := e.Platform.Status.Build.Registry.Secret
 			if secret != "" {
@@ -99,7 +98,7 @@ func (t *pullSecretTrait) Configure(e *Environment) (bool, error) {
 		}
 	}
 
-	return t.SecretName != "" || util.IsTrue(t.ImagePullerDelegation), nil
+	return t.SecretName != "" || IsTrue(t.ImagePullerDelegation), nil
 }
 
 func (t *pullSecretTrait) Apply(e *Environment) error {
@@ -110,7 +109,7 @@ func (t *pullSecretTrait) Apply(e *Environment) error {
 			})
 		})
 	}
-	if util.IsTrue(t.ImagePullerDelegation) {
+	if IsTrue(t.ImagePullerDelegation) {
 		if err := t.delegateImagePuller(e); err != nil {
 			return err
 		}

--- a/pkg/trait/pull_secret_test.go
+++ b/pkg/trait/pull_secret_test.go
@@ -61,7 +61,7 @@ func TestPullSecretAuto(t *testing.T) {
 	e, _ := getEnvironmentAndDeployment(t)
 
 	trait := newPullSecretTrait().(*pullSecretTrait)
-	trait.Auto = newFalse()
+	trait.Auto = BoolP(false)
 	enabled, err := trait.Configure(e)
 	assert.Nil(t, err)
 	assert.False(t, enabled)
@@ -71,8 +71,8 @@ func TestPullSecretImagePullerDelegation(t *testing.T) {
 	e, _ := getEnvironmentAndDeployment(t)
 
 	trait := newPullSecretTrait().(*pullSecretTrait)
-	trait.Auto = newFalse()
-	trait.ImagePullerDelegation = newTrue()
+	trait.Auto = BoolP(false)
+	trait.ImagePullerDelegation = BoolP(true)
 	enabled, err := trait.Configure(e)
 	assert.Nil(t, err)
 	assert.True(t, enabled)
@@ -122,14 +122,4 @@ func getEnvironmentAndDeployment(t *testing.T) (*Environment, *appsv1.Deployment
 	assert.NoError(t, err)
 
 	return e, &deployment
-}
-
-func newFalse() *bool {
-	b := false
-	return &b
-}
-
-func newTrue() *bool {
-	b := true
-	return &b
 }

--- a/pkg/trait/quarkus.go
+++ b/pkg/trait/quarkus.go
@@ -38,12 +38,8 @@ func newQuarkusTrait() Trait {
 	}
 }
 
-func (t *quarkusTrait) isEnabled() bool {
-	return t.Enabled == nil || *t.Enabled
-}
-
 func (t *quarkusTrait) Configure(e *Environment) (bool, error) {
-	return t.isEnabled(), nil
+	return IsNilOrTrue(t.Enabled), nil
 }
 
 func (t *quarkusTrait) Apply(e *Environment) error {

--- a/pkg/trait/quarkus_test.go
+++ b/pkg/trait/quarkus_test.go
@@ -38,7 +38,7 @@ func TestConfigureQuarkusTraitShouldSucceed(t *testing.T) {
 
 func TestConfigureDisabledQuarkusTraitShouldFail(t *testing.T) {
 	quarkusTrait, environment := createNominalQuarkusTest()
-	quarkusTrait.Enabled = new(bool)
+	quarkusTrait.Enabled = BoolP(false)
 
 	configured, err := quarkusTrait.Configure(environment)
 
@@ -67,8 +67,7 @@ func TestQuarkusTraitAddBuildStepsShouldSucceed(t *testing.T) {
 
 func createNominalQuarkusTest() (*quarkusTrait, *Environment) {
 	trait := newQuarkusTrait().(*quarkusTrait)
-	enabled := true
-	trait.Enabled = &enabled
+	trait.Enabled = BoolP(true)
 
 	environment := &Environment{
 		CamelCatalog: &camel.RuntimeCatalog{},

--- a/pkg/trait/route.go
+++ b/pkg/trait/route.go
@@ -81,7 +81,7 @@ func (t *routeTrait) IsAllowedInProfile(profile v1.TraitProfile) bool {
 }
 
 func (t *routeTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		if e.Integration != nil {
 			e.Integration.Status.SetCondition(
 				v1.IntegrationConditionExposureAvailable,

--- a/pkg/trait/service.go
+++ b/pkg/trait/service.go
@@ -54,12 +54,8 @@ func (t *serviceTrait) IsAllowedInProfile(profile v1.TraitProfile) bool {
 		profile == v1.TraitProfileOpenShift
 }
 
-func (t *serviceTrait) isEnabled() bool {
-	return t.Enabled == nil || *t.Enabled
-}
-
 func (t *serviceTrait) Configure(e *Environment) (bool, error) {
-	if !t.isEnabled() {
+	if IsFalse(t.Enabled) {
 		e.Integration.Status.SetCondition(
 			v1.IntegrationConditionServiceAvailable,
 			corev1.ConditionFalse,
@@ -74,7 +70,7 @@ func (t *serviceTrait) Configure(e *Environment) (bool, error) {
 		return false, nil
 	}
 
-	if t.Auto == nil || *t.Auto {
+	if IsNilOrTrue(t.Auto) {
 		sources, err := kubernetes.ResolveIntegrationSources(t.Ctx, t.Client, e.Integration, e.Resources)
 		if err != nil {
 			e.Integration.Status.SetCondition(
@@ -103,18 +99,13 @@ func (t *serviceTrait) Configure(e *Environment) (bool, error) {
 	return true, nil
 }
 
-func (t *serviceTrait) isNodePort() bool {
-	return t.NodePort == nil || *t.NodePort
-
-}
-
 func (t *serviceTrait) Apply(e *Environment) error {
 	svc := e.Resources.GetServiceForIntegration(e.Integration)
 	// add a new service if not already created
 	if svc == nil {
 		svc = getServiceFor(e)
 
-		if t.isNodePort() {
+		if IsNilOrTrue(t.NodePort) {
 			svc.Spec.Type = corev1.ServiceTypeNodePort
 		}
 	}

--- a/pkg/trait/service_binding.go
+++ b/pkg/trait/service_binding.go
@@ -49,7 +49,7 @@ func newServiceBindingTrait() Trait {
 }
 
 func (t *serviceBindingTrait) Configure(e *Environment) (bool, error) {
-	if t.Enabled != nil && !*t.Enabled {
+	if IsFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/toleration.go
+++ b/pkg/trait/toleration.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 )
 
@@ -54,7 +53,7 @@ func newTolerationTrait() Trait {
 }
 
 func (t *tolerationTrait) Configure(e *Environment) (bool, error) {
-	if util.IsNilOrFalse(t.Enabled) {
+	if IsNilOrFalse(t.Enabled) {
 		return false, nil
 	}
 

--- a/pkg/trait/toleration_test.go
+++ b/pkg/trait/toleration_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/apache/camel-k/pkg/util"
 )
 
 func TestConfigureTolerationTraitMissingTaint(t *testing.T) {
@@ -128,7 +126,7 @@ func TestTolerationValidTaints(t *testing.T) {
 
 func createNominalTolerationTrait() *tolerationTrait {
 	tolerationTrait := newTolerationTrait().(*tolerationTrait)
-	tolerationTrait.Enabled = util.BoolP(true)
+	tolerationTrait.Enabled = BoolP(true)
 	tolerationTrait.Taints = make([]string, 0)
 
 	return tolerationTrait

--- a/pkg/trait/util.go
+++ b/pkg/trait/util.go
@@ -220,3 +220,32 @@ func AddSourceDependencies(source v1.SourceSpec, catalog *camel.RuntimeCatalog) 
 
 	return dependencies
 }
+
+/// Bool pointer operations:
+
+// BoolP returns a pointer to a bool value
+func BoolP(b bool) *bool {
+	return &b
+}
+
+// IsTrue checks if the bool pointer is defined and true
+func IsTrue(b *bool) bool {
+	return b != nil && *b
+}
+
+// IsNilOrTrue checks if the bool pointer is nil or true.
+// You can use it if the bool pointer is meant to be true by default.
+func IsNilOrTrue(b *bool) bool {
+	return b == nil || *b
+}
+
+// IsFalse checks if the bool pointer is defined and false
+func IsFalse(b *bool) bool {
+	return b != nil && !*b
+}
+
+// IsNilOrFalse checks if the bool pointer is nil or false.
+// You can use it if the bool pointer is meant to be false by default.
+func IsNilOrFalse(b *bool) bool {
+	return b == nil || !*b
+}

--- a/pkg/trait/util_test.go
+++ b/pkg/trait/util_test.go
@@ -101,3 +101,24 @@ func TestCollectConfigurationPairs(t *testing.T) {
 		{Name: "p4", Value: "integration"},
 	})
 }
+
+func TestBoolPointerFunctions(t *testing.T) {
+	trueP := BoolP(true)
+	falseP := BoolP(false)
+
+	assert.True(t, IsTrue(trueP))
+	assert.False(t, IsTrue(falseP))
+	assert.False(t, IsTrue(nil))
+
+	assert.True(t, IsNilOrTrue(trueP))
+	assert.False(t, IsNilOrTrue(falseP))
+	assert.True(t, IsNilOrTrue(nil))
+
+	assert.False(t, IsFalse(trueP))
+	assert.True(t, IsFalse(falseP))
+	assert.False(t, IsFalse(nil))
+
+	assert.False(t, IsNilOrFalse(trueP))
+	assert.True(t, IsNilOrFalse(falseP))
+	assert.True(t, IsNilOrFalse(nil))
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -498,35 +498,6 @@ func GetEnvironmentVariable(variable string) (string, error) {
 	return value, nil
 }
 
-/// Bool operations:
-
-// BoolP returns a pointer to a bool value
-func BoolP(b bool) *bool {
-	return &b
-}
-
-// IsTrue checks if the bool pointer is defined and true
-func IsTrue(b *bool) bool {
-	return b != nil && *b
-}
-
-// IsNilOrTrue checks if the bool pointer is nil or true.
-// You can use it if the bool pointer is meant to be true by default.
-func IsNilOrTrue(b *bool) bool {
-	return b == nil || *b
-}
-
-// IsFalse checks if the bool pointer is defined and false
-func IsFalse(b *bool) bool {
-	return b != nil && !*b
-}
-
-// IsNilOrFalse checks if the bool pointer is nil or false.
-// You can use it if the bool pointer is meant to be false by default.
-func IsNilOrFalse(b *bool) bool {
-	return b == nil || !*b
-}
-
 // EvaluateCLIAndLazyEnvVars -- Function that creates a list of environment
 // variables with entries VAR=value that can be passed when running the integration.
 func EvaluateCLIAndLazyEnvVars() ([]string, error) {


### PR DESCRIPTION
<!-- Description -->

Initially I put the bool pointer functions in `pkg/util` but turned out they are only used within traits, so let's move them to where they are mostly used (`pkg/trait`).


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
