### PR TITLE
(backport) fix TestPermissionDenied should ignore darwin

### DIFF
--- a/pkg/cmd/util_test.go
+++ b/pkg/cmd/util_test.go
@@ -1,3 +1,5 @@
+// +build !darwin
+
 /*
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
<!-- Description -->

#2561 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
