### PR TITLE
Release instruction: remove QUARKUS placeholder, not used anymore in …

### DIFF
--- a/release.adoc
+++ b/release.adoc
@@ -75,7 +75,6 @@ The following tasks need to be done:
 
 - Align `KAMELET_CATALOG_REPO_BRANCH` in Makefile to latest released tag of the camel-kamelets repository
 - Align `RUNTIME_VERSION` in Makefile to latest runtime release
-- Align all libraries to the ones used in the chosen runtime (e.g. `CAMEL_QUARKUS_VERSION` and `QUARKUS_VERSION`)
 - Set `STAGING_RUNTIME_REPO` to the URL of the staging repo (if using a staged camel-k-runtime version)
 - Ensure `LAST_RELEASED_VERSION` points to latest released version of Camel K
 


### PR DESCRIPTION
**Release Note**
```release-note
NONE
```
