### PR TITLE
chore: refresh kamelets also when operator version does not change an…

### DIFF
--- a/e2e/common/kamelet_binding_test.go
+++ b/e2e/common/kamelet_binding_test.go
@@ -106,7 +106,7 @@ func CreateLogKamelet(ns string, name string) func() error {
 			Type: "string",
 		},
 	}
-	return CreateKamelet(ns, name, flow, props)
+	return CreateKamelet(ns, name, flow, props, nil)
 }
 
 func CreateErrorProducerKamelet(ns string, name string) func() error {
@@ -137,5 +137,5 @@ func CreateErrorProducerKamelet(ns string, name string) func() error {
 		},
 	}
 
-	return CreateKamelet(ns, name, flow, props)
+	return CreateKamelet(ns, name, flow, props, nil)
 }

--- a/e2e/common/kamelet_upgrade_test.go
+++ b/e2e/common/kamelet_upgrade_test.go
@@ -1,0 +1,77 @@
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/apache/camel-k/e2e/support"
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	. "github.com/onsi/gomega"
+)
+
+const preExistingKameletMarker = "pre-existing-kamelet"
+
+func TestKameletUpgrade(t *testing.T) {
+
+	WithNewTestNamespace(t, func(ns string) {
+		Expect(createOperatorManagedKamelet(ns, "http-sink")()).To(Succeed()) // Going to be replaced
+		Expect(createUserManagedKamelet(ns, "ftp-sink")()).To(Succeed())      // Left intact by the operator
+		// Leverages the fact that the default kamelet catalog contains embedded "http-sink" and "ftp-sink"
+
+		Expect(Kamel("install", "-n", ns).Execute()).To(Succeed())
+
+		Eventually(KameletHasLabel("http-sink", ns, preExistingKameletMarker)).Should(BeFalse())
+		Consistently(KameletHasLabel("ftp-sink", ns, preExistingKameletMarker), 5*time.Second, 1*time.Second).Should(BeTrue())
+
+		// Cleanup
+		Expect(Kamel("delete", "--all", "-n", ns).Execute()).Should(BeNil())
+	})
+}
+
+func createOperatorManagedKamelet(ns string, name string) func() error {
+	flow := map[string]interface{}{
+		"from": map[string]interface{}{
+			"uri": "kamelet:source",
+		},
+	}
+
+	labels := map[string]string{
+		preExistingKameletMarker:     "true",
+		v1alpha1.KameletBundledLabel: "true",
+	}
+	return CreateKamelet(ns, name, flow, nil, labels)
+}
+
+func createUserManagedKamelet(ns string, name string) func() error {
+	flow := map[string]interface{}{
+		"from": map[string]interface{}{
+			"uri": "kamelet:source",
+		},
+	}
+
+	labels := map[string]string{
+		preExistingKameletMarker: "true",
+	}
+	return CreateKamelet(ns, name, flow, nil, labels)
+}

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1236,6 +1236,19 @@ func Kamelet(name string, ns string) func() *v1alpha1.Kamelet {
 	}
 }
 
+func KameletHasLabel(name string, ns string, label string) func() bool {
+	return func() bool {
+		k := Kamelet(name, ns)()
+		if k == nil {
+			return false
+		}
+		if _, ok := k.Labels[label]; ok {
+			return true
+		}
+		return false
+	}
+}
+
 func ClusterDomainName() (string, error) {
 	dns := configv1.DNS{}
 	key := ctrl.ObjectKey{
@@ -1345,12 +1358,13 @@ func CreateKnativeChannel(ns string, name string) func() error {
 	Kamelets
 */
 
-func CreateKamelet(ns string, name string, flow map[string]interface{}, properties map[string]v1alpha1.JSONSchemaProp) func() error {
+func CreateKamelet(ns string, name string, flow map[string]interface{}, properties map[string]v1alpha1.JSONSchemaProp, labels map[string]string) func() error {
 	return func() error {
 		kamelet := v1alpha1.Kamelet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
 				Name:      name,
+				Labels:    labels,
 			},
 			Spec: v1alpha1.KameletSpec{
 				Definition: &v1alpha1.JSONSchemaProps{
@@ -1386,7 +1400,7 @@ func CreateTimerKamelet(ns string, name string) func() error {
 		},
 	}
 
-	return CreateKamelet(ns, name, flow, props)
+	return CreateKamelet(ns, name, flow, props, nil)
 }
 
 func BindKameletTo(ns string, name string, from corev1.ObjectReference, to corev1.ObjectReference, sourceProperties map[string]string, sinkProperties map[string]string) func() error {

--- a/pkg/install/kamelets.go
+++ b/pkg/install/kamelets.go
@@ -82,7 +82,7 @@ func KameletCatalog(ctx context.Context, c client.Client, namespace string) erro
 				}
 			}
 
-			if existing == nil || existing.Annotations[kamelVersionAnnotation] != defaults.Version {
+			if existing == nil || existing.Labels[v1alpha1.KameletBundledLabel] == "true" {
 				if k.GetAnnotations() == nil {
 					k.SetAnnotations(make(map[string]string))
 				}


### PR DESCRIPTION
…d do not replace user-defined kamelets

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
