### PR TITLE
fix(doc): escape characters in trait doc

### DIFF
--- a/cmd/util/doc-gen/generators/traitdocgen.go
+++ b/cmd/util/doc-gen/generators/traitdocgen.go
@@ -205,11 +205,12 @@ func writeMembers(t *types.Type, traitID string, content *[]string) {
 				res = append(res, "| "+strings.TrimPrefix(m.Type.Name.Name, "*"))
 				first := true
 				for _, l := range filterOutTagsAndComments(m.CommentLines) {
+					escapedComment := escapeASCIIDoc(l)
 					if first {
-						res = append(res, "| "+l)
+						res = append(res, "| "+escapedComment)
 						first = false
 					} else {
-						res = append(res, l)
+						res = append(res, escapedComment)
 					}
 				}
 				res = append(res, "")
@@ -241,6 +242,11 @@ func filterOutTagsAndComments(comments []string) []string {
 		}
 	}
 	return res
+}
+
+// escapeAsciiDoc is in charge to escape those chars used for formatting purposes
+func escapeASCIIDoc(text string) string {
+	return strings.Replace(text, "|", "\\|", -1)
 }
 
 func split(doc []string, startMarker, endMarker string) (pre []string, post []string) {

--- a/docs/modules/traits/pages/container.adoc
+++ b/docs/modules/traits/pages/container.adoc
@@ -79,7 +79,7 @@ The following configuration options are available:
 
 | container.image-pull-policy
 | PullPolicy
-| The pull policy: Always|Never|IfNotPresent
+| The pull policy: Always\|Never\|IfNotPresent
 
 | container.probes-enabled
 | bool


### PR DESCRIPTION
Closes #2626

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
