### PR TITLE
Fixes `kamel local run` panic on Windows

### DIFF
--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/apache/camel-k/pkg/util"
@@ -50,13 +50,7 @@ func assembleClasspathArgValue(properties []string, dependencies []string, route
 	classpathContents = append(classpathContents, properties...)
 	classpathContents = append(classpathContents, routes...)
 	classpathContents = append(classpathContents, dependencies...)
-
-	pathSeparator := ":"
-	if runtime.GOOS == "windows" {
-		pathSeparator = ";"
-	}
-
-	return strings.Join(classpathContents, pathSeparator)
+	return strings.Join(classpathContents, string(os.PathListSeparator))
 }
 
 func assembleIntegrationRunCommand(ctx context.Context, properties []string, dependencies []string, routes []string, propertiesDir string, stdout, stderr io.Writer, local bool) (*exec.Cmd, error) {

--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/apache/camel-k/pkg/util"
@@ -49,7 +50,13 @@ func assembleClasspathArgValue(properties []string, dependencies []string, route
 	classpathContents = append(classpathContents, properties...)
 	classpathContents = append(classpathContents, routes...)
 	classpathContents = append(classpathContents, dependencies...)
-	return strings.Join(classpathContents, ":")
+
+	pathSeparator := ":"
+	if runtime.GOOS == "windows" {
+		pathSeparator = ";"
+	}
+
+	return strings.Join(classpathContents, pathSeparator)
 }
 
 func assembleIntegrationRunCommand(ctx context.Context, properties []string, dependencies []string, routes []string, propertiesDir string, stdout, stderr io.Writer, local bool) (*exec.Cmd, error) {

--- a/pkg/resources/resources_support.go
+++ b/pkg/resources/resources_support.go
@@ -104,7 +104,7 @@ func WithPrefix(pathPrefix string) ([]string, error) {
 
 	var res []string
 	for i := range paths {
-		path := filepath.FromSlash(paths[i])
+		path := filepath.ToSlash(paths[i])
 		if result, _ := filepath.Match(pathPrefix+"*", path); result {
 			res = append(res, path)
 		}
@@ -150,5 +150,5 @@ func Resources(dirName string) ([]string, error) {
 }
 
 func openAsset(path string) (http.File, error) {
-	return assets.Open(filepath.FromSlash(path))
+	return assets.Open(filepath.ToSlash(path))
 }

--- a/pkg/resources/resources_support.go
+++ b/pkg/resources/resources_support.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -46,7 +47,7 @@ func Resource(name string) ([]byte, error) {
 		name = "/" + name
 	}
 
-	file, err := assets.Open(name)
+	file, err := assets.Open(fixPath(name))
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot access resource file %s", name)
 	}
@@ -85,7 +86,7 @@ func TemplateResource(name string, params interface{}) (string, error) {
 
 // DirExists tells if a directory exists and can be listed for files.
 func DirExists(dirName string) bool {
-	if _, err := assets.Open(dirName); err != nil {
+	if _, err := assets.Open(fixPath(dirName)); err != nil {
 		return false
 	}
 	return true
@@ -103,8 +104,9 @@ func WithPrefix(pathPrefix string) ([]string, error) {
 
 	var res []string
 	for i := range paths {
-		if result, _ := filepath.Match(pathPrefix+"*", paths[i]); result {
-			res = append(res, paths[i])
+		path := fixPath(paths[i])
+		if result, _ := filepath.Match(pathPrefix+"*", path); result {
+			res = append(res, path)
 		}
 	}
 
@@ -113,7 +115,7 @@ func WithPrefix(pathPrefix string) ([]string, error) {
 
 // Resources lists all file names in the given path (starts with '/').
 func Resources(dirName string) ([]string, error) {
-	dir, err := assets.Open(dirName)
+	dir, err := assets.Open(fixPath(dirName))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -145,4 +147,12 @@ func Resources(dirName string) ([]string, error) {
 	}
 
 	return res, dir.Close()
+}
+
+func fixPath(path string) string {
+	if runtime.GOOS == "windows" {
+		path = strings.ReplaceAll(path, "\\", "/")
+	}
+
+	return path
 }


### PR DESCRIPTION
<!-- Description -->

Fix panic while running `kamel local run` on Windows.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): fix panic while running kamel local run on Windows
```
