### PR TITLE
Fix #2616: correctly encode numbers in Kamelet parameters

### DIFF
--- a/pkg/apis/camel/v1alpha1/kamelet_binding_types_support.go
+++ b/pkg/apis/camel/v1alpha1/kamelet_binding_types_support.go
@@ -18,6 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -151,7 +152,9 @@ func (p *EndpointProperties) GetPropertyMap() (map[string]string, error) {
 
 	// Convert json property values to objects before getting their string representation
 	var props map[string]interface{}
-	if err := json.Unmarshal(p.RawMessage, &props); err != nil {
+	d := json.NewDecoder(bytes.NewReader(p.RawMessage))
+	d.UseNumber()
+	if err := d.Decode(&props); err != nil {
 		return nil, err
 	}
 	stringProps := make(map[string]string, len(props))

--- a/pkg/apis/camel/v1alpha1/kamelet_binding_types_support_test.go
+++ b/pkg/apis/camel/v1alpha1/kamelet_binding_types_support_test.go
@@ -1,0 +1,47 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNumberConversion(t *testing.T) {
+	props := map[string]interface{}{
+		"string":  "str",
+		"int32":   1000000,
+		"int64":   int64(10000000000),
+		"float32": float32(123.123),
+		"float64": float64(1111123.123),
+	}
+	ser, err := json.Marshal(props)
+	assert.NoError(t, err)
+	ep := EndpointProperties{
+		RawMessage: ser,
+	}
+	res, err := ep.GetPropertyMap()
+	assert.NoError(t, err)
+	assert.Equal(t, "str", res["string"])
+	assert.Equal(t, "1000000", res["int32"])
+	assert.Equal(t, "10000000000", res["int64"])
+	assert.Equal(t, "123.123", res["float32"])
+	assert.Equal(t, "1111123.123", res["float64"])
+}

--- a/pkg/kamelet/initialize.go
+++ b/pkg/kamelet/initialize.go
@@ -18,6 +18,7 @@ limitations under the License.
 package kamelet
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -92,7 +93,9 @@ func recomputeProperties(kamelet *v1alpha1.Kamelet) error {
 		defValue := ""
 		if v.Default != nil {
 			var val interface{}
-			if err := json.Unmarshal(v.Default.RawMessage, &val); err != nil {
+			d := json.NewDecoder(bytes.NewReader(v.Default.RawMessage))
+			d.UseNumber()
+			if err := d.Decode(&val); err != nil {
 				return errors.Wrapf(err, "cannot decode default value for property %q", k)
 			}
 			defValue = fmt.Sprintf("%v", val)


### PR DESCRIPTION
<!-- Description -->
Issue is due to JSON conversion from RawMessage that maps numbers (even integers) to float64 by default.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Numeric parameters are properly encoded in Kamelets
```
