### PR TITLE
feat(cli): Force arguments for the rebuild command

### DIFF
--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -46,11 +46,7 @@ func newCmdDelete(rootCmdOptions *RootCmdOptions) (*cobra.Command, *deleteCmdOpt
 			if err := options.validate(args); err != nil {
 				return err
 			}
-			if err := options.run(cmd, args); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-			}
-
-			return nil
+			return options.run(cmd, args)
 		},
 	}
 
@@ -66,10 +62,10 @@ type deleteCmdOptions struct {
 
 func (command *deleteCmdOptions) validate(args []string) error {
 	if command.DeleteAll && len(args) > 0 {
-		return errors.New("invalid combination: both all flag and named integrations are set")
+		return errors.New("invalid combination: --all flag is set and at least one integration name is provided")
 	}
 	if !command.DeleteAll && len(args) == 0 {
-		return errors.New("invalid combination: neither all flag nor named integrations are set")
+		return errors.New("invalid combination: provide one or several integration names or set --all flag for all integrations")
 	}
 
 	return nil

--- a/pkg/cmd/kamelet_delete.go
+++ b/pkg/cmd/kamelet_delete.go
@@ -35,19 +35,14 @@ func newKameletDeleteCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kamel
 	}
 
 	cmd := cobra.Command{
-		Use:     "delete <name>",
-		Short:   "Delete a Kamelet",
-		Long:    `Delete a Kamelet.`,
+		Use:     "delete [Kamelet1] [Kamelet2] ...",
+		Short:   "Delete Kamelets deployed on Kubernetes",
 		PreRunE: decode(&options),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(args); err != nil {
 				return err
 			}
-			if err := options.run(cmd, args); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-			}
-
-			return nil
+			return options.run(cmd, args)
 		},
 	}
 
@@ -63,10 +58,10 @@ type kameletDeleteCommandOptions struct {
 
 func (command *kameletDeleteCommandOptions) validate(args []string) error {
 	if command.All && len(args) > 0 {
-		return errors.New("invalid combination: both all flag and named kamelets are set")
+		return errors.New("invalid combination: --all flag is set and at least one kamelet name is provided")
 	}
 	if !command.All && len(args) == 0 {
-		return errors.New("invalid combination: neither all flag nor named kamelets are set")
+		return errors.New("invalid combination: provide one or several kamelet names or set --all flag for all kamelets")
 	}
 
 	return nil

--- a/pkg/cmd/kit_delete.go
+++ b/pkg/cmd/kit_delete.go
@@ -36,19 +36,14 @@ func newKitDeleteCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kitDelete
 	}
 
 	cmd := cobra.Command{
-		Use:     "delete <name>",
-		Short:   "Delete an Integration Kit",
-		Long:    `Delete an Integration Kit.`,
+		Use:     "delete [integration kit1] [integration kit2] ...",
+		Short:   "Delete integration kits deployed on Kubernetes",
 		PreRunE: decode(&options),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(args); err != nil {
 				return err
 			}
-			if err := options.run(cmd, args); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-			}
-
-			return nil
+			return options.run(cmd, args)
 		},
 	}
 
@@ -64,10 +59,10 @@ type kitDeleteCommandOptions struct {
 
 func (command *kitDeleteCommandOptions) validate(args []string) error {
 	if command.All && len(args) > 0 {
-		return errors.New("invalid combination: both all flag and named Kits are set")
+		return errors.New("invalid combination: --all flag is set and at least one integration kit name is provided")
 	}
 	if !command.All && len(args) == 0 {
-		return errors.New("invalid combination: neither all flag nor named Kits are set")
+		return errors.New("invalid combination: provide one or several integration kit names or set --all flag for all integration kits")
 	}
 
 	return nil

--- a/pkg/cmd/rebuild.go
+++ b/pkg/cmd/rebuild.go
@@ -42,11 +42,7 @@ func newCmdRebuild(rootCmdOptions *RootCmdOptions) (*cobra.Command, *rebuildCmdO
 			if err := options.validate(args); err != nil {
 				return err
 			}
-			if err := options.rebuild(cmd, args); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-			}
-
-			return nil
+			return options.run(cmd, args)
 		},
 	}
 
@@ -62,16 +58,16 @@ type rebuildCmdOptions struct {
 
 func (o *rebuildCmdOptions) validate(args []string) error {
 	if o.RebuildAll && len(args) > 0 {
-		return errors.New("invalid combination: both all flag and named integrations are set")
+		return errors.New("invalid combination: --all flag is set and at least one integration name is provided")
 	}
 	if !o.RebuildAll && len(args) == 0 {
-		return errors.New("invalid combination: neither all flag nor named integrations are set")
+		return errors.New("invalid combination: provide one or several integration names or set --all flag for all integrations")
 	}
 
 	return nil
 }
 
-func (o *rebuildCmdOptions) rebuild(cmd *cobra.Command, args []string) error {
+func (o *rebuildCmdOptions) run(cmd *cobra.Command, args []string) error {
 	c, err := o.GetCmdClient()
 	if err != nil {
 		return err

--- a/pkg/cmd/rebuild_test.go
+++ b/pkg/cmd/rebuild_test.go
@@ -1,0 +1,66 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/apache/camel-k/pkg/util/test"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+const cmdRebuild = "rebuild"
+
+// nolint: unparam
+func initializeRebuildCmdOptions(t *testing.T) (*rebuildCmdOptions, *cobra.Command, RootCmdOptions) {
+	t.Helper()
+
+	options, rootCmd := kamelTestPreAddCommandInit()
+	rebuildCmdOptions := addTestRebuildCmd(*options, rootCmd)
+	kamelTestPostAddCommandInit(t, rootCmd)
+
+	return rebuildCmdOptions, rootCmd, *options
+}
+
+func addTestRebuildCmd(options RootCmdOptions, rootCmd *cobra.Command) *rebuildCmdOptions {
+	// add a testing version of rebuild Command
+	rebuildCmd, rebuildOptions := newCmdRebuild(&options)
+	rebuildCmd.RunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	rebuildCmd.PostRunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	rebuildCmd.Args = test.ArbitraryArgs
+	rootCmd.AddCommand(rebuildCmd)
+	return rebuildOptions
+}
+
+func TestRebuildNonExistingFlag(t *testing.T) {
+	_, rootCmd, _ := initializeRebuildCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdRebuild, "--nonExistingFlag")
+	assert.NotNil(t, err)
+}
+
+func TestRebuildAllFlag(t *testing.T) {
+	rebuildCmdOptions, rootCmd, _ := initializeRebuildCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdRebuild, "--all")
+	assert.Nil(t, err)
+	assert.Equal(t, true, rebuildCmdOptions.RebuildAll)
+}

--- a/pkg/cmd/trait_help.go
+++ b/pkg/cmd/trait_help.go
@@ -89,10 +89,10 @@ type traitMetaData struct {
 
 func (command *traitHelpCommandOptions) validate(args []string) error {
 	if command.IncludeAll && len(args) > 0 {
-		return errors.New("invalid combination: both all flag and a named trait is set")
+		return errors.New("invalid combination: --all flag is set and a trait name is provided")
 	}
 	if !command.IncludeAll && len(args) == 0 {
-		return errors.New("invalid combination: neither all flag nor a named trait is set")
+		return errors.New("invalid combination: provide a trait name or set --all flag for all traits")
 	}
 	return nil
 }


### PR DESCRIPTION
fixes #3445

## Motivation

Allowing to accept no arguments to rebuild all the integrations is a bit risky so a new flag for this purpose must be explicitly provided by the end user.

## Modifications:

* Add the flag `--all` to the rebuild command to rebuild all integrations
* Sanitize the name of the integration to align the code with the delete command


**Release Note**
```release-note
The rebuild command no more supports empty arguments, either the flag `--all` must be set to rebuild all integrations, 
or the list of integration names to rebuild needs to be provided
```