### PR TITLE
[Backport 1.9.x] fix(#3390): Fix Knative addressable resolver cluster role binding

### DIFF
--- a/pkg/install/knative.go
+++ b/pkg/install/knative.go
@@ -32,26 +32,26 @@ import (
 
 const knativeAddressableResolverClusterRoleName = "addressable-resolver"
 
-// BindKnativeAddressableResolverClusterRole binds the Knative Addressable resolver aggregated ClusterRole
+// BindKnativeAddressableResolverClusterRole binds the Knative addressable resolver aggregated ClusterRole
 // to the operator ServiceAccount.
-func BindKnativeAddressableResolverClusterRole(ctx context.Context, c kubernetes.Interface, namespace string) error {
+func BindKnativeAddressableResolverClusterRole(ctx context.Context, c kubernetes.Interface, namespace string, operatorNamespace string) error {
 	if isKnative, err := knative.IsInstalled(ctx, c); err != nil {
 		return err
 	} else if !isKnative {
 		return nil
 	}
 	if namespace != "" {
-		return applyAddressableResolverRoleBinding(ctx, c, namespace)
+		return applyAddressableResolverRoleBinding(ctx, c, namespace, operatorNamespace)
 	}
-	return applyAddressableResolverClusterRoleBinding(ctx, c, namespace)
+	return applyAddressableResolverClusterRoleBinding(ctx, c, operatorNamespace)
 }
 
-func applyAddressableResolverRoleBinding(ctx context.Context, c kubernetes.Interface, namespace string) error {
+func applyAddressableResolverRoleBinding(ctx context.Context, c kubernetes.Interface, namespace string, operatorNamespace string) error {
 	rb := rbacv1ac.RoleBinding(fmt.Sprintf("%s-addressable-resolver", serviceAccountName), namespace).
 		WithSubjects(
 			rbacv1ac.Subject().
 				WithKind("ServiceAccount").
-				WithNamespace(namespace).
+				WithNamespace(operatorNamespace).
 				WithName(serviceAccountName),
 		).
 		WithRoleRef(rbacv1ac.RoleRef().
@@ -65,12 +65,12 @@ func applyAddressableResolverRoleBinding(ctx context.Context, c kubernetes.Inter
 	return err
 }
 
-func applyAddressableResolverClusterRoleBinding(ctx context.Context, c kubernetes.Interface, namespace string) error {
+func applyAddressableResolverClusterRoleBinding(ctx context.Context, c kubernetes.Interface, operatorNamespace string) error {
 	crb := rbacv1ac.ClusterRoleBinding(fmt.Sprintf("%s-addressable-resolver", serviceAccountName)).
 		WithSubjects(
 			rbacv1ac.Subject().
 				WithKind("ServiceAccount").
-				WithNamespace(namespace).
+				WithNamespace(operatorNamespace).
 				WithName(serviceAccountName),
 		).
 		WithRoleRef(rbacv1ac.RoleRef().

--- a/pkg/install/optional.go
+++ b/pkg/install/optional.go
@@ -65,7 +65,7 @@ func OperatorStartupOptionalTools(ctx context.Context, c client.Client, namespac
 	}
 
 	// Try to bind the Knative Addressable resolver aggregated ClusterRole to the operator ServiceAccount
-	if err := BindKnativeAddressableResolverClusterRole(ctx, c, namespace); err != nil {
+	if err := BindKnativeAddressableResolverClusterRole(ctx, c, namespace, operatorNamespace); err != nil {
 		log.Info("Cannot bind the Knative Addressable resolver aggregated ClusterRole: skipping.")
 		log.V(8).Info("Error while binding the Knative Addressable resolver aggregated ClusterRole", "error", err)
 	}


### PR DESCRIPTION
Use proper operator namespace in the service account role binding subject for global operators. Was using empty global operator watch namespace before which caused errors in the cluster role binding.

(cherry picked from commit 2ffdcfab6f8fa4ee90f9581b26ebf7cbe48aa685)

**Release Note**
```release-note
Fix(Knative): Cluster role binding for Knative addressable resolver. Bring back permissions for messaging.knative.dev resources (e.g. channel)
```
