### PR TITLE
fix: Camel Catalog generation fails with empty Maven effective settings (1.8.x backport)

### DIFF
--- a/pkg/util/camel/catalog.go
+++ b/pkg/util/camel/catalog.go
@@ -125,10 +125,10 @@ func GenerateCatalogCommon(
 		mc.AddSystemProperty("catalog.file", "catalog.yaml")
 		mc.AddSystemProperty("catalog.runtime", string(runtime.Provider))
 
-		if globalSettings != nil {
+		if len(globalSettings) > 0 {
 			mc.GlobalSettings = globalSettings
 		}
-		if userSettings != nil {
+		if len(userSettings) > 0 {
 			mc.UserSettings = userSettings
 		}
 


### PR DESCRIPTION
Backport #2929 to 1.8.x branch.

**Release Note**
```release-note
fix: Camel Catalog generation fails with empty Maven effective settings
```
