### PR TITLE
fix: The KameletBinding readiness condition should mirror its Integration one

### DIFF
--- a/e2e/common/kamelet_binding_test.go
+++ b/e2e/common/kamelet_binding_test.go
@@ -67,7 +67,7 @@ func TestErrorHandler(t *testing.T) {
 		t.Run("throw error test", func(t *testing.T) {
 			RegisterTestingT(t)
 
-			Expect(BindKameletToWithErrorHandler(ns, "throw-error-binding", from, to, map[string]string{"message": "throw Error"}, map[string]string{"loggerName": "integrationLogger"}, errorHandler)()).To(Succeed())
+			Expect(BindKameletToWithErrorHandler(ns, "throw-error-binding", map[string]string{}, from, to, map[string]string{"message": "throw Error"}, map[string]string{"loggerName": "integrationLogger"}, errorHandler)()).To(Succeed())
 
 			Eventually(IntegrationPodPhase(ns, "throw-error-binding"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationLogs(ns, "throw-error-binding"), TestTimeoutShort).Should(ContainSubstring("kameletErrorHandler"))
@@ -78,7 +78,7 @@ func TestErrorHandler(t *testing.T) {
 		t.Run("don't throw error test", func(t *testing.T) {
 			RegisterTestingT(t)
 
-			Expect(BindKameletToWithErrorHandler(ns, "no-error-binding", from, to, map[string]string{"message": "true"}, map[string]string{"loggerName": "integrationLogger"}, errorHandler)()).To(Succeed())
+			Expect(BindKameletToWithErrorHandler(ns, "no-error-binding", map[string]string{}, from, to, map[string]string{"message": "true"}, map[string]string{"loggerName": "integrationLogger"}, errorHandler)()).To(Succeed())
 
 			Eventually(IntegrationPodPhase(ns, "no-error-binding"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationLogs(ns, "no-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("kameletErrorHandler"))

--- a/e2e/common/scale_binding_test.go
+++ b/e2e/common/scale_binding_test.go
@@ -54,7 +54,7 @@ func TestKameletBindingScale(t *testing.T) {
 		Expect(Kamel("bind", "timer-source?message=HelloBinding", "log-sink", "-n", ns, "--name", name).Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		Eventually(KameletBindingCondition(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		Eventually(KameletBindingConditionStatus(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 		Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("HelloBinding"))
 
 		t.Run("Update binding scale spec", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestKameletBindingScale(t *testing.T) {
 			// Check the readiness condition becomes truthy back
 			Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 			// Finally check the readiness condition becomes truthy back on kamelet binding
-			Eventually(KameletBindingCondition(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			Eventually(KameletBindingConditionStatus(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 		})
 
 		t.Run("Scale kamelet binding with polymorphic client", func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestKameletBindingScale(t *testing.T) {
 			Expect(err).To(BeNil())
 
 			// Check the readiness condition is still truthy as down-scaling
-			Expect(KameletBindingCondition(ns, name, v1alpha1.KameletBindingConditionReady)()).To(Equal(corev1.ConditionTrue))
+			Expect(KameletBindingConditionStatus(ns, name, v1alpha1.KameletBindingConditionReady)()).To(Equal(corev1.ConditionTrue))
 			// Check the Integration scale subresource Spec field
 			Eventually(IntegrationSpecReplicas(ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 2)))
@@ -116,7 +116,7 @@ func TestKameletBindingScale(t *testing.T) {
 			Expect(err).To(BeNil())
 
 			// Check the readiness condition is still truthy as down-scaling in kamelet binding
-			Expect(KameletBindingCondition(ns, name, v1alpha1.KameletBindingConditionReady)()).To(Equal(corev1.ConditionTrue))
+			Expect(KameletBindingConditionStatus(ns, name, v1alpha1.KameletBindingConditionReady)()).To(Equal(corev1.ConditionTrue))
 			// Check the KameletBinding scale subresource Spec field
 			Eventually(KameletBindingSpecReplicas(ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 1)))

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -758,7 +758,35 @@ func KameletBindingStatusReplicas(ns string, name string) func() *int32 {
 	}
 }
 
-func KameletBindingCondition(ns string, name string, conditionType v1alpha1.KameletBindingConditionType) func() corev1.ConditionStatus {
+func KameletBindingCondition(ns string, name string, conditionType v1alpha1.KameletBindingConditionType) func() *v1alpha1.KameletBindingCondition {
+	return func() *v1alpha1.KameletBindingCondition {
+		kb := KameletBinding(ns, name)()
+		if kb == nil {
+			return nil
+		}
+		c := kb.Status.GetCondition(conditionType)
+		if c == nil {
+			return nil
+		}
+		return c
+	}
+}
+
+func KameletBindingConditionReason(c *v1alpha1.KameletBindingCondition) string {
+	if c == nil {
+		return ""
+	}
+	return c.Reason
+}
+
+func KameletBindingConditionMessage(c *v1alpha1.KameletBindingCondition) string {
+	if c == nil {
+		return ""
+	}
+	return c.Message
+}
+
+func KameletBindingConditionStatus(ns string, name string, conditionType v1alpha1.KameletBindingConditionType) func() corev1.ConditionStatus {
 	return func() corev1.ConditionStatus {
 		klb := KameletBinding(ns, name)()
 		if klb == nil {
@@ -1566,13 +1594,14 @@ func CreateTimerKamelet(ns string, name string) func() error {
 	return CreateKamelet(ns, name, flow, props, nil)
 }
 
-func BindKameletTo(ns string, name string, from corev1.ObjectReference, to corev1.ObjectReference, sourceProperties map[string]string, sinkProperties map[string]string) func() error {
-	return BindKameletToWithErrorHandler(ns, name, from, to, sourceProperties, sinkProperties, nil)
+func BindKameletTo(ns string, name string, annotations map[string]string, from corev1.ObjectReference, to corev1.ObjectReference, sourceProperties map[string]string, sinkProperties map[string]string) func() error {
+	return BindKameletToWithErrorHandler(ns, name, annotations, from, to, sourceProperties, sinkProperties, nil)
 }
 
-func BindKameletToWithErrorHandler(ns string, name string, from corev1.ObjectReference, to corev1.ObjectReference, sourceProperties map[string]string, sinkProperties map[string]string, errorHandler map[string]interface{}) func() error {
+func BindKameletToWithErrorHandler(ns string, name string, annotations map[string]string, from corev1.ObjectReference, to corev1.ObjectReference, sourceProperties map[string]string, sinkProperties map[string]string, errorHandler map[string]interface{}) func() error {
 	return func() error {
 		kb := v1alpha1.NewKameletBinding(ns, name)
+		kb.Annotations = annotations
 		kb.Spec = v1alpha1.KameletBindingSpec{
 			Source: v1alpha1.Endpoint{
 				Ref:        &from,

--- a/pkg/controller/kameletbinding/integration.go
+++ b/pkg/controller/kameletbinding/integration.go
@@ -22,6 +22,11 @@ import (
 	"encoding/json"
 	"sort"
 
+	"github.com/pkg/errors"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"github.com/apache/camel-k/pkg/client"
@@ -31,9 +36,6 @@ import (
 	"github.com/apache/camel-k/pkg/util/knative"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/apache/camel-k/pkg/util/property"
-	"github.com/pkg/errors"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -45,7 +47,8 @@ func CreateIntegrationFor(ctx context.Context, c client.Client, kameletbinding *
 	controller := true
 	blockOwnerDeletion := true
 	annotations := util.CopyMap(kameletbinding.Annotations)
-	delete(annotations, v1alpha1.AnnotationIcon) // avoid propagating the icon to the integration as it's heavyweight and not needed
+	// avoid propagating the icon to the integration as it's heavyweight and not needed
+	delete(annotations, v1alpha1.AnnotationIcon)
 
 	it := v1.Integration{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #3091.

This follows up #2682 and #2719.

**Release Note**
```release-note
fix: The KameletBinding readiness condition should mirror its Integration one
```
