### PR TITLE
fix: First bundle Kamelets install with client-side apply

### DIFF
--- a/pkg/install/kamelets.go
+++ b/pkg/install/kamelets.go
@@ -125,14 +125,16 @@ func applyKamelet(ctx context.Context, c client.Client, path string, namespace s
 		err := serverSideApply(ctx, c, kamelet)
 		switch {
 		case err == nil:
-			break
+			return nil
 		case isIncompatibleServerError(err):
 			hasServerSideApply = false
 		default:
 			return fmt.Errorf("could not apply Kamelet from file %q: %w", path, err)
 		}
-	} else {
-		return clientSideApply(ctx, c, kamelet)
+	}
+	err = clientSideApply(ctx, c, kamelet)
+	if err != nil {
+		return fmt.Errorf("could not apply Kamelet from file %q: %w", path, err)
 	}
 
 	return nil


### PR DESCRIPTION
Thanks to @zregvart that pointed out in #2814 the bundle Kamelets are not installed when falling back to client-side apply.

**Release Note**
```release-note
NONE
```
