### PR TITLE
chore(e2e): disable object truncation on test results

### DIFF
--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -40,6 +40,7 @@ import (
 	"github.com/apache/camel-k/pkg/platform"
 	"github.com/google/uuid"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -167,7 +168,10 @@ func init() {
 		}
 	}
 
+	// Gomega settings
 	gomega.SetDefaultEventuallyTimeout(TestTimeoutShort)
+	// Disable object truncation on test results
+	format.MaxLength = 0
 
 }
 


### PR DESCRIPTION
<!-- Description -->

Relates to #2742


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
