### PR TITLE
chore: Log build duration metrics

### DIFF
--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pkg/errors"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/util/kubernetes"
 )
 
 const timeoutAnnotation = "camel.apache.org/timeout"
@@ -121,8 +122,9 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 		duration := finishedAt.Sub(build.Status.StartedAt.Time)
 		build.Status.Duration = duration.String()
 
+		buildCreator := kubernetes.GetCamelCreator(build)
 		// Account for the Build metrics
-		observeBuildResult(build, build.Status.Phase, duration)
+		observeBuildResult(build, build.Status.Phase, buildCreator, duration)
 
 		for _, task := range build.Spec.Tasks {
 			if t := task.Buildah; t != nil {
@@ -166,8 +168,9 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 		duration := finishedAt.Sub(build.Status.StartedAt.Time)
 		build.Status.Duration = duration.String()
 
+		buildCreator := kubernetes.GetCamelCreator(build)
 		// Account for the Build metrics
-		observeBuildResult(build, build.Status.Phase, duration)
+		observeBuildResult(build, build.Status.Phase, buildCreator, duration)
 	}
 
 	return build, nil

--- a/pkg/controller/build/monitor_routine.go
+++ b/pkg/controller/build/monitor_routine.go
@@ -34,6 +34,7 @@ import (
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/builder"
 	"github.com/apache/camel-k/pkg/event"
+	"github.com/apache/camel-k/pkg/util/kubernetes"
 	"github.com/apache/camel-k/pkg/util/patch"
 )
 
@@ -174,8 +175,10 @@ tasks:
 
 	duration := metav1.Now().Sub(build.Status.StartedAt.Time)
 	status.Duration = duration.String()
+
+	buildCreator := kubernetes.GetCamelCreator(build)
 	// Account for the Build metrics
-	observeBuildResult(build, status.Phase, duration)
+	observeBuildResult(build, status.Phase, buildCreator, duration)
 
 	_ = action.updateBuildStatus(ctx, build, status)
 }

--- a/pkg/controller/build/schedule.go
+++ b/pkg/controller/build/schedule.go
@@ -29,6 +29,7 @@ import (
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/event"
+	"github.com/apache/camel-k/pkg/util/kubernetes"
 )
 
 func newScheduleAction(reader ctrl.Reader) Action {
@@ -116,8 +117,9 @@ func (action *scheduleAction) toPendingPhase(ctx context.Context, build *v1.Buil
 		return err
 	}
 
+	buildCreator := kubernetes.GetCamelCreator(build)
 	// Report the duration the Build has been waiting in the build queue
-	observeBuildQueueDuration(build)
+	observeBuildQueueDuration(build, buildCreator)
 
 	return nil
 }


### PR DESCRIPTION
In addition to exposing the build duration metrics via Prometheus also add a log statement that prints the build duration and build queue duration to the operator logs (similar to how time to first readiness is printed already). Users can easily correlate such logs via integration name when reviewing the operator logs.

Need to find the creator of a build CR though to get the correlated integration name and namespace as log value.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
