### PR TITLE
Replace MicroProfile Metrics with Micrometer as the default in Prometheus trait

### DIFF
--- a/docs/modules/traits/pages/prometheus.adoc
+++ b/docs/modules/traits/pages/prometheus.adoc
@@ -4,7 +4,7 @@
 The Prometheus trait configures a Prometheus-compatible endpoint. It also creates a `PodMonitor` resource,
 so that the endpoint can be scraped automatically, when using the Prometheus operator.
 
-The metrics are exposed using MicroProfile Metrics.
+The metrics are exposed using Micrometer.
 
 WARNING: The creation of the `PodMonitor` resource requires the https://github.com/coreos/prometheus-operator[Prometheus Operator]
 custom resource definition to be installed.

--- a/pkg/trait/prometheus.go
+++ b/pkg/trait/prometheus.go
@@ -32,7 +32,7 @@ import (
 // The Prometheus trait configures a Prometheus-compatible endpoint. It also creates a `PodMonitor` resource,
 // so that the endpoint can be scraped automatically, when using the Prometheus operator.
 //
-// The metrics are exposed using MicroProfile Metrics.
+// The metrics are exposed using Micrometer.
 //
 // WARNING: The creation of the `PodMonitor` resource requires the https://github.com/coreos/prometheus-operator[Prometheus Operator]
 // custom resource definition to be installed.
@@ -66,8 +66,8 @@ func (t *prometheusTrait) Configure(e *Environment) (bool, error) {
 
 func (t *prometheusTrait) Apply(e *Environment) (err error) {
 	if e.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
-		// Add the Camel Quarkus MP Metrics extension
-		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus:camel-quarkus-microprofile-metrics")
+		// Add the Camel Quarkus Micrometer extension
+		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus:camel-quarkus-micrometer")
 		return nil
 	}
 


### PR DESCRIPTION
**Release Note**
```release-note
action required
```

fixes #1773 

Should there be another version of https://github.com/apache/camel-k/tree/main/examples/traits/prometheus that uses Micrometer instead of MicroProfile Metrics?