### PR TITLE
feat(cli/run): Support dependencies defined using HTTP URLs

### DIFF
--- a/e2e/namespace/install/cli/run_test.go
+++ b/e2e/namespace/install/cli/run_test.go
@@ -129,5 +129,24 @@ func TestKamelCLIRun(t *testing.T) {
 			// Clean up
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
+		t.Run("Run with http dependency", func(t *testing.T) {
+			Expect(KamelRunWithID(operatorID, ns, "../../../global/common/traits/files/jvm/Classpath.java",
+				"-d", "https://github.com/apache/camel-k/raw/main/e2e/global/common/traits/files/jvm/sample-1.0.jar",
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "classpath"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationConditionStatus(ns, "classpath", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, "classpath"), TestTimeoutShort).Should(ContainSubstring("Hello World!"))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+		t.Run("Run with http dependency using options", func(t *testing.T) {
+			Expect(KamelRunWithID(operatorID, ns, "../../../global/common/traits/files/jvm/Classpath.java",
+				"-d", "https://github.com/apache/camel-k/raw/main/e2e/global/common/traits/files/jvm/sample-1.0.jar",
+				"-d", "https://raw.githubusercontent.com/apache/camel-k/main/e2e/namespace/install/cli/files/Java.java|targetPath=/tmp/foo",
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "classpath"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationConditionStatus(ns, "classpath", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, "classpath"), TestTimeoutShort).Should(ContainSubstring("Hello World!"))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
 	})
 }

--- a/pkg/cmd/run_help_test.go
+++ b/pkg/cmd/run_help_test.go
@@ -18,6 +18,10 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +42,39 @@ func TestFilterFileLocation(t *testing.T) {
 	assert.Equal(t, "/path/to/valid/file", filteredOptions[0])
 	assert.Equal(t, "app.properties", filteredOptions[1])
 	assert.Equal(t, "/validfile", filteredOptions[2])
+}
+
+func TestDownloadDependencyWithBadURL(t *testing.T) {
+	u, _ := url.Parse("http://foo")
+	_, err := downloadDependency(context.Background(), *u)
+	assert.NotNil(t, err)
+}
+
+func TestDownloadDependencyWithFileNameInURL(t *testing.T) {
+	u, _ := url.Parse("https://repo1.maven.org/maven2/org/apache/camel/camel-core/3.18.2/camel-core-3.18.2.jar")
+	path, err := downloadDependency(context.Background(), *u)
+	t.Cleanup(func() { os.Remove(path) })
+	assert.Nil(t, err)
+	assert.True(t, strings.HasSuffix(path, "camel-core-3.18.2.jar"), "The name of the jar file is expected")
+	_, err = os.Stat(path)
+	assert.Nil(t, err)
+}
+
+func TestDownloadDependencyWithFileNameInQuery(t *testing.T) {
+	u, _ := url.Parse("https://search.maven.org/remotecontent?filepath=org/apache/camel/quarkus/camel-quarkus-file/2.12.0/camel-quarkus-file-2.12.0.jar")
+	path, err := downloadDependency(context.Background(), *u)
+	t.Cleanup(func() { os.Remove(path) })
+	assert.Nil(t, err)
+	assert.True(t, strings.HasSuffix(path, "camel-quarkus-file-2.12.0.jar"), "The name of the jar file is expected")
+	_, err = os.Stat(path)
+	assert.Nil(t, err)
+}
+
+func TestDownloadDependencyWithoutFileName(t *testing.T) {
+	u, _ := url.Parse("https://search.maven.org")
+	path, err := downloadDependency(context.Background(), *u)
+	t.Cleanup(func() { os.Remove(path) })
+	assert.Nil(t, err)
+	_, err = os.Stat(path)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
fixes #240

## Motivation

We allow `mvn:` dependencies with `camel:` and `runtime:` wrapper. We should allow users to specify HTTP dependencies on libs (to load custom JAR that are not present in Maven central).

## Modifications:

* Downloads dependencies with `http` and `https` prefixes to a temporary folder
* Uploads the temporary file like local files

**Release Note**
```release-note
feat(cli/run): Support dependencies defined using HTTP URLs
```
