### PR TITLE
fix(trait): update outdated ca-cert path

### DIFF
--- a/docs/modules/traits/pages/jolokia.adoc
+++ b/docs/modules/traits/pages/jolokia.adoc
@@ -32,7 +32,7 @@ The following configuration options are available:
 | string
 | The PEM encoded CA certification file path, used to verify client certificates,
 applicable when `protocol` is `https` and `use-ssl-client-authentication` is `true`
-(default `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` for OpenShift).
+(default `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` for OpenShift).
 
 | jolokia.client-principal
 | []string

--- a/pkg/trait/jolokia.go
+++ b/pkg/trait/jolokia.go
@@ -38,7 +38,7 @@ type jolokiaTrait struct {
 	BaseTrait `property:",squash"`
 	// The PEM encoded CA certification file path, used to verify client certificates,
 	// applicable when `protocol` is `https` and `use-ssl-client-authentication` is `true`
-	// (default `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` for OpenShift).
+	// (default `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` for OpenShift).
 	CaCert *string `property:"ca-cert" json:"CACert,omitempty"`
 	// The principal(s) which must be given in a client certificate to allow access to the Jolokia endpoint,
 	// applicable when `protocol` is `https` and `use-ssl-client-authentication` is `true`
@@ -122,7 +122,7 @@ func (t *jolokiaTrait) Apply(e *Environment) (err error) {
 	// Configure HTTPS by default for OpenShift
 	if e.DetermineProfile() == v1.TraitProfileOpenShift {
 		t.setDefaultJolokiaOption(options, &t.Protocol, "protocol", "https")
-		t.setDefaultJolokiaOption(options, &t.CaCert, "caCert", "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt")
+		t.setDefaultJolokiaOption(options, &t.CaCert, "caCert", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 		t.setDefaultJolokiaOption(options, &t.ExtendedClientCheck, "extendedClientCheck", true)
 		t.setDefaultJolokiaOption(options, &t.UseSslClientAuthentication, "useSslClientAuthentication", true)
 		t.setDefaultJolokiaOption(options, &t.ClientPrincipal, "clientPrincipal", []string{

--- a/pkg/trait/jolokia_test.go
+++ b/pkg/trait/jolokia_test.go
@@ -77,7 +77,7 @@ func TestApplyJolokiaTraitForOpenShiftProfileShouldSucceed(t *testing.T) {
 	assert.NotNil(t, container)
 
 	assert.Equal(t, container.Args, []string{
-		"-javaagent:dependencies/lib/main/org.jolokia.jolokia-jvm-1.7.1.jar=caCert=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt," +
+		"-javaagent:dependencies/lib/main/org.jolokia.jolokia-jvm-1.7.1.jar=caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt," +
 			"clientPrincipal.1=cn=system:master-proxy,clientPrincipal.2=cn=hawtio-online.hawtio.svc," +
 			"clientPrincipal.3=cn=fuse-console.fuse.svc,discoveryEnabled=false,extendedClientCheck=true," +
 			"host=*,port=8778,protocol=https,useSslClientAuthentication=true",

--- a/resources/traits.yaml
+++ b/resources/traits.yaml
@@ -474,7 +474,7 @@ traits:
     type: string
     description: The PEM encoded CA certification file path, used to verify client
       certificates,applicable when `protocol` is `https` and `use-ssl-client-authentication`
-      is `true`(default `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
+      is `true`(default `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
       for OpenShift).
   - name: client-principal
     type: '[]string'


### PR DESCRIPTION
Fix #2827

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
