### PR TITLE
[Backport] fix(api): property leading space

### DIFF
--- a/pkg/apis/camel/v1/integration_types_support.go
+++ b/pkg/apis/camel/v1/integration_types_support.go
@@ -148,11 +148,18 @@ func (in *IntegrationSpec) GetConfigurationProperty(property string) string {
 		if confSpec.Type == "property" && strings.HasPrefix(confSpec.Value, property) {
 			splitConf := strings.Split(confSpec.Value, "=")
 			if len(splitConf) > 1 {
-				return splitConf[1]
+				return trimFirstLeadingSpace(splitConf[1])
 			}
 		}
 	}
 	return ""
+}
+
+func trimFirstLeadingSpace(val string) string {
+	if strings.HasPrefix(val, " ") {
+		return val[1:]
+	}
+	return val
 }
 
 // AddOrReplaceGeneratedResources --

--- a/pkg/apis/camel/v1/integration_types_support_test.go
+++ b/pkg/apis/camel/v1/integration_types_support_test.go
@@ -73,3 +73,28 @@ func TestAddDependency(t *testing.T) {
 	integration.AddDependency("file:dep")
 	assert.Equal(t, integration.Dependencies, []string{"file:dep"})
 }
+
+func TestGetConfigurationProperty(t *testing.T) {
+	integration := IntegrationSpec{}
+	integration.AddConfiguration("property", "key1=value1")
+	integration.AddConfiguration("property", "key2 = value2")
+	integration.AddConfiguration("property", "key3 = value with trailing space ")
+	integration.AddConfiguration("property", "key4 =  value with leading space")
+	integration.AddConfiguration("property", "key5 = ")
+	integration.AddConfiguration("property", "key6=")
+
+	missing := integration.GetConfigurationProperty("missing")
+	assert.Equal(t, "", missing)
+	v1 := integration.GetConfigurationProperty("key")
+	assert.Equal(t, "value1", v1)
+	v2 := integration.GetConfigurationProperty("key2")
+	assert.Equal(t, "value2", v2)
+	v3 := integration.GetConfigurationProperty("key3")
+	assert.Equal(t, "value with trailing space ", v3)
+	v4 := integration.GetConfigurationProperty("key4")
+	assert.Equal(t, " value with leading space", v4)
+	v5 := integration.GetConfigurationProperty("key5")
+	assert.Equal(t, "", v5)
+	v6 := integration.GetConfigurationProperty("key6")
+	assert.Equal(t, "", v6)
+}


### PR DESCRIPTION
Closes #2525

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
