### PR TITLE
Fixes `kamel local run` panic on Windows

### DIFF
--- a/pkg/cmd/util_commands.go
+++ b/pkg/cmd/util_commands.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -49,7 +50,7 @@ func assembleClasspathArgValue(properties []string, dependencies []string, route
 	classpathContents = append(classpathContents, properties...)
 	classpathContents = append(classpathContents, routes...)
 	classpathContents = append(classpathContents, dependencies...)
-	return strings.Join(classpathContents, ":")
+	return strings.Join(classpathContents, string(os.PathListSeparator))
 }
 
 func assembleIntegrationRunCommand(ctx context.Context, properties []string, dependencies []string, routes []string, propertiesDir string, stdout, stderr io.Writer, local bool) (*exec.Cmd, error) {

--- a/pkg/resources/resources_support.go
+++ b/pkg/resources/resources_support.go
@@ -104,7 +104,7 @@ func WithPrefix(pathPrefix string) ([]string, error) {
 
 	var res []string
 	for i := range paths {
-		path := filepath.FromSlash(paths[i])
+		path := filepath.ToSlash(paths[i])
 		if result, _ := filepath.Match(pathPrefix+"*", path); result {
 			res = append(res, path)
 		}
@@ -150,5 +150,5 @@ func Resources(dirName string) ([]string, error) {
 }
 
 func openAsset(path string) (http.File, error) {
-	return assets.Open(filepath.FromSlash(path))
+	return assets.Open(filepath.ToSlash(path))
 }


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): fix panic while running kamel local run on Windows
```
