### PR TITLE
fix(log): Structure keytool logs

### DIFF
--- a/pkg/util/command.go
+++ b/pkg/util/command.go
@@ -1,0 +1,67 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// RunAndLog starts the provided command, scans its standard and error outputs line by line,
+// to feed the provided handlers, and waits until the scans complete and the command returns.
+func RunAndLog(ctx context.Context, cmd *exec.Cmd, stdOutF func(string), stdErrF func(string)) (err error) {
+	stdOut, err := cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	stdErr, err := cmd.StderrPipe()
+	if err != nil {
+		return
+	}
+	err = cmd.Start()
+	if err != nil {
+		return
+	}
+	g, _ := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		scanner := bufio.NewScanner(stdOut)
+		for scanner.Scan() {
+			stdOutF(scanner.Text())
+		}
+		return nil
+	})
+	g.Go(func() error {
+		scanner := bufio.NewScanner(stdErr)
+		for scanner.Scan() {
+			stdErrF(scanner.Text())
+		}
+		return nil
+	})
+	err = g.Wait()
+	if err != nil {
+		return
+	}
+	err = cmd.Wait()
+	if err != nil {
+		return
+	}
+	return
+}

--- a/pkg/util/maven/maven_log.go
+++ b/pkg/util/maven/maven_log.go
@@ -47,6 +47,18 @@ const (
 
 var mavenLogger = log.WithName("maven.build")
 
+func mavenLogHandler(s string) {
+	mavenLog, parseError := parseLog(s)
+	if parseError == nil {
+		normalizeLog(mavenLog)
+	} else {
+		// Why we are ignoring the parsing errors here: there are a few scenarios where this would likely occur.
+		// For example, if something outside of Maven outputs something (i.e.: the JDK, a misbehaved plugin,
+		// etc). The build may still have succeeded, though.
+		nonNormalizedLog(s)
+	}
+}
+
 func parseLog(line string) (l mavenLog, err error) {
 	err = json.Unmarshal([]byte(line), &l)
 	return


### PR DESCRIPTION
This PR structures the logs emitted by the `keytool` CLI to standard and error outputs, when importing CA certificates into the JVM trust store.

**Release Note**
```release-note
fix(log): Structure keytool logs
```
