### PR TITLE
feat(cli): disconnected run and bind

### DIFF
--- a/pkg/cmd/bind_test.go
+++ b/pkg/cmd/bind_test.go
@@ -41,9 +41,6 @@ func initializeBindCmdOptions(t *testing.T) (*bindCmdOptions, *cobra.Command, Ro
 func addTestBindCmd(options RootCmdOptions, rootCmd *cobra.Command) *bindCmdOptions {
 	// add a testing version of bind Command
 	bindCmd, bindOptions := newCmdBind(&options)
-	bindCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
-		return nil
-	}
 	bindCmd.Args = test.ArbitraryArgs
 	rootCmd.AddCommand(bindCmd)
 	return bindOptions

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -76,9 +76,6 @@ func addTestRunCmd(options RootCmdOptions, rootCmd *cobra.Command) *runCmdOption
 func addTestRunCmdWithOutput(options RootCmdOptions, rootCmd *cobra.Command) *runCmdOptions {
 	// add a testing version of run Command with output
 	runCmd, runOptions := newCmdRun(&options)
-	runCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
-		return nil
-	}
 	runCmd.Args = test.ArbitraryArgs
 	rootCmd.AddCommand(runCmd)
 	return runOptions
@@ -604,9 +601,9 @@ func TestOutputYaml(t *testing.T) {
 	assert.Nil(t, ioutil.WriteFile(tmpFile.Name(), []byte(TestSrcContent), 0o400))
 	fileName := filepath.Base(tmpFile.Name())
 
-	buildCmdOptions, runCmd, _ := initializeRunCmdOptionsWithOutput(t)
+	runCmdOptions, runCmd, _ := initializeRunCmdOptionsWithOutput(t)
 	output, err := test.ExecuteCommand(runCmd, cmdRun, tmpFile.Name(), "-o", "yaml")
-	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
+	assert.Equal(t, "yaml", runCmdOptions.OutputFormat)
 
 	assert.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf(`apiVersion: camel.apache.org/v1
@@ -635,9 +632,9 @@ func TestTrait(t *testing.T) {
 	assert.Nil(t, ioutil.WriteFile(tmpFile.Name(), []byte(TestSrcContent), 0o400))
 	fileName := filepath.Base(tmpFile.Name())
 
-	buildCmdOptions, runCmd, _ := initializeRunCmdOptionsWithOutput(t)
+	runCmdOptions, runCmd, _ := initializeRunCmdOptionsWithOutput(t)
 	output, err := test.ExecuteCommand(runCmd, cmdRun, tmpFile.Name(), "-o", "yaml", "-t", "mount.configs=configmap:my-cm", "--connect", "my-service-binding")
-	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
+	assert.Equal(t, "yaml", runCmdOptions.OutputFormat)
 
 	assert.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf(`apiVersion: camel.apache.org/v1
@@ -674,9 +671,9 @@ func TestMissingTrait(t *testing.T) {
 	assert.Nil(t, tmpFile.Close())
 	assert.Nil(t, ioutil.WriteFile(tmpFile.Name(), []byte(TestSrcContent), 0o400))
 
-	buildCmdOptions, runCmd, _ := initializeRunCmdOptionsWithOutput(t)
+	runCmdOptions, runCmd, _ := initializeRunCmdOptionsWithOutput(t)
 	output, err := test.ExecuteCommand(runCmd, cmdRun, tmpFile.Name(), "-o", "yaml", "-t", "bogus.fail=i-must-fail")
-	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
+	assert.Equal(t, "yaml", runCmdOptions.OutputFormat)
 	assert.Equal(t, "Error: bogus.fail=i-must-fail is not a valid trait property\n", output)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
If we detect the -o option, then the CLI goes in offline mode, allowing to be used without a K8S cluster.

You can run
```
kamel run ./examples/languages/Sample.java -o yaml
kamel bind timer:foo log:bar -o yaml
```
and getting the output even if not connected to the cluster.

Closes #3021

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cli): disconnected run and bind
```
