### PR TITLE
fix: do not run smoke tests on 1.9 nightly

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -52,9 +52,11 @@ jobs:
           ref: ${{ inputs.ref }}
           persist-credentials: false
           submodules: recursive
-
+      
+      # TODO: remove this workaround once 1.11 is released, see #3613
+      - if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.ref == 'refs/heads/release-1.10.x' }}
       # Reuse the testing flows used for PRs
-      - name: Smoke tests
+        name: Smoke tests
         uses: ./.github/actions/e2e-common
         with:
           cluster-config-data: ${{ secrets.E2E_CLUSTER_CONFIG }}


### PR DESCRIPTION
Workaround to skip the execution of an action which is missing on release-1.9 branch.

Closes #3613 

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
