### PR TITLE
fix(knative): Make knative broker name configurable

### DIFF
--- a/e2e/global/knative/files/knative_broker_receiver.groovy
+++ b/e2e/global/knative/files/knative_broker_receiver.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+from('knative:event/hello.1?name=sample-broker')
+  .log('Received 1: ${body}')
+
+from('knative:event/hello.2?name=sample-broker')
+  .log('Received 2: ${body}')

--- a/e2e/global/knative/files/knative_broker_sender.groovy
+++ b/e2e/global/knative/files/knative_broker_sender.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+from('timer:tick')
+  .setBody().constant("Hello 1 from sample-broker")
+  .to('knative:event/hello.1?name=sample-broker')
+
+from('timer:tick')
+  .setBody().constant("Hello 2 from sample-broker")
+  .to('knative:event/hello.2?name=sample-broker')

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1763,6 +1763,22 @@ func CreateKnativeChannel(ns string, name string) func() error {
 	}
 }
 
+func CreateKnativeBroker(ns string, name string) func() error {
+	return func() error {
+		broker := eventing.Broker{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Broker",
+				APIVersion: eventing.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+		}
+		return TestClient().Create(TestContext, &broker)
+	}
+}
+
 /*
 	Kamelets
 */

--- a/e2e/yaks/common/kamelet-binding-broker/kamelet.feature
+++ b/e2e/yaks/common/kamelet-binding-broker/kamelet.feature
@@ -5,6 +5,6 @@ Feature: Camel K can bind Kamelets to the broker
       | maxAttempts          | 40   |
       | delayBetweenAttempts | 3000 |
 
-  Scenario: Sending event to the broker with KameletBinding
+  Scenario: Sending event to the custom broker with KameletBinding
     Given Camel K integration logger-sink-binding is running
-    Then Camel K integration logger-sink-binding should print message: Hello Custom Event
+    Then Camel K integration logger-sink-binding should print message: Hello Custom Event from sample-broker

--- a/e2e/yaks/common/kamelet-binding-broker/logger-sink-binding.yaml
+++ b/e2e/yaks/common/kamelet-binding-broker/logger-sink-binding.yaml
@@ -24,7 +24,7 @@ spec:
     ref:
       kind: Broker
       apiVersion: eventing.knative.dev/v1
-      name: default
+      name: sample-broker
     properties:
       type: custom-type
   sink:

--- a/e2e/yaks/common/kamelet-binding-broker/sample-broker.yaml
+++ b/e2e/yaks/common/kamelet-binding-broker/sample-broker.yaml
@@ -1,0 +1,4 @@
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: sample-broker

--- a/e2e/yaks/common/kamelet-binding-broker/timer-source-binding.yaml
+++ b/e2e/yaks/common/kamelet-binding-broker/timer-source-binding.yaml
@@ -26,12 +26,12 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: timer-source
     properties:
-      message: Hello Custom Event
+      message: Hello Custom Event from sample-broker
       period: 1000
   sink:
     ref:
       kind: Broker
       apiVersion: eventing.knative.dev/v1
-      name: default
+      name: sample-broker
     properties:
       type: custom-type

--- a/e2e/yaks/common/kamelet-binding-broker/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-broker/yaks-config.yaml
@@ -21,12 +21,9 @@ config:
 pre:
 - name: installation
   run: |
-    # One of the two labels should work
-    oc label namespace $YAKS_NAMESPACE eventing.knative.dev/injection=enabled
-    oc label namespace $YAKS_NAMESPACE knative-eventing-injection=enabled
-
     kamel install -n $YAKS_NAMESPACE --force --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
 
+    kubectl apply -f sample-broker.yaml -n $YAKS_NAMESPACE
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f logger-sink.kamelet.yaml -n $YAKS_NAMESPACE
 

--- a/pkg/apis/camel/v1/knative/types.go
+++ b/pkg/apis/camel/v1/knative/types.go
@@ -75,6 +75,7 @@ const (
 	CamelMetaKnativeKind       = "knative.kind"
 	CamelMetaKnativeAPIVersion = "knative.apiVersion"
 	CamelMetaKnativeReply      = "knative.reply"
+	CamelMetaKnativeName       = "knative.name"
 
 	CamelMetaEndpointKind = "camel.endpoint.kind"
 

--- a/pkg/apis/camel/v1/knative/types_support.go
+++ b/pkg/apis/camel/v1/knative/types_support.go
@@ -34,6 +34,7 @@ func BuildCamelServiceDefinition(name string, endpointKind CamelEndpointKind, se
 			CamelMetaEndpointKind:      string(endpointKind),
 			CamelMetaKnativeAPIVersion: apiVersion,
 			CamelMetaKnativeKind:       kind,
+			CamelMetaKnativeName:       name,
 		},
 	}
 

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -354,6 +354,7 @@ func (t *knativeTrait) configureEvents(e *Environment, env *knativeapi.CamelEnvi
 						knativeapi.CamelMetaEndpointKind:      string(knativeapi.CamelEndpointKindSource),
 						knativeapi.CamelMetaKnativeAPIVersion: ref.APIVersion,
 						knativeapi.CamelMetaKnativeKind:       ref.Kind,
+						knativeapi.CamelMetaKnativeName:       ref.Name,
 						knativeapi.CamelMetaKnativeReply:      "false",
 					},
 				}

--- a/pkg/util/bindings/bindings_test.go
+++ b/pkg/util/bindings/bindings_test.go
@@ -126,7 +126,7 @@ func TestBindings(t *testing.T) {
 					"type": "myeventtype",
 				}),
 			},
-			uri: "knative:event/myeventtype?apiVersion=eventing.knative.dev%2Fv1&kind=Broker",
+			uri: "knative:event/myeventtype?apiVersion=eventing.knative.dev%2Fv1&kind=Broker&name=default",
 		},
 		{
 			endpointType: v1alpha1.EndpointTypeSource,

--- a/pkg/util/bindings/knative_ref.go
+++ b/pkg/util/bindings/knative_ref.go
@@ -68,12 +68,9 @@ func (k KnativeRefBindingProvider) Translate(ctx BindingContext, endpointCtx End
 
 	var serviceURI string
 	if *serviceType == knativeapis.CamelServiceTypeEvent {
-		// TODO enable this when the runtime will support changing the broker name (https://github.com/apache/camel-k-runtime/issues/535)
-		/*
-			if props["name"] == "" {
-				props["name"] = e.Ref.Name
-			}
-		*/
+		if props["name"] == "" {
+			props["name"] = e.Ref.Name
+		}
 		if eventType, ok := props["type"]; ok {
 			// consume prop
 			delete(props, "type")


### PR DESCRIPTION
https://github.com/apache/camel-k/issues/2864

* Add e2e knative tests
* Change the kamelet-binding-broker yaks test to use a custom broker name

**Release Note**
```release-note
Make knative broker name configurable
```

* WIP: This PR depends on a [camel-knative fix](https://github.com/apache/camel/pull/7818). This is for an early review.