### PR TITLE
postgres user on readme was different than the one created on the yam…

### DIFF
--- a/examples/databases/postgres-deploy/README.md
+++ b/examples/databases/postgres-deploy/README.md
@@ -15,7 +15,7 @@ Connection credentials available in the _postgres-configmap.yaml_ descriptor.
 
 ```
 kubectl get svc postgres
-psql -h <IP> -U postgresadmin1 --password -p <PORT> postgresdb
+psql -h <IP> -U postgresadmin --password -p <PORT> postgresdb
 ```
 ## Create a test database and table
 ```


### PR DESCRIPTION
…l descriptor

Easy one. The configmap creates the postgresadmin user, whilst the readme tells to use the postgresadmin1. Typo probably

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
