### PR TITLE
Never stale a bug issue

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -32,7 +32,7 @@ jobs:
         days-before-close: 15
         operations-per-run: 10
         stale-issue-label: status/stale
-        exempt-issue-labels: status/never-stale
+        exempt-issue-labels: 'status/never-stale,kind/bug'
         stale-issue-message: |
           This issue has been automatically marked as stale due to 90 days of inactivity. 
           It will be closed if no further activity occurs within 15 days.


### PR DESCRIPTION
Hi, I think this will fix #3283.

*assumed exemption was unnecessary for pr-labels
*there's a newer version of stale if it matters (v5)