### PR TITLE
chore: Tune operator logging

### DIFF
--- a/pkg/controller/integration/integration_controller.go
+++ b/pkg/controller/integration/integration_controller.go
@@ -97,7 +97,7 @@ func add(mgr manager.Manager, c client.Client, r reconcile.Reconciler) error {
 						next != nil && next.Status == corev1.ConditionTrue && next.FirstTruthyTime != nil && !next.FirstTruthyTime.IsZero() &&
 						it.Status.InitializationTimestamp != nil {
 						duration := next.FirstTruthyTime.Time.Sub(it.Status.InitializationTimestamp.Time)
-						Log.WithValues("request-namespace", it.Namespace, "request-name", it.Name).
+						Log.WithValues("request-namespace", it.Namespace, "request-name", it.Name, "ready-after", duration.Seconds()).
 							ForIntegration(it).Infof("First readiness after %s", duration)
 						timeToFirstReadiness.Observe(duration.Seconds())
 					}

--- a/pkg/trait/trait_catalog.go
+++ b/pkg/trait/trait_catalog.go
@@ -108,8 +108,6 @@ func (c *Catalog) apply(environment *Environment) error {
 		}
 
 		if enabled {
-			c.L.Infof("Apply trait: %s", trait.ID())
-
 			err = trait.Apply(environment)
 			if err != nil {
 				return err
@@ -126,6 +124,12 @@ func (c *Catalog) apply(environment *Environment) error {
 			}
 		}
 	}
+
+	traitIds := make([]string, 0)
+	for _, trait := range environment.ExecutedTraits {
+		traitIds = append(traitIds, string(trait.ID()))
+	}
+	c.L.Debugf("Applied traits: %s", strings.Join(traitIds, ","))
 
 	if !applicable && environment.Platform == nil {
 		return errors.New("no trait can be executed because of no integration platform found")


### PR DESCRIPTION
- Add ready after seconds metric as a structured log value
- Set log level to debug when printing trait details in reconcile loop

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
