### PR TITLE
Update the operator-sdk version

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -22,7 +22,7 @@ BUILDAH_VERSION := 1.14.0
 KANIKO_VERSION := 0.17.1
 INSTALL_DEFAULT_KAMELETS := true
 CONTROLLER_GEN_VERSION := v0.4.1
-OPERATOR_SDK_VERSION := v1.5.0
+OPERATOR_SDK_VERSION := v1.14.0
 KUSTOMIZE_VERSION := v4.1.2
 BASE_IMAGE := adoptopenjdk/openjdk11:slim
 LOCAL_REPOSITORY := /tmp/artifacts/m2
@@ -411,6 +411,11 @@ ifeq (, $(shell which operator-sdk))
 	}
 OPERATOR_SDK=$(GOBIN)/operator-sdk
 else
+	@{ \
+	echo -n "operator-sdk already installed: "; \
+  operator-sdk version | sed -n 's/.*"v\([^"]*\)".*/\1/p'; \
+	echo " If this is less than $(OPERATOR_SDK_VERSION) then please consider moving it aside and allowing the approved version to be downloaded."; \
+	}
 OPERATOR_SDK=$(shell which operator-sdk)
 endif
 


### PR DESCRIPTION
* Raises the version to 1.14.0 that ensures that service-accounts used in
  the CSV are not duplicated in any separate resources.

* Provides a warning that if the operator-sdk is already installed then
  print its version and warn the user to check if its below version 1.14

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
