### PR TITLE
fix[cli]: format long subcommand descriptions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.uber.org/zap v1.21.0
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/inf.v0 v0.9.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.22.5

--- a/pkg/cmd/bind.go
+++ b/pkg/cmd/bind.go
@@ -44,7 +44,8 @@ func newCmdBind(rootCmdOptions *RootCmdOptions) (*cobra.Command, *bindCmdOptions
 	}
 	cmd := cobra.Command{
 		Use:     "bind [source] [sink] ...",
-		Short:   "Bind Kubernetes resources, such as Kamelets, in an integration flow. Endpoints are expected in the format \"[[apigroup/]version:]kind:[namespace/]name\" or plain Camel URIs.",
+		Short:   "Bind Kubernetes resources, such as Kamelets, in an integration flow.",
+		Long:    "Bind Kubernetes resources, such as Kamelets, in an integration flow. Endpoints are expected in the format \"[[apigroup/]version:]kind:[namespace/]name\" or plain Camel URIs.",
 		PreRunE: decode(&options),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(cmd, args); err != nil {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -252,13 +252,7 @@ func wrappedFlagUsages(cmd *cobra.Command) string {
 
 var usageTemplate = `Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
@@ -267,10 +261,7 @@ Flags:
 {{ wrappedFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 Global Flags:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-
-Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableSubCommands}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -85,9 +85,7 @@ func kamelPreAddCommandInit(options *RootCmdOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.Namespace, "namespace", "n", "", "Namespace to use for all operations")
 
 	cobra.AddTemplateFunc("wrappedFlagUsages", wrappedFlagUsages)
-	usageTmpl := cmd.UsageTemplate()
-	usageTmpl = strings.Replace(usageTmpl, ".LocalFlags.FlagUsages", " wrappedFlagUsages .", 1)
-	cmd.SetUsageTemplate(usageTmpl)
+	cmd.SetUsageTemplate(usageTemplate)
 
 	return &cmd
 }
@@ -251,3 +249,28 @@ func wrappedFlagUsages(cmd *cobra.Command) string {
 	}
 	return cmd.Flags().FlagUsagesWrapped(width - 1)
 }
+
+var usageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{ wrappedFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`


### PR DESCRIPTION
<!-- Description -->

Closes #2318
@squakez This is a draft PR for now. I would like to hear your thoughts on my plan to tackle this issue, to know if I'm on the right track. So I think the problem comes from the usage template string defined in the cobra package. Specifically this: `{{.LocalFlags.FlagUsages}}`. The returned string is not wrapped and so when a line break occurs, the output written to the terminal is not in order. My plan is to replace the `.LocalFlags.FlagUsages` with a template function that calls the `cmd.Flags().FlagUsagesWrapped` function. As you suggested previously, I'd need to get the terminal size. I will probably use the size to set the flag description length. What do you think am I on the right track? If not what suggestions could you give me?

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): format long subcommand descriptions
```
