### PR TITLE
chore(ci): Use `github.head_ref` as concurrency group key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ on:
       - "release-*"
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This allows concurrent runs on main branch, and only cancel in progress concurrency groups by pull request.

**Release Note**
```release-note
NONE
```