### PR TITLE
fix(build): Update Maven binary download URL

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ FROM quay.io/quarkus/ubi-quarkus-mandrel:21.2.0.0-Final-java11
 ARG MAVEN_VERSION="3.8.2"
 ARG MAVEN_HOME="/usr/share/maven"
 ARG SHA="b0bf39460348b2d8eae1c861ced6c3e8a077b6e761fb3d4669be5de09490521a74db294cf031b0775b2dfcd57bd82246e42ce10904063ef8e3806222e686f222"
-ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
+ARG BASE_URL="https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 USER 0
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,9 +15,9 @@
 
 FROM quay.io/quarkus/ubi-quarkus-mandrel:21.2.0.0-Final-java11
 
-ARG MAVEN_VERSION="3.8.2"
+ARG MAVEN_VERSION="3.8.3"
 ARG MAVEN_HOME="/usr/share/maven"
-ARG SHA="b0bf39460348b2d8eae1c861ced6c3e8a077b6e761fb3d4669be5de09490521a74db294cf031b0775b2dfcd57bd82246e42ce10904063ef8e3806222e686f222"
+ARG SHA="1c12a5df43421795054874fd54bb8b37d242949133b5bf6052a063a13a93f13a20e6e9dae2b3d85b9c7034ec977bbc2b6e7f66832182b9c863711d78bfe60faa"
 ARG BASE_URL="https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 USER 0


### PR DESCRIPTION
Changes to newest download URL, and upgrades to 3.8.3 as 3.8.2 as been removed for some reasons. 

**Release Note**
```release-note
chore(build): Upgrade Maven to version 3.8.3
```
