### PR TITLE
[website] fix attributes, unterminated listing warnings

### DIFF
--- a/docs/modules/ROOT/pages/contributing/developers.adoc
+++ b/docs/modules/ROOT/pages/contributing/developers.adoc
@@ -197,15 +197,16 @@ After you set up the IDE task, with Java 11+ to be used by default, you can run 
 NOTE: The operator can be fully debugged in Minishift, because it uses OpenShift S2I binary builds under the hood.
 The build phase cannot be (currently) debugged in Minikube because the Kaniko builder requires that the operator and the publisher pod share a common persistent volume.
 
-[publishing]
+[#publishing]
 == Building Metadata for Publishing the Operator in Operator Hub
-----
+
 
 Publishing to an operator hub requires creation and submission of metadata, required in a specific
 https://github.com/operator-framework/operator-registry/#manifest-format[format]. The
 https://sdk.operatorframework.io/docs/cli[operator-sdk] provides tools to help with the creation of this metadata.
 
 There are two formats for the publishing of the metadata:
+
 === Package Manifests
 The legacy packaging format used for deploying the operator to an OLM registry. While deprecated in Openshift 4.5+,
 it is still supported and used on that and other cluster types. A single CSV is generated, comprising of the operator

--- a/docs/modules/ROOT/pages/kamelets/kamelets-dev.adoc
+++ b/docs/modules/ROOT/pages/kamelets/kamelets-dev.adoc
@@ -563,11 +563,11 @@ public class Earthquake extends RouteBuilder {
 }
 ----
 <1> Modeline header defines the two parameters with a "development" value
-<2> Placeholder `{{period}}` is used
-<3> Placeholder `{{lookAhead}}` is used
+<2> Placeholder `{\{period}}` is used
+<3> Placeholder `{\{lookAhead}}` is used
 
-This looks the same as before, but notice that the `period` and `lookAhead` parameters are set in the modeline, while the route uses the `{{period}}`
-and `{{lookAhead}}` placeholders instead of the actual values.
+This looks the same as before, but notice that the `period` and `lookAhead` parameters are set in the modeline, while the route uses the `{\{period}}`
+and `{\{lookAhead}}` placeholders instead of the actual values.
 
 As before, this integration can be tested with `kamel local run Earthquake.java` (the modeline parameters will be automatically added by the kamel CLI).
 
@@ -758,7 +758,7 @@ spec:
       # ...
 ----
 <1> The definition part starts with general information about the Kamelet
-<2> Definition of the period parameter (used with the `{{period}}` placeholder in the route)
+<2> Definition of the period parameter (used with the `{\{period}}` placeholder in the route)
 <3> Definition of the lookAhead parameter
 
 === Step 7: add metadata and sugar


### PR DESCRIPTION
<!-- Description -->

This fixes some AsciiDoc attribute usage and an unterminated listing block.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
