### PR TITLE
fix(cli): Kamel CLI zero-code exists when trait properties validation fails

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -297,8 +297,7 @@ func (o *runCmdOptions) run(cmd *cobra.Command, args []string) error {
 			prefix = prefix[0:strings.Index(prefix, "[")]
 		}
 		if !util.StringSliceExists(tp, prefix) {
-			fmt.Printf("Error: %s is not a valid trait property\n", t)
-			return nil
+			return fmt.Errorf("%s is not a valid trait property", t)
 		}
 	}
 


### PR DESCRIPTION
**Release Note**
```release-note
fix(cli): Kamel CLI zero-code exists when trait properties validation fails
```
