### PR TITLE
Fix #3257: work with relative paths on windows to avoid extra semicolon

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -39,6 +39,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	runtimeos "runtime"
 	"strings"
 	"syscall"
 
@@ -964,12 +965,38 @@ func (o *runCmdOptions) extractGav(src *zip.File, localPath string, cmd *cobra.C
 func (o *runCmdOptions) uploadAsMavenArtifact(dependency maven.Dependency, path string, platform *v1.IntegrationPlatform, ns string, options spectrum.Options, cmd *cobra.Command) error {
 	artifactHTTPPath := getArtifactHTTPPath(dependency, platform, ns)
 	options.Target = fmt.Sprintf("%s/%s:%s", platform.Spec.Build.Registry.Address, artifactHTTPPath, dependency.Version)
+	if runtimeos.GOOS == "windows" {
+		// workaround for https://github.com/container-tools/spectrum/issues/8
+		// work with relative paths instead
+		rel, err := getRelativeToWorkingDirectory(path)
+		if err != nil {
+			return err
+		}
+		path = rel
+	}
 	_, err := spectrum.Build(options, fmt.Sprintf("%s:.", path))
 	if err != nil {
 		return err
 	}
 	o.PrintfVerboseOutf(cmd, "Uploaded: %s to %s \n", path, options.Target)
 	return uploadChecksumFiles(path, options, platform, artifactHTTPPath, dependency)
+}
+
+// Deprecated: workaround for https://github.com/container-tools/spectrum/issues/8
+func getRelativeToWorkingDirectory(path string) (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	path, err = filepath.Rel(wd, abs)
+	if err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // Currently swallows errors because our Project model is incomplete.


### PR DESCRIPTION
<!-- Description -->

Fixes #3257 until https://github.com/container-tools/spectrum/issues/8 is resolved. Thanks !


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
