### PR TITLE
chore: Improve extract Camel catalog script

### DIFF
--- a/script/get_catalog.sh
+++ b/script/get_catalog.sh
@@ -29,7 +29,16 @@ if [ -z $2 ]; then
 else
   # TODO: fix this workaround to use the above mvn statement with the staging repository as well
   echo "INFO: extracting a catalog from staging repository $2"
-  wget -q $2/org/apache/camel/k/camel-k-catalog/$1/camel-k-catalog-$1-catalog.yaml -O ${rootdir}/resources/camel-catalog-$1.yaml
+  wget -q $2/org/apache/camel/k/camel-k-catalog/$1/camel-k-catalog-$1-catalog.yaml -O ${rootdir}/resources/camel-catalog.yaml
+
+  if [ -s ${rootdir}/resources/camel-catalog.yaml ]; then
+    # the extracted catalog file is not empty
+    mv ${rootdir}/resources/camel-catalog.yaml ${rootdir}/resources/camel-catalog-$1.yaml
+  else
+    # the extracted catalog file is empty - some error in staging repository
+    echo "WARNING: could not extract catalog from staging repository $2"
+    rm ${rootdir}/resources/camel-catalog.yaml
+  fi
 fi
 
 


### PR DESCRIPTION
Avoid breaking Makefile when Camel catalog staging repository (e.g. https://repository.apache.org/content/repositories/orgapachecamel-1425) is not available for some reason. In case catalog is empty just log a WARNING and continue with the build.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
