### PR TITLE
chore(ci): support 1.10.x nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,11 @@ jobs:
       registryUsername: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
       registryPassword: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
 
-  v1_8_x:
+  v1_10_x:
     if: github.repository == 'apache/camel-k'
     uses: ./.github/workflows/release-workflow.yml
     with:
-      ref: "release-1.8.x"
+      ref: "release-1.10.x"
       goVersion: "1.17.x"
       javaVersion: "11"
     secrets:


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(ci): support 1.10.x nightly release
```
