### PR TITLE
fix(yaml): also consider toD while parsing YAML DSL steps

### DIFF
--- a/pkg/util/source/inspector_yaml.go
+++ b/pkg/util/source/inspector_yaml.go
@@ -161,7 +161,7 @@ func (i YAMLInspector) parseStep(key string, content interface{}, meta *Metadata
 		switch key {
 		case "from":
 			meta.FromURIs = append(meta.FromURIs, maybeURI)
-		case "to", "to-d":
+		case "to", "to-d", "toD":
 			meta.ToURIs = append(meta.ToURIs, maybeURI)
 		}
 	}


### PR DESCRIPTION
Recently (#2822) the YAML DSL parser was patched so that `to-d` steps would correctly resolve Kamelets. It seems `toD` will become the preferred name (apache/camel-kamelets#729).

Using the example from the linked issue, without this PR the error would be:
```
org.apache.camel.NoSuchEndpointException: No endpoint could be found for:
toD?uri=kamelet:example-kamelet?param1=static&param2=${exchangeProperty.prop},
please check your classpath contains the needed Camel component jar
```

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(yaml): Also take toD into account while parsing YAML DSL steps
```
