### PR TITLE
CI test dump improvements

### DIFF
--- a/e2e/support/util/dump.go
+++ b/e2e/support/util/dump.go
@@ -54,7 +54,7 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 	t.Logf("Found %d platforms:\n", len(pls.Items))
 	for _, p := range pls.Items {
 		ref := p
-		pdata, err := kubernetes.ToYAML(&ref)
+		pdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 	t.Logf("Found %d integrations:\n", len(its.Items))
 	for _, integration := range its.Items {
 		ref := integration
-		pdata, err := kubernetes.ToYAML(&ref)
+		pdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 	t.Logf("Found %d integration kits:\n", len(iks.Items))
 	for _, ik := range iks.Items {
 		ref := ik
-		pdata, err := kubernetes.ToYAML(&ref)
+		pdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 	}
 	t.Logf("Found %d builds:\n", len(builds.Items))
 	for _, build := range builds.Items {
-		data, err := kubernetes.ToYAML(&build)
+		data, err := kubernetes.ToYAMLNoManagedFields(&build)
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 	t.Logf("Found %d config maps:\n", len(cms.Items))
 	for _, cm := range cms.Items {
 		ref := cm
-		pdata, err := kubernetes.ToYAML(&ref)
+		pdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
 		if err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 	t.Logf("Found %d deployments:\n", len(iks.Items))
 	for _, deployment := range deployments.Items {
 		ref := deployment
-		data, err := kubernetes.ToYAML(&ref)
+		data, err := kubernetes.ToYAMLNoManagedFields(&ref)
 		if err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 	t.Logf("\nFound %d services:\n", len(svcs.Items))
 	for _, svc := range svcs.Items {
 		ref := svc
-		data, err := kubernetes.ToYAML(&ref)
+		data, err := kubernetes.ToYAMLNoManagedFields(&ref)
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 		t.Logf("\nFound %d routes:\n", len(routes.Items))
 		for _, route := range routes.Items {
 			ref := route
-			data, err := kubernetes.ToYAML(&ref)
+			data, err := kubernetes.ToYAMLNoManagedFields(&ref)
 			if err != nil {
 				return err
 			}

--- a/pkg/util/kubernetes/util.go
+++ b/pkg/util/kubernetes/util.go
@@ -38,3 +38,20 @@ func ToYAML(value runtime.Object) ([]byte, error) {
 
 	return util.JSONToYAML(data)
 }
+
+// ToYAMLNoManagedFields marshal to yaml format but without metadata.managedFields
+func ToYAMLNoManagedFields(value runtime.Object) ([]byte, error) {
+	jsondata, err := ToJSON(value)
+	if err != nil {
+		return nil, err
+	}
+
+	mapdata, err := util.JSONToMap(jsondata)
+	if err != nil {
+		return nil, err
+	}
+
+	delete(mapdata["metadata"].(map[string]interface{}), "managedFields")
+
+	return util.MapToYAML(mapdata)
+}

--- a/pkg/util/kubernetes/util_test.go
+++ b/pkg/util/kubernetes/util_test.go
@@ -1,0 +1,51 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestToYAMLNoManagedFields(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "util-test",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager: "util-test",
+				},
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{},
+		},
+	}
+
+	yaml, err := ToYAML(deploy)
+	assert.Nil(t, err)
+	assert.Contains(t, string(yaml), "managedFields")
+
+	yaml, err = ToYAMLNoManagedFields(deploy)
+	assert.Nil(t, err)
+	assert.NotContains(t, string(yaml), "managedFields")
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -394,12 +394,26 @@ func DependenciesToYAML(list []string) ([]byte, error) {
 }
 
 func JSONToYAML(src []byte) ([]byte, error) {
+	mapdata, err := JSONToMap(src)
+	if err != nil {
+		return nil, err
+	}
+
+	return MapToYAML(mapdata)
+}
+
+func JSONToMap(src []byte) (map[string]interface{}, error) {
 	jsondata := map[string]interface{}{}
 	err := json.Unmarshal(src, &jsondata)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling json: %v", err)
 	}
-	yamldata, err := yaml2.Marshal(&jsondata)
+
+	return jsondata, nil
+}
+
+func MapToYAML(src map[string]interface{}) ([]byte, error) {
+	yamldata, err := yaml2.Marshal(&src)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling to yaml: %v", err)
 	}


### PR DESCRIPTION
<!-- Description -->

- Make CI dump services and routes (for OpenShift) on test failures
- Remove lenghty `managedFields` from dump for log readability


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
