### PR TITLE
fix(e2e): Use X.Y channels for OLM upgrade e2e tests (1.7.x backport)

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -129,7 +129,11 @@ jobs:
         export CUSTOM_IMAGE=${{ env.LOCAL_IMAGE_NAME }}
         export LOCAL_IMAGE_BUNDLE=${KIND_REGISTRY}/apache/camel-k-bundle:${{ env.LOCAL_IMAGE_VERSION }}
         echo "LOCAL_IMAGE_BUNDLE=${LOCAL_IMAGE_BUNDLE}" >> $GITHUB_ENV
-        make bundle-build BUNDLE_IMAGE_NAME=${LOCAL_IMAGE_BUNDLE} DEFAULT_CHANNEL="stable" CHANNELS="stable"
+        export PREV_XY_CHANNEL=stable-$(make get-last-released-version | grep -Po "\d.\d")
+        echo "PREV_XY_CHANNEL=${PREV_XY_CHANNEL}" >> $GITHUB_ENV
+        export NEW_XY_CHANNEL=stable-$(make get-version | grep -Po "\d.\d")
+        echo "NEW_XY_CHANNEL=${NEW_XY_CHANNEL}" >> $GITHUB_ENV
+        make bundle-build BUNDLE_IMAGE_NAME=${LOCAL_IMAGE_BUNDLE} DEFAULT_CHANNEL="${NEW_XY_CHANNEL}" CHANNELS="stable,${NEW_XY_CHANNEL}"
         docker push ${LOCAL_IMAGE_BUNDLE}
     - name: Create new index image
       run: |
@@ -155,6 +159,8 @@ jobs:
         export CAMEL_K_NEW_IIB=${{ env.LOCAL_IIB }}
         export KAMEL_K_TEST_RELEASE_VERSION=$(make get-last-released-version)
         export KAMEL_K_TEST_OPERATOR_CURRENT_IMAGE=${CUSTOM_IMAGE}:${CUSTOM_VERSION}
+        export CAMEL_K_PREV_UPGRADE_CHANNEL=${{ env.PREV_XY_CHANNEL }}
+        export CAMEL_K_NEW_UPGRADE_CHANNEL=${{ env.NEW_XY_CHANNEL }}
 
         # Then run integration tests
         make test-upgrade

--- a/e2e/upgrade/olm_upgrade_test.go
+++ b/e2e/upgrade/olm_upgrade_test.go
@@ -121,10 +121,12 @@ func TestOLMAutomaticUpgrade(t *testing.T) {
 			if crossChannelUpgrade {
 				t.Log("Updating Camel-K subscription OLM update channel.")
 				s := ckSubscription(ns)()
-				ctrlutil.CreateOrUpdate(TestContext, TestClient(), s, func() error {
+				r, err := ctrlutil.CreateOrUpdate(TestContext, TestClient(), s, func() error {
 					s.Spec.Channel = newUpdateChannel
 					return nil
 				})
+				Expect(err).To(BeNil())
+				Expect(r).To(Equal(ctrlutil.OperationResultUpdated))
 			}
 			// Check the previous CSV is being replaced
 			Eventually(clusterServiceVersionPhase(func(csv olm.ClusterServiceVersion) bool {

--- a/e2e/upgrade/olm_upgrade_test.go
+++ b/e2e/upgrade/olm_upgrade_test.go
@@ -73,8 +73,8 @@ func TestOLMAutomaticUpgrade(t *testing.T) {
 
 		args := []string{"install", "-n", ns, "--olm=true", "--olm-source", catalogSourceName, "--olm-source-namespace", ns}
 
-		if crossChannelUpgrade {
-			args = append(args, "--olm-channel", os.Getenv("CAMEL_K_PREV_UPGRADE_CHANNEL"))
+		if prevUpdateChannel != "" {
+			args = append(args, "--olm-channel", prevUpdateChannel)
 		}
 
 		Expect(Kamel(args...).Execute()).To(Succeed())


### PR DESCRIPTION
Backport #2901 to 1.7.x branch.

**Release Note**
```release-note
fix(e2e): Use X.Y channels for OLM upgrade e2e tests
```
