### PR TITLE
fix: Install Kamelets as unstructured resources

### DIFF
--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -701,7 +701,7 @@ func PatchIntegration(ns string, name string, mutate func(it *v1.Integration)) e
 	}
 	target := it.DeepCopy()
 	mutate(target)
-	p, err := patch.PositiveMergePatch(it, target)
+	p, err := patch.MergePatch(it, target)
 	if err != nil {
 		return err
 	} else if len(p) == 0 {
@@ -774,7 +774,7 @@ func UpdateKameletBinding(ns string, name string, upd func(it *v1alpha1.KameletB
 	target := klb.DeepCopy()
 	upd(target)
 	// For some reasons, full patch fails on some clusters
-	p, err := patch.PositiveMergePatch(klb, target)
+	p, err := patch.MergePatch(klb, target)
 	if err != nil {
 		return err
 	} else if len(p) == 0 {

--- a/pkg/client/apply.go
+++ b/pkg/client/apply.go
@@ -77,7 +77,7 @@ func (a *ServerOrClientSideApplier) Apply(ctx context.Context, object ctrl.Objec
 }
 
 func (a *ServerOrClientSideApplier) serverSideApply(ctx context.Context, resource runtime.Object) error {
-	target, err := patch.PositiveApplyPatch(resource)
+	target, err := patch.ApplyPatch(resource)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (a *ServerOrClientSideApplier) clientSideApply(ctx context.Context, resourc
 	if err != nil {
 		return err
 	}
-	p, err := patch.PositiveMergePatch(object, resource)
+	p, err := patch.MergePatch(object, resource)
 	if err != nil {
 		return err
 	} else if len(p) == 0 {

--- a/pkg/cmd/builder/builder.go
+++ b/pkg/cmd/builder/builder.go
@@ -78,7 +78,7 @@ func Run(namespace string, buildName string, taskName string) {
 	// is made on the build containers.
 	target.Status.Phase = v1.BuildPhaseNone
 	// Patch the build status with the result
-	p, err := patch.PositiveMergePatch(build, target)
+	p, err := patch.MergePatch(build, target)
 	exitOnError(err, "cannot create merge patch")
 
 	if len(p) > 0 {

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -715,7 +715,7 @@ func createDefaultMavenSettingsConfigMap(ctx context.Context, client client.Clie
 			return err
 		}
 
-		p, err := patch.PositiveMergePatch(existing, cm)
+		p, err := patch.MergePatch(existing, cm)
 		if err != nil {
 			return err
 		} else if len(p) != 0 {

--- a/pkg/controller/build/monitor_routine.go
+++ b/pkg/controller/build/monitor_routine.go
@@ -186,7 +186,7 @@ func (action *monitorRoutineAction) updateBuildStatus(ctx context.Context, build
 	// Copy the failure field from the build to persist recovery state
 	target.Status.Failure = build.Status.Failure
 	// Patch the build status with the result
-	p, err := patch.PositiveMergePatch(build, target)
+	p, err := patch.MergePatch(build, target)
 	if err != nil {
 		action.L.Errorf(err, "Cannot patch build status: %s", build.Name)
 		event.NotifyBuildError(ctx, action.client, action.recorder, build, target, err)

--- a/pkg/controller/kameletbinding/initialize.go
+++ b/pkg/controller/kameletbinding/initialize.go
@@ -85,7 +85,7 @@ func (action *initializeAction) propagateIcon(ctx context.Context, binding *v1al
 	if _, ok := clone.Annotations[v1alpha1.AnnotationIcon]; !ok {
 		clone.Annotations[v1alpha1.AnnotationIcon] = icon
 	}
-	p, err := patch.PositiveMergePatch(binding, clone)
+	p, err := patch.MergePatch(binding, clone)
 	if err != nil {
 		action.L.Errorf(err, "cannot compute patch to update icon for kamelet binding %q", binding.Name)
 		return

--- a/pkg/install/kamelets.go
+++ b/pkg/install/kamelets.go
@@ -131,7 +131,7 @@ func KameletCatalog(ctx context.Context, c client.Client, namespace string) erro
 }
 
 func serverSideApply(ctx context.Context, c client.Client, resource runtime.Object) error {
-	target, err := patch.PositiveApplyPatch(resource)
+	target, err := patch.ApplyPatch(resource)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func clientSideApply(ctx context.Context, c client.Client, resource ctrl.Object)
 	if err != nil {
 		return err
 	}
-	p, err := patch.PositiveMergePatch(object, resource)
+	p, err := patch.MergePatch(object, resource)
 	if err != nil {
 		return err
 	} else if len(p) == 0 {

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -368,7 +368,7 @@ func installClusterRoleBinding(ctx context.Context, c client.Client, collection 
 	// The ClusterRoleBinding.Subjects field does not have a patchStrategy key in its field tag,
 	// so a strategic merge patch would use the default patch strategy, which is replace.
 	// Let's compute a simple JSON merge patch from the existing resource, and patch it.
-	p, err := patch.PositiveMergePatch(existing, target)
+	p, err := patch.MergePatch(existing, target)
 	if err != nil {
 		return err
 	} else if len(p) == 0 {

--- a/pkg/trait/deployer.go
+++ b/pkg/trait/deployer.go
@@ -62,7 +62,7 @@ func (t *deployerTrait) Apply(e *Environment) error {
 	e.PostActions = append(e.PostActions, func(env *Environment) error {
 		for _, resource := range env.Resources.Items() {
 			// We assume that server-side apply is enabled by default.
-			// It is currently convoluted to check pro-actively whether server-side apply
+			// It is currently convoluted to check proactively whether server-side apply
 			// is enabled. This is possible to fetch the OpenAPI endpoint, which returns
 			// the entire server API document, then lookup the resource PATCH endpoint, and
 			// check its list of accepted MIME types.
@@ -92,7 +92,7 @@ func (t *deployerTrait) Apply(e *Environment) error {
 }
 
 func (t *deployerTrait) serverSideApply(env *Environment, resource ctrl.Object) error {
-	target, err := patch.PositiveApplyPatch(resource)
+	target, err := patch.ApplyPatch(resource)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (t *deployerTrait) clientSideApply(env *Environment, resource ctrl.Object) 
 	if err != nil {
 		return err
 	}
-	p, err := patch.PositiveMergePatch(object, resource)
+	p, err := patch.MergePatch(object, resource)
 	if err != nil {
 		return err
 	} else if len(p) == 0 {

--- a/pkg/util/kubernetes/loader.go
+++ b/pkg/util/kubernetes/loader.go
@@ -29,7 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// LoadResourceFromYaml loads a k8s resource from a yaml definition.
+// LoadResourceFromYaml returns a Kubernetes resource from its serialized YAML definition.
 func LoadResourceFromYaml(scheme *runtime.Scheme, data string) (ctrl.Object, error) {
 	source := []byte(data)
 	jsonSource, err := yaml.ToJSON(source)
@@ -53,19 +53,18 @@ func LoadResourceFromYaml(scheme *runtime.Scheme, data string) (ctrl.Object, err
 	return o, nil
 }
 
-// LoadRawResourceFromYaml loads a k8s resource from a yaml definition without making assumptions on the underlying type.
-func LoadRawResourceFromYaml(data string) (runtime.Object, error) {
-	source := []byte(data)
-	jsonSource, err := yaml.ToJSON(source)
+// LoadUnstructuredFromYaml returns an unstructured resource from its serialized YAML definition.
+func LoadUnstructuredFromYaml(data string) (ctrl.Object, error) {
+	source, err := yaml.ToJSON([]byte(data))
 	if err != nil {
 		return nil, err
 	}
-	var objmap map[string]interface{}
-	if err = json.Unmarshal(jsonSource, &objmap); err != nil {
+	var obj map[string]interface{}
+	if err = json.Unmarshal(source, &obj); err != nil {
 		return nil, err
 	}
 	return &unstructured.Unstructured{
-		Object: objmap,
+		Object: obj,
 	}, nil
 }
 


### PR DESCRIPTION
This PR fixes an issue introduced with #2814, that removes nil objects from the apply patches, that are computed to install the Kamelets from the embedded catalog. This breaks Kamelets that use YAML DSL with empty objects, e.g.:  

```yaml
  flow:
    from:
      steps:
      - marshal:
          json: {}
```

or:

```yaml
  flow:
    from:
      steps:
      - filter:
        steps:
        - stop: {}
```

Positive patch is only needed when applying structured objects, whose initialised fields would take ownership even for non-managed fields. The "plain" patch can be used when applying unstructured objects. So this PR moves to installing the Kamelets as unstructured objects, so as to maintain the exact definition from the `.spec.flow` field, that's encoded as a `RawMessage` struct. 

**Release Note**
```release-note
fix: Install Kamelets as unstructured resources
```
