### PR TITLE
fix(cmd/run): allow multiple resources

### DIFF
--- a/docs/modules/ROOT/pages/configuration/runtime-resources.adoc
+++ b/docs/modules/ROOT/pages/configuration/runtime-resources.adoc
@@ -130,17 +130,17 @@ In our `Integration` we plan to use only one of the resources of the `Secret`:
 [source,groovy]
 .resource-configmap-key-location-route.groovy
 ----
-from('file:/tmp/app/data/?fileName=my-configmap-key-2&noop=true&idempotent=false')
+from('file:/tmp/app/data/?fileName=test.txt&noop=true&idempotent=false')
     .log('resource file content is: ${body} consumed from ${header.CamelFileName}')
 ----
 
 Let's use the _key_ filtering. Also notice that we're combining with the _@path_ syntax to declare where to mount the file:
 
 ----
-kamel run --resource configmap:my-cm-multi/my-configmap-key-2@/tmp/app/data resource-configmap-key-location-route.groovy --dev
+kamel run --resource configmap:my-cm-multi/my-configmap-key-2@/tmp/app/data/test.txt resource-configmap-key-location-route.groovy --dev
 ----
 
-You may check in the `Integration` `Pod` that only the _my-configmap-key-2_ file has been mounted under _/tmp/app/data_ directory.
+You may check in the `Integration` `Pod` that only the _test.txt_ file has been mounted under _/tmp/app/data_ directory containing the information you had in _my-configmap-key-2_.
 
 [[runtime-resources-config]]
 == Runtime config

--- a/e2e/common/config/config_test.go
+++ b/e2e/common/config/config_test.go
@@ -110,7 +110,7 @@ func TestRunConfigExamples(t *testing.T) {
 		t.Run("Resource configmap with filtered key and destination", func(t *testing.T) {
 			// We'll use the configmap contaning 2 values filtering only 1 key
 
-			Expect(Kamel("run", "-n", ns, "./files/resource-configmap-key-location-route.groovy", "--resource", "configmap:my-cm-multi/my-configmap-key-2@/tmp/app").Execute()).To(Succeed())
+			Expect(Kamel("run", "-n", ns, "./files/resource-configmap-key-location-route.groovy", "--resource", "configmap:my-cm-multi/my-configmap-key-2@/tmp/app/test.txt").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, "resource-configmap-key-location-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationConditionStatus(ns, "resource-configmap-key-location-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 			Eventually(IntegrationLogs(ns, "resource-configmap-key-location-route"), TestTimeoutShort).ShouldNot(ContainSubstring(cmDataMulti["my-configmap-key"]))

--- a/e2e/common/config/files/resource-configmap-key-location-route.groovy
+++ b/e2e/common/config/files/resource-configmap-key-location-route.groovy
@@ -16,5 +16,5 @@
  * limitations under the License.
  */
 
-from('file:/tmp/app/?noop=true&idempotent=false')
+from('file:/tmp/app/?fileName=test.txt&noop=true&idempotent=false')
     .log('resource file content is: ${body}')

--- a/examples/user-config/resource-configmap-key-location-route.groovy
+++ b/examples/user-config/resource-configmap-key-location-route.groovy
@@ -20,8 +20,8 @@
 // To run this integrations use:
 // 
 // kubectl create configmap my-cm-multi --from-literal=my-configmap-key="configmap content" --from-literal=my-configmap-key-2="another content"
-// kamel run --resource configmap:my-cm-multi/my-configmap-key-2@/tmp/app/data resource-configmap-key-location-route.groovy --dev
+// kamel run --resource configmap:my-cm-multi/my-configmap-key-2@/tmp/app/data/test.txt resource-configmap-key-location-route.groovy --dev
 //
 
-from('file:/tmp/app/data/?fileName=my-configmap-key-2&noop=true&idempotent=false')
+from('file:/tmp/app/data/?fileName=test.txt&noop=true&idempotent=false')
     .log('resource file content is: ${body} consumed from ${header.CamelFileName}')


### PR DESCRIPTION
* Possibility to project a configmap key to a file location
* Slight change to the documentation to reflect the new behavior

Closes #2943

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
 fix(cmd/run): allow multiple resources
```
