### PR TITLE
fix(cli): apply --registry* flags even on OpenShift for kamel install

### DIFF
--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -436,11 +436,13 @@ func PlatformOrCollect(ctx context.Context, c client.Client, clusterType string,
 	}
 	pl := platformObject.(*v1.IntegrationPlatform)
 
-	if !isOpenShift && !skipRegistrySetup {
+	if !skipRegistrySetup {
+		// Let's apply registry settings whether it's OpenShift or not
+		// Some OpenShift variants such as Microshift might not have a built-in registry
 		pl.Spec.Build.Registry = registry
 
 		// Kubernetes only (Minikube)
-		if registry.Address == "" {
+		if !isOpenShift && registry.Address == "" {
 			// This operation should be done here in the installer
 			// because the operator is not allowed to look into the "kube-system" namespace
 			address, err := minikube.FindRegistry(ctx, c)


### PR DESCRIPTION
Relates to #2473 Make sure Camel K runs on Microshift

<!-- Description -->

It's a split-off from PR #2643 as having this part in main is convenient for me to further proceed with #2473.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
