### PR TITLE
Fix #3257: fix uploading checksum files to the image registry on Windows

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -1063,6 +1063,15 @@ func uploadChecksumFile(hash hash.Hash, tmpDir string, ext string, path string, 
 
 	filename := "maven_" + filepath.Base(path) + ext
 	filepath := filepath.Join(tmpDir, filename)
+	if runtimeos.GOOS == "windows" {
+		// workaround for https://github.com/container-tools/spectrum/issues/8
+		// work with relative paths instead
+		rel, err := getRelativeToWorkingDirectory(path)
+		if err != nil {
+			return err
+		}
+		filepath = rel
+	}
 
 	if err = writeChecksumToFile(filepath, hash); err != nil {
 		return err


### PR DESCRIPTION
<!-- Description -->

Thanks


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
