### PR TITLE
Fix link in documentation

### DIFF
--- a/docs/modules/traits/pages/resume.adoc
+++ b/docs/modules/traits/pages/resume.adoc
@@ -4,8 +4,7 @@
 The Resume trait can be used to manage and configure resume strategies.
 
 This feature is meant to allow quick resume of processing by Camel K instances after they have been restarted. This
-is an experimental implementation based on the support available on Camel Core:
-https://camel.apache.org/components/next/eips/resume-strategies.html.
+is an experimental implementation based on the support available on xref:components::eips/resume-strategies.html[Camel Core resume strategy].
 
 The Resume trait is disabled by default.
 


### PR DESCRIPTION
current error:

[check:html     ] public/camel-k/next/traits/resume.html
[check:html     ]   1:26860  error  For links within camel.apache.org use relative links, found: https://camel.apache.org/components/next/eips/resume-strategies.html  camel/relative-links

https://github.com/apache/camel-website/actions/runs/3044416569/jobs/4904782627#step:5:9

Can someone with either a camel-website configured correctly locally or know from the top of their head validate that i provided the correct syntax?


cc @tadayosi 

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
