### PR TITLE
allow setting resources & securityContext in Helm Chart values

### DIFF
--- a/helm/camel-k/README.md
+++ b/helm/camel-k/README.md
@@ -79,6 +79,8 @@ Camel K chart and their default values. The chart allows configuration of an `In
 | `platform.build.registry.insecure`     | Indicates if the registry is not secured                                  | true                           |
 | `platform.cluster`                     | The kind of Kubernetes cluster (Kubernetes or OpenShift)                  | `Kubernetes`                   |
 | `platform.profile`                     | The trait profile to use (Knative, Kubernetes or OpenShift)               | auto                           |
+| `operator.resources`                   | the resource requests and limits to use for the operator                  |                                |
+| `operator.securityContext`             | The (container-related) securityContext to use for the operato            |                                |
 
 ## Contributing
 

--- a/helm/camel-k/templates/operator.yaml
+++ b/helm/camel-k/templates/operator.yaml
@@ -68,5 +68,6 @@ spec:
           ports:
             - containerPort: 8080
               name: metrics
-          resources: {}
+          resources: {{ .Values.operator.resources }}
+          securityContext: {{ .Values.operator.securityContext }}
       serviceAccountName: camel-k-operator

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -24,6 +24,8 @@ fullnameOverride: ""
 
 operator:
   image: docker.io/apache/camel-k:1.10.0-SNAPSHOT
+  resources: {}
+  securityContext: {}
 
 platform:
   build:


### PR DESCRIPTION
<!-- Description -->

one of the best practices for operating workloads in Kubernetes is to set resource requests and limits as well as securityContext related settings. 

This PR introduces the possibility to set those resource requests and limits as well as securityContext related settings. Since the exact settings cant be known and depend on the environment as well as the number and complexity of camel routes, users will be able to freely define their settings in the `values.yaml`.

<!--
no release note is required

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
