### PR TITLE
fix(doc): standardise Camel dependency notation in docs and examples

### DIFF
--- a/docs/modules/ROOT/pages/configuration/dependencies.adoc
+++ b/docs/modules/ROOT/pages/configuration/dependencies.adoc
@@ -23,10 +23,10 @@ NOTE: Camel K won't be able to automatically the dependencies when your routes s
 You can explicitly add dependency using the `-d` flag of the `kamel run` command. This is useful when you need to use dependencies that are not included in the Camel catalog or when the URI of your routes cannot be automatically discovered (see Dynamic URIs). For example:
 
 ```
-kamel run -d mvn:com.google.guava:guava:26.0-jre -d camel-mina2 Integration.java
+kamel run -d mvn:com.google.guava:guava:26.0-jre -d camel:http Integration.java
 ```
 
-With that command you will add a dependency of Guava and the Camel Mina component. This feature can also be disabled if needed (although we discourage you from doing it) by disabling the _dependencies_ trait (`-t dependencies.enabled=false`).
+With that command you will add a dependency of Guava and the Camel HTTP component. This feature can also be disabled if needed (although we discourage you from doing it) by disabling the _dependencies_ trait (`-t dependencies.enabled=false`).
 
 [[dependencies-kind]]
 == Kind of dependencies
@@ -35,9 +35,9 @@ The `-d` flag of the `kamel run` command is flexible and support multiple kind o
 
 *Camel dependencies* can be added directly using the `-d` flag like this:
 ```
-kamel run -d camel-mina2 Integration.java
+kamel run -d camel:http Integration.java
 ```
-In this case, the dependency will be added with the correct version.
+In this case, the dependency will be added with the correct version. Note that the standard notation for specifying a Camel dependency is `camel:xxx`, while `kamel` also accepts `camel-xxx` for usability.
 
 *External dependencies* can be added using the `-d` flag, the `mvn` prefix, and the maven coordinates:
 ```

--- a/docs/modules/ROOT/pages/configuration/runtime-resources.adoc
+++ b/docs/modules/ROOT/pages/configuration/runtime-resources.adoc
@@ -25,7 +25,7 @@ from('file:/etc/camel/resources/?fileName=resources-data.zip&noop=true&idempoten
 We have this file available locally, so we can use the `--resource` _file_ flag command to copy this file in the `Integration`:
 
 ----
-kamel run --resource file:resources-data.zip resource-file-binary-route.groovy -d camel-zipfile --dev
+kamel run --resource file:resources-data.zip resource-file-binary-route.groovy -d camel:zipfile --dev
 ----
 
 NOTE: when you're providing a resource file, we try to recognize if it's a binary file and process it accordingly creating a binary representation that will be decoded transparently in the `Integration`.

--- a/docs/modules/ROOT/pages/contributing/developers.adoc
+++ b/docs/modules/ROOT/pages/contributing/developers.adoc
@@ -163,7 +163,7 @@ To add additional dependencies to your routes:
 
 [source]
 ----
-./kamel run -d camel-dns examples/dns.js
+./kamel run -d camel:dns examples/dns.js
 ----
 
 [[local-development]]

--- a/e2e/global/common/build/incremental_build_test.go
+++ b/e2e/global/common/build/incremental_build_test.go
@@ -53,7 +53,7 @@ func TestRunIncrementalBuild(t *testing.T) {
 		name2 := "java2"
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name2,
-			"-d", "camel-zipfile",
+			"-d", "camel:zipfile",
 		).Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name2), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, name2, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/global/common/config/config_test.go
+++ b/e2e/global/common/config/config_test.go
@@ -188,7 +188,7 @@ func TestRunConfigExamples(t *testing.T) {
 		})
 
 		t.Run("Binary (zip) resource file", func(t *testing.T) {
-			Expect(KamelRunWithID(operatorID, ns, "./files/resource-file-binary-route.groovy", "--resource", "file:./files/resources-data.zip", "-d", "camel-zipfile").Execute()).To(Succeed())
+			Expect(KamelRunWithID(operatorID, ns, "./files/resource-file-binary-route.groovy", "--resource", "file:./files/resources-data.zip", "-d", "camel:zipfile").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, "resource-file-binary-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationConditionStatus(ns, "resource-file-binary-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 			Eventually(IntegrationLogs(ns, "resource-file-binary-route"), TestTimeoutShort).Should(ContainSubstring("the file body"))

--- a/examples/pulsar/pulsar.groovy
+++ b/examples/pulsar/pulsar.groovy
@@ -19,7 +19,7 @@
 //
 // To run this integration use:
 //
-//     kamel run --name pulsar-groovy --dev -d camel-pulsar examples/pulsar.groovy
+//     kamel run --name pulsar-groovy --dev -d camel:pulsar examples/pulsar.groovy
 //
 //  Notes: 
 //  camel-pulsar may be unecessary as camel-k can detect automatically dependencies from component calls for example from("pulsar://localhost:6650/tenant/namespace/topic")

--- a/examples/saga/README.md
+++ b/examples/saga/README.md
@@ -15,14 +15,14 @@ kubectl apply -f lra-coordinator.yaml
 
 * Start the three demo services
 ```
-kamel run -d camel-lra Payment.java
-kamel run -d camel-lra Flight.java
-kamel run -d camel-lra Train.java
+kamel run -d camel:lra Payment.java
+kamel run -d camel:lra Flight.java
+kamel run -d camel:lra Train.java
 ```
 
 * Start the saga application
 ```
-kamel run -d camel-lra Saga.java
+kamel run -d camel:lra Saga.java
 ```
 
 Then you can use ```kamel logs saga``` to check the output of the transactions.

--- a/examples/traits/tracing/InventoryService.java
+++ b/examples/traits/tracing/InventoryService.java
@@ -18,7 +18,7 @@
 
 /* 
 
-kamel run InventoryService.java --name inventory -d camel-opentracing -d mvn:io.jaegertracing:jaeger-client:1.2.0 -d rest-api -d camel-jackson --property-file application.properties
+kamel run InventoryService.java --name inventory -d camel:opentracing -d mvn:io.jaegertracing:jaeger-client:1.2.0 -d rest-api -d camel:jackson --property-file application.properties
 
 */
 

--- a/examples/traits/tracing/OrderService.java
+++ b/examples/traits/tracing/OrderService.java
@@ -18,7 +18,7 @@
 
 /*
 
-kamel run --name=order-service-api -d camel-swagger-java -d camel-jackson -d camel-undertow  OrderService.java --dev
+kamel run --name=order-service-api -d camel:swagger-java -d camel:jackson -d camel:undertow  OrderService.java --dev
 
 */
 

--- a/examples/traits/tracing/README.md
+++ b/examples/traits/tracing/README.md
@@ -31,13 +31,13 @@ Quarkus OpenTracing extension in Camel automatically creates a Camel OpenTracing
 
 See `quarkus.properties` for details.
 
-    kamel run InventoryService.java --name inventory -d mvn:org.apache.camel.quarkus:camel-quarkus-opentracing  -d camel-jackson --property-file quarkus.properties -t quarkus.enabled=true
+    kamel run InventoryService.java --name inventory -d mvn:org.apache.camel.quarkus:camel-quarkus-opentracing  -d camel:jackson --property-file quarkus.properties -t quarkus.enabled=true
 
 Let's inject the Opentracing Tracer to the camel OrderService.java application. Let's start the inventory service. 
 
 See `customizers/OpentracingCustomizer.java` for more details. 
 
-    kamel run --name order OrderService.java customizers/OpentracingCustomizer.java -d camel-opentracing -d mvn:io.jaegertracing:jaeger-client:1.2.0 -d camel-jackson -d camel-undertow -d camel-swagger-java --property-file application.properties
+    kamel run --name order OrderService.java customizers/OpentracingCustomizer.java -d camel:opentracing -d mvn:io.jaegertracing:jaeger-client:1.2.0 -d camel:jackson -d camel:undertow -d camel:swagger-java --property-file application.properties
 
 ## View the Jaeger UI 
 

--- a/examples/user-config/resource-file-binary-route.groovy
+++ b/examples/user-config/resource-file-binary-route.groovy
@@ -18,7 +18,7 @@
 
 //
 // To run this integrations use:
-// kamel run --resource file:resources-data.zip resource-file-binary-route.groovy -d camel-zipfile --dev
+// kamel run --resource file:resources-data.zip resource-file-binary-route.groovy -d camel:zipfile --dev
 //
 
 from('file:/etc/camel/resources/?fileName=resources-data.zip&noop=true&idempotent=false')

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -75,7 +75,7 @@ import (
 	"github.com/apache/camel-k/pkg/util/watch"
 )
 
-const usageDependency = `A dependency that should be included, e.g., "-d camel-mail" for a Camel component, "-d mvn:org.my:app:1.0" for a Maven dependency or "file://localPath[?targetPath=<path>&registry=<registry_URL>&skipChecksums=<true>&skipPOM=<true>]" for local files (experimental)`
+const usageDependency = `A dependency that should be included, e.g., "-d camel:mail" for a Camel component, "-d mvn:org.my:app:1.0" for a Maven dependency or "file://localPath[?targetPath=<path>&registry=<registry_URL>&skipChecksums=<true>&skipPOM=<true>]" for local files (experimental)`
 
 func newCmdRun(rootCmdOptions *RootCmdOptions) (*cobra.Command, *runCmdOptions) {
 	options := runCmdOptions{


### PR DESCRIPTION
Fix #3291

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
