### PR TITLE
fix(e2e): resolve Camel version from catalog for test local

### DIFF
--- a/e2e/local/local_build_test.go
+++ b/e2e/local/local_build_test.go
@@ -33,11 +33,23 @@ import (
 	. "github.com/apache/camel-k/e2e/support"
 	testutil "github.com/apache/camel-k/e2e/support/util"
 	"github.com/apache/camel-k/pkg/util"
+	"github.com/apache/camel-k/pkg/util/camel"
 )
 
 // Camel version used to validate the test results
-// TODO: read version for the Camel catalog
-var camelVersion = "3.14.1"
+var camelVersion = getCamelVersion()
+
+func getCamelVersion() string {
+	catalog, err := camel.DefaultCatalog()
+	if err != nil {
+		panic(err)
+	}
+	version := catalog.GetCamelVersion()
+	if version == "" {
+		panic("unable to resolve the Camel version from catalog")
+	}
+	return version
+}
 
 func TestLocalBuild(t *testing.T) {
 	RegisterTestingT(t)
@@ -97,11 +109,6 @@ func TestLocalBuildWithTrait(t *testing.T) {
 	Eventually(logScanner.IsFound(msgTagged), TestTimeoutMedium).Should(BeTrue())
 	Eventually(logScanner.IsFound(image), TestTimeoutMedium).Should(BeTrue())
 	Eventually(DockerImages, TestTimeoutMedium).Should(ContainSubstring(image))
-}
-
-func dependency(dir string, jar string, params ...interface{}) string {
-	params = append([]interface{}{dir}, params...)
-	return fmt.Sprintf("%s/dependencies/"+jar, params...)
 }
 
 func TestLocalBuildIntegrationDirectory(t *testing.T) {
@@ -229,4 +236,9 @@ func TestLocalBuildModelineDependencies(t *testing.T) {
 	// github dependency
 	Eventually(dependency(dir, "com.github.squakez.samplejp-v1.0.jar"), TestTimeoutMedium).Should(BeAnExistingFile())
 	Eventually(dir+"/routes/dependency.groovy", TestTimeoutShort).Should(BeAnExistingFile())
+}
+
+func dependency(dir string, jar string, params ...interface{}) string {
+	params = append([]interface{}{dir}, params...)
+	return fmt.Sprintf("%s/dependencies/"+jar, params...)
 }

--- a/pkg/util/camel/camel_runtime_catalog.go
+++ b/pkg/util/camel/camel_runtime_catalog.go
@@ -129,6 +129,11 @@ func (c *RuntimeCatalog) GetJavaTypeDependency(camelType string) (string, bool) 
 	return javaType, ok
 }
 
+// GetCamelVersion returns the Camel version the runtime is based on.
+func (c *RuntimeCatalog) GetCamelVersion() string {
+	return c.Runtime.Metadata["camel.version"]
+}
+
 // VisitArtifacts --.
 func (c *RuntimeCatalog) VisitArtifacts(visitor func(string, v1.CamelArtifact) bool) {
 	for id, artifact := range c.Artifacts {


### PR DESCRIPTION
<!-- Description -->

Resolve Camel version from catalog so that we won't need to update the version manually each time we upgrade runtime.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
