### PR TITLE
fix http-proxy-docs

### DIFF
--- a/docs/modules/ROOT/pages/configuration/http-proxy.adoc
+++ b/docs/modules/ROOT/pages/configuration/http-proxy.adoc
@@ -81,7 +81,7 @@ spec:
 <1> Deactivates the propagation of HTTP proxy environment variables at the platform level
 
 [[openshift]]
-=== OpenShift
+== OpenShift
 
 On OpenShift 4, cluster-wide egress proxy can be configured by editing the `cluster` Proxy resource:
 


### PR DESCRIPTION
This fixes the AsciiDoc syntax error in

commit 4e15b691d47ed8c2aff86c4a08eb0b783f50d636
Author: Antonin Stefanutti <antonin@stefanutti.fr>
Date:   Wed Jan 12 11:33:37 2022 +0100

    feat: Add HTTP proxy documentation
