### PR TITLE
chore(cli): refactor run cmd to remove nolint maintidx

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,5 +46,5 @@ jobs:
         env:
           GOGC: 20
         with:
-          version: v1.47.2
+          version: v1.47.3
           args: --verbose --deadline 15m --config .golangci.yml

--- a/pkg/cmd/source/source.go
+++ b/pkg/cmd/source/source.go
@@ -85,6 +85,10 @@ func (s *Source) setContent(content []byte) error {
 	return nil
 }
 
+func (s Source) IsYaml() bool {
+	return strings.HasSuffix(s.Name, ".yaml") || strings.HasSuffix(s.Name, ".yml")
+}
+
 // Resolve resolves sources from a variety of locations including local and remote.
 func Resolve(ctx context.Context, locations []string, compress bool, cmd *cobra.Command) ([]Source, error) {
 	sources := make([]Source, 0, len(locations))


### PR DESCRIPTION
<!-- Description -->

It just refactors `(o *runCmdOptions) createOrUpdateIntegration` method by splitting the long method into small submethods so that `nolint: maintidx` can be removed. It doesn't change any behaviours other than upgrading golangci-lint to 1.47.3.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
