### PR TITLE
chore(build): Use global operator in YAKS E2E tests

### DIFF
--- a/.github/actions/e2e-knative-yaks/action.yml
+++ b/.github/actions/e2e-knative-yaks/action.yml
@@ -90,6 +90,19 @@ runs:
       image-registry-insecure: ${{steps.config-cluster.outputs.cluster-image-registry-insecure }}
       image-version: ${{ steps.build-kamel.outputs.build-binary-local-image-version }}
 
+  - id: install-global-operator
+    name: "Install Global Operator"
+    uses: ./.github/actions/kamel-install-global-operator
+    with:
+      global-operator-namespace: default
+      catalog-source-name: ${{ steps.config-cluster.outputs.cluster-catalog-source-name }}
+      catalog-source-namespace: ${{ steps.config-cluster.outputs.cluster-catalog-source-namespace }}
+      image-namespace: ${{ steps.config-cluster.outputs.cluster-image-namespace }}
+      image-registry-host: ${{ steps.config-cluster.outputs.cluster-image-registry-pull-host }}
+      image-name: ${{ steps.build-kamel.outputs.build-binary-local-image-name }}
+      image-registry-insecure: ${{steps.config-cluster.outputs.cluster-image-registry-insecure }}
+      image-version: ${{ steps.build-kamel.outputs.build-binary-local-image-version }}
+
   - name: Install YAKS
     uses: ./.github/actions/kamel-install-yaks
     with:

--- a/e2e/yaks/common/apache-kamelet-catalog/yaks-config.yaml
+++ b/e2e/yaks/common/apache-kamelet-catalog/yaks-config.yaml
@@ -21,10 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -w -n $YAKS_NAMESPACE --force
-
-    kubectl wait kamelets.camel.apache.org/timer-source --for=condition=Ready --timeout=120s -n $YAKS_NAMESPACE
-
     kamel run logger.groovy -w -n $YAKS_NAMESPACE
 post:
   - name: print dump

--- a/e2e/yaks/common/kamelet-beans/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-beans/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --force
-
     kubectl apply -f beans-source.kamelet.yaml -n $YAKS_NAMESPACE
 post:
   - name: print dump

--- a/e2e/yaks/common/kamelet-binding-autoload/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-autoload/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --force --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
-
     kubectl apply -f secret-default.yaml -n $YAKS_NAMESPACE
     kubectl apply -f secret-specific.yaml -n $YAKS_NAMESPACE
 

--- a/e2e/yaks/common/kamelet-binding-broker/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-broker/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --force --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
-
     kubectl apply -f sample-broker.yaml -n $YAKS_NAMESPACE
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f logger-sink.kamelet.yaml -n $YAKS_NAMESPACE

--- a/e2e/yaks/common/kamelet-binding-http/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-http/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --force --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
-
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
 
     kamel run display.groovy -w -n $YAKS_NAMESPACE

--- a/e2e/yaks/common/kamelet-binding-property-encoding/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-property-encoding/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --force --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
-
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f properties-binding.yaml -n $YAKS_NAMESPACE
 post:

--- a/e2e/yaks/common/kamelet-binding/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --force --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
-
     kubectl apply -f messages-channel.yaml -n $YAKS_NAMESPACE
 
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE

--- a/e2e/yaks/common/kamelet-no-properties/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-no-properties/yaks-config.yaml
@@ -18,10 +18,6 @@
 config:
   namespace:
     temporary: true
-pre:
-- name: installation
-  run: |
-    kamel install -n $YAKS_NAMESPACE --force
 post:
   - name: print dump
     if: env:CI=true && failure()

--- a/e2e/yaks/common/kamelet-steps/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-steps/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --force --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
-
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f prefix-action.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f steps-binding.yaml -n $YAKS_NAMESPACE

--- a/e2e/yaks/common/kamelet/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false --force
-
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f echo-sink.kamelet.yaml -n $YAKS_NAMESPACE
 

--- a/e2e/yaks/common/knative-broker/knative-broker.feature
+++ b/e2e/yaks/common/knative-broker/knative-broker.feature
@@ -45,6 +45,9 @@ Feature: Camel K can correctly filter messages from broker
     And Camel K integration receiver should print From all: event-1
     And Camel K integration receiver should print From all: event-2
     And Camel K integration receiver should print From all: event-all
+    And Camel K resource polling configuration
+      | maxAttempts          | 5    |
+      | delayBetweenAttempts | 1000 |
     And Camel K integration receiver should not print From evt1: event-2
     And Camel K integration receiver should not print From evt1: event-all
     And Camel K integration receiver should not print From evt2: event-1

--- a/e2e/yaks/common/knative-broker/yaks-config.yaml
+++ b/e2e/yaks/common/knative-broker/yaks-config.yaml
@@ -18,10 +18,6 @@
 config:
   namespace:
     temporary: true
-pre:
-- name: installation
-  run: |
-    kamel install -n $YAKS_NAMESPACE --force
 post:
   - name: print dump
     if: env:CI=true && failure()

--- a/e2e/yaks/common/knative-sinkbinding/yaks-config.yaml
+++ b/e2e/yaks/common/knative-sinkbinding/yaks-config.yaml
@@ -21,8 +21,6 @@ config:
 pre:
 - name: installation
   run: |
-    kamel install -n $YAKS_NAMESPACE --force
-
     kubectl apply -n $YAKS_NAMESPACE -f messages-channel.yaml
 
     kamel run receiver.groovy -w -n $YAKS_NAMESPACE

--- a/e2e/yaks/openshift/monitoring/yaks-config.yaml
+++ b/e2e/yaks/openshift/monitoring/yaks-config.yaml
@@ -21,9 +21,6 @@ config:
 pre:
   - name: ObtainToken
     script: ./obtainToken.sh
-  - name: Camel-k install
-    run: |
-      kamel install -w -n ${YAKS_NAMESPACE}
   - name: Setup monitoring resources
     script: ./monitoringResources.sh
   - name: Dependency install


### PR DESCRIPTION
- Use global Camel K operator in YAKS E2E tests (avoid to install operator for each test)
- Optimize waiting time in knative broker tests
- Significantly reduces the YAKS E2e test job execution time (was ~90mins now is ~30mins)