### PR TITLE
feat(cli): reduce binary size by 1/3

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -100,7 +100,7 @@ else
 $(warning Could not retrieve a valid Git Commit)
 endif
 
-GOFLAGS = -ldflags "$(GOLDFLAGS)" -trimpath
+GOFLAGS = -ldflags "-s -w $(GOLDFLAGS)" -trimpath
 
 define LICENSE_HEADER
 Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
Adding -s and -w flag reduce significatively the size of the output (52 vs 73 MiB)
```
$ ll kamel -h
-rwxrwxr-x 1 squake squake 73M abr 28 16:47 kamel*
```
vs
```
$ ll kamel -h
-rwxrwxr-x 1 squake squake 52M abr 28 16:50 kamel*
```
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cli): reduce binary size by 1/3
```
