### PR TITLE
Fixed helm install failing

### DIFF
--- a/helm/camel-k/templates/operator.yaml
+++ b/helm/camel-k/templates/operator.yaml
@@ -84,4 +84,4 @@ spec:
       {{- with .Values.operator.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-      {{-end }}
+      {{- end }}


### PR DESCRIPTION
Fixed helm install failing due to lack of space.

```
$ helm install --generate-name camel-k/camel-k
Error: INSTALLATION FAILED: parse error at (camel-k/templates/operator.yaml:87): "-en"
```