### PR TITLE
chore(ci): Better GitHub Actions concurrency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -44,7 +44,7 @@ on:
       - 'NOTICE'
 
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ on:
       - "release-*"
 
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Aim at enabling concurrent runs on main branch, and cancelling in progress concurrency groups by pull request.

**Release Note**
```release-note
NONE
```
