### PR TITLE
extend operator yaml for easier customisation

### DIFF
--- a/helm/camel-k/templates/operator.yaml
+++ b/helm/camel-k/templates/operator.yaml
@@ -22,6 +22,7 @@ metadata:
     app: camel-k
     camel.apache.org/component: operator
     {{- include "camel-k.labels" . | nindent 4 }}
+  annotations:
   name: camel-k-operator
 spec:
   replicas: 1
@@ -37,6 +38,7 @@ spec:
         camel.apache.org/component: operator
         name: camel-k-operator
     spec:
+      imagePullSecrets:
       containers:
         - command:
             - kamel
@@ -69,4 +71,6 @@ spec:
             - containerPort: 8080
               name: metrics
           resources: {}
+          volumeMounts:
+      volumes:
       serviceAccountName: camel-k-operator


### PR DESCRIPTION
<!-- Description -->
The change is supposed to extend possibilities of customizing operator.
It adds empty fields to operator.yaml that do not affect current setup.

Namely:
annotations - e.g. for attaching prometheus
imagePullSecrets - for secrets used to pull images in closed environments, where we are not allowed to pull from public repositories
volumes and volumeMounts - for inserting self-signed certificate in closed environment (corporate) for images pull/push

I found it more effective to send PR directly than creating an issue. If this approach was not suitable for you, please let me know, so I do not repeat it in future :)

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
