### PR TITLE
fix(cli): modeline build-property check

### DIFF
--- a/pkg/cmd/modeline.go
+++ b/pkg/cmd/modeline.go
@@ -136,7 +136,7 @@ func createKamelWithModelineCommand(ctx context.Context, args []string) (*cobra.
 	cliParamNames := []string{}
 	index := 0
 	for _, arg := range args {
-		if arg == "-p" || arg == "--property" || arg == "-t" || arg == "--trait" {
+		if arg == "-p" || arg == "--property" || arg == "-t" || arg == "--trait" || arg == "--build-property" {
 			// Property or trait is assumed to be in the form: <name>=<value>
 			splitValues := strings.Split(args[index+1], "=")
 			cliParamNames = append(cliParamNames, splitValues[0])
@@ -149,7 +149,7 @@ func createKamelWithModelineCommand(ctx context.Context, args []string) (*cobra.
 	for _, o := range opts {
 		// Check if property name is given by user.
 		paramAlreadySpecifiedByUser := false
-		if o.Name == "property" || o.Name == "trait" {
+		if o.Name == "property" || o.Name == "trait" || o.Name == "build-property" {
 			paramComponents := strings.Split(o.Value, "=")
 			for _, paramName := range cliParamNames {
 				if paramName == paramComponents[0] {

--- a/pkg/cmd/modeline_test.go
+++ b/pkg/cmd/modeline_test.go
@@ -148,6 +148,32 @@ func TestModelineRunDuplicatedProperties(t *testing.T) {
 	assert.Equal(t, []string{"run", fileName, "-p", "prop1=true", "--property", "prop2=true", "--property=foo=bar"}, flags)
 }
 
+func TestModelineRunDuplicatedBuildProperties(t *testing.T) {
+	dir, err := ioutil.TempDir("", "camel-k-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	subDir := path.Join(dir, "sub")
+	err = os.Mkdir(subDir, 0777)
+	assert.NoError(t, err)
+
+	file := `
+		// camel-k: build-property=prop1=false
+		// camel-k: build-property=prop2=false
+		// camel-k: build-property=foo=bar
+	`
+	fileName := path.Join(subDir, "simple.groovy")
+	err = ioutil.WriteFile(fileName, []byte(file), 0777)
+	assert.NoError(t, err)
+
+	cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName,
+		"--build-property", "prop1=true", "--build-property", "prop2=true"})
+	assert.NoError(t, err)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, []string{"run", fileName, "--build-property", "prop1=true", "--build-property", "prop2=true",
+		"--build-property=foo=bar"}, flags)
+}
+
 func TestModelineRunPropertyFiles(t *testing.T) {
 	dir, err := ioutil.TempDir("", "camel-k-test-")
 	assert.NoError(t, err)


### PR DESCRIPTION
Adding buid-property option to be checked for input submitted by user

Closes #2569

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
