### PR TITLE
1.8.x: Updated compatibility matrix for 1.8.1

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -29,16 +29,16 @@ nav:
 asciidoc:
   attributes:
     requires: "'util=camel-website-util,ck=xref:js/ck.js'"
-    camel-kamelets-version: 0.7.0 # Makefile KAMELET_CATALOG_REPO_BRANCH
+    camel-kamelets-version: 0.7.1 # Makefile KAMELET_CATALOG_REPO_BRANCH
     camel-kamelets-docs-version: 0.7.x # Makefile KAMELET_CATALOG_REPO_BRANCH
-    camel-k-runtime-version: 1.11.0 # Makefile RUNTIME_VERSION
+    camel-k-runtime-version: 1.21.0 # Makefile RUNTIME_VERSION
     camel-api-versions: camel.apache.org/v1 camel.apache.org/v1alpha1 # Makefile BUNDLE_CAMEL_APIS
     # from camel-k-runtime parent pom:
-    camel-version: 3.14.0
+    camel-version: 3.14.1
     camel-docs-version: 3.14.x
-    camel-quarkus-version: 2.6.0
-    camel-quarkus-docs-version: 2.6.x
-    quarkus-version: 2.6.0.Final
+    camel-quarkus-version: 2.7.0
+    camel-quarkus-docs-version: 2.7.x
+    quarkus-version: 2.7.0.Final
     graalvm-version: 21.3.0
     graalvm-docs-version: 21.3
 


### PR DESCRIPTION
**Release Note**
```release-note
NONE
```
