### PR TITLE
fix(knative): Fix the knative pods created until exhaustion

### DIFF
--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -472,15 +472,6 @@ func (t *knativeTrait) configureSinkBinding(e *Environment, env *knativeapi.Came
 					// before the reference source, so that the SinkBinding webhook has
 					// all the information to perform injection.
 					e.Resources.AddFirst(knativeutil.CreateSinkBinding(source, target))
-
-					// Make sure the Eventing webhook will select the source resource,
-					// in order to inject the sink information.
-					// This is necessary for Knative environments, that are configured
-					// with SINK_BINDING_SELECTION_MODE=inclusion.
-					// See:
-					// - https://knative.dev/v0.20-docs/eventing/sources/sinkbinding/
-					// - https://github.com/knative/operator/blob/c60e62bb86ff318c44d1520927d2182659cfdeb5/docs/configuration.md#specsinkbindingselectionmode
-					controller.GetLabels()["bindings.knative.dev/include"] = "true"
 				}
 				return nil
 			})

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -228,6 +228,14 @@ func (t *knativeServiceTrait) getServiceFor(e *Environment) (*serving.Service, e
 
 	serviceLabels := map[string]string{
 		v1.IntegrationLabel: e.Integration.Name,
+		// Make sure the Eventing webhook will select the source resource,
+		// in order to inject the sink information.
+		// This is necessary for Knative environments, that are configured
+		// with SINK_BINDING_SELECTION_MODE=inclusion.
+		// See:
+		// - https://knative.dev/v1.3-docs/eventing/custom-event-source/sinkbinding/create-a-sinkbinding/#optional-choose-sinkbinding-namespace-selection-behavior
+		// - https://github.com/knative/operator/blob/release-1.2/docs/configuration.md#specsinkbindingselectionmode
+		"bindings.knative.dev/include": "true",
 	}
 	if t.Visibility != "" {
 		serviceLabels[knativeServingVisibilityLabel] = t.Visibility


### PR DESCRIPTION
Setting the sinkbing label when the knative service is
created seems the right place, instead to update the label
seems to trigger a new knative configuration

https://github.com/apache/camel-k/issues/3522

-->

**Release Note**
```release-note
Fix knative service triggering new pods until node exhaustion
```
