### PR TITLE
fix(ci): nightly release workaround

### DIFF
--- a/.github/actions/e2e-common/action.yml
+++ b/.github/actions/e2e-common/action.yml
@@ -1,0 +1,40 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: e2e-common
+description: 'End-to-End tests for build use-cases'
+
+runs:
+  using: "composite"
+
+  steps:
+
+  - id: prepare-env
+    name: Prepare Test Environment
+    uses: ./.github/actions/kamel-prepare-env
+
+  - name: Cache modules
+    uses: actions/cache@v1
+    with:
+      path: ~/go/pkg/mod
+      key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      restore-keys: |
+        ${{ runner.os }}-go-
+
+  - name: Test
+    shell: bash
+    run: make


### PR DESCRIPTION
Creating an action needed by nightly release procedure to add some smoke test. Given that 1.9 diverges from `main` we're using a different strategy here, copying the build action and using this as smoke test.

Ref #3613

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ci): nightly release workaround
```
