### PR TITLE
Fix #2788: use kamelets 0.7.0 and align with new dir structure

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -59,7 +59,7 @@ STAGING_RUNTIME_REPO :=
 # Define here the repo containing the default Kamelet catalog (if any)
 KAMELET_CATALOG_REPO := https://github.com/apache/camel-kamelets.git
 # Optional branch for the default Kamelet catalog (change this to a tag before release)
-KAMELET_CATALOG_REPO_BRANCH := v0.5.0
+KAMELET_CATALOG_REPO_BRANCH := v0.7.0
 
 # When packaging artifacts into the docker image, you can "copy" them from local maven
 # or "download" them from Apache Snapshots and Maven Central

--- a/script/bundle_kamelets.sh
+++ b/script/bundle_kamelets.sh
@@ -44,6 +44,6 @@ echo "Cloning repository $repo on branch $branch to bundle kamelets..."
 rm -rf ./tmp_kamelet_catalog
 git clone -b $branch --single-branch --depth 1 $repo ./tmp_kamelet_catalog
 
-cp ./tmp_kamelet_catalog/*.kamelet.yaml $target
+cp ./tmp_kamelet_catalog/kamelets/*.kamelet.yaml $target
 
 rm -rf ./tmp_kamelet_catalog


### PR DESCRIPTION
<!-- Description -->

Fix #2788


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
