### PR TITLE
Global test on ns with its own op fix

### DIFF
--- a/e2e/builder/global_test.go
+++ b/e2e/builder/global_test.go
@@ -53,7 +53,7 @@ func TestRunGlobalInstall(t *testing.T) {
 
 	WithGlobalOperatorNamespace(t, func(operatorNamespace string) {
 		Expect(Kamel("install", "-n", operatorNamespace, "--global", "--force").Execute()).To(Succeed())
-
+		Eventually(OperatorPodPhase(operatorNamespace), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 		t.Run("Global test on namespace with platform", func(t *testing.T) {
 			WithNewTestNamespace(t, func(ns2 string) {
 				// Creating platform
@@ -74,12 +74,18 @@ func TestRunGlobalInstall(t *testing.T) {
 
 		t.Run("Global test on namespace with its own operator", func(t *testing.T) {
 			WithNewTestNamespace(t, func(ns3 string) {
-				Expect(Kamel("install", "-n", ns3, "--olm=false").Execute()).To(Succeed())
-
+				if NoOlmOperatorImage != "" {
+					Expect(Kamel("install", "-n", ns3, "--olm=false", "--operator-image", NoOlmOperatorImage).Execute()).To(Succeed())
+				} else {
+					Expect(Kamel("install", "-n", ns3, "--olm=false").Execute()).To(Succeed())
+				}
+				Eventually(OperatorPodPhase(ns3), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 				Expect(Kamel("run", "-n", ns3, "files/Java.java").Execute()).To(Succeed())
 				Eventually(IntegrationPodPhase(ns3, "java"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 				Eventually(IntegrationLogs(ns3, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 				Expect(IntegrationConditionMessage(IntegrationCondition(ns3, "java", v1.IntegrationConditionPlatformAvailable)())).To(MatchRegexp(ns3 + "\\/.*"))
+				kit := IntegrationKit(ns3, "java")()
+				Expect(Kits(ns3)()).Should(WithTransform(integrationKitsToNamesTransform(), ContainElement(kit)))
 				Expect(Kamel("delete", "--all", "-n", ns3).Execute()).To(Succeed())
 
 				Expect(Lease(ns3, platform.OperatorLockName)()).ShouldNot(BeNil(),

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -91,6 +91,7 @@ const kubeConfigEnvVar = "KUBECONFIG"
 var TestTimeoutShort = 1 * time.Minute
 var TestTimeoutMedium = 5 * time.Minute
 var TestTimeoutLong = 10 * time.Minute
+var NoOlmOperatorImage string
 
 var TestContext context.Context
 var testClient client.Client
@@ -162,6 +163,14 @@ func init() {
 			TestTimeoutMedium = duration
 		} else {
 			fmt.Printf("Can't parse CAMEL_K_TEST_TIMEOUT_MEDIUM. Using default value: %s", TestTimeoutMedium)
+		}
+	}
+
+	if imageNoOlm, ok := os.LookupEnv("CAMEL_K_TEST_NO_OLM_OPERATOR_IMAGE"); ok {
+		if imageNoOlm != "" {
+			NoOlmOperatorImage = imageNoOlm
+		} else {
+			fmt.Printf("Can't parse CAMEL_K_TEST_NO_OLM_OPERATOR_IMAGE. Using default value from kamel")
 		}
 	}
 


### PR DESCRIPTION
<!-- Description -->

Fix an issue of e2e/global_test/Global_test_on_namespace_with_its_own_operator which relied to the default ck operator image using "--olm=false" flag value


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
