### PR TITLE
Update defaults.go to use 1.13.0 runtime

### DIFF
--- a/pkg/util/defaults/defaults.go
+++ b/pkg/util/defaults/defaults.go
@@ -26,7 +26,7 @@ const (
 	Version = "1.9.0-SNAPSHOT"
 
 	// DefaultRuntimeVersion --
-	DefaultRuntimeVersion = "1.12.0"
+	DefaultRuntimeVersion = "1.13.0"
 
 	// BuildahVersion --
 	BuildahVersion = "1.14.0"


### PR DESCRIPTION
**Release Note**
```release-note
NONE
```
