### PR TITLE
feat(cli): kamel bind --trait option

### DIFF
--- a/pkg/cmd/bind_test.go
+++ b/pkg/cmd/bind_test.go
@@ -161,3 +161,33 @@ spec:
 status: {}
 `, output)
 }
+
+func TestBindTraits(t *testing.T) {
+	buildCmdOptions, bindCmd, _ := initializeBindCmdOptions(t)
+	output, err := test.ExecuteCommand(bindCmd, cmdBind, "my:src", "my:dst", "-o", "yaml", "-t", "mount.configs=configmap:my-cm", "-c", "my-service-binding")
+	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
+
+	assert.Nil(t, err)
+	assert.Equal(t, `apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  creationTimestamp: null
+  name: my-to-my
+spec:
+  integration:
+    traits:
+      mount:
+        configuration:
+          configs:
+          - configmap:my-cm
+      service-binding:
+        configuration:
+          services:
+          - my-service-binding
+  sink:
+    uri: my:dst
+  source:
+    uri: my:src
+status: {}
+`, output)
+}

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -49,6 +49,7 @@ func kamelTestPreAddCommandInit() (*RootCmdOptions, *cobra.Command) {
 }
 
 func TestLoadFromEnvVar(t *testing.T) {
+	defer teardown(t)
 	// shows how to include a "," character inside an env value see VAR1 value
 	if err := os.Setenv("KAMEL_RUN_ENVS", "\"VAR1=value,\"\"othervalue\"\"\",VAR2=value2"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -89,6 +90,7 @@ func TestLoadFromFile(t *testing.T) {
 }
 
 func TestPrecedenceEnvVarOverFile(t *testing.T) {
+	defer teardown(t)
 	if err := os.Setenv("KAMEL_RUN_ENVS", "VAR1=envVar"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -112,6 +114,7 @@ func TestPrecedenceEnvVarOverFile(t *testing.T) {
 }
 
 func TestPrecedenceCommandLineOverEverythingElse(t *testing.T) {
+	defer teardown(t)
 	if err := os.Setenv("KAMEL_RUN_ENVS", "VAR1=envVar"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -141,4 +144,13 @@ func readViperConfigFromBytes(t *testing.T, propertiesFile []byte) {
 	if unexpectedErr != nil {
 		t.Fatalf("Unexpected error: %v", unexpectedErr)
 	}
+}
+
+// We must ALWAYS clean the environment variables and viper library properties to avoid mess up with the rest of the tests.
+func teardown(t *testing.T) {
+	t.Helper()
+	if err := os.Setenv("KAMEL_RUN_ENVS", ""); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	readViperConfigFromBytes(t, make([]byte, 0))
 }

--- a/pkg/cmd/trait_help.go
+++ b/pkg/cmd/trait_help.go
@@ -26,12 +26,14 @@ import (
 	"strings"
 
 	"github.com/fatih/structs"
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/resources"
 	"github.com/apache/camel-k/pkg/trait"
+	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/indentedwriter"
 )
 
@@ -260,4 +262,109 @@ func outputTraits(descriptions []*traitDescription) (string, error) {
 
 		return nil
 	})
+}
+
+func validateTraits(catalog *trait.Catalog, traits []string) error {
+	tp := catalog.ComputeTraitsProperties()
+	for _, t := range traits {
+		kv := strings.SplitN(t, "=", 2)
+		prefix := kv[0]
+		if strings.Contains(prefix, "[") {
+			prefix = prefix[0:strings.Index(prefix, "[")]
+		}
+		if !util.StringSliceExists(tp, prefix) {
+			return fmt.Errorf("%s is not a valid trait property", t)
+		}
+	}
+
+	return nil
+}
+
+func configureTraits(options []string, catalog trait.Finder) (map[string]v1.TraitSpec, error) {
+	traits := make(map[string]map[string]interface{})
+
+	for _, option := range options {
+		parts := traitConfigRegexp.FindStringSubmatch(option)
+		if len(parts) < 4 {
+			return nil, errors.New("unrecognized config format (expected \"<trait>.<prop>=<value>\"): " + option)
+		}
+		id := parts[1]
+		fullProp := parts[2][1:]
+		value := parts[3]
+		if _, ok := traits[id]; !ok {
+			traits[id] = make(map[string]interface{})
+		}
+
+		propParts := util.ConfigTreePropertySplit(fullProp)
+		var current = traits[id]
+		if len(propParts) > 1 {
+			c, err := util.NavigateConfigTree(current, propParts[0:len(propParts)-1])
+			if err != nil {
+				return nil, err
+			}
+			if cc, ok := c.(map[string]interface{}); ok {
+				current = cc
+			} else {
+				return nil, errors.New("trait configuration cannot end with a slice")
+			}
+		}
+
+		prop := propParts[len(propParts)-1]
+		switch v := current[prop].(type) {
+		case []string:
+			current[prop] = append(v, value)
+		case string:
+			// Aggregate multiple occurrences of the same option into a string array, to emulate POSIX conventions.
+			// This enables executing:
+			// $ kamel run -t <trait>.<property>=<value_1> ... -t <trait>.<property>=<value_N>
+			// Or:
+			// $ kamel run --trait <trait>.<property>=<value_1>,...,<trait>.<property>=<value_N>
+			current[prop] = []string{v, value}
+		case nil:
+			current[prop] = value
+		}
+	}
+
+	specs := make(map[string]v1.TraitSpec)
+	for id, config := range traits {
+		t := catalog.GetTrait(id)
+		if t != nil {
+			// let's take a clone to prevent default values set at runtime from being serialized
+			zero := reflect.New(reflect.TypeOf(t)).Interface()
+			err := configureTrait(config, zero)
+			if err != nil {
+				return nil, err
+			}
+			data, err := json.Marshal(zero)
+			if err != nil {
+				return nil, err
+			}
+			var spec v1.TraitSpec
+			err = json.Unmarshal(data, &spec.Configuration)
+			if err != nil {
+				return nil, err
+			}
+			specs[id] = spec
+		}
+	}
+
+	return specs, nil
+}
+
+func configureTrait(config map[string]interface{}, trait interface{}) error {
+	md := mapstructure.Metadata{}
+
+	decoder, err := mapstructure.NewDecoder(
+		&mapstructure.DecoderConfig{
+			Metadata:         &md,
+			WeaklyTypedInput: true,
+			TagName:          "property",
+			Result:           &trait,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(config)
 }


### PR DESCRIPTION
<!-- Description -->
With this PR we'll include the `kamel bind --trait` option which will simplify the trait settings from CLI, ie:
```
kamel bind timer:foo log:bar -t logging.level=DEBUG
```
Closes #2596
<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cli): kamel bind --trait option
```
