### PR TITLE
feat: Consistent Integration scale status

### DIFF
--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -161,9 +161,9 @@ func (r *reconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 	switch pl.Status.Build.BuildStrategy {
 	case v1.IntegrationPlatformBuildStrategyPod:
 		actions = []Action{
-			newInitializePodAction(),
+			newInitializePodAction(r.reader),
 			newScheduleAction(r.reader),
-			newMonitorPodAction(),
+			newMonitorPodAction(r.reader),
 			newErrorRecoveryAction(),
 			newErrorAction(),
 		}

--- a/pkg/controller/build/initialize_pod.go
+++ b/pkg/controller/build/initialize_pod.go
@@ -20,17 +20,22 @@ package build
 import (
 	"context"
 
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/pkg/errors"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 )
 
-func newInitializePodAction() Action {
-	return &initializePodAction{}
+func newInitializePodAction(reader ctrl.Reader) Action {
+	return &initializePodAction{
+		reader: reader,
+	}
 }
 
 type initializePodAction struct {
 	baseAction
+	reader ctrl.Reader
 }
 
 // Name returns a common name of the action
@@ -49,7 +54,7 @@ func (action *initializePodAction) Handle(ctx context.Context, build *v1.Build) 
 		return nil, errors.Wrap(err, "cannot delete build pod")
 	}
 
-	pod, err := getBuilderPod(ctx, action.client, build)
+	pod, err := getBuilderPod(ctx, action.reader, build)
 	if err != nil || pod != nil {
 		// We return and wait for the pod to be deleted before de-queue the build pod.
 		return nil, err

--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -39,12 +39,15 @@ import (
 
 const timeoutAnnotation = "camel.apache.org/timeout"
 
-func newMonitorPodAction() Action {
-	return &monitorPodAction{}
+func newMonitorPodAction(reader ctrl.Reader) Action {
+	return &monitorPodAction{
+		reader: reader,
+	}
 }
 
 type monitorPodAction struct {
 	baseAction
+	reader ctrl.Reader
 }
 
 // Name returns a common name of the action
@@ -59,7 +62,7 @@ func (action *monitorPodAction) CanHandle(build *v1.Build) bool {
 
 // Handle handles the builds
 func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v1.Build, error) {
-	pod, err := getBuilderPod(ctx, action.client, build)
+	pod, err := getBuilderPod(ctx, action.reader, build)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +71,7 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 		switch build.Status.Phase {
 
 		case v1.BuildPhasePending:
-			if pod, err = newBuildPod(ctx, action.client, build); err != nil {
+			if pod, err = newBuildPod(ctx, action.reader, build); err != nil {
 				return nil, err
 			}
 			// Set the Build as the Pod owner and controller

--- a/pkg/controller/integrationplatform/integrationplatform_controller.go
+++ b/pkg/controller/integrationplatform/integrationplatform_controller.go
@@ -57,6 +57,7 @@ func newReconciler(mgr manager.Manager, c client.Client) reconcile.Reconciler {
 	return monitoring.NewInstrumentedReconciler(
 		&reconcileIntegrationPlatform{
 			client:   c,
+			reader:   mgr.GetAPIReader(),
 			scheme:   mgr.GetScheme(),
 			recorder: mgr.GetEventRecorderFor("camel-k-integration-platform-controller"),
 		},
@@ -108,7 +109,9 @@ var _ reconcile.Reconciler = &reconcileIntegrationPlatform{}
 type reconcileIntegrationPlatform struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the API server
-	client   client.Client
+	client client.Client
+	// Non-caching client
+	reader   ctrl.Reader
 	scheme   *runtime.Scheme
 	recorder record.EventRecorder
 }
@@ -148,7 +151,7 @@ func (r *reconcileIntegrationPlatform) Reconcile(ctx context.Context, request re
 
 	actions := []Action{
 		NewInitializeAction(),
-		NewWarmAction(),
+		NewWarmAction(r.reader),
 		NewCreateAction(),
 		NewMonitorAction(),
 	}

--- a/pkg/controller/integrationplatform/warm.go
+++ b/pkg/controller/integrationplatform/warm.go
@@ -25,16 +25,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 )
 
-// NewWarmAction returns a action that creates resources needed by the platform
-func NewWarmAction() Action {
-	return &warmAction{}
+func NewWarmAction(reader ctrl.Reader) Action {
+	return &warmAction{
+		reader: reader,
+	}
 }
 
 type warmAction struct {
 	baseAction
+	reader ctrl.Reader
 }
 
 func (action *warmAction) Name() string {
@@ -58,7 +62,7 @@ func (action *warmAction) Handle(ctx context.Context, platform *v1.IntegrationPl
 		},
 	}
 
-	err := action.client.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, &pod)
+	err := action.reader.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, &pod)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/integrationplatform/warm_test.go
+++ b/pkg/controller/integrationplatform/warm_test.go
@@ -58,7 +58,7 @@ func TestWarm_Succeeded(t *testing.T) {
 
 	assert.Nil(t, platform.ConfigureDefaults(context.TODO(), c, &ip, false))
 
-	h := NewWarmAction()
+	h := NewWarmAction(c)
 	h.InjectLogger(log.Log)
 	h.InjectClient(c)
 
@@ -93,7 +93,7 @@ func TestWarm_Failing(t *testing.T) {
 
 	assert.Nil(t, platform.ConfigureDefaults(context.TODO(), c, &ip, false))
 
-	h := NewWarmAction()
+	h := NewWarmAction(c)
 	h.InjectLogger(log.Log)
 	h.InjectClient(c)
 
@@ -128,7 +128,7 @@ func TestWarm_WarmingUp(t *testing.T) {
 
 	assert.Nil(t, platform.ConfigureDefaults(context.TODO(), c, &ip, false))
 
-	h := NewWarmAction()
+	h := NewWarmAction(c)
 	h.InjectLogger(log.Log)
 	h.InjectClient(c)
 

--- a/pkg/platform/operator.go
+++ b/pkg/platform/operator.go
@@ -19,12 +19,10 @@ package platform
 
 import (
 	"context"
-	"errors"
 	"os"
 	"strings"
 
 	coordination "k8s.io/api/coordination/v1"
-	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,25 +34,7 @@ const operatorPodNameEnvVariable = "POD_NAME"
 
 const OperatorLockName = "camel-k-lock"
 
-// GetCurrentOperatorImage returns the image currently used by the running operator if present (when running out of cluster, it may be absent).
-func GetCurrentOperatorImage(ctx context.Context, c ctrl.Reader) (string, error) {
-	ns := GetOperatorNamespace()
-	name := GetOperatorPodName()
-	if ns == "" || name == "" {
-		return "", nil
-	}
-
-	pod := v1.Pod{}
-	if err := c.Get(ctx, ctrl.ObjectKey{Namespace: ns, Name: name}, &pod); err != nil && k8serrors.IsNotFound(err) {
-		return "", nil
-	} else if err != nil {
-		return "", err
-	}
-	if len(pod.Spec.Containers) == 0 {
-		return "", errors.New("no containers found in operator pod")
-	}
-	return pod.Spec.Containers[0].Image, nil
-}
+var OperatorImage string
 
 // IsCurrentOperatorGlobal returns true if the operator is configured to watch all namespaces
 func IsCurrentOperatorGlobal() bool {


### PR DESCRIPTION
This PR provides a more robust Integration scaling status, by directly reconciling Integration Pods, rather than relying on owned resources, like Deployment, KnativeService and CronJob, that do not provide a minimal common denominator. 

It fixes several issues, for which the reported number of replicas was incorrect, when the wrong ReplicaSet was selected for example.

It also restricts the caching of Pods by Integration label selector, in order to limit memory requirement for the operator, when scaling the number of Integrations.

Last but not least, It prepares better error handling, for which proper replicas reporting is a pre-requisite.

**Release Note**
```release-note
feat: Consistent Integration scale status
```
