### PR TITLE
Olm image test 1.8.x

### DIFF
--- a/e2e/upgrade/olm_upgrade_test.go
+++ b/e2e/upgrade/olm_upgrade_test.go
@@ -152,6 +152,7 @@ func TestOLMAutomaticUpgrade(t *testing.T) {
 			Expect(prevCSVVersion.Version.String()).NotTo(Equal(newCSVVersion.Version.String()))
 
 			Eventually(OperatorPodPhase(ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			Eventually(OperatorImage(ns), TestTimeoutShort).Should(Equal(defaults.OperatorImage()))
 
 			// Check the IntegrationPlatform has been reconciled
 			Eventually(PlatformVersion(ns)).Should(ContainSubstring(newIPVersionPrefix))

--- a/pkg/util/defaults/defaults_support.go
+++ b/pkg/util/defaults/defaults_support.go
@@ -18,6 +18,7 @@ limitations under the License.
 package defaults
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
@@ -26,6 +27,10 @@ import (
 
 func BaseImage() string {
 	return envOrDefault(baseImage, "KAMEL_BASE_IMAGE", "RELATED_IMAGE_BASE")
+}
+
+func OperatorImage() string {
+	return envOrDefault(fmt.Sprintf("%s:%s", ImageName, Version), "KAMEL_OPERATOR_IMAGE", "KAMEL_K_TEST_OPERATOR_CURRENT_IMAGE")
 }
 
 func InstallDefaultKamelets() bool {


### PR DESCRIPTION
- stabilize upgrade test (Patch the Subscription to avoid conflicts with concurrent updates performed by OLM)
- test operator image installed by the OLM