### PR TITLE
fix(#3390): Bring back rbac permission for Knative channels

### DIFF
--- a/config/rbac/operator-role-knative.yaml
+++ b/config/rbac/operator-role-knative.yaml
@@ -49,6 +49,8 @@ rules:
   - messaging.knative.dev
   resources:
   - subscriptions
+  - channels
+  - inmemorychannels
   verbs:
   - create
   - delete


### PR DESCRIPTION
Fixes #3390 
- Kamelet bindings connecting with Knative channels/inmemorychannels as source/sink do require this permission

**Release Note**
```release-note
Fix(Knative): Bring back permissions on messaging.knative.dev channels/inmemorychannels
```
