### PR TITLE
test(e2e): add tests for `kamel local build`

### DIFF
--- a/e2e/local/files/dependency.groovy
+++ b/e2e/local/files/dependency.groovy
@@ -1,0 +1,25 @@
+// camel-k: language=groovy dependency=camel:twitter dependency=mvn:com.google.guava:guava:31.1-jre dependency=github:squakez/samplejp:v1.0
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+from('timer:groovy?period=1000')
+    .routeId('groovy')
+    .setHeader("m").constant("string!")
+    .setBody()
+        .simple('Magic${header.m}')
+    .to('log:info?showAll=false')

--- a/e2e/local/files/trait.groovy
+++ b/e2e/local/files/trait.groovy
@@ -1,0 +1,25 @@
+// camel-k: language=groovy trait=jolokia.enabled=true
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+from('timer:groovy?period=1000')
+    .routeId('groovy')
+    .setHeader("m").constant("string!")
+    .setBody()
+        .simple('Magic${header.m}')
+    .to('log:info?showAll=false')

--- a/e2e/local/local_build_test.go
+++ b/e2e/local/local_build_test.go
@@ -1,0 +1,242 @@
+//go:build integration
+// +build integration
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/apache/camel-k/e2e/support"
+	testutil "github.com/apache/camel-k/e2e/support/util"
+	"github.com/apache/camel-k/pkg/util"
+)
+
+// Camel version used to validate the test results
+// TODO: read version for the Camel catalog
+var camelVersion = "3.14.1"
+
+func getDockerImages() []byte {
+	cmd := exec.CommandContext(TestContext, "docker", "images")
+	out, err := cmd.Output()
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func TestLocalBuild(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(TestContext)
+	defer cancel()
+	piper, pipew := io.Pipe()
+	defer pipew.Close()
+	defer piper.Close()
+
+	file := testutil.MakeTempCopy(t, "files/yaml.yaml")
+	image := "test/test-" + strings.ToLower(util.RandomString(10))
+
+	kamelBuild := KamelWithContext(ctx, "local", "build", file, "--image", image)
+	kamelBuild.SetOut(pipew)
+
+	msgTagged := "Successfully tagged"
+	logScanner := testutil.NewLogScanner(ctx, piper, msgTagged, image)
+
+	go func() {
+		err := kamelBuild.Execute()
+		assert.NoError(t, err)
+		cancel()
+	}()
+
+	Eventually(logScanner.IsFound(msgTagged), TestTimeoutMedium).Should(BeTrue())
+	Eventually(logScanner.IsFound(image), TestTimeoutMedium).Should(BeTrue())
+	Eventually(getDockerImages, TestTimeoutShort).Should(ContainSubstring(image))
+}
+
+func TestLocalBuildWithTrait(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(TestContext)
+	defer cancel()
+	piper, pipew := io.Pipe()
+	defer pipew.Close()
+	defer piper.Close()
+
+	file := testutil.MakeTempCopy(t, "files/trait.groovy")
+	image := "test/test-" + strings.ToLower(util.RandomString(10))
+
+	kamelBuild := KamelWithContext(ctx, "local", "build", file, "--image", image)
+	kamelBuild.SetOut(pipew)
+
+	msgWarning := "Warning: traits are specified but don't take effect for local run: [jolokia.enabled=true]"
+	msgTagged := "Successfully tagged"
+	logScanner := testutil.NewLogScanner(ctx, piper, msgWarning, msgTagged, image)
+
+	go func() {
+		err := kamelBuild.Execute()
+		assert.NoError(t, err)
+		cancel()
+	}()
+
+	Eventually(logScanner.IsFound(msgWarning), TestTimeoutMedium).Should(BeTrue())
+	Eventually(logScanner.IsFound(msgTagged), TestTimeoutMedium).Should(BeTrue())
+	Eventually(logScanner.IsFound(image), TestTimeoutMedium).Should(BeTrue())
+	Eventually(getDockerImages, TestTimeoutMedium).Should(ContainSubstring(image))
+}
+
+func dependency(dir string, jar string, params ...interface{}) string {
+	params = append([]interface{}{dir}, params...)
+	return fmt.Sprintf("%s/dependencies/"+jar, params...)
+}
+
+func TestLocalBuildIntegrationDirectory(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(TestContext)
+	defer cancel()
+
+	file := testutil.MakeTempCopy(t, "files/yaml.yaml")
+	dir := testutil.MakeTempDir(t)
+
+	kamelBuild := KamelWithContext(ctx, "local", "build", file, "--integration-directory", dir)
+
+	go func() {
+		err := kamelBuild.Execute()
+		assert.NoError(t, err)
+	}()
+
+	Eventually(dir+"/dependencies", TestTimeoutShort).Should(BeADirectory())
+	Eventually(dependency(dir, "org.apache.camel.camel-timer-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Eventually(dependency(dir, "org.apache.camel.camel-log-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Eventually(dir+"/properties", TestTimeoutShort).Should(BeADirectory())
+	Eventually(dir+"/routes/yaml.yaml", TestTimeoutShort).Should(BeAnExistingFile())
+
+	// Run the same command again on the existing directory
+	err := kamelBuild.Execute()
+	assert.NoError(t, err)
+}
+
+func TestLocalBuildIntegrationDirectoryWithSpaces(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(TestContext)
+	defer cancel()
+
+	file := testutil.MakeTempCopy(t, "files/yaml.yaml")
+	dir := testutil.MakeTempDir(t) + " - Camel rocks!"
+
+	kamelBuild := KamelWithContext(ctx, "local", "build", file, "--integration-directory", dir)
+
+	go func() {
+		err := kamelBuild.Execute()
+		assert.NoError(t, err)
+		cancel()
+	}()
+
+	Eventually(dir+"/dependencies", TestTimeoutShort).Should(BeADirectory())
+	Eventually(dependency(dir, "org.apache.camel.camel-timer-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Eventually(dependency(dir, "org.apache.camel.camel-log-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Eventually(dir+"/properties", TestTimeoutShort).Should(BeADirectory())
+	Eventually(dir+"/routes/yaml.yaml", TestTimeoutShort).Should(BeAnExistingFile())
+}
+
+func TestLocalBuildIntegrationDirectoryWithMultiBytes(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(TestContext)
+	defer cancel()
+
+	file := testutil.MakeTempCopy(t, "files/yaml.yaml")
+	dir := testutil.MakeTempDir(t) + "_らくだ" // Camel
+
+	kamelBuild := KamelWithContext(ctx, "local", "build", file, "--integration-directory", dir)
+
+	go func() {
+		err := kamelBuild.Execute()
+		assert.NoError(t, err)
+		cancel()
+	}()
+
+	Eventually(dir+"/dependencies", TestTimeoutShort).Should(BeADirectory())
+	Eventually(dependency(dir, "org.apache.camel.camel-timer-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Eventually(dependency(dir, "org.apache.camel.camel-log-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Eventually(dir+"/properties", TestTimeoutShort).Should(BeADirectory())
+	Eventually(dir+"/routes/yaml.yaml", TestTimeoutShort).Should(BeAnExistingFile())
+}
+
+func TestLocalBuildDependenciesOnly(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(TestContext)
+	defer cancel()
+
+	file := testutil.MakeTempCopy(t, "files/yaml.yaml")
+	dir := testutil.MakeTempDir(t)
+
+	kamelBuild := KamelWithContext(ctx, "local", "build", file, "--integration-directory", dir, "--dependencies-only")
+
+	go func() {
+		err := kamelBuild.Execute()
+		assert.NoError(t, err)
+		cancel()
+	}()
+
+	Eventually(dir+"/dependencies", TestTimeoutShort).Should(BeADirectory())
+	Eventually(dependency(dir, "org.apache.camel.camel-timer-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Eventually(dependency(dir, "org.apache.camel.camel-log-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Expect(dir + "/properties").ShouldNot(BeADirectory())
+	Expect(dir + "/routes/yaml.yaml").ShouldNot(BeAnExistingFile())
+}
+
+func TestLocalBuildModelineDependencies(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithCancel(TestContext)
+	defer cancel()
+
+	file := testutil.MakeTempCopy(t, "files/dependency.groovy")
+	dir := testutil.MakeTempDir(t)
+
+	kamelBuild := KamelWithContext(ctx, "local", "build", file, "--integration-directory", dir)
+
+	go func() {
+		err := kamelBuild.Execute()
+		assert.NoError(t, err)
+	}()
+
+	Eventually(dir+"/dependencies", TestTimeoutShort).Should(BeADirectory())
+	Eventually(dependency(dir, "org.apache.camel.camel-timer-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	Eventually(dependency(dir, "org.apache.camel.camel-log-%s.jar", camelVersion), TestTimeoutShort).Should(BeAnExistingFile())
+	// camel dependency
+	Eventually(dependency(dir, "org.apache.camel.camel-twitter-%s.jar", camelVersion), TestTimeoutMedium).Should(BeAnExistingFile())
+	// mvn dependency
+	Eventually(dependency(dir, "com.google.guava.guava-31.1-jre.jar"), TestTimeoutMedium).Should(BeAnExistingFile())
+	// github dependency
+	Eventually(dependency(dir, "com.github.squakez.samplejp-v1.0.jar"), TestTimeoutMedium).Should(BeAnExistingFile())
+	Eventually(dir+"/routes/dependency.groovy", TestTimeoutShort).Should(BeAnExistingFile())
+}

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -28,8 +28,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	consoleV1 "github.com/openshift/api/console/v1"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"os"
@@ -38,6 +36,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	consoleV1 "github.com/openshift/api/console/v1"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/google/uuid"
 	"github.com/onsi/gomega"
@@ -226,7 +227,8 @@ func KamelWithContext(ctx context.Context, args ...string) *cobra.Command {
 			},
 		}
 	} else {
-		c, err = cmd.NewKamelCommand(ctx)
+		// Use modeline CLI as it's closer to the real usage
+		c, args, err = cmd.NewKamelWithModelineCommand(ctx, append([]string{"kamel"}, args...))
 	}
 	if err != nil {
 		panic(err)

--- a/pkg/util/jvm/keystore.go
+++ b/pkg/util/jvm/keystore.go
@@ -21,12 +21,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/apache/camel-k/pkg/util"
 	"github.com/apache/camel-k/pkg/util/log"
@@ -75,33 +73,5 @@ func GenerateKeystore(ctx context.Context, keystoreDir, keystoreName, keystorePa
 // The keytool CLI mandates a password at least 6 characters long
 // to access any key stores.
 func NewKeystorePassword() string {
-	return randString(10)
-}
-
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-const (
-	letterIdxBits = 6                    // 6 bits to represent a letter index
-	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
-)
-
-var src = rand.NewSource(time.Now().UnixNano())
-
-func randString(n int) string {
-	sb := strings.Builder{}
-	sb.Grow(n)
-	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
-		if remain == 0 {
-			cache, remain = src.Int63(), letterIdxMax
-		}
-		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
-			sb.WriteByte(letterBytes[idx])
-			i--
-		}
-		cache >>= letterIdxBits
-		remain--
-	}
-
-	return sb.String()
+	return util.RandomString(10)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -31,6 +32,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/multierr"
 
@@ -195,6 +197,34 @@ func SubstringFrom(s string, substr string) string {
 	}
 
 	return ""
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+var randomSource = rand.NewSource(time.Now().UnixNano())
+
+func RandomString(n int) string {
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i, cache, remain := n-1, randomSource.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = randomSource.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			sb.WriteByte(letterBytes[idx])
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return sb.String()
 }
 
 func EncodeXML(content interface{}) ([]byte, error) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -28,3 +28,8 @@ func TestStringContainsPrefix(t *testing.T) {
 	assert.True(t, StringContainsPrefix(args, "--operator-image="))
 	assert.False(t, StringContainsPrefix(args, "--olm"))
 }
+
+func TestRandomString(t *testing.T) {
+	assert.Equal(t, 10, len(RandomString(10)))
+	assert.NotEqual(t, RandomString(10), RandomString(10))
+}

--- a/script/Makefile
+++ b/script/Makefile
@@ -211,7 +211,7 @@ test-builder: build
 
 test-local: build
 	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" \
-	go test -timeout 10m -v ./e2e/local -tags=integration $(TEST_LOCAL_RUN)
+	go test -timeout 30m -v ./e2e/local -tags=integration $(TEST_LOCAL_RUN)
 
 test-kamel-cli: build
 	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" \


### PR DESCRIPTION
<!-- Description -->

**Now all e2e tests that use `Kamel` or `KamelWithContext` test support functions are forced to be based on the modeline version of kamel CLI,** as it's closer to the real use of the command.

Fix #2074


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
