### PR TITLE
feat(cmd): OLM default discovery

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -102,14 +102,14 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *installCmdO
 
 	// OLM
 	cmd.Flags().Bool("olm", true, "Try to install everything via OLM (Operator Lifecycle Manager) if available")
-	cmd.Flags().String("olm-operator-name", olm.DefaultOperatorName, "Name of the Camel K operator in the OLM source or marketplace")
-	cmd.Flags().String("olm-package", olm.DefaultPackage, "Name of the Camel K package in the OLM source or marketplace")
-	cmd.Flags().String("olm-channel", olm.DefaultChannel, "Name of the Camel K channel in the OLM source or marketplace")
-	cmd.Flags().String("olm-source", olm.DefaultSource, "Name of the OLM source providing the Camel K package (defaults to the standard Operator Hub source)")
-	cmd.Flags().String("olm-source-namespace", olm.DefaultSourceNamespace, "Namespace where the OLM source is available")
-	cmd.Flags().String("olm-starting-csv", olm.DefaultStartingCSV, "Allow to install a specific version from the operator source instead of latest available "+
+	cmd.Flags().String("olm-operator-name", "", "Name of the Camel K operator in the OLM source or marketplace")
+	cmd.Flags().String("olm-package", "", "Name of the Camel K package in the OLM source or marketplace")
+	cmd.Flags().String("olm-channel", "", "Name of the Camel K channel in the OLM source or marketplace")
+	cmd.Flags().String("olm-source", "", "Name of the OLM source providing the Camel K package (defaults to the standard Operator Hub source)")
+	cmd.Flags().String("olm-source-namespace", "", "Namespace where the OLM source is available")
+	cmd.Flags().String("olm-starting-csv", "", "Allow to install a specific version from the operator source instead of latest available "+
 		"from the channel")
-	cmd.Flags().String("olm-global-namespace", olm.DefaultGlobalNamespace, "A namespace containing an OperatorGroup that defines global scope for the "+
+	cmd.Flags().String("olm-global-namespace", "", "A namespace containing an OperatorGroup that defines global scope for the "+
 		"operator (used in combination with the --global flag)")
 
 	// Maven

--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/util/olm"
 	"github.com/apache/camel-k/pkg/util/test"
 )
 
@@ -70,12 +69,12 @@ func TestInstallNoFlag(t *testing.T) {
 	assert.Equal(t, false, installCmdOptions.Save)
 	assert.Equal(t, false, installCmdOptions.Force)
 	assert.Equal(t, true, installCmdOptions.Olm)
-	assert.Equal(t, olm.DefaultOperatorName, installCmdOptions.olmOptions.OperatorName)
-	assert.Equal(t, olm.DefaultPackage, installCmdOptions.olmOptions.Package)
-	assert.Equal(t, olm.DefaultChannel, installCmdOptions.olmOptions.Channel)
-	assert.Equal(t, olm.DefaultSource, installCmdOptions.olmOptions.Source)
-	assert.Equal(t, olm.DefaultSourceNamespace, installCmdOptions.olmOptions.SourceNamespace)
-	assert.Equal(t, olm.DefaultGlobalNamespace, installCmdOptions.olmOptions.GlobalNamespace)
+	assert.Equal(t, "", installCmdOptions.olmOptions.OperatorName)
+	assert.Equal(t, "", installCmdOptions.olmOptions.Package)
+	assert.Equal(t, "", installCmdOptions.olmOptions.Channel)
+	assert.Equal(t, "", installCmdOptions.olmOptions.Source)
+	assert.Equal(t, "", installCmdOptions.olmOptions.SourceNamespace)
+	assert.Equal(t, "", installCmdOptions.olmOptions.GlobalNamespace)
 	assert.Equal(t, int32(8081), installCmdOptions.HealthPort)
 	assert.Equal(t, false, installCmdOptions.Monitoring)
 	assert.Equal(t, int32(8080), installCmdOptions.MonitoringPort)

--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -62,9 +62,9 @@ func newCmdUninstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *uninstall
 	cmd.Flags().Bool("skip-kamelets", false, "Do not uninstall the Kamelets in the current namespace")
 	cmd.Flags().Bool("global", false, "Indicates that a global installation is going to be uninstalled (affects OLM)")
 	cmd.Flags().Bool("olm", true, "Try to uninstall via OLM (Operator Lifecycle Manager) if available")
-	cmd.Flags().String("olm-operator-name", olm.DefaultOperatorName, "Name of the Camel K operator in the OLM source or marketplace")
-	cmd.Flags().String("olm-package", olm.DefaultPackage, "Name of the Camel K package in the OLM source or marketplace")
-	cmd.Flags().String("olm-global-namespace", olm.DefaultGlobalNamespace, "A namespace containing an OperatorGroup that defines "+
+	cmd.Flags().String("olm-operator-name", "", "Name of the Camel K operator in the OLM source or marketplace")
+	cmd.Flags().String("olm-package", "", "Name of the Camel K package in the OLM source or marketplace")
+	cmd.Flags().String("olm-global-namespace", "", "A namespace containing an OperatorGroup that defines "+
 		"global scope for the operator (used in combination with the --global flag)")
 	cmd.Flags().Bool("all", false, "Do uninstall all Camel K resources")
 

--- a/pkg/util/olm/operator.go
+++ b/pkg/util/olm/operator.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/apache/camel-k/pkg/client"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
+	"github.com/apache/camel-k/pkg/util/openshift"
 )
 
 // The following properties can be overridden at build time via ldflags
@@ -73,7 +74,10 @@ type Options struct {
 
 // IsOperatorInstalled tells if a OLM CSV or a Subscription is already installed in the namespace
 func IsOperatorInstalled(ctx context.Context, client client.Client, namespace string, global bool, options Options) (bool, error) {
-	options = fillDefaults(options)
+	options, err := fillDefaults(options, client)
+	if err != nil {
+		return false, err
+	}
 	// CSV is present in current namespace for both local and global installation modes
 	if csv, err := findCSV(ctx, client, namespace, options); err != nil {
 		return false, err
@@ -141,7 +145,10 @@ func HasPermissionToInstall(ctx context.Context, client client.Client, namespace
 // Install creates a subscription for the OLM package
 func Install(ctx context.Context, client client.Client, namespace string, global bool, options Options, collection *kubernetes.Collection,
 	tolerations []string, nodeSelectors []string, resourcesRequirements []string, envVars []string) (bool, error) {
-	options = fillDefaults(options)
+	options, err := fillDefaults(options, client)
+	if err != nil {
+		return false, err
+	}
 	if installed, err := IsOperatorInstalled(ctx, client, namespace, global, options); err != nil {
 		return false, err
 	} else if installed {
@@ -169,7 +176,7 @@ func Install(ctx context.Context, client client.Client, namespace string, global
 		},
 	}
 	// Additional configuration
-	err := maybeSetTolerations(&sub, tolerations)
+	err = maybeSetTolerations(&sub, tolerations)
 	if err != nil {
 		return false, errors.Wrap(err, "could not set tolerations")
 	}
@@ -265,6 +272,10 @@ func maybeSetEnvVars(sub *operatorsv1alpha1.Subscription, envVars []string) erro
 
 // Uninstall removes CSV and subscription from the namespace
 func Uninstall(ctx context.Context, client client.Client, namespace string, global bool, options Options) error {
+	options, err := fillDefaults(options, client)
+	if err != nil {
+		return err
+	}
 	sub, err := findSubscription(ctx, client, namespace, global, options)
 	if err != nil {
 		return err
@@ -333,7 +344,7 @@ func findOperatorGroup(ctx context.Context, client client.Client, namespace stri
 	return nil, nil
 }
 
-func fillDefaults(o Options) Options {
+func fillDefaults(o Options, client client.Client) (Options, error) {
 	if o.OperatorName == "" {
 		o.OperatorName = DefaultOperatorName
 	}
@@ -343,17 +354,35 @@ func fillDefaults(o Options) Options {
 	if o.Channel == "" {
 		o.Channel = DefaultChannel
 	}
-	if o.Source == "" {
-		o.Source = DefaultSource
-	}
-	if o.SourceNamespace == "" {
-		o.SourceNamespace = DefaultSourceNamespace
-	}
 	if o.StartingCSV == "" {
 		o.StartingCSV = DefaultStartingCSV
 	}
-	if o.GlobalNamespace == "" {
-		o.GlobalNamespace = DefaultGlobalNamespace
+	isOCP, err := openshift.IsOpenShift(client)
+	if err != nil {
+		return o, err
 	}
-	return o
+	if isOCP {
+		if o.Source == "" {
+			o.Source = DefaultSource
+		}
+		if o.SourceNamespace == "" {
+			o.SourceNamespace = DefaultSourceNamespace
+		}
+		if o.GlobalNamespace == "" {
+			o.GlobalNamespace = DefaultGlobalNamespace
+		}
+	} else {
+		// Use a different set of defaults value
+		if o.Source == "" {
+			o.Source = "operatorhubio-catalog"
+		}
+		if o.SourceNamespace == "" {
+			o.SourceNamespace = "olm"
+		}
+		if o.GlobalNamespace == "" {
+			o.GlobalNamespace = "operators"
+		}
+	}
+
+	return o, nil
 }


### PR DESCRIPTION
If the cluster which we are connected is a plain K8S cluster, we will use Operator SDK community parameters during OLM installation procedure.

With this PR we're discovering the cluster type dynamically and provide the proper OLM configuration during install/uninstall phase.

Closes #2113

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cmd): OLM default discovery
```
