### PR TITLE
Add operator global option when installing with Helm Chart

### DIFF
--- a/helm/camel-k/README.md
+++ b/helm/camel-k/README.md
@@ -79,8 +79,9 @@ Camel K chart and their default values. The chart allows configuration of an `In
 | `platform.build.registry.insecure`     | Indicates if the registry is not secured                                  | true                           |
 | `platform.cluster`                     | The kind of Kubernetes cluster (Kubernetes or OpenShift)                  | `Kubernetes`                   |
 | `platform.profile`                     | The trait profile to use (Knative, Kubernetes or OpenShift)               | auto                           |
-| `operator.resources`                   | the resource requests and limits to use for the operator                  |                                |
-| `operator.securityContext`             | The (container-related) securityContext to use for the operato            |                                |
+| `operator.global`                      | Indicates if the operator should watch all namespaces                     | `false`                        |
+| `operator.resources`                   | The resource requests and limits to use for the operator                  |                                |
+| `operator.securityContext`             | The (container-related) securityContext to use for the operator           |                                |
 
 ## Contributing
 

--- a/helm/camel-k/templates/operator-cluster-role-bindings.yaml
+++ b/helm/camel-k/templates/operator-cluster-role-bindings.yaml
@@ -1,0 +1,179 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+{{- if eq .Values.operator.global "true" }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator
+  apiGroup: rbac.authorization.k8s.io
+
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-custom-resource-definitions
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator-custom-resource-definitions
+  apiGroup: rbac.authorization.k8s.io
+
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-events
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator-events
+  apiGroup: rbac.authorization.k8s.io
+
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-keda
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator-keda
+  apiGroup: rbac.authorization.k8s.io
+
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-leases
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator-leases
+  apiGroup: rbac.authorization.k8s.io
+
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-podmonitors
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator-podmonitors
+  apiGroup: rbac.authorization.k8s.io
+
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-strimzi
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator-strimzi
+  apiGroup: rbac.authorization.k8s.io
+
+
+{{- if eq .Values.platform.cluster "OpenShift" }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-console-openshift
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator-console-openshift
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-openshift
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: camel-k-operator-openshift
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+
+{{- end }}

--- a/helm/camel-k/templates/operator-cluster-roles.yaml
+++ b/helm/camel-k/templates/operator-cluster-roles.yaml
@@ -15,8 +15,57 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-{{- if eq .Values.operator.global "false" }}
-kind: Role
+{{- if eq .Values.operator.global "true" }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-edit
+  labels:
+    app: "camel-k"
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - builds
+  - camelcatalogs
+  - integrationkits
+  - integrationplatforms
+  - integrations
+  - kameletbindings
+  - kamelets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - builds/status
+  - camelcatalogs/status
+  - integrationkits/status
+  - integrationplatforms/status
+  - integrations/scale
+  - integrations/status
+  - kameletbindings/scale
+  - kameletbindings/status
+  - kamelets/status
+  verbs:
+  - get
+  - patch
+  - update
+
+
+---
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: camel-k-operator
@@ -167,6 +216,34 @@ rules:
   - patch
   - update
   - watch
+
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-custom-resource-definitions
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-events
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
 - apiGroups:
   - ""
   resources:
@@ -177,8 +254,19 @@ rules:
   - get
   - list
   - watch
+
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-keda
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
 - apiGroups:
-  - keda.sh
+  - "keda.sh"
   resources:
   - scaledobjects
   - triggerauthentications
@@ -191,53 +279,19 @@ rules:
   - patch
   - update
   - watch
+
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-leases
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
 - apiGroups:
-  - serving.knative.dev
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - eventing.knative.dev
-  resources:
-  - triggers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - messaging.knative.dev
-  resources:
-  - subscriptions
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - sources.knative.dev
-  resources:
-  - sinkbindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - coordination.k8s.io
+  - "coordination.k8s.io"
   resources:
   - leases
   verbs:
@@ -249,6 +303,99 @@ rules:
   - patch
   - update
   - watch
+
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-local-registry
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["local-registry-hosting"]
+    verbs: ["get"]
+
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-podmonitors
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-strimzi
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkatopics
+  - kafkas
+  verbs:
+  - get
+  - list
+  - watch
+
+
+{{- if eq .Values.platform.cluster "OpenShift" }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-console-openshift
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleclidownloads
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-operator-openshift
+  labels:
+    app: "camel-k"
+    {{- include "camel-k.labels" . | nindent 4 }}
+rules:
 - apiGroups:
   - camel.apache.org
   resources:
@@ -261,7 +408,7 @@ rules:
   - update
 - apiGroups:
   - ""
-  - build.openshift.io
+  - "build.openshift.io"
   resources:
   - buildconfigs
   - buildconfigs/webhooks
@@ -277,7 +424,7 @@ rules:
   - watch
 - apiGroups:
   - ""
-  - image.openshift.io
+  - "image.openshift.io"
   resources:
   - imagestreamimages
   - imagestreammappings
@@ -304,7 +451,7 @@ rules:
   - create
 - apiGroups:
   - ""
-  - route.openshift.io
+  - "route.openshift.io"
   resources:
   - routes
   verbs:
@@ -323,38 +470,6 @@ rules:
   - routes/custom-host
   verbs:
   - create
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - podmonitors
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - kafka.strimzi.io
-  resources:
-  - kafkatopics
-  - kafkas
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
-  verbs:
-  - bind
+{{- end }}
+
 {{- end }}

--- a/helm/camel-k/templates/operator-role-binding.yaml
+++ b/helm/camel-k/templates/operator-role-binding.yaml
@@ -15,6 +15,7 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
+{{- if eq .Values.operator.global "false" }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -29,3 +30,4 @@ roleRef:
   kind: Role
   name: camel-k-operator
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/camel-k/templates/operator.yaml
+++ b/helm/camel-k/templates/operator.yaml
@@ -43,9 +43,13 @@ spec:
             - operator
           env:
             - name: WATCH_NAMESPACE
+              {{- if eq .Values.operator.global "false" }}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+              {{- else }}
+              value: ""
+              {{- end }}
             - name: OPERATOR_NAME
               value: camel-k
             - name: POD_NAME

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -24,6 +24,7 @@ fullnameOverride: ""
 
 operator:
   image: docker.io/apache/camel-k:1.10.0-SNAPSHOT
+  global: "false"
   resources: {}
   securityContext: {}
 


### PR DESCRIPTION
<!-- Description -->

This PR introduces the ability to configure global installation of Camel K Operator via Helm Chart as mentioned in #3054 
