### PR TITLE
fix(cli): kamel install fails with error: Object 'Kind' is missing in 'null'

### DIFF
--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -224,7 +224,7 @@ func OperatorOrCollect(ctx context.Context, c client.Client, cfg OperatorConfigu
 		if err := installOpenShiftRoles(ctx, c, cfg.Namespace, customizer, collection, force); err != nil {
 			return err
 		}
-		if err := installClusterRoleBinding(ctx, c, collection, cfg.Namespace, "camel-k-operator-console-openshift", "/rbac/operator-cluster-role-console-binding-openshift.yaml"); err != nil {
+		if err := installClusterRoleBinding(ctx, c, collection, cfg.Namespace, "camel-k-operator-console-openshift", "/rbac/openshift/operator-cluster-role-console-binding-openshift.yaml"); err != nil {
 			if k8serrors.IsForbidden(err) {
 				fmt.Println("Warning: the operator will not be able to manage ConsoleCLIDownload resources. Try installing the operator as cluster-admin.")
 			} else {

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -301,7 +301,11 @@ func installClusterRoleBinding(ctx context.Context, c client.Client, collection 
 	existing, err := c.RbacV1().ClusterRoleBindings().Get(ctx, name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		existing = nil
-		obj, err := kubernetes.LoadResourceFromYaml(c.GetScheme(), resources.ResourceAsString(path))
+		yaml := resources.ResourceAsString(path)
+		if yaml == "" {
+			return errors.Errorf("resource file %v not found", path)
+		}
+		obj, err := kubernetes.LoadResourceFromYaml(c.GetScheme(), yaml)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix #2674

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
