### PR TITLE
Fix #3271: Prepend Organization/Namespace in HTTP path when uploading…

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -1109,11 +1109,11 @@ func getArtifactHTTPPath(dependency maven.Dependency, platform *v1.IntegrationPl
 	// Some vendors don't allow '/' or '.' in repository name so let's replace them with '_'
 	artifactHTTPPath = strings.ReplaceAll(artifactHTTPPath, "/", "_")
 	artifactHTTPPath = strings.ReplaceAll(artifactHTTPPath, ".", "_")
-	if platform.Spec.Cluster == v1.IntegrationPlatformClusterOpenShift {
-		// image must be uploaded in the namespace
-		artifactHTTPPath = fmt.Sprintf("%s/%s", ns, artifactHTTPPath)
+	organization := platform.Spec.Build.Registry.Organization
+	if organization == "" {
+		organization = ns
 	}
-	return artifactHTTPPath
+	return fmt.Sprintf("%s/%s", organization, artifactHTTPPath)
 }
 
 func createDefaultGav(path string, dirName string, integrationName string) (maven.Dependency, error) {

--- a/pkg/trait/registry.go
+++ b/pkg/trait/registry.go
@@ -103,14 +103,16 @@ func (t *registryTrait) Apply(e *Environment) error {
 		}
 		build.Maven.Servers = append(build.Maven.Servers, server)
 	}
-	addRegistryAndExtensionToMaven(registryAddress, build, e.Platform.Status.Cluster, e.Platform.Namespace)
+	addRegistryAndExtensionToMaven(registryAddress, build, e.Platform)
 	return nil
 }
 
-func addRegistryAndExtensionToMaven(registryAddress string, build *v1.BuilderTask, clusterType v1.IntegrationPlatformCluster, ns string) {
-	if clusterType == v1.IntegrationPlatformClusterOpenShift {
-		registryAddress = fmt.Sprintf("%s/%s", registryAddress, ns)
+func addRegistryAndExtensionToMaven(registryAddress string, build *v1.BuilderTask, platform *v1.IntegrationPlatform) {
+	organization := platform.Spec.Build.Registry.Organization
+	if organization == "" {
+		organization = platform.Namespace
 	}
+	registryAddress = fmt.Sprintf("%s/%s", registryAddress, organization)
 	ext := v1.MavenArtifact{
 		GroupID:    "com.github.johnpoth",
 		ArtifactID: "wagon-docker-registry",


### PR DESCRIPTION
… to the image registry from the command line

<!-- Description -->

Fixes #3271, Thanks !

Will backport to 1.9.x once merged ... thanks !



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
