### PR TITLE
fix: kamel run -o incompatible with --dev

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -244,7 +244,7 @@ func (o *runCmdOptions) validate() error {
 	}
 
 	if o.OutputFormat != "" && o.Dev {
-		return errors.New("option '-o' is not compatible with '--dev'")
+		return fmt.Errorf("cannot use --dev with -o/--output option")
 	}
 
 	for _, label := range o.Labels {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -243,6 +243,10 @@ func (o *runCmdOptions) validate() error {
 		return err
 	}
 
+	if o.OutputFormat != "" && o.Dev {
+		return errors.New("option '-o' is not compatible with '--dev'")
+	}
+
 	for _, label := range o.Labels {
 		parts := strings.Split(label, "=")
 		if len(parts) != 2 {

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -132,6 +132,16 @@ func TestRunDevFlag(t *testing.T) {
 	assert.Equal(t, true, runCmdOptions.Dev)
 }
 
+func TestRunDevModeOutputFlag(t *testing.T) {
+	runCmdOptions, rootCmd, _ := initializeRunCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdRun, "--dev", "-o", "yaml", integrationSource)
+	assert.Equal(t, true, runCmdOptions.Dev)
+	assert.Equal(t, "yaml", runCmdOptions.OutputFormat)
+	assert.NotNil(t, err)
+	assert.Equal(t, "option '-o' is not compatible with '--dev'",
+		err.Error())
+}
+
 func TestRunEnvFlag(t *testing.T) {
 	runCmdOptions, rootCmd, _ := initializeRunCmdOptions(t)
 	_, err := test.ExecuteCommand(rootCmd, cmdRun,

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -138,7 +138,7 @@ func TestRunDevModeOutputFlag(t *testing.T) {
 	assert.Equal(t, true, runCmdOptions.Dev)
 	assert.Equal(t, "yaml", runCmdOptions.OutputFormat)
 	assert.NotNil(t, err)
-	assert.Equal(t, "option '-o' is not compatible with '--dev'",
+	assert.Equal(t, "cannot use --dev with -o/--output option",
 		err.Error())
 }
 


### PR DESCRIPTION
<!-- Description -->

Closes #3195
@astefanutti @squakez I included a test first for the fix. For the fix, I added a check for both flags. If both flags are present, an error is returned with the error message written to the error writer. Please review and let me know if there are any more things I could do.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
