### PR TITLE
Make quarkus dependencies management more robust

### DIFF
--- a/pkg/cmd/util_containerization.go
+++ b/pkg/cmd/util_containerization.go
@@ -157,13 +157,22 @@ func createAndBuildIntegrationImage(ctx context.Context, containerRegistry strin
 	}
 
 	// Copy quarkus files in maven subdirectory
-	updateQuarkusDirectory()
+	err = updateQuarkusDirectory()
+	if err != nil {
+		return err
+	}
 
 	// Copy app files in maven subdirectory
-	updateAppDirectory()
+	err = updateAppDirectory()
+	if err != nil {
+		return err
+	}
 
 	// Copy lib files in maven subdirectory
-	updateLibDirectory()
+	err = updateLibDirectory()
+	if err != nil {
+		return err
+	}
 
 	// Get integration run command to be run inside the container. This means the command
 	// has to be created with the paths which will be valid inside the container.

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -71,7 +71,6 @@ func CreateIntegrationImageDockerFile(integrationRunCmd *exec.Cmd, startsFromLoc
 		dockerFile = append(dockerFile, COPY(util.CustomQuarkusDirectoryName, util.ContainerQuarkusDirectoryName))
 		dockerFile = append(dockerFile, COPY(util.CustomLibDirectoryName, util.ContainerLibDirectoryName))
 		dockerFile = append(dockerFile, COPY(util.CustomAppDirectoryName, util.ContainerAppDirectoryName))
-
 	}
 
 	// All Env variables the command requires need to be set in the container.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -647,18 +647,17 @@ func CopyQuarkusAppFiles(localDependenciesDirectory string, localQuarkusDir stri
 		return err
 	}
 
-	source := path.Join(localDependenciesDirectory, "quarkus-application.dat")
-	destination := path.Join(localQuarkusDir, "quarkus-application.dat")
-	_, err = CopyFile(source, destination)
-	if err != nil {
-		return err
-	}
-
-	source = path.Join(localDependenciesDirectory, "generated-bytecode.jar")
-	destination = path.Join(localQuarkusDir, "generated-bytecode.jar")
-	_, err = CopyFile(source, destination)
-	if err != nil {
-		return err
+	// Transfer all files with a .dat extension and all files with a *-bytecode.jar suffix.
+	files, err := getRegularFileNamesInDir(localDependenciesDirectory)
+	for _, file := range files {
+		if strings.HasSuffix(file, ".dat") || strings.HasSuffix(file, "-bytecode.jar") {
+			source := path.Join(localDependenciesDirectory, file)
+			destination := path.Join(localQuarkusDir, file)
+			_, err = CopyFile(source, destination)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Description -->

Make quarkus dependencies management more robust.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
