### PR TITLE
fix(ci): release action tag params

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ name: release
 
 on:
   schedule:
-  - cron: "45 23 * * *"
+  - cron: "10 23 * * *"
 
 jobs:
   release:
@@ -94,4 +94,7 @@ jobs:
         prerelease: true
         allowUpdates: true
         replacesArtifacts: true
+        tag: ${{ env.VERSION }}
+        commit: main
+        
 


### PR DESCRIPTION
<!-- Description -->

It seems they are required when the tag has not yet been created: https://github.com/ncipollo/release-action#notes


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
