### PR TITLE
fix(rbac): missing clusterrolebinding permission

### DIFF
--- a/config/rbac/operator-role.yaml
+++ b/config/rbac/operator-role.yaml
@@ -109,6 +109,7 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterrolebindings
   verbs:
   - create
   - delete


### PR DESCRIPTION
When camel-k-operator is installed in global mode, [pkg/install/knative.go](https://github.com/apache/camel-k/blob/2ffdcfab6f8fa4ee90f9581b26ebf7cbe48aa685/pkg/install/knative.go#L82) wants to patch a `ClusterRoleBinding`, but it fails with 
```
Cannot bind the Knative addressable resolver aggregated ClusterRole: skipping
Error while binding the Knative Addressable resolver aggregated ClusterRole",
  "error":"clusterrolebindings.rbac.authorization.k8s.io \"camel-k-operator-addressable-resolver\" is forbidden: User \"system:serviceaccount:cmiranda-ops:camel-k-operator\" cannot patch resource \"clusterrolebindings\" in API group \"rbac.authorization.k8s.io\" at the cluster scope"}
```
There is a missing permission to patch it.
```
$ k auth can-i -A patch clusterrolebindings.rbac.authorization.k8s.io --as=system:serviceaccount:cmiranda-ops:camel-k-operator
no
```


**Release Note**
```release-note
NONE
```
