### PR TITLE
chore: stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,12 @@
+daysUntilStale: 90
+daysUntilClose: 15
+exemptLabels:
+  - status/never-stale
+staleLabel: status/stale
+markComment: >
+  This issue has been automatically marked as stale due to 90 days of inactivity. 
+  It will be closed if no further activity occurs within 15 days.
+  If you think that’s incorrect or the issue should never stale, please simply write any comment.
+  Thanks for your contributions!
+closeComment: false
+only: issues


### PR DESCRIPTION
Closes #2623

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
