### PR TITLE
fix: Prevent operator panic on wrong Kamelet binding

### DIFF
--- a/pkg/controller/kameletbinding/error_handler_test.go
+++ b/pkg/controller/kameletbinding/error_handler_test.go
@@ -101,3 +101,18 @@ func TestParseErrorHandlerSinkWithParametersDoesSucceed(t *testing.T) {
 	assert.Equal(t, "value1", parameters["camel.beans.defaultErrorHandler.param1"])
 	assert.Equal(t, "value2", parameters["camel.beans.defaultErrorHandler.param2"])
 }
+
+func TestParseErrorHandlerWithWrongDefinition(t *testing.T) {
+	_, err := parseErrorHandler(
+		[]byte(`{
+			"sink": {
+				"ref": {
+					"kind": "Kamelet",
+					"apiVersion": "camel.apache.org/v1alpha1",
+					"name": "err-sink"
+				}
+			}
+		}`),
+	)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
fixes #3586 

## Motivation

A Kamelet binding in the wrong format can lead to operator panic which needs to be avoided.

## Modifications:

* Adds a function to verify the Kamelet binding to return an error in case of an invalid format. 

**Release Note**
```release-note
fix: Prevent operator panic on wrong Kamelet binding
```
