### PR TITLE
test(e2e): add timer-source to apache-kamelet-catalog

### DIFF
--- a/e2e/yaks/common/apache-kamelet-catalog/timer-source.kamelet.yaml
+++ b/e2e/yaks/common/apache-kamelet-catalog/timer-source.kamelet.yaml
@@ -15,14 +15,40 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-config:
-  namespace:
-    temporary: true
-pre:
-- name: installation
-  run: |
-    kamel install -n $YAKS_NAMESPACE
-    
-    kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
-
-    kamel run logger.groovy -w -n $YAKS_NAMESPACE
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: timer-source
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Timer"
+    description: "Produces periodic events with a custom payload"
+    required:
+      - message
+    properties:
+      period:
+        title: Period
+        description: The time interval between two events
+        type: integer
+        default: 1000
+      message:
+        title: Message
+        description: The message to generate
+        type: string
+  types:
+    out:
+      mediaType: application/json
+      schema:
+        id: text.camel.apache.org
+        type: string
+  flow:
+    from:
+      uri: timer:tick
+      parameters:
+        period: "{{period}}"
+      steps:
+        - set-body:
+            constant: "{{message}}"
+        - to: "kamelet:sink"


### PR DESCRIPTION
<!-- Description -->
The apache-kamelet-catalog is failing with prod version of camel-k due to missing timer-source kamelet. Adding the kamelet to the yaks test prevents this test failure. 

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
