### PR TITLE
Feat/2494 kamel bind error

### DIFF
--- a/pkg/cmd/bind_test.go
+++ b/pkg/cmd/bind_test.go
@@ -82,3 +82,79 @@ func TestBindOutputUnknownFormat(t *testing.T) {
 
 	assert.Equal(t, "invalid output format option 'fail', should be one of: yaml|json\n", output)
 }
+
+func TestBindErrorHandlerDLCKamelet(t *testing.T) {
+	buildCmdOptions, bindCmd, _ := initializeBindCmdOptions(t)
+	output, err := test.ExecuteCommand(bindCmd, cmdBind, "my:src", "my:dst", "-o", "yaml",
+		"--error-handler", "dlc:my-kamelet", "-p", "error-handler.my-prop=value")
+	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
+
+	assert.Nil(t, err)
+	assert.Equal(t, `apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  creationTimestamp: null
+  name: my-to-my
+spec:
+  errorHandler:
+    dead-letter-channel:
+      endpoint:
+        properties:
+          my-prop: value
+        ref:
+          apiVersion: camel.apache.org/v1alpha1
+          kind: Kamelet
+          name: my-kamelet
+  sink:
+    uri: my:dst
+  source:
+    uri: my:src
+status: {}
+`, output)
+}
+
+func TestBindErrorHandlerNone(t *testing.T) {
+	buildCmdOptions, bindCmd, _ := initializeBindCmdOptions(t)
+	output, err := test.ExecuteCommand(bindCmd, cmdBind, "my:src", "my:dst", "-o", "yaml",
+		"--error-handler", "none")
+	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
+
+	assert.Nil(t, err)
+	assert.Equal(t, `apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  creationTimestamp: null
+  name: my-to-my
+spec:
+  errorHandler:
+    none: null
+  sink:
+    uri: my:dst
+  source:
+    uri: my:src
+status: {}
+`, output)
+}
+
+func TestBindErrorHandlerRef(t *testing.T) {
+	buildCmdOptions, bindCmd, _ := initializeBindCmdOptions(t)
+	output, err := test.ExecuteCommand(bindCmd, cmdBind, "my:src", "my:dst", "-o", "yaml",
+		"--error-handler", "ref:my-registry-reference")
+	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
+
+	assert.Nil(t, err)
+	assert.Equal(t, `apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  creationTimestamp: null
+  name: my-to-my
+spec:
+  errorHandler:
+    ref: my-registry-reference
+  sink:
+    uri: my:dst
+  source:
+    uri: my:src
+status: {}
+`, output)
+}


### PR DESCRIPTION
<!-- Description -->
With this PR we introduce the possibility to use `--error-handler` option directly with the `kamel bind`. There is a simple syntax that will allow the user to chose one of the different error handler available (none, log, dlc, bean, ref). The `dlc` is using what it is already used for `step` as it expects the same configuration (ie, a `Kamelet`).

As an example, we'll be now allowed to execute:
```
kamel bind my:src my:dst --error-handler dlc:my-kamelet -p error-handler.my-prop=value
```
Which will turn into a `KameletBinding` with a dlc error handler and relative property setting.

Closes #2494 

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
