### PR TITLE
fix(e2e): make package-artifacts to be aware of staging repo

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -379,7 +379,7 @@ check-platform:
 maven-overlay:
 	@echo "####### Preparing maven dependencies bundle..."
 	mkdir -p build/_maven_overlay
-	./script/maven_overlay.sh $(RUNTIME_VERSION) build/_maven_overlay $(STAGING_RUNTIME_REPO) $(CAMEL_K_RUNTIME_DIR)
+	./script/maven_overlay.sh -s "$(STAGING_RUNTIME_REPO)" -d "$(CAMEL_K_RUNTIME_DIR)" $(RUNTIME_VERSION) build/_maven_overlay
 
 kamel-overlay:
 	@echo "####### Copying kamel CLI to output build directory..."
@@ -469,7 +469,7 @@ package-examples:
 
 package-artifacts:
 	# useful for development purpose only in order to include any local development runtime dependency
-	./script/package_maven_artifacts.sh $(RUNTIME_VERSION) $(CAMEL_K_RUNTIME_DIR)
+	./script/package_maven_artifacts.sh -s "$(STAGING_RUNTIME_REPO)" -d "$(CAMEL_K_RUNTIME_DIR)" $(RUNTIME_VERSION)
 
 release: clean codegen set-module-version set-version build-resources check-licenses build images images-push cross-compile package-examples git-tag
 

--- a/script/maven_overlay.sh
+++ b/script/maven_overlay.sh
@@ -18,8 +18,22 @@
 location=$(dirname $0)
 rootdir=$(realpath ${location}/../)
 
+while getopts "d:s:" opt; do
+  case "${opt}" in
+    d)
+      local_runtime_dir="${OPTARG}"
+      ;;
+    s)
+      staging_repo="${OPTARG}"
+      ;;
+    *)
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
 if [ "$#" -lt 2 ]; then
-  echo "usage: $0 <Camel K runtime version> <output directory> [<staging repository>] [<local Camel K runtime project directory>]"
+  echo "usage: $0 [-s <staging repository>] [-d <local Camel K runtime project directory>] <Camel K runtime version> <output directory>"
   exit 1
 fi
 
@@ -30,42 +44,37 @@ fi
 
 runtime_version=$1
 output_dir=$2
-staging_repo=${3:-}
-local_runtime_dir=${4:-}
 
 if [ -n "$staging_repo" ]; then
     if  [[ $staging_repo == http:* ]] || [[ $staging_repo == https:* ]]; then
         options="${options} -s ${rootdir}/settings.xml"
         cat << EOF > ${rootdir}/settings.xml
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-   <profiles>
-     <profile>
-       <id>camel-k-staging</id>
-       <repositories>
-         <repository>
-           <id>camel-k-staging-releases</id>
-           <name>Camel K Staging</name>
-           <url>${staging_repo}</url>
-           <releases>
-             <enabled>true</enabled>
-             <updatePolicy>never</updatePolicy>
-           </releases>
-           <snapshots>
-             <enabled>false</enabled>
-           </snapshots>
-         </repository>
-       </repositories>
-     </profile>
-   </profiles>
-   <activeProfiles>
-     <activeProfile>camel-k-staging</activeProfile>
-   </activeProfiles>
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+      <id>camel-k-staging</id>
+      <repositories>
+        <repository>
+          <id>camel-k-staging-releases</id>
+          <name>Camel K Staging</name>
+          <url>${staging_repo}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>camel-k-staging</activeProfile>
+  </activeProfiles>
 </settings>
 EOF
-    else
-        local_runtime_dir="${staging_repo}"
-        staging_repo=""
     fi
 fi
 

--- a/script/package_maven_artifacts.sh
+++ b/script/package_maven_artifacts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,27 +16,83 @@
 # limitations under the License.
 
 location=$(dirname $0)
+rootdir=$(realpath ${location}/../)
+
+while getopts "d:s:" opt; do
+  case "${opt}" in
+    d)
+      local_runtime_dir="${OPTARG}"
+      ;;
+    s)
+      staging_repo="${OPTARG}"
+      ;;
+    *)
+      ;;
+  esac
+done
+shift $((OPTIND-1))
 
 if [ "$#" -lt 1 ]; then
-    echo "usage: $0 <Camel K runtime version> [<local Camel K runtime project directory>]"
+    echo "usage: $0 [-s <staging repository>] [-d <local Camel K runtime project directory>] <Camel K runtime version>"
     exit 1
+fi
+
+options=""
+if [ "$CI" = "true" ]; then
+  options="--batch-mode"
 fi
 
 camel_k_destination="$PWD/build/_maven_output"
 camel_k_runtime_version=$1
+maven_repo=${staging_repo:-https://repo1.maven.org/maven2}
 
-if [ -z "$2" ]; then
-    is_snapshot=$(echo "$1" | grep "SNAPSHOT")
-    if [ "$is_snapshot" = "$1" ]; then
+if [ -n "$staging_repo" ]; then
+    if  [[ $staging_repo == http:* ]] || [[ $staging_repo == https:* ]]; then
+        options="${options} -s ${rootdir}/settings.xml"
+        cat << EOF > ${rootdir}/settings.xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+      <id>camel-k-staging</id>
+      <repositories>
+        <repository>
+          <id>camel-k-staging-releases</id>
+          <name>Camel K Staging</name>
+          <url>${staging_repo}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>camel-k-staging</activeProfile>
+  </activeProfiles>
+</settings>
+EOF
+    fi
+fi
+
+if [ -z "${local_runtime_dir}" ]; then
+    is_snapshot=$(echo "${camel_k_runtime_version}" | grep "SNAPSHOT")
+    if [ "$is_snapshot" = "${camel_k_runtime_version}" ]; then
         echo "You're trying to package SNAPSHOT artifacts. You probably wants them from your local environment, try calling:"
         echo "$0 <Camel K runtime version> <local Camel K runtime project directory>"
         exit 3
     fi
 
     # Take the dependencies officially released
-    wget https://repo1.maven.org/maven2/org/apache/camel/k/apache-camel-k-runtime/$1/apache-camel-k-runtime-$1-source-release.zip -O $PWD/build/apache-camel-k-runtime-$1-source-release.zip
-    unzip -q -o $PWD/build/apache-camel-k-runtime-$1-source-release.zip -d $PWD/build
-    mvn -q -f $PWD/build/apache-camel-k-runtime-$1/pom.xml \
+    wget ${maven_repo}/org/apache/camel/k/apache-camel-k-runtime/${camel_k_runtime_version}/apache-camel-k-runtime-${camel_k_runtime_version}-source-release.zip -O $PWD/build/apache-camel-k-runtime-${camel_k_runtime_version}-source-release.zip
+    unzip -q -o $PWD/build/apache-camel-k-runtime-${camel_k_runtime_version}-source-release.zip -d $PWD/build
+    mvn -q \
+        $options \
+        -f $PWD/build/apache-camel-k-runtime-${camel_k_runtime_version}/pom.xml \
         dependency:copy-dependencies \
         -DincludeScope=runtime \
         -Dmdep.copyPom=true \
@@ -45,15 +101,17 @@ if [ -z "$2" ]; then
     rm -rf $PWD/build/apache-camel-k-runtime*
 else
     # Take the dependencies from a local development environment
-    camel_k_runtime_source=$2
-    camel_k_runtime_source_version=$(mvn -f $camel_k_runtime_source/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+    camel_k_runtime_source=${local_runtime_dir}
+    camel_k_runtime_source_version=$(mvn $options -f $camel_k_runtime_source/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
 
     if [ "$camel_k_runtime_version" != "$camel_k_runtime_source_version" ]; then
         echo "Misaligned version. You're building Camel K project using $camel_k_runtime_version but trying to bundle dependencies from local Camel K runtime $camel_k_runtime_source_version"
         exit 2
     fi
 
-    mvn -q -f $camel_k_runtime_source/pom.xml \
+    mvn -q \
+        $options \
+        -f $camel_k_runtime_source/pom.xml \
     dependency:copy-dependencies \
         -DincludeScope=runtime \
         -Dmdep.copyPom=true \


### PR DESCRIPTION
<!-- Description -->

~It appears that the builder test is failing just because it's taking longer time to download dependencies from staging repo. Let's see if this simple fix can solve the failures.~

While it doesn't still fix the original builder e2e failures, it fixes `./script/package_maven_artifacts.sh` to make it aware of staging repo and it seems e2e results have become improved.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
