### PR TITLE
fix: release action to use secrets properly

### DIFF
--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -23,6 +23,17 @@ inputs:
   javaVersion:
     required: true
     type: string
+  # Make sure to treat the below values confidential (ie, not logging)
+  secretE2ECluster:
+    required: true
+  secretE2EKube:
+    required: true
+  secretDockerHubUser:
+    required: true
+  secretDockerHubPassword:
+    required: true    
+  secretGithubToken:
+    required: true
 
 runs:
   using: "composite"
@@ -37,12 +48,11 @@ runs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ inputs.goVersion }}
-    # Reuse the testing flows used for PRs
-      name: Smoke tests
+    - name: Smoke tests
       uses: ./.github/actions/e2e-common
       with:
-        cluster-config-data: ${{ secrets.E2E_CLUSTER_CONFIG }}
-        cluster-kube-config-data: ${{ secrets.E2E_KUBE_CONFIG }}
+        cluster-config-data: ${{ inputs.secretE2ECluster }}
+        cluster-kube-config-data: ${{ inputs.secretE2EKube }}
     - name: Cache modules
       uses: actions/cache@v1
       with:
@@ -58,6 +68,7 @@ runs:
         echo "VERSION=$V" >> $GITHUB_ENV
         echo "UPD_DATE=$D" >> $GITHUB_ENV
     - name: Global Env
+      shell: bash
       run: |
         echo "Using VERSION=${{ env.VERSION }}"
 
@@ -68,24 +79,22 @@ runs:
         MAVEN_REPOSITORY=$(make get-staging-repo)
         echo "Using MAVEN_REPOSITORY=$MAVEN_REPOSITORY"
         echo "MAVEN_REPOSITORY=$MAVEN_REPOSITORY" >> $GITHUB_ENV
-
     - name: Login to Container Registry
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
-
+        username: ${{ inputs.secretDockerHubUser }}
+        password: ${{ inputs.secretDockerHubPassword }}
     - name: Codegen
+      shell: bash
       run: |
         make VERSION=${{ env.VERSION }} IMAGE_NAME=${{ env.IMAGE_NAME }} codegen set-version build-resources
-
     - name: Build
+      shell: bash
       run: |
         make VERSION=${{ env.VERSION }} IMAGE_NAME=${{ env.IMAGE_NAME }} release-nightly
-
     - name: Check
+      shell: bash
       run: ls -l
-
     - name: Create Release
       id: create_release
       uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37
@@ -102,7 +111,7 @@ runs:
           ```
           
           NOTE: last updated on ${{ env.UPD_DATE }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ inputs.secretGithubToken }}
         draft: false
         prerelease: true
         allowUpdates: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
       with:
         goVersion: "1.17.x"
         javaVersion: "11"
+        secretE2ECluster: ${{ secrets.E2E_CLUSTER_CONFIG }}
+        secretE2EKube: ${{ secrets.E2E_KUBE_CONFIG }}
+        secretDockerHubUser: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
+        secretDockerHubPassword: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
+        secretGithubToken: ${{ secrets.GITHUB_TOKEN }}
 
   v1_10_x:
     if: github.repository == 'apache/camel-k'
@@ -53,6 +58,11 @@ jobs:
       with:
         goVersion: "1.17.x"
         javaVersion: "11"
+        secretE2ECluster: ${{ secrets.E2E_CLUSTER_CONFIG }}
+        secretE2EKube: ${{ secrets.E2E_KUBE_CONFIG }}
+        secretDockerHubUser: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
+        secretDockerHubPassword: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
+        secretGithubToken: ${{ secrets.GITHUB_TOKEN }}        
 
   v1_9_x:
     if: github.repository == 'apache/camel-k'
@@ -69,4 +79,9 @@ jobs:
       with:
         goVersion: "1.16.x"
         javaVersion: "11"
+        secretE2ECluster: ${{ secrets.E2E_CLUSTER_CONFIG }}
+        secretE2EKube: ${{ secrets.E2E_KUBE_CONFIG }}
+        secretDockerHubUser: ${{ secrets.TEST_DOCKER_HUB_USERNAME }}
+        secretDockerHubPassword: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
+        secretGithubToken: ${{ secrets.GITHUB_TOKEN }}        
         


### PR DESCRIPTION
<!-- Description -->
It looks like we need to pass the secrets from workflow to the action.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
