### PR TITLE
fix(lint): temporarily disable nolintlint to suppress false alarm in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
     - nestif
     - nilnil
     - nlreturn
+    - nolintlint
     - paralleltest
     - tagliatelle
     - tenv

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,36 +23,36 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - cyclop
     - dupl
+    - exhaustive
+    - exhaustivestruct
     - forbidigo
     - funlen
-    - gomoddirectives
-    - godox
-    - gomnd
+    - gci
+    - gochecknoglobals
     - gochecknoinits
     - gocognit
-    - lll
-    - nestif
-    - cyclop
-    - exhaustivestruct
-    - gochecknoglobals
-    - testpackage
-    - goerr113
-    - varnamelen
-    - tagliatelle
-    - paralleltest
-    - wrapcheck
-    - ireturn
-    - gofumpt
-    - gci
-    - wsl
     - goconst
-    - tenv
-    - whitespace
     - gocyclo
-    - nlreturn
-    - nilnil
-    - exhaustive
-    - nakedret
+    - godox
+    - goerr113
+    - gofumpt
+    - gomnd
+    - gomoddirectives
+    - ireturn
+    - lll
     - maligned
+    - nakedret
+    - nestif
+    - nilnil
+    - nlreturn
+    - paralleltest
+    - tagliatelle
+    - tenv
+    - testpackage
+    - varnamelen
+    - whitespace
+    - wrapcheck
+    - wsl
 


### PR DESCRIPTION
<!-- Description -->

Let's temporarily disable `nolintlint` to suppress the annoying false alarm in validate CI:
```
  Error: directive `// nolint: staticcheck` is unused for linter "staticcheck" (nolintlint)
```


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
