### PR TITLE
fix: The error handler trait should update status dependencies (1.8.x backport)

### DIFF
--- a/pkg/trait/error_handler.go
+++ b/pkg/trait/error_handler.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/util"
 )
 
 // The error-handler is a platform trait used to inject Error Handler source into the integration runtime.
@@ -82,10 +83,10 @@ func (t *errorHandlerTrait) Apply(e *Environment) error {
 func (t *errorHandlerTrait) addErrorHandlerDependencies(e *Environment, uri string) {
 	candidateComp, scheme := e.CamelCatalog.DecodeComponent(uri)
 	if candidateComp != nil {
-		e.Integration.Spec.AddDependency(candidateComp.GetDependencyID())
+		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, candidateComp.GetDependencyID())
 		if scheme != nil {
 			for _, dep := range candidateComp.GetProducerDependencyIDs(scheme.ID) {
-				e.Integration.Spec.AddDependency(dep)
+				util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, dep)
 			}
 		}
 	}

--- a/pkg/trait/error_handler_test.go
+++ b/pkg/trait/error_handler_test.go
@@ -89,5 +89,5 @@ func TestErrorHandlerApplyDependency(t *testing.T) {
 	assert.True(t, enabled)
 	err = trait.Apply(e)
 	assert.Nil(t, err)
-	assert.Equal(t, "camel:log", e.Integration.Spec.Dependencies[0])
+	assert.Equal(t, "camel:log", e.Integration.Status.Dependencies[0])
 }


### PR DESCRIPTION
Backport #3056 to 1.8.x branch.

**Release Note**
```release-note
fix: The error handler trait should update status dependencies 
```
