### PR TITLE
chore: Upgrade Kamelet catalog to version 0.7.1

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -66,7 +66,7 @@ STAGING_RUNTIME_REPO :=
 # Define here the repo containing the default Kamelet catalog (if any)
 KAMELET_CATALOG_REPO := https://github.com/apache/camel-kamelets.git
 # Optional branch for the default Kamelet catalog (change this to a tag before release)
-KAMELET_CATALOG_REPO_BRANCH := v0.7.0
+KAMELET_CATALOG_REPO_BRANCH := v0.7.1
 
 # When packaging artifacts into the docker image, you can "copy" them from local maven
 # or "download" them from Apache Snapshots and Maven Central


### PR DESCRIPTION
This aligns `main` branch to 1.8.x branch.

**Release Note**
```release-note
chore: Upgrade Kamelet catalog to version 0.7.1
```
