### PR TITLE
feat(cli): environment promotion

### DIFF
--- a/e2e/common/cli/files/promote-route.groovy
+++ b/e2e/common/cli/files/promote-route.groovy
@@ -1,0 +1,25 @@
+// camel-k: language=groovy
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+from('timer:configmap')
+    .setBody()
+        .simple("resource:classpath:my-configmap-key")
+    .log('configmap: ${body}')
+    .setBody()
+        .simple("resource:classpath:my-secret-key")
+    .log('secret: ${body}')

--- a/e2e/common/cli/promote_test.go
+++ b/e2e/common/cli/promote_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/apache/camel-k/e2e/support"
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+)
+
+func TestKamelCLIPromote(t *testing.T) {
+	// Dev environment namespace
+	WithNewTestNamespace(t, func(nsDev string) {
+		Expect(Kamel("install", "-n", nsDev).Execute()).To(Succeed())
+		// Dev content configmap
+		var cmData = make(map[string]string)
+		cmData["my-configmap-key"] = "I am development configmap!"
+		NewPlainTextConfigmap(nsDev, "my-cm", cmData)
+		// Dev secret
+		var secData = make(map[string]string)
+		secData["my-secret-key"] = "very top secret development"
+		NewPlainTextSecret(nsDev, "my-sec", secData)
+
+		t.Run("plain integration", func(t *testing.T) {
+			Expect(Kamel("run", "-n", nsDev, "./files/promote-route.groovy",
+				"--config", "configmap:my-cm",
+				"--config", "secret:my-sec",
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(nsDev, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationConditionStatus(nsDev, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			Eventually(IntegrationLogs(nsDev, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am development configmap!"))
+			Eventually(IntegrationLogs(nsDev, "promote-route"), TestTimeoutShort).Should(ContainSubstring("very top secret development"))
+		})
+
+		t.Run("kamelet integration", func(t *testing.T) {
+			Expect(CreateTimerKamelet(nsDev, "my-own-timer-source")()).To(Succeed())
+			Expect(Kamel("run", "-n", nsDev, "files/timer-kamelet-usage.groovy").Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(nsDev, "timer-kamelet-usage"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(nsDev, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
+		})
+
+		// Prod environment namespace
+		WithNewTestNamespace(t, func(nsProd string) {
+			Expect(Kamel("install", "-n", nsProd).Execute()).To(Succeed())
+
+			t.Run("no configmap in destination", func(t *testing.T) {
+				Expect(Kamel("promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).NotTo(Succeed())
+			})
+			// Prod content configmap
+			var cmData = make(map[string]string)
+			cmData["my-configmap-key"] = "I am production!"
+			NewPlainTextConfigmap(nsProd, "my-cm", cmData)
+
+			t.Run("no secret in destination", func(t *testing.T) {
+				Expect(Kamel("promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).NotTo(Succeed())
+			})
+
+			// Prod secret
+			var secData = make(map[string]string)
+			secData["my-secret-key"] = "very top secret production"
+			NewPlainTextSecret(nsProd, "my-sec", secData)
+
+			t.Run("Production integration", func(t *testing.T) {
+				Expect(Kamel("promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).To(Succeed())
+				Eventually(IntegrationPodPhase(nsProd, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				Eventually(IntegrationConditionStatus(nsProd, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+				Eventually(IntegrationLogs(nsProd, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am production!"))
+				Eventually(IntegrationLogs(nsProd, "promote-route"), TestTimeoutShort).Should(ContainSubstring("very top secret production"))
+				// They must use the same image
+				Expect(IntegrationPodImage(nsProd, "promote-route")()).Should(Equal(IntegrationPodImage(nsDev, "promote-route")()))
+			})
+
+			t.Run("no kamelet in destination", func(t *testing.T) {
+				Expect(Kamel("promote", "-n", nsDev, "timer-kamelet-usage", "--to", nsProd).Execute()).NotTo(Succeed())
+			})
+
+			t.Run("kamelet integration", func(t *testing.T) {
+				Expect(CreateTimerKamelet(nsProd, "my-own-timer-source")()).To(Succeed())
+				Expect(Kamel("promote", "-n", nsDev, "timer-kamelet-usage", "--to", nsProd).Execute()).To(Succeed())
+				Eventually(IntegrationPodPhase(nsProd, "timer-kamelet-usage"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				Eventually(IntegrationLogs(nsProd, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
+				// They must use the same image
+				Expect(IntegrationPodImage(nsProd, "timer-kamelet-usage")()).Should(Equal(IntegrationPodImage(nsDev, "timer-kamelet-usage")()))
+			})
+		})
+	})
+}

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -1,0 +1,288 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/client"
+	"github.com/apache/camel-k/pkg/metadata"
+	"github.com/apache/camel-k/pkg/util"
+	"github.com/apache/camel-k/pkg/util/camel"
+	"github.com/apache/camel-k/pkg/util/kubernetes"
+	"github.com/apache/camel-k/pkg/util/source"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// newCmdPromote --.
+func newCmdPromote(rootCmdOptions *RootCmdOptions) (*cobra.Command, *promoteCmdOptions) {
+	options := promoteCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+	cmd := cobra.Command{
+		Use:     "promote integration -to [namespace] ...",
+		Short:   "Promote an Integration from an environment to another",
+		Long:    "Promote an Integration from an environment to another, for example from a Development environment to a Production environment",
+		Aliases: []string{"cp", "mv"},
+		Args:    options.validate,
+		PreRunE: decode(&options),
+		RunE:    options.run,
+	}
+
+	cmd.Flags().StringP("to", "", "", "The namespace where to promote the Integration")
+
+	return &cmd, &options
+}
+
+type promoteCmdOptions struct {
+	*RootCmdOptions
+	To string `mapstructure:"to" yaml:",omitempty"`
+}
+
+func (o *promoteCmdOptions) validate(_ *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("promote expects an integration name argument")
+	}
+
+	return nil
+}
+
+func (o *promoteCmdOptions) run(cmd *cobra.Command, args []string) error {
+	it := args[0]
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	opSource, err := operatorInfo(o.Context, c, o.Namespace)
+	if err != nil {
+		return fmt.Errorf("could not retrieve info for Camel K operator source")
+	}
+	opDest, err := operatorInfo(o.Context, c, o.To)
+	if err != nil {
+		return fmt.Errorf("could not retrieve info for Camel K operator source")
+	}
+
+	checkOpsCompatibility(cmd, opSource, opDest)
+
+	sourceIntegration, err := o.getIntegration(c, it)
+	o.validateDestResources(c, sourceIntegration)
+	//destIntegration := o.editIntegration(sourceIntegration)
+
+	//return c.Create(o.Context, destIntegration)
+	return nil
+}
+
+func checkOpsCompatibility(cmd *cobra.Command, source, dest map[string]string) {
+	if !compatibleVersions(source["Version"], dest["Version"], cmd) {
+		panic(fmt.Sprintf("source (%s) and destination (%s) Camel K operator versions are not compatible", source["version"], dest["version"]))
+	}
+	if !compatibleVersions(source["Runtime Version"], dest["Runtime Version"], cmd) {
+		panic(fmt.Sprintf("source (%s) and destination (%s) Camel K runtime versions are not compatible", source["runtime version"], dest["runtime version"]))
+	}
+	if source["Registry Address"] != source["Registry Address"] {
+		panic(fmt.Sprintf("source (%s) and destination (%s) Camel K container images registries are not the same", source["registry address"], dest["registry address"]))
+	}
+}
+
+func (o *promoteCmdOptions) getIntegration(c client.Client, name string) (*v1.Integration, error) {
+	it := v1.NewIntegration(o.Namespace, name)
+	key := k8sclient.ObjectKey{
+		Name:      name,
+		Namespace: o.Namespace,
+	}
+	if err := c.Get(o.Context, key, &it); err != nil {
+		return nil, fmt.Errorf("could not find integration %s in namespace %s", it.Name, o.Namespace)
+	}
+
+	return &it, nil
+}
+
+func (o *promoteCmdOptions) validateDestResources(c client.Client, it *v1.Integration) {
+	var traits map[string][]string
+	var configmaps []string
+	var secrets []string
+	var pvcs []string
+	var kamelets []string
+	// Mount trait
+	mounts := it.Spec.Traits["mount"]
+	json.Unmarshal(mounts.Configuration.RawMessage, &traits)
+	for t, v := range traits {
+		if t == "configs" || t == "resources" {
+			for _, c := range v {
+				//TODO proper parse resources, now it does not account for complex parsing
+				if strings.HasPrefix(c, "configmap:") {
+					configmaps = append(configmaps, strings.Split(c, ":")[1])
+				}
+				if strings.HasPrefix(c, "secret:") {
+					secrets = append(secrets, strings.Split(c, ":")[1])
+				}
+			}
+		} else if t == "volumes" {
+			for _, c := range v {
+				pvcs = append(pvcs, strings.Split(c, ":")[0])
+			}
+		}
+	}
+	// Openapi trait
+	openapis := it.Spec.Traits["openapi"]
+	json.Unmarshal(openapis.Configuration.RawMessage, &traits)
+	for k, v := range traits {
+		for _, c := range v {
+			if k == "configmaps" {
+				configmaps = append(configmaps, c)
+			}
+		}
+	}
+	// Kamelet trait
+	kamelets = o.listKamelets(c, it)
+
+	anyError := false
+	for _, name := range configmaps {
+		if !existsCm(o.Context, c, name, o.To) {
+			anyError = true
+			fmt.Printf("Configmap %s is missing from %s namespace\n", name, o.To)
+		}
+	}
+	for _, name := range secrets {
+		if !existsSecret(o.Context, c, name, o.To) {
+			anyError = true
+			fmt.Printf("Secret %s is missing from %s namespace\n", name, o.To)
+		}
+	}
+	for _, name := range pvcs {
+		if !existsPv(o.Context, c, name, o.To) {
+			anyError = true
+			fmt.Printf("PersistentVolume %s is missing from %s namespace\n", name, o.To)
+		}
+	}
+	for _, name := range kamelets {
+		if !existsKamelet(o.Context, c, name, o.To) {
+			anyError = true
+			fmt.Printf("Kamelet %s is missing from %s namespace\n", name, o.To)
+		}
+	}
+
+	if anyError {
+		os.Exit(1)
+	}
+}
+
+func (o *promoteCmdOptions) listKamelets(c client.Client, it *v1.Integration) []string {
+	// TODO collect any kamelets which may be coming into the kamelet trait as well
+	var kamelets []string
+
+	sources, _ := kubernetes.ResolveIntegrationSources(o.Context, c, it, &kubernetes.Collection{})
+	catalog, _ := camel.DefaultCatalog()
+	metadata.Each(catalog, sources, func(_ int, meta metadata.IntegrationMetadata) bool {
+		util.StringSliceUniqueConcat(&kamelets, meta.Kamelets)
+		return true
+	})
+
+	// Check if a Kamelet is configured as default error handler URI
+	defaultErrorHandlerURI := it.Spec.GetConfigurationProperty(v1alpha1.ErrorHandlerAppPropertiesPrefix + ".deadLetterUri")
+	if defaultErrorHandlerURI != "" {
+		if strings.HasPrefix(defaultErrorHandlerURI, "kamelet:") {
+			kamelets = append(kamelets, source.ExtractKamelet(defaultErrorHandlerURI))
+		}
+	}
+
+	return kamelets
+}
+
+func existsCm(ctx context.Context, c client.Client, name string, namespace string) bool {
+	var obj corev1.ConfigMap
+	key := k8sclient.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+	if err := c.Get(ctx, key, &obj); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func existsSecret(ctx context.Context, c client.Client, name string, namespace string) bool {
+	var obj corev1.Secret
+	key := k8sclient.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+	if err := c.Get(ctx, key, &obj); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func existsPv(ctx context.Context, c client.Client, name string, namespace string) bool {
+	var obj corev1.PersistentVolume
+	key := k8sclient.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+	if err := c.Get(ctx, key, &obj); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func existsKamelet(ctx context.Context, c client.Client, name string, namespace string) bool {
+	var obj v1alpha1.Kamelet
+	key := k8sclient.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+	if err := c.Get(ctx, key, &obj); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func (o *promoteCmdOptions) editIntegration(it *v1.Integration) *v1.Integration {
+	dst := v1.NewIntegration(o.To, it.Name)
+	contImage := it.Status.Image
+	dst.Spec = *it.Spec.DeepCopy()
+	dst.Spec.Traits = map[string]v1.TraitSpec{
+		"container": traitSpecFromMap(map[string]interface{}{
+			"image": contImage,
+		}),
+	}
+
+	return &dst
+}
+
+// TODO refactor properly
+func traitSpecFromMap(spec map[string]interface{}) v1.TraitSpec {
+	var trait v1.TraitSpec
+	data, _ := json.Marshal(spec)
+	_ = json.Unmarshal(data, &trait.Configuration)
+	return trait
+}

--- a/pkg/cmd/promote_test.go
+++ b/pkg/cmd/promote_test.go
@@ -1,0 +1,53 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/apache/camel-k/pkg/util/test"
+	"github.com/spf13/cobra"
+)
+
+const cmdPromote = "promote"
+
+// nolint: unparam
+func initializePromoteCmdOptions(t *testing.T) (*promoteCmdOptions, *cobra.Command, RootCmdOptions) {
+	t.Helper()
+
+	options, rootCmd := kamelTestPreAddCommandInit()
+	promoteCmdOptions := addTestPromoteCmd(*options, rootCmd)
+	kamelTestPostAddCommandInit(t, rootCmd)
+
+	return promoteCmdOptions, rootCmd, *options
+}
+
+// nolint: unparam
+func addTestPromoteCmd(options RootCmdOptions, rootCmd *cobra.Command) *promoteCmdOptions {
+	// add a testing version of operator Command
+	operatorCmd, promoteOptions := newCmdPromote(&options)
+	operatorCmd.RunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	operatorCmd.PostRunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	operatorCmd.Args = test.ArbitraryArgs
+	rootCmd.AddCommand(operatorCmd)
+	return promoteOptions
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -150,6 +150,7 @@ func addKamelSubcommands(cmd *cobra.Command, options *RootCmdOptions) {
 	cmd.AddCommand(cmdOnly(newCmdDump(options)))
 	cmd.AddCommand(newCmdLocal(options))
 	cmd.AddCommand(cmdOnly(newCmdBind(options)))
+	cmd.AddCommand(cmdOnly(newCmdPromote(options)))
 	cmd.AddCommand(newCmdKamelet(options))
 }
 

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -143,6 +143,7 @@ func operatorInfo(ctx context.Context, c client.Client, namespace string) (map[s
 	infos["version"] = platform.Status.Version
 	infos["publishStrategy"] = string(platform.Status.Build.PublishStrategy)
 	infos["runtimeVersion"] = platform.Status.Build.RuntimeVersion
+	infos["registryAddress"] = platform.Status.Build.Registry.Address
 
 	if platform.Status.Info != nil {
 		for k, v := range platform.Status.Info {

--- a/pkg/trait/mount.go
+++ b/pkg/trait/mount.go
@@ -43,7 +43,7 @@ type mountTrait struct {
 	// A list of configuration pointing to configmap/secret.
 	// The configuration are expected to be UTF-8 resources as they are processed by runtime Camel Context and tried to be parsed as property files.
 	// They are also made available on the classpath in order to ease their usage directly from the Route.
-	// Syntax: [configmap|secret]:name[key], where name represents the resource name and key optionally represents the resource key to be filtered
+	// Syntax: [configmap|secret]:name[/key], where name represents the resource name and key optionally represents the resource key to be filtered
 	Configs []string `property:"configs" json:"configs,omitempty"`
 	// A list of resources (text or binary content) pointing to configmap/secret.
 	// The resources are expected to be any resource type (text or binary content).

--- a/pkg/util/kamelets/util.go
+++ b/pkg/util/kamelets/util.go
@@ -1,0 +1,56 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kamelets
+
+import (
+	"context"
+	"strings"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"github.com/apache/camel-k/pkg/client"
+	"github.com/apache/camel-k/pkg/metadata"
+	"github.com/apache/camel-k/pkg/util"
+	"github.com/apache/camel-k/pkg/util/camel"
+	"github.com/apache/camel-k/pkg/util/kubernetes"
+	"github.com/apache/camel-k/pkg/util/source"
+)
+
+// ExtractKameletFromSources provide a list of Kamelets referred into the Integration sources.
+func ExtractKameletFromSources(context context.Context, c client.Client, catalog *camel.RuntimeCatalog, resources *kubernetes.Collection, it *v1.Integration) ([]string, error) {
+	var kamelets []string
+
+	sources, err := kubernetes.ResolveIntegrationSources(context, c, it, resources)
+	if err != nil {
+		return nil, err
+	}
+	metadata.Each(catalog, sources, func(_ int, meta metadata.IntegrationMetadata) bool {
+		util.StringSliceUniqueConcat(&kamelets, meta.Kamelets)
+		return true
+	})
+
+	// Check if a Kamelet is configured as default error handler URI
+	defaultErrorHandlerURI := it.Spec.GetConfigurationProperty(v1alpha1.ErrorHandlerAppPropertiesPrefix + ".deadLetterUri")
+	if defaultErrorHandlerURI != "" {
+		if strings.HasPrefix(defaultErrorHandlerURI, "kamelet:") {
+			kamelets = append(kamelets, source.ExtractKamelet(defaultErrorHandlerURI))
+		}
+	}
+
+	return kamelets, nil
+}


### PR DESCRIPTION
With this PR the user can run:
```
kamel promote sample -n development --to production
```
in order to copy the Integration spec and the related container image from one environment (namespace) to another. In order to work the Operators have to share the same Image registry.

Features:

* Check compatibility version between source and dest operators
* Verify namespaced resources (ie, mount traits) are present in dest namespace
* Verify the operators registries are the same
* Verify Kamelets are available in dest namespace
* Copy the Integration spec from namespace source to ns dest
* Set `container.image` trait on destination to reuse image (tested) from the source Integration

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cli): environment promotion
```
