### PR TITLE
fix: Propagate readiness condition message in KameletBinding if present (1.8.x backport)

### DIFF
--- a/e2e/knative/kamelet_test.go
+++ b/e2e/knative/kamelet_test.go
@@ -69,8 +69,10 @@ func TestKameletChange(t *testing.T) {
 		Eventually(KameletBindingConditionStatus(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
 		Eventually(KameletBindingCondition(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutMedium).Should(And(
 			WithTransform(KameletBindingConditionReason, Equal(v1.IntegrationConditionDeploymentProgressingReason)),
-			WithTransform(KameletBindingConditionMessage, Equal(fmt.Sprintf("Integration %q readiness condition is %q", name, corev1.ConditionFalse))),
-		))
+			WithTransform(KameletBindingConditionMessage, Or(
+				Equal("0/1 updated replicas"),
+				Equal("0/1 ready replicas"),
+			))))
 
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, "timer-binding", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
@@ -79,7 +81,7 @@ func TestKameletChange(t *testing.T) {
 		Eventually(KameletBindingConditionStatus(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 		Eventually(KameletBindingCondition(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutMedium).Should(And(
 			WithTransform(KameletBindingConditionReason, Equal(v1.IntegrationConditionDeploymentReadyReason)),
-			WithTransform(KameletBindingConditionMessage, Equal(fmt.Sprintf("Integration %q readiness condition is %q", name, corev1.ConditionTrue))),
+			WithTransform(KameletBindingConditionMessage, Equal(fmt.Sprintf("1/1 ready replicas"))),
 		))
 
 		// Update the KameletBinding
@@ -88,8 +90,10 @@ func TestKameletChange(t *testing.T) {
 		Eventually(KameletBindingConditionStatus(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
 		Eventually(KameletBindingCondition(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutMedium).Should(And(
 			WithTransform(KameletBindingConditionReason, Equal(v1.IntegrationConditionDeploymentProgressingReason)),
-			WithTransform(KameletBindingConditionMessage, Equal(fmt.Sprintf("Integration %q readiness condition is %q", name, corev1.ConditionFalse))),
-		))
+			WithTransform(KameletBindingConditionMessage, Or(
+				Equal("0/1 updated replicas"),
+				Equal("0/1 ready replicas"),
+			))))
 
 		Eventually(IntegrationPodPhase(ns, "timer-binding"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, "timer-binding", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
@@ -99,7 +103,7 @@ func TestKameletChange(t *testing.T) {
 		Eventually(KameletBindingCondition(ns, name, v1alpha1.KameletBindingConditionReady), TestTimeoutMedium).
 			Should(And(
 				WithTransform(KameletBindingConditionReason, Equal(v1.IntegrationConditionDeploymentReadyReason)),
-				WithTransform(KameletBindingConditionMessage, Equal(fmt.Sprintf("Integration %q readiness condition is %q", name, corev1.ConditionTrue))),
+				WithTransform(KameletBindingConditionMessage, Equal("1/1 ready replicas")),
 			))
 
 		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())

--- a/pkg/controller/kameletbinding/monitor.go
+++ b/pkg/controller/kameletbinding/monitor.go
@@ -125,11 +125,15 @@ func (action *monitorAction) Handle(ctx context.Context, kameletbinding *v1alpha
 
 func setKameletBindingReadyCondition(kb *v1alpha1.KameletBinding, it *v1.Integration) {
 	if condition := it.Status.GetCondition(v1.IntegrationConditionReady); condition != nil {
+		message := condition.Message
+		if message == "" {
+			message = fmt.Sprintf("Integration %q readiness condition is %q", it.GetName(), condition.Status)
+		}
 		kb.Status.SetCondition(
 			v1alpha1.KameletBindingConditionReady,
 			condition.Status,
 			condition.Reason,
-			fmt.Sprintf("Integration %q readiness condition is %q", it.GetName(), condition.Status),
+			message,
 		)
 	} else {
 		kb.Status.SetCondition(


### PR DESCRIPTION
Backport #3108 to 1.8.x.

**Release Note**
```release-note
fix: Propagate readiness condition message in KameletBinding if present
```
