### PR TITLE
chore(build): Restrict release workflow execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'apache/camel-k'
     uses: ./.github/workflows/release-workflow.yml
     with:
       ref: "main"
@@ -33,6 +34,7 @@ jobs:
       registryPassword: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
 
   v1_8_x:
+    if: github.repository == 'apache/camel-k'
     uses: ./.github/workflows/release-workflow.yml
     with:
       ref: "release-1.8.x"
@@ -43,6 +45,7 @@ jobs:
       registryPassword: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
 
   v1_9_x:
+    if: github.repository == 'apache/camel-k'
     uses: ./.github/workflows/release-workflow.yml
     with:
       ref: "release-1.9.x"


### PR DESCRIPTION
- Run workflow only on Camel K repository
- Avoid to run workflow on forks because it will fail