### PR TITLE
fix(cli): modeline warn output to stderr

### DIFF
--- a/pkg/cmd/modeline.go
+++ b/pkg/cmd/modeline.go
@@ -76,12 +76,12 @@ func NewKamelWithModelineCommand(ctx context.Context, osArgs []string) (*cobra.C
 	}
 	if len(originalFlags) != len(flags) {
 		// Give a feedback about the actual command that is run
-		fmt.Fprintln(rootCmd.OutOrStdout(), "Modeline options have been loaded from source files")
-		fmt.Fprint(rootCmd.OutOrStdout(), "Full command: kamel ")
+		fmt.Fprintln(rootCmd.ErrOrStderr(), "Modeline options have been loaded from source files")
+		fmt.Fprint(rootCmd.ErrOrStderr(), "Full command: kamel ")
 		for _, a := range flags {
-			fmt.Fprintf(rootCmd.OutOrStdout(), "%s ", a)
+			fmt.Fprintf(rootCmd.ErrOrStderr(), "%s ", a)
 		}
-		fmt.Fprintln(rootCmd.OutOrStdout())
+		fmt.Fprintln(rootCmd.ErrOrStderr())
 	}
 	return rootCmd, flags, nil
 }


### PR DESCRIPTION
With this PR we will provide the warning output in the stderr, allowing the user to execute:
```
$ ./kamel run ./examples/modeline/SampleModeline.java -o yaml 2>/tmp/kamel.log
```
Which will output the Integration only.

Closes #3177

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): modeline warn output to stderr
```
