### PR TITLE
fix(knative): Make knative broker name configurable in KameletBinding (1.6.x)

### DIFF
--- a/pkg/util/bindings/bindings_test.go
+++ b/pkg/util/bindings/bindings_test.go
@@ -122,7 +122,7 @@ func TestBindings(t *testing.T) {
 					"type": "myeventtype",
 				}),
 			},
-			uri: "knative:event/myeventtype?apiVersion=eventing.knative.dev%2Fv1&kind=Broker",
+			uri: "knative:event/myeventtype?apiVersion=eventing.knative.dev%2Fv1&kind=Broker&name=default",
 		},
 		{
 			endpointType: v1alpha1.EndpointTypeSource,

--- a/pkg/util/bindings/knative_ref.go
+++ b/pkg/util/bindings/knative_ref.go
@@ -68,10 +68,9 @@ func (k KnativeRefBindingProvider) Translate(ctx BindingContext, endpointCtx End
 
 	var serviceURI string
 	if *serviceType == knativeapis.CamelServiceTypeEvent {
-		// TODO enable this when the runtime will support changing the broker name (https://github.com/apache/camel-k-runtime/issues/535)
-		//if props["name"] == "" {
-		//	props["name"] = e.Ref.Name
-		//}
+		if props["name"] == "" {
+			props["name"] = e.Ref.Name
+		}
 		if eventType, ok := props["type"]; ok {
 			// consume prop
 			delete(props, "type")


### PR DESCRIPTION
Backport of https://github.com/apache/camel-k/issues/2864

**Release Note**
```release-note
Make knative broker name configurable in KameletBinding
```
