### PR TITLE
feat(cmd/run): secret/configmap as runtime/build-time properties

### DIFF
--- a/docs/modules/ROOT/pages/configuration/build-time-properties.adoc
+++ b/docs/modules/ROOT/pages/configuration/build-time-properties.adoc
@@ -50,10 +50,70 @@ kamel run --build-property=file:quarkus.properties build-property-route.groovy
 
 The property file is parsed and its properties configured on the `Integration`. As soon as the application starts, you will see the log with the expected configuration.
 
+[[build-time-configmap]]
+== Property from ConfigMap/Secret
+
+In case some build-time properties are stored into a `Configmap` or a `Secret`, you can use the `--build-property` flag with a value of type respectively _configmap:name-of-configmap_ or _secret:name-of-secret_ to refer to the specific resource to use as build-time properties.
+
+As an example, let's create a `Configmap` named _my-cm-bp_ containing the build-time properties to load. You can alternatively use any `Configmap` you've already stored in your cluster:
+
+----
+kubectl create configmap my-cm-bp --from-literal=quarkus.application.name="my-great-application" --from-literal=quarkus.banner.enabled="true"
+----
+
+Here, as an example we have create a configmap with 2 `Quarkus` properties.
+
+[source,groovy]
+.build-property-route.groovy
+----
+from('timer:build-property')
+    .log('The application name: {{quarkus.application.name}}')
+----
+
+The `quarkus.banner.enabled` is configured to show the banner during the `Integration` startup. Let's use `--build-property` flag in conjunction with file:
+
+----
+kamel run --build-property=configmap:my-cm-bp build-property-route.groovy
+----
+
+The key-value pairs of the `ConfigMap` are loaded and used as build-time properties of the `Integration`. As soon as the application starts, you will see the log with the expected configuration.
+
+[[build-time-configmap-as-file]]
+== Property from ConfigMap/Secret as file
+
+When you have a lot of key-value pairs to store into a given `ConfigMap`/`Secret`, you may consider storing some build-time properties as a file into a specific key-value pair for the sake of simplicity. 
+
+The only constraint is to use `.properties` as a suffix of the key to indicate that the value is actually a property file, not a simple value.
+
+As an example, let's use the same `Integration` as the previous section but with a `ConfigMap` that contains all the properties into the same key-value pair.
+
+For this we need a properties file as next:
+
+[source,properties]
+.quarkus.properties
+----
+quarkus.application.name = my-super-application
+quarkus.banner.enabled = true
+----
+
+That we will load into a specific `ConfigMap` using the following command:
+
+----
+kubectl create configmap my-cm-bps --from-file=quarkus.properties
+----
+
+Then we launch the `run` command with the `--build-property` flag whose value matches with the appropriate syntax to refer to `my-cm-bps`:
+
+----
+kamel run --build-property configmap:my-cm-bps build-property-route.groovy
+----
+
+The value of the key-value of the `ConfigMap` is loaded as a property file and used as build-time properties of the `Integration`. you will see the log with the expected configuration.
+
 [[build-time-props-file-precedence]]
 == Property collision priority
 
-If you have a property repeated more than once, the general rule is that the last one declared in your `kamel run` statement will be taken in consideration. If the same property is found both in a single option declaration and inside a file, then, the single option will have higher priority and will be used.
+If you have a property repeated more than once, the general rule is that the last one declared in your `kamel run` statement will be taken in consideration. If the same property is found both in a single option declaration and inside a file/configmap/secret, then, the single option will have higher priority and will be used.
 
 [[build-time-runtime-conf]]
 == Run time properties

--- a/docs/modules/ROOT/pages/configuration/runtime-properties.adoc
+++ b/docs/modules/ROOT/pages/configuration/runtime-properties.adoc
@@ -67,10 +67,70 @@ kamel run --property file:my.properties property-route.groovy
 
 The property file is parsed and its properties configured on the `Integration`. As soon as the application starts, you will see the log with the expected configuration.
 
+[[runtime-configmap]]
+== Property from ConfigMap/Secret
+
+In case some runtime properties are stored into a `Configmap` or a `Secret`, you can use the `--property` flag with a value of type respectively _configmap:name-of-configmap_ or _secret:name-of-secret_ to refer to the specific resource to use as runtime properties.
+
+As an example, let's create a `Configmap` named _my-cm-rp_ containing the runtime properties to load. You can alternatively use any `Configmap` you've already stored in your cluster:
+
+----
+kubectl create configmap my-cm-rp --from-literal=name="Will Smith" --from-literal=period="2000"
+----
+
+In our `Integration` we can simply refer to the properties defined in the `ConfigMap` as we'd do with any other property:
+
+[source,groovy]
+.property-configmap-route.groovy
+----
+from('timer:property?period={{period}}')
+    .log('Hello {{name}}!')
+----
+
+Then we launch the `run` command with the `--property` flag whose value matches with the appropriate syntax to refer to `my-cm-rp`:
+
+----
+kamel run --property configmap:my-cm-rp property-configmap-route.groovy
+----
+
+The key-value pairs of the `ConfigMap` are loaded and used as runtime properties of the `Integration`. As soon as the application starts, you will see the log with the expected message.
+
+[[runtime-configmap-as-file]]
+== Property from ConfigMap/Secret as file
+
+When you have a lot of key-value pairs to store into a given `ConfigMap`/`Secret`, you may consider storing some runtime properties as a file into a specific key-value pair for the sake of simplicity. 
+
+The only constraint is to use `.properties` as a suffix of the key to indicate that the value is actually a property file, not a simple value.
+
+As an example, let's use the same `Integration` as the previous section but with a `ConfigMap` that contains all the properties into the same key-value pair.
+
+For this we need a properties file as next:
+
+[source,text]
+.some.properties
+----
+name=John Smith
+period=2000
+----
+
+That we will load into a specific `ConfigMap` using the following command:
+
+----
+kubectl create configmap my-cm-rps --from-file=some.properties
+----
+
+Then we launch the `run` command with the `--property` flag whose value matches with the appropriate syntax to refer to `my-cm-rps`:
+
+----
+kamel run --property configmap:my-cm-rps property-configmap-route.groovy
+----
+
+The value of the key-value of the `ConfigMap` is loaded as a property file and used as runtime properties of the `Integration`. As soon as the application starts, you will see the log with the expected message.
+
 [[runtime-props-file-precedence]]
 == Property collision priority
 
-If you have a property repeated more than once, the general rule is that the last one declared in your `kamel run` statement will be taken in consideration. If the same property is found both in a single option declaration and inside a file, then, the single option will have higher priority and will be used.
+If you have a property repeated more than once, the general rule is that the last one declared in your `kamel run` statement will be taken in consideration. If the same property is found both in a single option declaration and inside a file/configmap/secret, then, the single option will have higher priority and will be used.
 
 [[runtime-build-time-conf]]
 == Build time properties

--- a/pkg/cmd/run_help_test.go
+++ b/pkg/cmd/run_help_test.go
@@ -18,8 +18,6 @@ limitations under the License.
 package cmd
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,65 +38,4 @@ func TestFilterFileLocation(t *testing.T) {
 	assert.Equal(t, "/path/to/valid/file", filteredOptions[0])
 	assert.Equal(t, "app.properties", filteredOptions[1])
 	assert.Equal(t, "/validfile", filteredOptions[2])
-}
-
-func TestExtractProperties_SingleKeyValue(t *testing.T) {
-	correctValues := []string{"key=val", "key = val", "key= val", " key   =  val"}
-	for _, val := range correctValues {
-		prop, err := extractProperties(val)
-		assert.Nil(t, err)
-		value, ok := prop.Get("key")
-		assert.True(t, ok)
-		assert.Equal(t, "val", value)
-	}
-}
-
-func TestExtractProperties_FromFile(t *testing.T) {
-	var tmpFile1 *os.File
-	var err error
-	if tmpFile1, err = ioutil.TempFile("", "camel-k-*.properties"); err != nil {
-		t.Error(err)
-	}
-
-	assert.Nil(t, tmpFile1.Close())
-	assert.Nil(t, ioutil.WriteFile(tmpFile1.Name(), []byte(`
-	key=value
-	#key2=value2
-	my.key=value
-	`), 0o400))
-
-	props, err := extractProperties("file:" + tmpFile1.Name())
-	assert.Nil(t, err)
-	assert.Equal(t, 2, props.Len())
-	for _, prop := range props.Keys() {
-		value, ok := props.Get(prop)
-		assert.True(t, ok)
-		assert.Equal(t, "value", value)
-	}
-}
-
-func TestExtractPropertiesFromFileAndSingleValue(t *testing.T) {
-	var tmpFile1 *os.File
-	var err error
-	if tmpFile1, err = ioutil.TempFile("", "camel-k-*.properties"); err != nil {
-		t.Error(err)
-	}
-
-	assert.Nil(t, tmpFile1.Close())
-	assert.Nil(t, ioutil.WriteFile(tmpFile1.Name(), []byte(`
-	key=value
-	#key2=value2
-	my.key=value
-	`), 0o400))
-
-	properties := []string{"key=override", "file:" + tmpFile1.Name(), "my.key = override"}
-	props, err := mergePropertiesWithPrecedence(properties)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, props.Len())
-	val, ok := props.Get("key")
-	assert.True(t, ok)
-	assert.Equal(t, "override", val)
-	val, ok = props.Get("my.key")
-	assert.True(t, ok)
-	assert.Equal(t, "override", val)
 }


### PR DESCRIPTION
fixes #3002

## Motivation:

It would be nice to provide the possibility to use configmap and secret as runtime or build-time properties for the camel and builder traits.

## Modifications:

* Add the support of `configmap:name-of-configmap` and `secret:name-of-secret` to the flags `property` and `build-property`
* Move the functions `extractProperties` and `mergePropertiesWithPrecedence` from `run_help.go` to `run.go` as we need to add a receiver
* Move the unit tests of the functions moved to the corresponding test file
* Add related E2E test
* Add related doc

**Release Note**
```release-note
feat(cmd/run): secret/configmap as runtime/build-time properties
```
