### PR TITLE
fix: Fix cross-namespace creator resource events

### DIFF
--- a/pkg/controller/integration/build_kit.go
+++ b/pkg/controller/integration/build_kit.go
@@ -122,13 +122,13 @@ func (action *buildKitAction) Handle(ctx context.Context, integration *v1.Integr
 	// Add some information for post-processing, this may need to be refactored
 	// to a proper data structure
 	platformKit.Labels = map[string]string{
-		"camel.apache.org/kit.type":             v1.IntegrationKitTypePlatform,
-		"camel.apache.org/created.by.kind":      v1.IntegrationKind,
-		"camel.apache.org/created.by.name":      integration.Name,
-		"camel.apache.org/created.by.namespace": integration.Namespace,
-		"camel.apache.org/created.by.version":   integration.ResourceVersion,
-		"camel.apache.org/runtime.version":      integration.Status.RuntimeVersion,
-		"camel.apache.org/runtime.provider":     string(integration.Status.RuntimeProvider),
+		"camel.apache.org/kit.type":           v1.IntegrationKitTypePlatform,
+		"camel.apache.org/runtime.version":    integration.Status.RuntimeVersion,
+		"camel.apache.org/runtime.provider":   string(integration.Status.RuntimeProvider),
+		kubernetes.CamelCreatorLabelKind:      v1.IntegrationKind,
+		kubernetes.CamelCreatorLabelName:      integration.Name,
+		kubernetes.CamelCreatorLabelNamespace: integration.Namespace,
+		kubernetes.CamelCreatorLabelVersion:   integration.ResourceVersion,
 	}
 
 	// Set the kit to have the same characteristics as the integrations

--- a/pkg/trait/container.go
+++ b/pkg/trait/container.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"sort"
 
+	"github.com/apache/camel-k/pkg/util/kubernetes"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -181,11 +182,11 @@ func (t *containerTrait) configureDependencies(e *Environment) error {
 			// Add some information for post-processing, this may need to be refactored
 			// to a proper data structure
 			kit.Labels = map[string]string{
-				"camel.apache.org/kit.type":             v1.IntegrationKitTypeExternal,
-				"camel.apache.org/created.by.kind":      v1.IntegrationKind,
-				"camel.apache.org/created.by.name":      e.Integration.Name,
-				"camel.apache.org/created.by.namespace": e.Integration.Namespace,
-				"camel.apache.org/created.by.version":   e.Integration.ResourceVersion,
+				"camel.apache.org/kit.type":           v1.IntegrationKitTypeExternal,
+				kubernetes.CamelCreatorLabelKind:      v1.IntegrationKind,
+				kubernetes.CamelCreatorLabelName:      e.Integration.Name,
+				kubernetes.CamelCreatorLabelNamespace: e.Integration.Namespace,
+				kubernetes.CamelCreatorLabelVersion:   e.Integration.ResourceVersion,
 			}
 
 			t.L.Infof("image %s", kit.Spec.Image)

--- a/pkg/util/kubernetes/camel.go
+++ b/pkg/util/kubernetes/camel.go
@@ -20,18 +20,20 @@ package kubernetes
 import (
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	camelv1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 )
 
 const (
 	CamelCreatorLabelPrefix = "camel.apache.org/created.by"
 
-	CamelCreatorLabelKind = CamelCreatorLabelPrefix + ".kind"
-	CamelCreatorLabelName = CamelCreatorLabelPrefix + ".name"
+	CamelCreatorLabelKind      = CamelCreatorLabelPrefix + ".kind"
+	CamelCreatorLabelName      = CamelCreatorLabelPrefix + ".name"
+	CamelCreatorLabelNamespace = CamelCreatorLabelPrefix + ".namespace"
+	CamelCreatorLabelVersion   = CamelCreatorLabelPrefix + ".version"
 )
 
 // FilterCamelCreatorLabels is used to inherit the creator information among resources
@@ -57,16 +59,20 @@ func MergeCamelCreatorLabels(source map[string]string, target map[string]string)
 }
 
 // GetCamelCreator returns the Camel creator object referenced by this runtime object, if present
-func GetCamelCreator(obj runtime.Object) *v1.ObjectReference {
+func GetCamelCreator(obj runtime.Object) *corev1.ObjectReference {
 	if m, ok := obj.(metav1.Object); ok {
 		kind := m.GetLabels()[CamelCreatorLabelKind]
 		name := m.GetLabels()[CamelCreatorLabelName]
+		namespace, ok := m.GetLabels()[CamelCreatorLabelNamespace]
+		if !ok {
+			namespace = m.GetNamespace()
+		}
 		if kind != "" && name != "" {
-			return &v1.ObjectReference{
+			return &corev1.ObjectReference{
 				Kind:       kind,
-				Namespace:  m.GetNamespace(),
+				Namespace:  namespace,
 				Name:       name,
-				APIVersion: camelv1.SchemeGroupVersion.String(),
+				APIVersion: v1.SchemeGroupVersion.String(),
 			}
 		}
 	}


### PR DESCRIPTION
The _creator_ resource retrieval fails when it's in another namespace, like for IntegrationKits in global installation, which leads to errors when emitting events.

**Release Note**
```release-note
fix: Fix cross-namespace creator resource events
```
