### PR TITLE
makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Binary files
 /kamel
+/kamel.*
 /license-check
 /**/platform-check
 

--- a/script/Makefile
+++ b/script/Makefile
@@ -388,10 +388,12 @@ kamel-overlay:
 
 images: build kamel-overlay maven-overlay bundle-kamelets
 	@echo "####### Building Camel K operator container image..."
+	mkdir -p build/_maven_output
 	docker build -t $(CUSTOM_IMAGE):$(CUSTOM_VERSION) -f build/Dockerfile .
 
 images-arch: build kamel-overlay maven-overlay bundle-kamelets
 	@echo "####### Building Camel K operator container image for multi architectures..."
+	mkdir -p build/_maven_output
 	docker buildx rm --all-inactive --force
 	docker buildx create --append --name builder
 ifeq ($(shell uname -m), x86_x64)


### PR DESCRIPTION
- chore: add gitignore directove for platform specific build
- fix: force the creation of the build/_maven_output to prevent image building from failing

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
