### PR TITLE
fix(trait): force a volume path when key is set

### DIFF
--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -608,7 +608,9 @@ func convertToKeyToPath(k, v string) []corev1.KeyToPath {
 	if k == "" {
 		return nil
 	}
-
+	if v == "" {
+		v = k
+	}
 	kp := []corev1.KeyToPath{
 		{
 			Key:  k,

--- a/pkg/trait/trait_types_test.go
+++ b/pkg/trait/trait_types_test.go
@@ -114,3 +114,42 @@ func TestCollectConfigurationPairs(t *testing.T) {
 		{Name: "p4", Value: "integration"},
 	})
 }
+
+func TestVolumeWithKeyAndPath(t *testing.T) {
+	v := getVolume("SomeVolName", "secret", "SomeSecretName", "SomeKey", "SomePath")
+	assert.NotNil(t, v)
+	assert.Equal(t, "SomeVolName", v.Name)
+	s := v.VolumeSource.Secret
+	assert.NotNil(t, s)
+	assert.Equal(t, "SomeSecretName", s.SecretName)
+	items := s.Items
+	assert.NotNil(t, items)
+	assert.Equal(t, 1, len(items))
+	assert.Equal(t, "SomeKey", items[0].Key)
+	assert.Equal(t, "SomePath", items[0].Path)
+}
+
+func TestVolumeWithPathOnly(t *testing.T) {
+	v := getVolume("SomeVolName", "secret", "SomeSecretName", "", "SomePath")
+	assert.NotNil(t, v)
+	assert.Equal(t, "SomeVolName", v.Name)
+	s := v.VolumeSource.Secret
+	assert.NotNil(t, s)
+	assert.Equal(t, "SomeSecretName", s.SecretName)
+	items := s.Items
+	assert.Nil(t, items)
+}
+
+func TestVolumeWithKeyOnly(t *testing.T) {
+	v := getVolume("SomeVolName", "secret", "SomeSecretName", "SomeKey", "")
+	assert.NotNil(t, v)
+	assert.Equal(t, "SomeVolName", v.Name)
+	s := v.VolumeSource.Secret
+	assert.NotNil(t, s)
+	assert.Equal(t, "SomeSecretName", s.SecretName)
+	items := s.Items
+	assert.NotNil(t, items)
+	assert.Equal(t, 1, len(items))
+	assert.Equal(t, "SomeKey", items[0].Key)
+	assert.Equal(t, "SomeKey", items[0].Path)
+}


### PR DESCRIPTION
fixes #3543

## Motivation

When we try to run an integration that needs to mount a volume with filtering but without a path, it fails with `[spec.template.spec.volumes[2].secret.items[0].path: Required``

## Modifications:

* Use the key when no mount path is proposed 

**Release Note**
```release-note
fix(trait): force a volume path when key is set
```
