### PR TITLE
chore: Bypass cache round-trips to reconcile integration status

### DIFF
--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -25,11 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
-
-	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PositiveMergePatch(source runtime.Object, target runtime.Object) ([]byte, error) {
+func PositiveMergePatch(source interface{}, target interface{}) ([]byte, error) {
 	sourceJSON, err := json.Marshal(source)
 	if err != nil {
 		return nil, err
@@ -65,7 +63,7 @@ func PositiveMergePatch(source runtime.Object, target runtime.Object) ([]byte, e
 	return json.Marshal(positivePatch)
 }
 
-func PositiveApplyPatch(source runtime.Object) (ctrl.Object, error) {
+func PositiveApplyPatch(source runtime.Object) (*unstructured.Unstructured, error) {
 	sourceJSON, err := json.Marshal(source)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
That PR makes the _deployer_ trait reflecting the responses from the API server into the trait execution environment when applying resources. That enables further reconciliation logic to proceed in a single reconcile request, on latest revisions, without relying on the cached client, that may be stale by the time informers catch up.  

**Release Note**
```release-note
chore: Bypass cache round-trips to reconcile integration status
```
