### PR TITLE
feat(gc): Skip GC for first integration generation

### DIFF
--- a/pkg/trait/gc_test.go
+++ b/pkg/trait/gc_test.go
@@ -44,8 +44,19 @@ func TestConfigureDisabledGarbageCollectorTraitDoesNotSucceed(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestApplyGarbageCollectorTraitDoesSucceed(t *testing.T) {
+func TestApplyGarbageCollectorTraitFirstGenerationDoesSucceed(t *testing.T) {
 	gcTrait, environment := createNominalGarbageCollectorTest()
+
+	err := gcTrait.Apply(environment)
+
+	assert.Nil(t, err)
+	assert.Len(t, environment.PostProcessors, 1)
+	assert.Len(t, environment.PostActions, 0)
+}
+
+func TestApplyGarbageCollectorTraitNextGenerationDoesSucceed(t *testing.T) {
+	gcTrait, environment := createNominalGarbageCollectorTest()
+	environment.Integration.Generation = 2
 
 	err := gcTrait.Apply(environment)
 
@@ -73,7 +84,8 @@ func createNominalGarbageCollectorTest() (*garbageCollectorTrait, *Environment) 
 		Catalog: NewCatalog(nil),
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "integration-name",
+				Name:       "integration-name",
+				Generation: 1,
 			},
 			Status: v1.IntegrationStatus{
 				Phase: v1.IntegrationPhaseRunning,


### PR DESCRIPTION
The GC trait relies on the generation metadata field of the integration, by propagating it to owned resources in a label, and listing the laters with label selection using the `<` selector operator. Assuming the generation field is a monotonically increasing strictly positive integer, it's safe to skip garbage collection on the first integration generation, i.e., when the generation field is less or equal to one, to reduce the overhead on the API server.

**Release Note**
```release-note
feat(gc): Skip GC for first integration generation
```
