### PR TITLE
fix: Affinity trait must run after the Knative Service trait

### DIFF
--- a/pkg/trait/affinity.go
+++ b/pkg/trait/affinity.go
@@ -53,7 +53,7 @@ type affinityTrait struct {
 
 func newAffinityTrait() Trait {
 	return &affinityTrait{
-		BaseTrait:       NewBaseTrait("affinity", 1300),
+		BaseTrait:       NewBaseTrait("affinity", 1500),
 		PodAffinity:     BoolP(false),
 		PodAntiAffinity: BoolP(false),
 	}


### PR DESCRIPTION
Configuring affinity in Knative is possible when the node affinity extension is enabled [1]. For the _Affinity_ trait to work correctly in that case, it must run after the _Knative Service_ trait, so that the customisation of the `PodSpec` is possible.

[1] https://knative.dev/docs/admin/serving/feature-flags/#kubernetes-node-affinity

**Release Note**
```release-note
fix: Affinity trait must run after the Knative Service trait
```
