### PR TITLE
fix(trait): camel to use a single properties file 

### DIFF
--- a/e2e/global/common/integration_fail_test.go
+++ b/e2e/global/common/integration_fail_test.go
@@ -55,17 +55,10 @@ func TestBadRouteIntegration(t *testing.T) {
 				Should(gstruct.PointTo(BeNumerically("==", 2)))
 			// Check the Integration stays in error phase
 			Eventually(IntegrationPhase(ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
+
+			// Clean up
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
-
-		// Clean up
-		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
-	})
-}
-
-func TestMissingDependencyIntegration(t *testing.T) {
-	WithNewTestNamespace(t, func(ns string) {
-		operatorID := "camel-k-missing-dependencies"
-		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
 
 		t.Run("run missing dependency java route", func(t *testing.T) {
 			RegisterTestingT(t)
@@ -80,9 +73,9 @@ func TestMissingDependencyIntegration(t *testing.T) {
 			build := Build(ns, kitName)()
 			Eventually(build.Status.Phase, TestTimeoutShort).Should(Equal(v1.BuildPhaseError))
 			Eventually(build.Status.Failure.Recovery.Attempt, TestTimeoutShort).Should(Equal(5))
-		})
 
-		// Clean up
-		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+			// Clean up
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
 	})
 }

--- a/e2e/global/common/kamelet_binding_test.go
+++ b/e2e/global/common/kamelet_binding_test.go
@@ -97,7 +97,7 @@ func TestKameletBinding(t *testing.T) {
 		// Kamelet binding with traits testing
 		t.Run("test kamelet binding with trait", func(t *testing.T) {
 			RegisterTestingT(t)
-			Expect(createTimerKamelet(ns, "my-own-timer-source")()).To(Succeed())
+			Expect(CreateTimerKamelet(ns, "my-own-timer-source")()).To(Succeed())
 			// Log sink kamelet exists from previous test
 
 			from := corev1.ObjectReference{
@@ -161,32 +161,6 @@ func createErrorProducerKamelet(ns string, name string) func() error {
 				{
 					"set-body": map[string]interface{}{
 						"simple": "${mandatoryBodyAs(Boolean)}",
-					},
-				},
-				{
-					"to": "kamelet:sink",
-				},
-			},
-		},
-	}
-
-	return CreateKamelet(ns, name, flow, props, nil)
-}
-
-func createTimerKamelet(ns string, name string) func() error {
-	props := map[string]v1alpha1.JSONSchemaProp{
-		"message": {
-			Type: "string",
-		},
-	}
-
-	flow := map[string]interface{}{
-		"from": map[string]interface{}{
-			"uri": "timer:tick",
-			"steps": []map[string]interface{}{
-				{
-					"set-body": map[string]interface{}{
-						"constant": "{{message}}",
 					},
 				},
 				{


### PR DESCRIPTION
<!-- Description -->

Removed duplicated properties file created by the trait and merged into a single one.

Closes #3458


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): camel to use a single properties file
```
