### PR TITLE
Update documentation for kamelet type that can also be action

### DIFF
--- a/docs/modules/ROOT/pages/kamelets/kamelets-user.adoc
+++ b/docs/modules/ROOT/pages/kamelets/kamelets-user.adoc
@@ -466,8 +466,8 @@ The following annotations and labels are also defined on the resource:
 |name |Description |Type |Example
 
 |label: `camel.apache.org/kamelet.type`
-|Indicates if the Kamelet can be used as source or sink
-|enum: `source`, `sink`
+|Indicates if the Kamelet can be used as source, action or sink.
+|enum: `source`, `action`, `sink`
 |E.g. `source`
 |===
 


### PR DESCRIPTION
the type can now also be action, not only source and sink.

For instance, see https://github.com/apache/camel-kamelets/blob/b98e61105b8c782422028b0c2ea857a90c97a550/kamelets/avro-deserialize-action.kamelet.yaml#L29

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
