### PR TITLE
fix: Round meta.Time fields to second precision as they are marshalled in RFC3339 format

### DIFF
--- a/pkg/apis/camel/v1/integration_types_support.go
+++ b/pkg/apis/camel/v1/integration_types_support.go
@@ -20,7 +20,6 @@ package v1
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -351,12 +350,12 @@ func (in *IntegrationStatus) SetErrorCondition(condType IntegrationConditionType
 // reason then we are not going to update.
 func (in *IntegrationStatus) SetConditions(conditions ...IntegrationCondition) {
 	// Round to second precision, as meta.Time fields are marshalled in RFC3339 format
-	now := metav1.NewTime(time.Now().Round(time.Second))
+	now := metav1.Now().Rfc3339Copy()
 	for _, condition := range conditions {
 		currentCond := in.GetCondition(condition.Type)
 
 		if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason && currentCond.Message == condition.Message {
-			return
+			break
 		}
 
 		if condition.LastUpdateTime.IsZero() {

--- a/pkg/controller/integration/initialize.go
+++ b/pkg/controller/integration/initialize.go
@@ -86,7 +86,8 @@ func (action *initializeAction) Handle(ctx context.Context, integration *v1.Inte
 	integration.Status.Phase = v1.IntegrationPhaseBuildingKit
 	integration.Status.Version = defaults.Version
 	if timestamp := integration.Status.InitializationTimestamp; timestamp == nil || timestamp.IsZero() {
-		now := metav1.Now()
+		// Round to second precision, as meta.Time fields are marshalled in RFC3339 format
+		now := metav1.Now().Rfc3339Copy()
 		integration.Status.InitializationTimestamp = &now
 	}
 


### PR DESCRIPTION
This should fix the flaky operator metrics e2e tests.

**Release Note**
```release-note
NONE
```
