### PR TITLE
feat(cmd): operator additional info

### DIFF
--- a/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -542,6 +542,10 @@ spec:
                   - value
                   type: object
                 type: array
+              info:
+                additionalProperties:
+                  type: string
+                type: object
               kamelet:
                 description: IntegrationPlatformKameletSpec --
                 properties:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/container-tools/spectrum v0.3.4
 	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e // indirect
 	github.com/evanphx/json-patch v4.11.0+incompatible
+	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/structs v1.1.0
 	github.com/gertd/go-pluralize v0.1.1
 	github.com/go-logr/logr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,7 @@ github.com/evanphx/json-patch/v5 v5.5.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2Vvl
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -542,6 +542,10 @@ spec:
                   - value
                   type: object
                 type: array
+              info:
+                additionalProperties:
+                  type: string
+                type: object
               kamelet:
                 description: IntegrationPlatformKameletSpec --
                 properties:

--- a/pkg/apis/camel/v1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1/integrationplatform_types.go
@@ -47,6 +47,7 @@ type IntegrationPlatformStatus struct {
 	Phase      IntegrationPlatformPhase       `json:"phase,omitempty"`
 	Conditions []IntegrationPlatformCondition `json:"conditions,omitempty"`
 	Version    string                         `json:"version,omitempty"`
+	Info       map[string]string              `json:"info,omitempty"`
 }
 
 // +genclient

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -62,8 +62,6 @@ import (
 
 var log = logf.Log.WithName("cmd")
 
-var GitCommit string
-
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
@@ -71,7 +69,7 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Kaniko Version: %v", defaults.KanikoVersion))
 	log.Info(fmt.Sprintf("Camel K Operator Version: %v", defaults.Version))
 	log.Info(fmt.Sprintf("Camel K Default Runtime Version: %v", defaults.DefaultRuntimeVersion))
-	log.Info(fmt.Sprintf("Camel K Git Commit: %v", GitCommit))
+	log.Info(fmt.Sprintf("Camel K Git Commit: %v", defaults.GitCommit))
 }
 
 // Run starts the Camel K operator

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -20,8 +20,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver"
+	"github.com/fatih/camelcase"
 	"github.com/spf13/cobra"
 
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +35,10 @@ import (
 
 // VersionVariant may be overridden at build time
 var VersionVariant = ""
+
+const (
+	infoVersion = "Version"
+)
 
 func newCmdVersion(rootCmdOptions *RootCmdOptions) (*cobra.Command, *versionCmdOptions) {
 	options := versionCmdOptions{
@@ -50,6 +56,8 @@ func newCmdVersion(rootCmdOptions *RootCmdOptions) (*cobra.Command, *versionCmdO
 	}
 
 	cmd.Flags().Bool("operator", false, "Display Operator version")
+	cmd.Flags().BoolP("verbose", "v", false, "Display all available extra information")
+	cmd.Flags().BoolP("all", "a", false, "Display both Client and Operator version")
 
 	return &cmd, &options
 }
@@ -57,10 +65,12 @@ func newCmdVersion(rootCmdOptions *RootCmdOptions) (*cobra.Command, *versionCmdO
 type versionCmdOptions struct {
 	*RootCmdOptions
 	Operator bool `mapstructure:"operator"`
+	Verbose  bool `mapstructure:"verbose"`
+	All      bool `mapstructure:"all"`
 }
 
 func (o *versionCmdOptions) preRunE(cmd *cobra.Command, args []string) error {
-	if !o.Operator {
+	if !o.Operator && !o.All {
 		// let the command to work in offline mode
 		cmd.Annotations[offlineCommandLabel] = "true"
 	}
@@ -68,40 +78,58 @@ func (o *versionCmdOptions) preRunE(cmd *cobra.Command, args []string) error {
 }
 
 func (o *versionCmdOptions) run(cmd *cobra.Command, _ []string) error {
-	if o.Operator {
+	if o.All || !o.Operator {
+		o.displayClientVersion(cmd)
+	}
+	if o.All {
+		// breaking line
+		fmt.Fprintln(cmd.OutOrStdout(), "")
+	}
+	if o.All || o.Operator {
 		c, err := o.GetCmdClient()
 		if err != nil {
 			return err
 		}
-		displayOperatorVersion(o.Context, cmd, c, o.Namespace)
-	} else {
-		displayClientVersion(cmd)
+		o.displayOperatorVersion(cmd, c)
 	}
 	return nil
 }
 
-func displayClientVersion(cmd *cobra.Command) {
+func (o *versionCmdOptions) displayClientVersion(cmd *cobra.Command) {
 	if VersionVariant != "" {
 		fmt.Fprintf(cmd.OutOrStdout(), "Camel K Client %s %s\n", VersionVariant, defaults.Version)
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "Camel K Client %s\n", defaults.Version)
 	}
+	if o.Verbose {
+		fmt.Fprintf(cmd.OutOrStdout(), "Git Commit: %s\n", defaults.GitCommit)
+	}
 }
 
-func displayOperatorVersion(ctx context.Context, cmd *cobra.Command, c client.Client, namespace string) {
-	operatorVersion, err := operatorVersion(ctx, c, namespace)
+func (o *versionCmdOptions) displayOperatorVersion(cmd *cobra.Command, c client.Client) {
+	operatorInfo, err := operatorInfo(o.Context, c, o.Namespace)
 	if err != nil {
 		fmt.Fprintf(cmd.OutOrStdout(), "Unable to retrieve operator version: %s\n", err)
 	} else {
-		if operatorVersion == "" {
+		if operatorInfo[infoVersion] == "" {
 			fmt.Fprintf(cmd.OutOrStdout(), "Unable to retrieve operator version: The IntegrationPlatform resource hasn't been reconciled yet!")
 		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "Camel K Operator %s\n", operatorVersion)
+			fmt.Fprintf(cmd.OutOrStdout(), "Camel K Operator %s\n", operatorInfo[infoVersion])
+
+			if o.Verbose {
+				for k, v := range operatorInfo {
+					if k != infoVersion {
+						fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", k, v)
+					}
+				}
+			}
 		}
 	}
 }
 
-func operatorVersion(ctx context.Context, c client.Client, namespace string) (string, error) {
+func operatorInfo(ctx context.Context, c client.Client, namespace string) (map[string]string, error) {
+	infos := make(map[string]string)
+
 	platform := v1.NewIntegrationPlatform(namespace, "camel-k")
 	platformKey := k8sclient.ObjectKey{
 		Namespace: namespace,
@@ -109,10 +137,38 @@ func operatorVersion(ctx context.Context, c client.Client, namespace string) (st
 	}
 
 	if err := c.Get(ctx, platformKey, &platform); err != nil {
-		return "", err
+		return nil, err
+	}
+	// Useful information
+	infos["version"] = platform.Status.Version
+	infos["publishStrategy"] = string(platform.Status.Build.PublishStrategy)
+	infos["runtimeVersion"] = platform.Status.Build.RuntimeVersion
+
+	if platform.Status.Info != nil {
+		for k, v := range platform.Status.Info {
+			infos[k] = v
+		}
 	}
 
-	return platform.Status.Version, nil
+	return fromCamelCase(infos), nil
+}
+
+func fromCamelCase(infos map[string]string) map[string]string {
+	textKeys := make(map[string]string)
+	for k, v := range infos {
+		key := strings.Title(strings.Join(camelcase.Split(k), " "))
+		textKeys[key] = v
+	}
+
+	return textKeys
+}
+
+func operatorVersion(ctx context.Context, c client.Client, namespace string) (string, error) {
+	infos, err := operatorInfo(ctx, c, namespace)
+	if err != nil {
+		return "", err
+	}
+	return infos[infoVersion], nil
 }
 
 func compatibleVersions(aVersion, bVersion string) bool {

--- a/pkg/cmd/version_test.go
+++ b/pkg/cmd/version_test.go
@@ -18,8 +18,10 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/apache/camel-k/pkg/util/defaults"
 	"github.com/apache/camel-k/pkg/util/test"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -41,12 +43,6 @@ func initializeVersionCmdOptions(t *testing.T) (*versionCmdOptions, *cobra.Comma
 func addTestVersionCmd(options RootCmdOptions, rootCmd *cobra.Command) *versionCmdOptions {
 	// add a testing version of version Command
 	versionCmd, versionOptions := newCmdVersion(&options)
-	versionCmd.RunE = func(c *cobra.Command, args []string) error {
-		return nil
-	}
-	versionCmd.PostRunE = func(c *cobra.Command, args []string) error {
-		return nil
-	}
 	versionCmd.Args = test.ArbitraryArgs
 	rootCmd.AddCommand(versionCmd)
 	return versionOptions
@@ -58,11 +54,26 @@ func TestVersionNonExistingFlag(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestVersionClient(t *testing.T) {
+	_, rootCmd, _ := initializeVersionCmdOptions(t)
+	output, err := test.ExecuteCommand(rootCmd, cmdVersion)
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("Camel K Client %s\n", defaults.Version), output)
+}
+
 func TestVersionOperatorFlag(t *testing.T) {
 	versionCmdOptions, rootCmd, _ := initializeVersionCmdOptions(t)
 	_, err := test.ExecuteCommand(rootCmd, cmdVersion, "--operator")
 	assert.Nil(t, err)
 	assert.Equal(t, true, versionCmdOptions.Operator)
+}
+
+func TestVersionClientVerbose(t *testing.T) {
+	versionCmdOptions, rootCmd, _ := initializeVersionCmdOptions(t)
+	output, err := test.ExecuteCommand(rootCmd, cmdVersion, "-v")
+	assert.Nil(t, err)
+	assert.Equal(t, true, versionCmdOptions.Verbose)
+	assert.Equal(t, fmt.Sprintf("Camel K Client %s\nGit Commit: %s\n", defaults.Version, defaults.GitCommit), output)
 }
 
 func TestCompatibleVersions(t *testing.T) {

--- a/pkg/platform/defaults.go
+++ b/pkg/platform/defaults.go
@@ -20,6 +20,7 @@ package platform
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -237,6 +238,7 @@ func setPlatformDefaults(ctx context.Context, c client.Client, p *v1.Integration
 			URI: repository.DefaultRemoteRepository,
 		})
 	}
+	setStatusAdditionalInfo(p)
 
 	if verbose {
 		log.Log.Infof("RuntimeVersion set to %s", p.Status.Build.RuntimeVersion)
@@ -246,6 +248,18 @@ func setPlatformDefaults(ctx context.Context, c client.Client, p *v1.Integration
 	}
 
 	return nil
+}
+
+func setStatusAdditionalInfo(platform *v1.IntegrationPlatform) {
+	platform.Status.Info = make(map[string]string)
+	if platform.Spec.Build.PublishStrategy == v1.IntegrationPlatformBuildPublishStrategyBuildah {
+		platform.Status.Info["buildahVersion"] = defaults.BuildahVersion
+	} else if platform.Spec.Build.PublishStrategy == v1.IntegrationPlatformBuildPublishStrategyKaniko {
+		platform.Status.Info["kanikoVersion"] = defaults.KanikoVersion
+	}
+	platform.Status.Info["goVersion"] = runtime.Version()
+	platform.Status.Info["goOS"] = runtime.GOOS
+	platform.Status.Info["gitCommit"] = defaults.GitCommit
 }
 
 func createDefaultMavenSettingsConfigMap(ctx context.Context, client client.Client, p *v1.IntegrationPlatform, settings maven.Settings) error {

--- a/pkg/util/defaults/defaults.go
+++ b/pkg/util/defaults/defaults.go
@@ -46,3 +46,6 @@ const (
 	// installDefaultKamelets --
 	installDefaultKamelets = true
 )
+
+//GitCommit must be provided during application build
+var GitCommit string

--- a/script/Makefile
+++ b/script/Makefile
@@ -82,7 +82,12 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Build
-GOLDFLAGS += -X github.com/apache/camel-k/pkg/cmd/operator.GitCommit=$(GIT_COMMIT)
+ifdef GIT_COMMIT
+GOLDFLAGS += -X github.com/apache/camel-k/pkg/util/defaults.GitCommit=$(GIT_COMMIT)
+else
+$(warning Could not retrieve a valid Git Commit)
+endif
+
 GOFLAGS = -ldflags "$(GOLDFLAGS)" -trimpath
 
 define LICENSE_HEADER
@@ -107,6 +112,7 @@ default: test
 
 # Generates the version file
 codegen:
+	$(info Regenerating $(VERSIONFILE))
 	@echo "/*" > $(VERSIONFILE)
 	@echo "$$LICENSE_HEADER" >> $(VERSIONFILE)
 	@echo "*/" >> $(VERSIONFILE)
@@ -143,6 +149,10 @@ codegen:
 	@echo "  installDefaultKamelets = $(INSTALL_DEFAULT_KAMELETS)" >> $(VERSIONFILE)
 	@echo ")" >> $(VERSIONFILE)
 	@echo "" >> $(VERSIONFILE)
+	@echo "//GitCommit must be provided during application build" >> $(VERSIONFILE)
+	@echo "var GitCommit string" >> $(VERSIONFILE)
+	@echo "" >> $(VERSIONFILE)
+
 	gofmt -w pkg/util/defaults/defaults.go
 
 generate: generate-deepcopy generate-crd generate-client generate-doc generate-json-schema generate-strimzi
@@ -180,7 +190,6 @@ test-integration: build
 	go test -timeout 60m -v ./e2e/common/config -tags=integration && \
 	go test -timeout 60m -v ./e2e/common/languages -tags=integration && \
 	go test -timeout 60m -v ./e2e/common/traits -tags=integration
-
 
 test-knative: build
 	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" \


### PR DESCRIPTION
With this PR we enhance the `kamel version` command to allow retrieve more information such as:
```
$ ./kamel version -av -n operator-test
Camel K Client 1.7.0-SNAPSHOT
Git Commit: 2629b4e7b8e91d40d006474f73f9b5cf6be377cb

Camel K Operator 1.7.0-SNAPSHOT
Runtime Version: 1.10.0-SNAPSHOT
Git Commit: fcf6dbaa7b5bb565e433fb390b3dccb2ec9aa900
Go OS: linux
Go Version: go1.17
Publish Strategy: Spectrum
```

* Added some useful information into IntegrationPlatform
* It can be later retrieved by `kamel version --operator -v` command
* Enhanced the command to include `--all` showing both client and operator info
* Added unit test

Closes #1947

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cmd): operator additional info
```
