### PR TITLE
fix(e2e): Migrate to OLM file-based catalog format

### DIFF
--- a/.github/actions/kamel-build-bundle/action.yaml
+++ b/.github/actions/kamel-build-bundle/action.yaml
@@ -58,12 +58,11 @@ runs:
       name: Install opm if required
       shell: bash
       run: |
-        if ! command -v opm &> /dev/null
-        then
-          curl -L https://github.com/operator-framework/operator-registry/releases/download/v1.19.5/linux-amd64-opm -o opm
-          chmod +x opm
-          sudo mv opm /usr/local/bin/
-        fi
+        make opm
+
+        # Append to PATH if not already
+        echo "${{ env.GOPATH }}/bin" >> $GITHUB_PATH
+        which opm || { echo 'opm not found' ; exit 1; }
 
     - id: build-index-image
       name: Create New Index Image

--- a/.github/actions/kamel-build-bundle/action.yaml
+++ b/.github/actions/kamel-build-bundle/action.yaml
@@ -60,7 +60,7 @@ runs:
       run: |
         if ! command -v opm &> /dev/null
         then
-          curl -L https://github.com/operator-framework/operator-registry/releases/download/v1.16.1/linux-amd64-opm -o opm
+          curl -L https://github.com/operator-framework/operator-registry/releases/download/v1.19.5/linux-amd64-opm -o opm
           chmod +x opm
           sudo mv opm /usr/local/bin/
         fi

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@
 # Bundle directory
 /bundle
 
+# Catalog directory
+/catalog
+catalog.Dockerfile
+
 # IDEs
 .idea
 *.iml

--- a/script/Makefile
+++ b/script/Makefile
@@ -29,6 +29,9 @@ BASE_IMAGE := adoptopenjdk/openjdk11:slim
 LOCAL_REPOSITORY := /tmp/artifacts/m2
 IMAGE_NAME := docker.io/apache/camel-k
 
+OPM_VERSION := v1.21.0 # <- Not yet released
+OPM_PKG := github.com/operator-framework/operator-registry
+
 #
 # Situations when user wants to override
 # the image name and version
@@ -393,7 +396,7 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
-.PHONY: kubectl kustomize operator-sdk
+.PHONY: kubectl kustomize operator-sdk opm
 
 kubectl:
 ifeq (, $(shell which kubectl))
@@ -439,6 +442,24 @@ else
 	echo " If this is less than $(OPERATOR_SDK_VERSION) then please consider moving it aside and allowing the approved version to be downloaded."; \
 	}
 OPERATOR_SDK=$(shell which operator-sdk)
+endif
+
+opm:
+ifeq (, $(shell which opm))
+	@{ \
+	set -e ;\
+	OPM_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$OPM_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	go get \
+		-ldflags '-w -extldflags "-static"' -tags "json1" \
+		-ldflags "-X '$(OPM_PKG)/cmd/opm/version.opmVersion=$(OPM_VERSION)'" \
+		$(OPM_PKG)/cmd/opm@$(OPM_VERSION) ;\
+		rm -rf $$OPM_GEN_TMP_DIR ;\
+	}
+OPM=$(GOBIN)/opm
+else
+OPM=$(shell which opm)
 endif
 
 .PHONY: generate-crd $(BUNDLE_CAMEL_APIS) bundle bundle-build


### PR DESCRIPTION
This PR fixes the OLM upgrade e2e tests that are expectedly breaking as OLM is removing the SQLite format in favour of a new file-based catalog format:

https://github.com/k8s-operatorhub/community-operators/discussions/505

**Release Note**
```release-note
fix(e2e): Migrate to OLM file-based catalog format
```
