### PR TITLE
fix(script): goldflag with empty space

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -323,7 +323,9 @@ git-tag:
 	./script/git_tag.sh $(CUSTOM_VERSION) $(RELEASE_GIT_REMOTE)
 
 cross-compile:
-	./script/cross_compile.sh $(CUSTOM_VERSION) '$(GOFLAGS)'
+	# we must wrap the goldflags parameters with quotes as they will need to 
+	# be processed as a single argument by the cross compile script
+	./script/cross_compile.sh $(CUSTOM_VERSION) $(subst ","\",$(GOFLAGS))
 
 package-examples:
 	./script/package_examples.sh $(CUSTOM_VERSION)

--- a/script/cross_compile.sh
+++ b/script/cross_compile.sh
@@ -22,13 +22,14 @@ rm -rf ${builddir}
 
 basename=camel-k-client
 
-if [ "$#" -ne 2 ]; then
-    echo "usage: $0 version build_flags"
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 <version> <build_flags...>"
     exit 1
 fi
 
 version=$1
-build_flags=$2
+shift
+build_flags="$*"
 
 cross_compile () {
 	local label=$1
@@ -42,7 +43,7 @@ cross_compile () {
 	fi
 
 	targetdir=${builddir}/${label}
-	eval go build "$build_flags" -o ${targetdir}/kamel${extension} ./cmd/kamel/...
+	eval go build $build_flags -o ${targetdir}/kamel${extension} ./cmd/kamel/...
 
 	if [ -n "$GPG_PASS" ]; then
 	    gpg --output ${targetdir}/kamel${extension}.asc --armor --detach-sig --passphrase ${GPG_PASS} ${targetdir}/kamel${extension}


### PR DESCRIPTION
Enhanced the script to allow including a Goldflag with empty space (ie, 'my test').

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
