### PR TITLE
chore(e2e): Increase JVM build memory limit in builder e2e tests

### DIFF
--- a/e2e/builder/build_test.go
+++ b/e2e/builder/build_test.go
@@ -40,7 +40,7 @@ type kitOptions struct {
 }
 
 func TestKitTimerToLogFullBuild(t *testing.T) {
-	doKitFullBuild(t, "timer-to-log", "300Mi", "5m0s", TestTimeoutLong, kitOptions{
+	doKitFullBuild(t, "timer-to-log", "500Mi", "5m0s", TestTimeoutLong, kitOptions{
 		dependencies: []string{
 			"camel:timer", "camel:log",
 		},
@@ -48,7 +48,7 @@ func TestKitTimerToLogFullBuild(t *testing.T) {
 }
 
 func TestKitKnativeFullBuild(t *testing.T) {
-	doKitFullBuild(t, "knative", "300mi", "5m0s", TestTimeoutLong, kitOptions{
+	doKitFullBuild(t, "knative", "500mi", "5m0s", TestTimeoutLong, kitOptions{
 		dependencies: []string{
 			"camel-k-knative",
 		},


### PR DESCRIPTION
The builder test suite keeps failing consistently lately, I wonder it that's caused by the specific memory limit set for JVM builds.

**Release Note**
```release-note
NONE
```
