### PR TITLE
Fix README in examples/openapi

### DIFF
--- a/examples/openapi/README.md
+++ b/examples/openapi/README.md
@@ -7,7 +7,7 @@ Find useful examples about how to expose an Open API specification in a Camel K 
 Deploy the examples running
 
 ```
-kamel run --dev --name greetings --open-api greetings-api.json greetings.groovy
+kamel run --dev --name greetings --open-api file:greetings-api.json greetings.groovy
 ```
 
 Then you can test by calling the hello endpoint, ie:


### PR DESCRIPTION
`run` is failed because there is no `file:` prefix.
```
$ kamel run --dev --name greetings --open-api greetings-api.json greetings.groovy
Error: invalid openapi specification "greetings-api.json". It supports only file or configmap
```
To fix this, I added `file:`
```
$ kamel run --dev --name greetings --open-api file:greetings-api.json greetings.groovy
Integration "greetings" created
```