### PR TITLE
doc(kamelets): trait array vaue syntax

### DIFF
--- a/docs/modules/ROOT/pages/kamelets/kamelets-user.adoc
+++ b/docs/modules/ROOT/pages/kamelets/kamelets-user.adoc
@@ -383,6 +383,8 @@ spec:
 
 In this example, we've set the `logging` trait to specify certain configuration we want to apply. You can do the same with all the traits available, just by setting `trait.camel.apache.org/trait-name.trait-property` with the expected value.
 
+NOTE: if you need to specify an array of values, the syntax will be `trait.camel.apache.org/trait.conf: "[\"opt1\", \"opt2\", ...]"`
+
 [[kamelets-troubleshooting]]
 == Troubleshooting
 

--- a/pkg/trait/trait_configure_test.go
+++ b/pkg/trait/trait_configure_test.go
@@ -147,3 +147,21 @@ func TestTraitListConfigurationFromAnnotations(t *testing.T) {
 	assert.Equal(t, []string{"opt1", "opt2"}, c.GetTrait("jolokia").(*jolokiaTrait).Options)
 	assert.Equal(t, []string{"Binding:xxx"}, c.GetTrait("service-binding").(*serviceBindingTrait).ServiceBindings)
 }
+
+func TestTraitSplitConfiguration(t *testing.T) {
+	env := Environment{
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"trait.camel.apache.org/owner.target-labels": "[\"opt1\", \"opt2\"]",
+				},
+			},
+			Spec: v1.IntegrationSpec{
+				Profile: v1.TraitProfileKubernetes,
+			},
+		},
+	}
+	c := NewCatalog(context.Background(), nil)
+	assert.NoError(t, c.configure(&env))
+	assert.Equal(t, []string{"opt1", "opt2"}, c.GetTrait("owner").(*ownerTrait).TargetLabels)
+}


### PR DESCRIPTION
Closes #2446

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
