### PR TITLE
test: Use camel-k repo in the test for the add-repo command

### DIFF
--- a/e2e/global/common/kamelet_test.go
+++ b/e2e/global/common/kamelet_test.go
@@ -62,7 +62,7 @@ func TestKameletClasspathLoading(t *testing.T) {
 		t.Run("test custom Kamelet repository", func(t *testing.T) {
 
 			// Add the custom repository
-			Expect(Kamel("kamelet", "add-repo", "github:essobedo/camel-k-test/kamelets", "-n", ns, "-x", operatorID).Execute()).To(Succeed())
+			Expect(Kamel("kamelet", "add-repo", "github:apache/camel-k/e2e/global/common/files/kamelets", "-n", ns, "-x", operatorID).Execute()).To(Succeed())
 
 			Expect(KamelRunWithID(operatorID, ns, "files/TimerCustomKameletIntegration.java").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, "timer-custom-kamelet-integration"), TestTimeoutLong).Should(Equal(corev1.PodRunning))


### PR DESCRIPTION
related to #3623

## Motivation

The e2e test for the add-repo command relies on an external GitHub repository which is not good for the sustainability of the test, it should rather use a folder in the camel-k repository

## Modifications:

* Change the location of the custom repository for something in the camel-k repository

**Release Note**
```release-note
NONE
```
