### PR TITLE
Fix local builds from directory for containerized and non-containerized uses.

### DIFF
--- a/pkg/cmd/local_build.go
+++ b/pkg/cmd/local_build.go
@@ -221,9 +221,9 @@ func (command *localBuildCmdOptions) run(cmd *cobra.Command, args []string) erro
 
 	// Integration directory can only be used when building an integration image or when we just
 	// build the integration without also building the image. A local build of the integration is
-	// represented by all the files that define	 the integration: dependencies, properties and routes.
+	// represented by all the files that define the integration: dependencies, properties and routes.
 
-	// The only case where we should not execute the image integration creation is when we want to
+	// The only case in which we should not execute the integration image creation is when we want to
 	// just output the files that comprise the integration locally.
 	if command.IntegrationDirectory != "" && command.Image == "" {
 		return nil
@@ -231,7 +231,7 @@ func (command *localBuildCmdOptions) run(cmd *cobra.Command, args []string) erro
 
 	// Create and build integration image.
 	err := createAndBuildIntegrationImage(command.Context, command.ContainerRegistry, command.BaseImage,
-		command.Image, propertyFilesList, dependenciesList, routeFiles, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		command.Image, propertyFilesList, dependenciesList, routeFiles, false, cmd.OutOrStdout(), cmd.ErrOrStderr())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -110,7 +110,7 @@ func createAndBuildBaseImage(ctx context.Context) error {
 }
 
 func createAndBuildIntegrationImage(ctx context.Context, containerRegistry string, justBaseImage bool, image string,
-	propertyFiles []string, dependencies []string, routes []string, stdout, stderr io.Writer) error {
+	propertyFiles []string, dependencies []string, routes []string, startsFromLocalFolder bool, stdout, stderr io.Writer) error {
 	// This ensures the Dockerfile for the base image will not end up in an undesired location.
 	if docker.BaseWorkingDirectory == "" {
 		return errors.New("base directory that holds the base image Dockerfile has not been set correctly")
@@ -156,6 +156,15 @@ func createAndBuildIntegrationImage(ctx context.Context, containerRegistry strin
 		return err
 	}
 
+	// Copy quarkus files in maven subdirectory
+	updateQuarkusDirectory()
+
+	// Copy app files in maven subdirectory
+	updateAppDirectory()
+
+	// Copy lib files in maven subdirectory
+	updateLibDirectory()
+
 	// Get integration run command to be run inside the container. This means the command
 	// has to be created with the paths which will be valid inside the container.
 	containerCmd, err := GetContainerIntegrationRunCommand(ctx, propertyFiles, dependencies, routes, stdout, stderr)
@@ -164,7 +173,7 @@ func createAndBuildIntegrationImage(ctx context.Context, containerRegistry strin
 	}
 
 	// Create the integration image Docker file.
-	err = docker.CreateIntegrationImageDockerFile(containerCmd)
+	err = docker.CreateIntegrationImageDockerFile(containerCmd, startsFromLocalFolder)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/util_dependencies.go
+++ b/pkg/cmd/util_dependencies.go
@@ -452,6 +452,39 @@ func updateIntegrationRoutes(routes []string) error {
 	return nil
 }
 
+func updateQuarkusDirectory() error {
+	err := util.CreateLocalQuarkusDirectory()
+	if err != nil {
+		return err
+	}
+
+	util.CopyQuarkusAppFiles(util.CustomQuarkusDirectoryName, util.GetLocalQuarkusDir())
+
+	return nil
+}
+
+func updateAppDirectory() error {
+	err := util.CreateLocalAppDirectory()
+	if err != nil {
+		return err
+	}
+
+	util.CopyAppFile(util.CustomAppDirectoryName, util.GetLocalAppDir())
+
+	return nil
+}
+
+func updateLibDirectory() error {
+	err := util.CreateLocalLibDirectory()
+	if err != nil {
+		return err
+	}
+
+	util.CopyLibFiles(util.CustomLibDirectoryName, util.GetLocalLibDir())
+
+	return nil
+}
+
 func createMavenWorkingDirectory() error {
 	// Create local Maven context
 	temporaryDirectory, err := ioutil.TempDir(os.TempDir(), "maven-")
@@ -482,4 +515,57 @@ func getCustomPropertiesDir(integrationDirectory string) string {
 
 func getCustomRoutesDir(integrationDirectory string) string {
 	return path.Join(integrationDirectory, "routes")
+}
+
+func getCustomQuarkusDir() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(currentDir, "quarkus"), nil
+}
+
+func getCustomLibDir() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(currentDir, "lib/main"), nil
+}
+
+func getCustomAppDir() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(currentDir, "app"), nil
+}
+
+func deleteLocalIntegrationDirs() error {
+	directory, err := getCustomQuarkusDir()
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(directory)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll("lib")
+	if err != nil {
+		return err
+	}
+
+	directory, err = getCustomAppDir()
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(directory)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -68,8 +68,6 @@ func CreateIntegrationImageDockerFile(integrationRunCmd *exec.Cmd, startsFromLoc
 		dockerFile = append(dockerFile, RUNMakeDir(util.ContainerLibDirectoryName))
 		dockerFile = append(dockerFile, RUNMakeDir(util.ContainerAppDirectoryName))
 
-		dockerFile = append(dockerFile, WORKDIR("/workspace"))
-
 		dockerFile = append(dockerFile, COPY(util.CustomQuarkusDirectoryName, util.ContainerQuarkusDirectoryName))
 		dockerFile = append(dockerFile, COPY(util.CustomLibDirectoryName, util.ContainerLibDirectoryName))
 		dockerFile = append(dockerFile, COPY(util.CustomAppDirectoryName, util.ContainerAppDirectoryName))

--- a/pkg/util/docker/docker_base.go
+++ b/pkg/util/docker/docker_base.go
@@ -129,6 +129,14 @@ func FullImageArg(dockerImage string) []string {
 	if len(imageComponents) == 2 {
 		// Image has a tag already.
 		return ImageArg(imageComponents[0], imageComponents[1])
+	} else if len(imageComponents) > 2 {
+		// Image has an image registry name with a colon inside it:
+		// localhost:5000
+		// and image also has a tag:
+		// localhost:5000/image:latest
+		// Assume tag is always included and is last in the imageComponents list.
+		last := len(imageComponents) - 1
+		return ImageArg(strings.Join(imageComponents[:last], ":"), imageComponents[last])
 	}
 
 	// Image has no tag, latest tag will be added automatically.


### PR DESCRIPTION
Fix building of integrations starting from local integration directories i.e. the output of a `kamel local build` command.

Step 1: Build local files for integrations:

```
kamel local build --integration-directory <directory-name> <input_file>
```

`kamel local run` can run the integration by passing the directory to as input:

Step 2: Take the previously-created directory as input to run the integration:

```
kamel local run --integration-directory <directory-name>
```

Step 2': The directory can also be used when running a containerized integration:

```
kamel local run --containerize --network=host --image <registry>/<image_name> --integration-directory <directory-name>
```

Note that no input files are given to `kamel local run` in the above steps 2 and 2'.

<!-- Description -->

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
