### PR TITLE
Disable deprecate linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,4 +55,7 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
+    - interfacer
+    - scopelint
+    - golint
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,3 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
-    
-    
-   
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,7 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
-    - interfacer
+    
     
    
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,8 @@ linters:
     - gofumpt
     - gomnd
     - gomoddirectives
+    - golint
+    - interfacer
     - ireturn
     - lll
     - maligned
@@ -50,12 +52,13 @@ linters:
     - paralleltest
     - tagliatelle
     - tenv
+    - scopelint
     - testpackage
     - varnamelen
     - whitespace
     - wrapcheck
     - wsl
     - interfacer
-    - scopelint
-    - golint
+    
+   
 


### PR DESCRIPTION
<!-- Description -->
I had to disable the linters to fix the warning in https://github.com/apache/camel-k/issues/3012. We already have an "enable-all" in the linters' section of the config file set to true, then the recommended linters for deprecated are all enabled.




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
