### PR TITLE
feat(cli): Add add-repo command to add a repo for custom Kamelet catalog

### DIFF
--- a/e2e/global/common/files/TimerCustomKameletIntegration.java
+++ b/e2e/global/common/files/TimerCustomKameletIntegration.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.Exception;
+import java.lang.Override;
+import org.apache.camel.builder.RouteBuilder;
+
+public class TimerCustomKameletIntegration extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("kamelet:timer-custom-source?message=great%20message")
+            .to("log:info");
+    }
+}

--- a/e2e/global/common/files/kamelets/timer-custom-source.kamelet.yaml
+++ b/e2e/global/common/files/kamelets/timer-custom-source.kamelet.yaml
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: timer-custom-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "main-SNAPSHOT"
+    camel.apache.org/kamelet.icon: data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gU3ZnIFZlY3RvciBJY29ucyA6IGh0dHA6Ly93d3cub25saW5ld2ViZm9udHMuY29tL2ljb24gLS0+DQo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPg0KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB2aWV3Qm94PSIwIDAgMTAwMCAxMDAwIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAwIDEwMDAiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPG1ldGFkYXRhPiBTdmcgVmVjdG9yIEljb25zIDogaHR0cDovL3d3dy5vbmxpbmV3ZWJmb250cy5jb20vaWNvbiA8L21ldGFkYXRhPg0KPGc+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC4wMDAwMDAsNTExLjAwMDAwMCkgc2NhbGUoMC4xMDAwMDAsLTAuMTAwMDAwKSI+PHBhdGggZD0iTTM4ODguMSw0Nzc0Ljl2LTIzNS4xaDQxMS40aDQxNC4zbC04LjgtMzI5LjFsLTguOC0zMzJsLTExNy41LTguOGMtMjI5LjItMTQuNy02MjAtOTkuOS05MjUuNi0xOTYuOUMyMjU3LjQsMzIyMC42LDExNjcuMiwyMDY1LjgsODAyLjksNjQ5LjZjLTUxMS4zLTE5ODYuMywzODQuOS00MDAyLDIyMDYuNy00OTY1LjhjMzAyLjYtMTYxLjYsNzU4LjEtMzIwLjIsMTE1NC44LTQwNS41YzQyNi4xLTkxLjEsMTI1MS43LTkxLjEsMTY4MC43LDBjMTc2OC45LDM4MiwzMDQ0LjEsMTY1Ny4yLDM0MjYuMSwzNDI2LjFjOTEuMSw0MjYuMSw5MS4xLDEyNTQuNiwwLDE2NzcuOGMtNDIwLjIsMTk0Mi4yLTE5MzYuNCwzMzAyLjYtMzg5MC4zLDM0OTYuNmwtMTk5LjgsMjAuNnYzMjAuM3YzMjAuM2g0MTEuNGg0MTEuNHYyMzUuMVY1MDEwSDQ5NDUuOUgzODg4LjFWNDc3NC45eiBNNTc1My45LDMzNDkuOWM3NzguNy0xNjEuNiwxNDE5LjItNTA4LjMsMTk4My40LTEwNzIuNWM1NjQuMi01NjEuMiw4ODcuNC0xMTU3LjcsMTA2MC43LTE5NDIuMmM5OS45LTQzNy44LDk5LjktMTE0MywzLTE1ODAuOEM4NTYzLTIzMDYuNCw3OTY2LjUtMzE1OC41LDcwNDMuOS0zNzUyYy0zMzUtMjE0LjUtNzg3LjUtMzk2LjctMTI0OC44LTQ5OS41Yy00MzcuOC05Ny0xMTQzLTk3LTE1ODAuOCwyLjljLTc4NC41LDE3My4zLTEzODEsNDk2LjYtMTk0Mi4yLDEwNjAuN2MtNTcwLDU2Ny4xLTkwNy45LDExOTguOC0xMDc4LjQsMTk5OC4xYy03My41LDM0Ni43LTczLjUsMTEyMi40LDAsMTQ2OS4yYzE3MC40LDc5OS4yLDUwOC4zLDE0MzEsMTA3OC40LDE5OThDMjg5NSwyOTAwLjMsMzYzOC40LDMyNzMuNSw0NDkzLjQsMzM5MUM0Nzc4LjQsMzQzMi4xLDU0NzQuOCwzNDA4LjYsNTc1My45LDMzNDkuOXoiLz48cGF0aCBkPSJNNDcxMC44LDEzNzUuM1YyMDUuOUw0NTUyLjIsNjcuOGMtMzE3LjMtMjc5LjEtMzQwLjgtNjc4LjctNTUuOC05OTMuMWMyODcuOS0zMjAuMyw2OTMuNC0zMTcuMywxMDEzLjcsNS45bDE3MC40LDE3MC40aDEwNDMuMWgxMDQzLjFWLTUxNFYtMjc5SDY3MjkuNUg1NjkyLjJsLTQ5LjksMTE0LjZjLTU4LjgsMTMyLjItMjUyLjcsMzE3LjMtMzc2LjEsMzYxLjRsLTg1LjIsMjkuNHYxMTU3Ljd2MTE1Ny43aC0yMzUuMWgtMjM1LjFWMTM3NS4zeiBNNTE2Ni4zLTI5My42YzE0Ni45LTE0NCw0NC4xLTM5Ni43LTE2MS42LTM5Ni43Yy01NS44LDAtMTE3LjUsMjYuNC0xNjEuNiw3My40Yy00Nyw0NC4xLTczLjUsMTA1LjgtNzMuNSwxNjEuNnMyNi40LDExNy41LDczLjUsMTYxLjZjNDQuMSw0NywxMDUuOCw3My41LDE2MS42LDczLjVDNTA2MC41LTIyMC4yLDUxMjIuMi0yNDYuNyw1MTY2LjMtMjkzLjZ6Ii8+PC9nPjwvZz4NCjwvc3ZnPg==
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Timer"
+  labels:
+    camel.apache.org/kamelet.type: source
+    camel.apache.org/kamelet.verified: "true"
+spec:
+  definition:
+    title: Timer Custom Source
+    description: Produces periodic events with a custom payload in a custom way.
+    required:
+      - message
+    type: object
+    properties:
+      period:
+        title: Period
+        description: The interval between two events in milliseconds
+        type: integer
+        default: 1000
+      message:
+        title: Message
+        description: The message to generate
+        type: string
+        example: hello world
+      contentType:
+        title: Content Type
+        description: The content type of the message being generated
+        type: string
+        default: text/plain
+  dependencies:
+    - "camel:core"
+    - "camel:timer"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: timer:tick
+      parameters:
+        period: "{{period}}"
+      steps:
+        - set-body:
+            constant: "{{message}}"
+        - set-header:
+            name: "Content-Type"
+            constant: "{{contentType}}"
+        - to: kamelet:sink

--- a/pkg/cmd/kamelet.go
+++ b/pkg/cmd/kamelet.go
@@ -30,6 +30,7 @@ func newCmdKamelet(rootCmdOptions *RootCmdOptions) *cobra.Command {
 
 	cmd.AddCommand(cmdOnly(newKameletGetCmd(rootCmdOptions)))
 	cmd.AddCommand(cmdOnly(newKameletDeleteCmd(rootCmdOptions)))
+	cmd.AddCommand(cmdOnly(newKameletAddRepoCmd(rootCmdOptions)))
 
 	return &cmd
 }

--- a/pkg/cmd/kamelet_add_repo.go
+++ b/pkg/cmd/kamelet_add_repo.go
@@ -1,0 +1,111 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/spf13/cobra"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// kameletRepositoryURIRegexp is the regular expression used to validate the URI of a Kamelet repository.
+var kameletRepositoryURIRegexp = regexp.MustCompile(`^github:[^/]+/[^/]+((/[^/]+)*)?$`)
+
+func newKameletAddRepoCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kameletAddRepoCommandOptions) {
+	options := kameletAddRepoCommandOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		Use:     "add-repo github:owner/repo[/path_to_kamelets_folder][@version] ...",
+		Short:   "Add a Kamelet repository",
+		Long:    `Add a Kamelet repository.`,
+		PreRunE: decode(&options),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.validate(args); err != nil {
+				return err
+			}
+			return options.run(cmd, args)
+		},
+	}
+
+	cmd.Flags().StringP("operator-id", "x", "camel-k", "Id of the Operator to update.")
+
+	return &cmd, &options
+}
+
+type kameletAddRepoCommandOptions struct {
+	*RootCmdOptions
+	OperatorID string `mapstructure:"operator-id" yaml:",omitempty"`
+}
+
+func (o *kameletAddRepoCommandOptions) validate(args []string) error {
+	if len(args) == 0 {
+		return errors.New("at least one Kamelet repository is expected")
+	}
+	if o.OperatorID == "" {
+		return fmt.Errorf("cannot use empty operator id")
+	}
+	return nil
+}
+
+func (o *kameletAddRepoCommandOptions) run(cmd *cobra.Command, args []string) error {
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return err
+	}
+	key := client.ObjectKey{
+		Namespace: o.Namespace,
+		Name:      o.OperatorID,
+	}
+	platform := v1.IntegrationPlatform{}
+	if err := c.Get(o.Context, key, &platform); err != nil {
+		if k8serrors.IsNotFound(err) {
+			// IntegrationPlatform may be in the operator namespace, but we currently don't have a way to determine it: we just warn
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: IntegrationPlatform %q not found in namespace %q\n", key.Name, key.Namespace)
+			return nil
+		}
+		return err
+	}
+	for _, uri := range args {
+		if err := checkURI(uri, platform.Spec.Kamelet.Repositories); err != nil {
+			return err
+		}
+		platform.Spec.Kamelet.Repositories = append(platform.Spec.Kamelet.Repositories, v1.IntegrationPlatformKameletRepositorySpec{
+			URI: uri,
+		})
+	}
+	return c.Update(o.Context, &platform)
+}
+
+func checkURI(uri string, repositories []v1.IntegrationPlatformKameletRepositorySpec) error {
+	if !kameletRepositoryURIRegexp.MatchString(uri) {
+		return fmt.Errorf("malformed Kamelet repository uri %s, the expected format is github:owner/repo[/path_to_kamelets_folder][@version]", uri)
+	}
+	for _, repo := range repositories {
+		if repo.URI == uri {
+			return fmt.Errorf("duplicate Kamelet repository uri %s", uri)
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/kamelet_add_repo_test.go
+++ b/pkg/cmd/kamelet_add_repo_test.go
@@ -1,0 +1,90 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/util/test"
+)
+
+const cmdKameletAddRepo = "add-repo"
+
+// nolint: unparam
+func initializeKameletAddRepoCmdOptions(t *testing.T) (*kameletAddRepoCommandOptions, *cobra.Command, RootCmdOptions) {
+	t.Helper()
+
+	options, rootCmd := kamelTestPreAddCommandInit()
+	kameletAddRepoCommandOptions := addTestKameletAddRepoCmd(*options, rootCmd)
+	kamelTestPostAddCommandInit(t, rootCmd)
+
+	return kameletAddRepoCommandOptions, rootCmd, *options
+}
+
+func addTestKameletAddRepoCmd(options RootCmdOptions, rootCmd *cobra.Command) *kameletAddRepoCommandOptions {
+	// Add a testing version of kamelet add-repo Command
+	kameletAddRepoCmd, kameletAddRepoOptions := newKameletAddRepoCmd(&options)
+	kameletAddRepoCmd.RunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	kameletAddRepoCmd.PostRunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	kameletAddRepoCmd.Args = test.ArbitraryArgs
+	rootCmd.AddCommand(kameletAddRepoCmd)
+	return kameletAddRepoOptions
+}
+
+func TestKameletAddRepoNoFlag(t *testing.T) {
+	_, rootCmd, _ := initializeKameletAddRepoCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdKameletAddRepo, "foo")
+	assert.Nil(t, err)
+}
+
+func TestKameletAddRepoNonExistingFlag(t *testing.T) {
+	_, rootCmd, _ := initializeKameletAddRepoCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdKameletAddRepo, "--nonExistingFlag", "foo")
+	assert.NotNil(t, err)
+}
+
+func TestKameletAddRepoInvalidRepositoryURI(t *testing.T) {
+	repositories := []v1.IntegrationPlatformKameletRepositorySpec{}
+	assert.NotNil(t, checkURI("foo", repositories))
+	assert.NotNil(t, checkURI("github", repositories))
+	assert.NotNil(t, checkURI("github:", repositories))
+	assert.NotNil(t, checkURI("github:foo", repositories))
+	assert.NotNil(t, checkURI("github:foo/", repositories))
+}
+
+func TestKameletAddRepoValidRepositoryURI(t *testing.T) {
+	repositories := []v1.IntegrationPlatformKameletRepositorySpec{}
+	assert.Nil(t, checkURI("github:foo/bar", repositories))
+	assert.Nil(t, checkURI("github:foo/bar/some/path", repositories))
+	assert.Nil(t, checkURI("github:foo/bar@1.0", repositories))
+	assert.Nil(t, checkURI("github:foo/bar/some/path@1.0", repositories))
+}
+
+func TestKameletAddRepoDuplicateRepositoryURI(t *testing.T) {
+	repositories := []v1.IntegrationPlatformKameletRepositorySpec{{URI: "github:foo/bar"}}
+	assert.NotNil(t, checkURI("github:foo/bar", repositories))
+	assert.Nil(t, checkURI("github:foo/bar2", repositories))
+}

--- a/pkg/cmd/kamelet_get.go
+++ b/pkg/cmd/kamelet_get.go
@@ -44,11 +44,8 @@ func newKameletGetCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kameletG
 			if err := options.validate(); err != nil {
 				return err
 			}
-			if err := options.run(cmd); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-			}
 
-			return nil
+			return options.run(cmd)
 		},
 	}
 

--- a/pkg/cmd/kit_get.go
+++ b/pkg/cmd/kit_get.go
@@ -42,11 +42,8 @@ func newKitGetCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kitGetComman
 			if err := options.validate(cmd, args); err != nil {
 				return err
 			}
-			if err := options.run(cmd); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-			}
 
-			return nil
+			return options.run(cmd)
 		},
 	}
 


### PR DESCRIPTION
fixes #2850

## Motivation

Up to now, the only way to define a Kamelet repository is to edit the integration platform to add it manually which is not really convenient. The idea of the improvement is to add a new command to be able to add Kamelet repositories.

## Modifications:

* Add a new sub-command of `kamelet` called `add-repo`
* Align the code of some commands regarding how to run them with the rest of the commands (not directly related)

**Release Note**
```release-note
feat(cli): Add add-repo command to add a repo for custom Kamelet catalog
```
