### PR TITLE
fix(e2e): Update base CSV for 1.7.x release branch

### DIFF
--- a/config/manifests/bases/camel-k.clusterserviceversion.yaml
+++ b/config/manifests/bases/camel-k.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/apache/camel-k
     support: Camel
-  name: camel-k.v1.7.0
+  name: camel-k.v1.7.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -154,4 +154,4 @@ spec:
   selector:
     matchLabels:
       name: camel-k-operator
-  version: 1.7.0-snapshot
+  version: 1.7.1-snapshot


### PR DESCRIPTION
This fixes the OLM upgrade e2e tests for 1.7.x.

**Release Note**
```release-note
NONE
```
