### PR TITLE
chore: add pod tolerations options to operator

### DIFF
--- a/helm/camel-k/README.md
+++ b/helm/camel-k/README.md
@@ -82,6 +82,7 @@ Camel K chart and their default values. The chart allows configuration of an `In
 | `operator.global`                      | Indicates if the operator should watch all namespaces                     | `false`                        |
 | `operator.resources`                   | The resource requests and limits to use for the operator                  |                                |
 | `operator.securityContext`             | The (container-related) securityContext to use for the operator           |                                |
+| `operator.tolerations`                 | The list of tolerations to use for the operator                           |                                |
 
 ## Contributing
 

--- a/helm/camel-k/templates/operator.yaml
+++ b/helm/camel-k/templates/operator.yaml
@@ -81,3 +81,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       serviceAccountName: camel-k-operator
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{-end }}

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -27,6 +27,7 @@ operator:
   global: "false"
   resources: {}
   securityContext: {}
+  tolerations: []
 
 platform:
   build:


### PR DESCRIPTION
<!-- Description -->

This PR adds the option to configure tolerations on the operator's deployment manifest, so that the pod can be configured to be scheduled onto appropriate nodes with specific taints.