### PR TITLE
Handle OCP3 in e2e kustomize install tests

### DIFF
--- a/.github/actions/kamel-config-cluster-ocp3/action.yml
+++ b/.github/actions/kamel-config-cluster-ocp3/action.yml
@@ -199,7 +199,7 @@ runs:
       if: ${{ env.CLUSTER_OCP3_CONFIGURED != 'true' }}
       run: |
         echo "::set-output name=cluster-image-registry-pull-host::"
-        echo "::set-output name=cluster-image-registry-pull-host::"
+        echo "::set-output name=cluster-image-registry-push-host::"
         echo "::set-output name=cluster-image-registry-insecure::$(echo true)"
         echo "::set-output name=cluster-has-olm::$(echo false)"
         echo "::set-output name=cluster-image-namespace::$(echo apache)"

--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -44,6 +44,21 @@ on:
       - 'NOTICE'
   workflow_dispatch:
     inputs:
+      pre-built-kamel-image:
+        description: 'Kamel image url for skipping building of kamel stages. Used for debugging'
+        required: false
+      skip-problematic:
+        description: 'Whether tests marked as problematic should be skipped - false by default (sets CAMEL_K_TEST_SKIP_PROBLEMATIC)'
+        required: false
+        default: false
+      test-filters:
+        description: |
+          List of comma-separated key/value pairs to filter the tests in this test suite:
+            TEST_INTEGRATION_COMMON_RUN,        TEST_INTEGRATION_COMMON_BUILD_RUN, TEST_INTEGRATION_COMMON_CONFIG_RUN,
+            TEST_INTEGRATION_COMMON_LANG_RUN,   TEST_INTEGRATION_COMMON_TRAITS_RUN
+            TEST_SERVICE_RUN,                   TEST_REGISTRY_MAVEN_WAGON_RUN
+          eg. TEST_INTEGRATION_COMMON_RUN=TestBasic will only run tests prefixed with 'TestBasic'
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -92,9 +107,10 @@ jobs:
     - name: Run IT 1
       run: |
         # Then run integration tests
+        export CAMEL_K_CLUSTER_OCP3=true
+
         make test-integration
         make test-builder
-        make test-quarkus-native
 
     - id: change-context
       name: Change the Kamel Cluster Context to Admin
@@ -105,4 +121,7 @@ jobs:
     - name: Run IT 2
       run: |
         # Then run integration tests
+        export CAMEL_K_CLUSTER_OCP3=true
+
+        make test-quarkus-native
         make test-install

--- a/e2e/namespace/install/kustomize/common.go
+++ b/e2e/namespace/install/kustomize/common.go
@@ -73,8 +73,28 @@ func ExecMake(t *testing.T, command *exec.Cmd) {
 	session.Wait()
 	Eventually(session).Should(gexec.Exit(0))
 	assert.Nil(t, err)
-	assert.NotContains(t, cmdErr.String(), "Error")
-	assert.NotContains(t, cmdErr.String(), "ERROR")
+	assert.NotContains(t, strings.ToUpper(cmdErr.String()), "ERROR")
+}
+
+//
+// Expect a make error with an exit code of 1
+//
+func ExecMakeError(t *testing.T, command *exec.Cmd) {
+	var cmdOut strings.Builder
+	var cmdErr strings.Builder
+
+	defer func() {
+		if t.Failed() {
+			t.Logf("Output from make command:\n%s\n", cmdOut.String())
+			t.Logf("Error from make command:\n%s\n", cmdErr.String())
+		}
+	}()
+
+	session, err := gexec.Start(command, &cmdOut, &cmdErr)
+	session.Wait()
+	Eventually(session).ShouldNot(gexec.Exit(0))
+	assert.Nil(t, err)
+	assert.Contains(t, strings.ToUpper(cmdErr.String()), "ERROR")
 }
 
 // Clean up the cluster ready for the next set of tests

--- a/e2e/namespace/install/kustomize/operator_test.go
+++ b/e2e/namespace/install/kustomize/operator_test.go
@@ -31,7 +31,21 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestOcp3CrdError(t *testing.T) {
+	if os.Getenv("CAMEL_K_CLUSTER_OCP3") != "true" {
+		t.Skip("INFO: Skipping test as only applicable to OCP3")
+	}
+
+	WithNewTestNamespace(t, func(ns string) {
+		ExecMakeError(t, Make("setup-cluster", fmt.Sprintf("NAMESPACE=%s", ns)))
+	})
+}
+
 func TestBasicOperator(t *testing.T) {
+	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
+		t.Skip("INFO: Skipping test as not supported on OCP3")
+	}
+
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed
@@ -50,6 +64,10 @@ func TestBasicOperator(t *testing.T) {
 }
 
 func TestAlternativeImageOperator(t *testing.T) {
+	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
+		t.Skip("INFO: Skipping test as not supported on OCP3")
+	}
+
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed
@@ -72,6 +90,10 @@ func TestAlternativeImageOperator(t *testing.T) {
 }
 
 func TestGlobalOperator(t *testing.T) {
+	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
+		t.Skip("INFO: Skipping test as not supported on OCP3")
+	}
+
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed

--- a/e2e/namespace/install/kustomize/setup_test.go
+++ b/e2e/namespace/install/kustomize/setup_test.go
@@ -32,6 +32,10 @@ import (
 )
 
 func TestBasicSetup(t *testing.T) {
+	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
+		t.Skip("INFO: Skipping test as not supported on OCP3")
+	}
+
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed
@@ -61,6 +65,10 @@ func TestBasicSetup(t *testing.T) {
 }
 
 func TestGlobalSetup(t *testing.T) {
+	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
+		t.Skip("INFO: Skipping test as not supported on OCP3")
+	}
+
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed

--- a/install/Makefile
+++ b/install/Makefile
@@ -155,6 +155,16 @@ endif
 check-admin: kubectl
 	@output=$$(kubectl get crd 2>&1) || (echo "****" && echo "**** ERROR: Cannot continue as user is not a Cluster-Admin ****" && echo "****"; exit 1)
 
+crd-api-support: kubectl
+ifndef CRD_SUPPORT
+CRD_SUPPORT=$(shell script/check_crd_api_support.sh)
+endif
+
+check-crd-api-support: crd-api-support
+ifneq ($(CRD_SUPPORT),OK)
+	$(error *** CRD API FAILURE: $(CRD_SUPPORT) ****)
+endif
+
 #
 # Setup the cluster installation by installing crds and cluster roles.
 #
@@ -168,7 +178,7 @@ check-admin: kubectl
 #   PLATFORM:  Override the discovered platform, if required
 #   DRY_RUN:     true - Prints the resources to be applied instead of applying them
 #
-setup-cluster: check-admin have-platform kustomize kubectl
+setup-cluster: check-admin check-crd-api-support have-platform kustomize kubectl
 # Set the namespace in the setup-cluster kustomization yaml
 	@$(call set-kustomize-namespace,$@)
 ifeq ($(PLATFORM), openshift)
@@ -270,7 +280,7 @@ endif
 #   LOGGING_LEVEL:      Set the level of logging [info|debug]
 #   DRY_RUN:            Prints the resources to be applied instead of applying them
 #
-operator: check-admin have-platform kustomize kubectl .operator-port-patch .operator-log-level-patch
+operator: check-admin have-platform check-crd-api-support kustomize kubectl .operator-port-patch .operator-log-level-patch
 ifeq ($(MONITORING), true)
 	@$(MAKE) -s .operator-can-monitor
 	@$(call add-remove-operator-monitoring,$@,add)

--- a/install/script/check_crd_api_support.sh
+++ b/install/script/check_crd_api_support.sh
@@ -1,0 +1,1 @@
+../../script/check_crd_api_support.sh

--- a/script/check_crd_api_support.sh
+++ b/script/check_crd_api_support.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+is_binary_available() {
+
+  client="${1}"
+
+  # Check path first if it already exists
+  set +e
+  which "${client}" &>/dev/null
+  if [ $? -eq 0 ]; then
+    set -e
+    echo "OK"
+    return
+  fi
+
+  set -e
+
+  # Error, no oc found
+  echo "ERROR: No '${client}' binary found in path."
+}
+
+location=$(dirname $0)
+rootdir=$location/../
+
+cd $rootdir
+
+client="oc"
+hasclient=$(is_binary_available "${client}")
+if [ "${hasclient}" != "OK" ]; then
+  client="kubectl"
+	hasclient=$(is_binary_available "${client}")
+	if [ "${hasclient}" != "OK" ]; then
+	  echo "ERROR: No kube client installed."
+	  exit 1
+	fi
+fi
+
+crd_version=$("${client}" explain customresourcedefinitions | grep VERSION | awk '{print $2}')
+api="apiextensions.k8s.io"
+
+if [ "${crd_version}" == "${api}/v1beta1" ]; then
+	echo "ERROR: CRD API version is too old to install camel-k in this way. Try using the client CLI app, which is able to convert the APIs."
+elif [ "${crd_version}" != "${api}/v1" ]; then
+	echo "ERROR: CRD API version '${crd_version}' is not supported."
+else
+	echo "OK"
+fi


### PR DESCRIPTION
* OCP3 has obsolete CRD API, which is handled in the golang binary but
  not in the kustomize install

* Adds plumbing to the kustomize install to error out gracefully if the
  CRD API is the obsolete version

* Adds env var to e2e tests to skip tests if cluster target is OCP3

* Modifies openshift github workflow to move the test-quarkus-native
  to executing as cluster-admin

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
