### PR TITLE
Generate crd API docs as AsciiDoc (main) (Update)

### DIFF
--- a/script/gen_crd/gen_crd_api.sh
+++ b/script/gen_crd/gen_crd_api.sh
@@ -24,13 +24,14 @@ echo "Generating CRD API documentation..."
 # to run a local copy use something like
 #go run /Users/david/projects/camel/gen-crd-api-reference-docs/main.go \
 #you will probably need to comment out use of blackfriday.
-go run github.com/djencks/gen-crd-api-reference-docs@7400a10b36d7cfa7563ea48ce0df15a9d4c2de87 \
+go run github.com/djencks/gen-crd-api-reference-docs@e63530f10b55be5f2d82e223d83f86c13e5158e5 \
     -config $location/gen-crd-api-config.json \
     -template-dir $location/template \
     -api-dir "github.com/apache/camel-k/pkg/apis/camel/v1" \
     -out-file $crd_file_camel
 
-go run github.com/djencks/gen-crd-api-reference-docs@7400a10b36d7cfa7563ea48ce0df15a9d4c2de87 \
+#go run /Users/david/projects/camel/gen-crd-api-reference-docs/main.go \
+go run github.com/djencks/gen-crd-api-reference-docs@e63530f10b55be5f2d82e223d83f86c13e5158e5 \
     -config $location/gen-kamelets-crd-api-config.json \
     -template-dir $location/template \
     -api-dir "github.com/apache/camel-k/pkg/apis/camel/v1alpha1" \

--- a/script/gen_crd/template/members.tpl
+++ b/script/gen_crd/template/members.tpl
@@ -5,7 +5,7 @@
 |`{{ fieldName . }}` +
 {{ if linkForType .Type -}}
   {{- if isLocalType .Type -}}
-*xref:{{ linkForType .Type}}[{{ asciiDocAttributeEscape (typeDisplayName .Type) }}]*
+*xref:#{{ sanitizeId (anchorIDForType .Type) }}[{{ asciiDocAttributeEscape (typeDisplayName .Type) }}]*
   {{- else -}}
 *{{ linkForType .Type}}[{{ asciiDocAttributeEscape (typeDisplayName .Type) }}]*
   {{- end -}}

--- a/script/gen_crd/template/pkg.tpl
+++ b/script/gen_crd/template/pkg.tpl
@@ -1,7 +1,7 @@
 {{ define "packages" -}}
 {{ range .packages -}}
 
-[#{{ packageAnchorID . }}]
+[#{{ sanitizeId (packageAnchorID .) }}]
 == {{ packageDisplayName . }}
 
     {{- with (index .GoPackages 0 ) -}}

--- a/script/gen_crd/template/type.tpl
+++ b/script/gen_crd/template/type.tpl
@@ -1,12 +1,12 @@
 {{ define "type" }}
 
-[#{{ anchorIDForType . }}]
+[#{{ sanitizeId (anchorIDForType .) }}]
 === {{ .Name.Name }}{{ if eq .Kind "Alias" }}(`{{.Underlying}}` alias){{ end }}
 {{- with (typeReferences .) }}
 
 *Appears on:*
 {{ range . }}
-* <<{{ linkForType . }}, {{ typeDisplayName . }}>>
+* <<#{{ sanitizeId (anchorIDForType .) }}, {{ typeDisplayName . }}>>
 {{- end -}}
 {{- end }}
 


### PR DESCRIPTION
update templates to use exposed sanitizeId function.

See #2898

It may be a good idea to see if the upstream generator project accepts my PR or asks for more changes before merging this, this reflects the current state of https://github.com/ahmetb/gen-crd-api-reference-docs/pull/45.

Preview for all branches of this iteration is at https://pr-769--camel.netlify.app/camel-k/next/apis/camel-k.html and related pages.