### PR TITLE
fix(e2e): Do not add snapshot bundle to stable channel (1.6.x backport)

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -147,8 +147,7 @@ jobs:
         echo "PREV_XY_CHANNEL=${PREV_XY_CHANNEL}" >> $GITHUB_ENV
         export NEW_XY_CHANNEL=stable-$(make get-version | grep -Po "\d.\d")
         echo "NEW_XY_CHANNEL=${NEW_XY_CHANNEL}" >> $GITHUB_ENV
-        make bundle-build METADATA_IMAGE_NAME=${LOCAL_IMAGE_BUNDLE} BUNDLE_METADATA_OPTS="--channels stable"
-        make bundle-build METADATA_IMAGE_NAME=${LOCAL_IMAGE_BUNDLE} BUNDLE_METADATA_OPTS="--default-channel=${NEW_XY_CHANNEL} --channels=stable,${NEW_XY_CHANNEL}"
+        make bundle-build METADATA_IMAGE_NAME=${LOCAL_IMAGE_BUNDLE} BUNDLE_METADATA_OPTS="--default-channel=${NEW_XY_CHANNEL} --channels=${NEW_XY_CHANNEL}"
         docker push ${LOCAL_IMAGE_BUNDLE}
     - name: Create new index image
       run: |


### PR DESCRIPTION
Backport #2939 to 1.6.x branch.

**Release Note**
```release-note
fix(e2e): Do not add snapshot bundle to stable channel
```
