### PR TITLE
fix: Bump remaining resources to 1.9.2

### DIFF
--- a/.github/actions/kamel-build-bundle/build-index-image.sh
+++ b/.github/actions/kamel-build-bundle/build-index-image.sh
@@ -213,7 +213,7 @@ schema: olm.channel
 package: camel-k
 name: stable-dev-$(make get-version | grep -Po "\d.\d")
 entries:
-  - name: camel-k.v$(make get-version | grep -Po "\d.\d.\d")
+  - name: $(make get-csv-name)
     replaces: $(make get-last-released-img-name).v$(make get-last-released-version | grep -Po "\d.\d.\d")
 EOF
 

--- a/config/manifests/bases/camel-k.clusterserviceversion.yaml
+++ b/config/manifests/bases/camel-k.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: docker.io/apache/camel-k:1.9.2-SNAPSHOT
-    createdAt: 2022-04-26T08:32:16Z
+    createdAt: 2022-05-13T13:57:18Z
     description: Apache Camel K is a lightweight integration platform, born on Kubernetes,
       with serverless superpowers.
     operators.operatorframework.io/builder: operator-sdk-v1.3.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -31,7 +31,3 @@ resources:
 
 patchesStrategicMerge:
 - patch-delete-user-cluster-role.yaml
-images:
-- name: docker.io/apache/camel-k
-  newName: docker.io/apache/camel-k
-  newTag: 1.9.1-SNAPSHOT

--- a/pkg/util/defaults/defaults.go
+++ b/pkg/util/defaults/defaults.go
@@ -23,7 +23,7 @@ package defaults
 
 const (
 	// Version --
-	Version = "1.9.1-SNAPSHOT"
+	Version = "1.9.2-SNAPSHOT"
 
 	// DefaultRuntimeVersion --
 	DefaultRuntimeVersion = "1.13.0"

--- a/script/Makefile
+++ b/script/Makefile
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 VERSIONFILE := pkg/util/defaults/defaults.go
-VERSION ?= 1.9.1-SNAPSHOT
+VERSION ?= 1.9.2-SNAPSHOT
 OPERATOR_VERSION := $(subst -SNAPSHOT,,$(VERSION))
 LAST_RELEASED_IMAGE_NAME := camel-k-operator
-LAST_RELEASED_VERSION := 1.9.0
+LAST_RELEASED_VERSION := 1.9.1
 RUNTIME_VERSION := 1.13.0
 BUILDAH_VERSION := 1.14.0
 KANIKO_VERSION := 0.17.1
@@ -54,11 +54,15 @@ DEFAULT_CHANNEL ?= $(OPERATOR_VERSION)
 PACKAGE := camel-k
 CSV_VERSION := $(CUSTOM_VERSION:-SNAPSHOT=)
 CSV_NAME := $(PACKAGE).v$(CSV_VERSION)
+# Final CSV name that replaces the name required by the operator-sdk
+# Has to be replaced after the bundle has been generated
+CSV_PRODUCTION_NAME := $(PACKAGE)-operator.v$(CSV_VERSION)
 CSV_DISPLAY_NAME := Camel K Operator
 CSV_SUPPORT := Camel
 CSV_REPLACES := $(LAST_RELEASED_IMAGE_NAME).v$(LAST_RELEASED_VERSION)
 CSV_FILENAME := $(PACKAGE).clusterserviceversion.yaml
 CSV_PATH := config/manifests/bases/$(CSV_FILENAME)
+CSV_GENERATED_PATH := bundle/manifests/$(CSV_FILENAME)
 
 # Used to push pre-release artifacts
 STAGING_IMAGE_NAME := docker.io/camelk/camel-k
@@ -356,7 +360,7 @@ get-last-released-version:
 	@echo $(LAST_RELEASED_VERSION)
 
 get-csv-name:
-	@echo $(CSV_NAME)
+	@echo $(CSV_PRODUCTION_NAME)
 
 set-version:
 	./script/set_version.sh $(CUSTOM_VERSION) $(CUSTOM_IMAGE)
@@ -471,7 +475,7 @@ else
 OPM=$(shell command -v opm 2> /dev/null)
 endif
 
-.PHONY: generate-crd $(BUNDLE_CAMEL_APIS) bundle bundle-build
+.PHONY: generate-crd $(BUNDLE_CAMEL_APIS) pre-bundle bundle bundle-build
 
 # - Have to copy pkg/apis since it is a module in its own right
 # - The dependency of v1alpha1 api on v1 results in duplication
@@ -535,6 +539,9 @@ else
 endif
 	@# Adds the licence headers to the csv file
 	./script/add_license.sh bundle/manifests ./script/headers/yaml.txt
+# Rename the CSV name to conform with the existing released operator versions
+# This cannot happen in pre-bundle as the operator-sdk generation expects a CSV name the same as PACKAGE
+	@sed -i "s/^  name: $(CSV_NAME)/  name: $(CSV_PRODUCTION_NAME)/" $(CSV_GENERATED_PATH)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Build the bundle image.


### PR DESCRIPTION
* Tweak Makefile to change post-generated bundle CSV to
  production name

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
