### PR TITLE
increased timeout for route creation in TestRunRoutes

### DIFF
--- a/e2e/common/traits/route_test.go
+++ b/e2e/common/traits/route_test.go
@@ -50,7 +50,7 @@ import (
 const(
 	secretName = "test-certificate"
 	integrationName = "platform-http-server"
-	waitBeforeHttpRequest = 7 * time.Second
+	waitBeforeHttpRequest = 15 * time.Second
 )
 
 type keyCertificatePair struct {


### PR DESCRIPTION
Increased timeout for route creation in TestRunRoutes because issues with ocp4.11

**Release Note**
```release-note
NONE
```
