### PR TITLE
fix(#3399): Improve operator log level adjustments

### DIFF
--- a/docs/modules/ROOT/pages/observability/logging/operator.adoc
+++ b/docs/modules/ROOT/pages/observability/logging/operator.adoc
@@ -13,3 +13,22 @@ For example, the Maven build logs display like this:
 ----
 
 This may differ when running the operator locally, for development purposes, in which case the local Maven installation that is used may provide a different output.
+
+[[operator-logging-level]]
+== Logging Level
+
+The operator log level is controlled by an environment setting (`LOG_LEVEL`) on the operator deployment. You can set the log level on the kamel install command like this
+
+[source,bash]
+----
+kamel install --log-level debug
+----
+
+This will set the log level to `debug`, so you can expect a more verbose operator output. The default level is `info`.
+
+In general log levels are represented by numeric verbosity levels where `0` is the standard
+info log level and `1` is debug level. All values `2-10` represent different trace levels.
+You can set numeric values or one of the preset values `info`, `debug`, `error`.
+
+As an alternative to using the `--log-level` option on the kamel CLI you can add an environment variable (`LOG_LEVEL=debug`) directly to the Camel K operator deployment.
+You may need to restart the operator pods controlled by the deployment to see the effect in the log output.

--- a/pkg/cmd/bind.go
+++ b/pkg/cmd/bind.go
@@ -85,7 +85,7 @@ type bindCmdOptions struct {
 
 func (o *bindCmdOptions) preRunE(cmd *cobra.Command, args []string) error {
 	if o.OutputFormat != "" {
-		// let the command to work in offline mode
+		// let the command work in offline mode
 		cmd.Annotations[offlineCommandLabel] = "true"
 	}
 	return o.RootCmdOptions.preRun(cmd, args)

--- a/pkg/install/optional.go
+++ b/pkg/install/optional.go
@@ -21,18 +21,17 @@ import (
 	"context"
 	"strings"
 
-	"github.com/go-logr/logr"
-
 	"github.com/apache/camel-k/pkg/client"
 	"github.com/apache/camel-k/pkg/util/defaults"
+	logutil "github.com/apache/camel-k/pkg/util/log"
 )
 
 // OperatorStartupOptionalTools tries to install optional tools at operator startup and warns if something goes wrong.
-func OperatorStartupOptionalTools(ctx context.Context, c client.Client, namespace string, operatorNamespace string, log logr.Logger) {
+func OperatorStartupOptionalTools(ctx context.Context, c client.Client, namespace string, operatorNamespace string, log logutil.Logger) {
 	// Try to register the OpenShift CLI Download link if possible
 	if err := OpenShiftConsoleDownloadLink(ctx, c); err != nil {
 		log.Info("Cannot install OpenShift CLI download link: skipping.")
-		log.V(8).Info("Error while installing OpenShift CLI download link", "error", err)
+		log.Debug("Error while installing OpenShift CLI download link", "error", err)
 	}
 
 	// Try to install Kamelet Catalog automatically
@@ -49,7 +48,7 @@ func OperatorStartupOptionalTools(ctx context.Context, c client.Client, namespac
 		if defaults.InstallDefaultKamelets() {
 			if err := KameletCatalog(ctx, c, kameletNamespace); err != nil {
 				log.Info("Cannot install bundled Kamelet Catalog: skipping.")
-				log.V(8).Info("Error while installing bundled Kamelet Catalog", "error", err)
+				log.Debug("Error while installing bundled Kamelet Catalog", "error", err)
 			}
 		} else {
 			log.Info("Kamelet Catalog installation is disabled")
@@ -59,14 +58,14 @@ func OperatorStartupOptionalTools(ctx context.Context, c client.Client, namespac
 			// Make sure that Kamelets installed in operator namespace can be used by others
 			if err := KameletViewerRole(ctx, c, kameletNamespace); err != nil {
 				log.Info("Cannot install global Kamelet viewer role: skipping.")
-				log.V(8).Info("Error while installing global Kamelet viewer role", "error", err)
+				log.Debug("Error while installing global Kamelet viewer role", "error", err)
 			}
 		}
 	}
 
 	// Try to bind the Knative Addressable resolver aggregated ClusterRole to the operator ServiceAccount
 	if err := BindKnativeAddressableResolverClusterRole(ctx, c, namespace, operatorNamespace); err != nil {
-		log.Info("Cannot bind the Knative Addressable resolver aggregated ClusterRole: skipping.")
-		log.V(8).Info("Error while binding the Knative Addressable resolver aggregated ClusterRole", "error", err)
+		log.Info("Cannot bind the Knative addressable resolver aggregated ClusterRole: skipping.")
+		log.Debug("Error while binding the Knative Addressable resolver aggregated ClusterRole", "error", err)
 	}
 }

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -149,6 +149,11 @@ func (l Logger) ForKameletBinding(target *v1alpha1.KameletBinding) Logger {
 	)
 }
 
+// AsLogger --.
+func (l Logger) AsLogger() logr.Logger {
+	return l.delegate
+}
+
 // ***********************************
 //
 // Helpers


### PR DESCRIPTION
- Use zap log level enabler implementation to set global log level
- Use Camel K logger wrapper in operator
- Use Debug wrapper methods
- Add some documentation of LOG_LEVEL envvar and its setting via kamel CLI