### PR TITLE
Remove pre-release and build versions from the IntegrationKit version…

### DIFF
--- a/e2e/upgrade/olm_upgrade_test.go
+++ b/e2e/upgrade/olm_upgrade_test.go
@@ -1,4 +1,3 @@
-//go:build integration
 // +build integration
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
@@ -176,6 +175,7 @@ func TestOLMAutomaticUpgrade(t *testing.T) {
 
 			// Check the previous kit is not garbage collected
 			Eventually(Kits(ns, KitWithVersion(prevCSVVersion.String()))).Should(HaveLen(1))
+			Eventually(Kits(ns, kitWithVersion(fmt.Sprintf("%d.%d.%d", prevCSVVersion.Version.Major, prevCSVVersion.Version.Minor, prevCSVVersion.Version.Patch)))).Should(HaveLen(1))
 			// Check a new kit is created with the current version
 			Eventually(Kits(ns, KitWithVersion(defaults.Version))).Should(HaveLen(1))
 			// Check the new kit is ready


### PR DESCRIPTION
The CSV version may contain `pre-release` or the `build` version. The integrationKit version should match with the `Major.Minor.Patch` version only.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
