### PR TITLE
feat(cli): add flag --skip-default-kamelets-setup to kamel install

### DIFF
--- a/e2e/common/cli/install_test.go
+++ b/e2e/common/cli/install_test.go
@@ -76,3 +76,11 @@ func TestSkipRegistryInstallation(t *testing.T) {
 		}, TestTimeoutMedium).Should(Equal(v1.RegistrySpec{}))
 	})
 }
+
+func TestInstallSkipDefaultKameletsInstallation(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		Expect(Kamel("install", "-n", ns, "--skip-default-kamelets-setup").Execute()).To(Succeed())
+		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
+		Expect(KameletList(ns)()).Should(BeEmpty())
+	})
+}

--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -63,6 +63,7 @@ func TestInstallNoFlag(t *testing.T) {
 	assert.Equal(t, false, installCmdOptions.ClusterSetupOnly)
 	assert.Equal(t, false, installCmdOptions.SkipOperatorSetup)
 	assert.Equal(t, false, installCmdOptions.SkipClusterSetup)
+	assert.Equal(t, false, installCmdOptions.SkipDefaultKameletsSetup)
 	assert.Equal(t, false, installCmdOptions.ExampleSetup)
 	assert.Equal(t, false, installCmdOptions.Global)
 	assert.Equal(t, false, installCmdOptions.KanikoBuildCache)
@@ -315,6 +316,13 @@ func TestInstallSkipRegistrySetupFlag(t *testing.T) {
 	_, err := test.ExecuteCommand(rootCmd, cmdInstall, "--skip-registry-setup")
 	assert.Nil(t, err)
 	assert.Equal(t, true, installCmdOptions.SkipRegistrySetup)
+}
+
+func TestInstallSkipDefaultKameletsSetupFlag(t *testing.T) {
+	installCmdOptions, rootCmd, _ := initializeInstallCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdInstall, "--skip-default-kamelets-setup")
+	assert.Nil(t, err)
+	assert.Equal(t, true, installCmdOptions.SkipDefaultKameletsSetup)
 }
 
 func TestInstallTraitProfileFlag(t *testing.T) {


### PR DESCRIPTION
Fix #2560

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Added flag `--skip-default-kamelets-setup` to `kamel install`
```
