### PR TITLE
Enable parsing pod template as a modeline.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/magiconair/properties v1.8.6
+	github.com/mattn/go-shellwords v1.0.3
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/onsi/gomega v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -890,6 +890,7 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-shellwords v1.0.3 h1:K/VxK7SZ+cvuPgFSLKi5QPI9Vr/ipOf4C1gN+ntueUk=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pkg/cmd/modeline_test.go
+++ b/pkg/cmd/modeline_test.go
@@ -515,7 +515,7 @@ func TestModelineQuotedPodTemplate(t *testing.T) {
 		// camel-k: pod-template='{ "containers": [], "security": { "podSecurityContext": { "supplementalGroups": [ 553 ] }, "volumes": [] } }'
 	`
 		fileName := path.Join(dir, "simple.groovy")
-		err := ioutil.WriteFile(fileName, []byte(file), 0777)
+		err := ioutil.WriteFile(fileName, []byte(file), 0o400)
 		assert.NoError(t, err)
 
 		cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})

--- a/pkg/cmd/modeline_test.go
+++ b/pkg/cmd/modeline_test.go
@@ -507,3 +507,24 @@ func TestModelineInspectMultipleDeps(t *testing.T) {
 
 	assert.NoError(t, err)
 }
+
+func TestModelineQuotedPodTemplate(t *testing.T) {
+	err := util.WithTempDir("camel-k-test-", func(dir string) error {
+
+		file := `
+		// camel-k: pod-template='{ "containers": [], "security": { "podSecurityContext": { "supplementalGroups": [ 553 ] }, "volumes": [] } }'
+	`
+		fileName := path.Join(dir, "simple.groovy")
+		err := ioutil.WriteFile(fileName, []byte(file), 0777)
+		assert.NoError(t, err)
+
+		cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
+		assert.NoError(t, err)
+		assert.NotNil(t, cmd)
+		assert.Equal(t, []string{"run", fileName, "--pod-template={ \"containers\": [], \"security\": { \"podSecurityContext\": { \"supplementalGroups\": [ 553 ] }, \"volumes\": [] } }"}, flags)
+
+		return nil
+	})
+
+	assert.NoError(t, err)
+}

--- a/pkg/cmd/modeline_test.go
+++ b/pkg/cmd/modeline_test.go
@@ -512,7 +512,7 @@ func TestModelineQuotedPodTemplate(t *testing.T) {
 	err := util.WithTempDir("camel-k-test-", func(dir string) error {
 
 		file := `
-		// camel-k: pod-template='{ "containers": [], "security": { "podSecurityContext": { "supplementalGroups": [ 553 ] }, "volumes": [] } }'
+		// camel-k: pod-template='{ "containers": [], "securityContext": { "supplementalGroups": [ 553 ] }, "volumes": [] } }'
 	`
 		fileName := path.Join(dir, "simple.groovy")
 		err := ioutil.WriteFile(fileName, []byte(file), 0o400)
@@ -521,7 +521,7 @@ func TestModelineQuotedPodTemplate(t *testing.T) {
 		cmd, flags, err := NewKamelWithModelineCommand(context.TODO(), []string{"kamel", "run", fileName})
 		assert.NoError(t, err)
 		assert.NotNil(t, cmd)
-		assert.Equal(t, []string{"run", fileName, "--pod-template={ \"containers\": [], \"security\": { \"podSecurityContext\": { \"supplementalGroups\": [ 553 ] }, \"volumes\": [] } }"}, flags)
+		assert.Equal(t, []string{"run", fileName, "--pod-template={ \"containers\": [], \"securityContext\": { \"supplementalGroups\": [ 553 ] }, \"volumes\": [] } }"}, flags)
 
 		return nil
 	})

--- a/pkg/util/modeline/parser.go
+++ b/pkg/util/modeline/parser.go
@@ -24,14 +24,13 @@ import (
 	"strings"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/mattn/go-shellwords"
 )
 
 var (
 	commonModelineRegexp = regexp.MustCompile(`^\s*//\s*camel-k\s*:\s*([^\s]+.*)$`)
 	yamlModelineRegexp   = regexp.MustCompile(`^\s*#+\s*camel-k\s*:\s*([^\s]+.*)$`)
 	xmlModelineRegexp    = regexp.MustCompile(`^.*<!--\s*camel-k\s*:\s*([^\s]+[^>]*)-->.*$`)
-
-	delimiter = regexp.MustCompile(`\s+`)
 )
 
 func Parse(name, content string) (res []Option, err error) {
@@ -53,7 +52,7 @@ func getModelineOptions(line string, lang v1.Language) (res []Option) {
 	}
 	strs := reg.FindStringSubmatch(line)
 	if len(strs) == 2 {
-		tokens := delimiter.Split(strs[1], -1)
+		tokens, _ := shellwords.Parse(strs[1])
 		for _, token := range tokens {
 			if len(strings.Trim(token, "\t\n\f\r ")) == 0 {
 				continue


### PR DESCRIPTION
<!-- Description -->

A patch to allow pod templates in json to be declared in modelines.

As it is today, this does not work:

```java
// camel-k: pod-template='{ "containers": [], "securityContext": { "supplementalGroups": [ 553 ] }, "volumes": [] } }'
```

but this does:

```java
// camel-k: pod-template={"containers":[],"securityContext":{"supplementalGroups":[553]},"volumes":[]}}
```

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Enable parsing pod template as a modeline
```
