### PR TITLE
chore: enable latest LTS nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,17 +64,17 @@ jobs:
         secretDockerHubPassword: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
         secretGithubToken: ${{ secrets.GITHUB_TOKEN }}        
 
-  v1_9_x:
+  v1_8_x_lts:
     if: github.repository == 'apache/camel-k'
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
-        ref: release-1.9.x
+        ref: release-1.8.x
         persist-credentials: false
         submodules: recursive    
-    - name: Release 1.9 nightly 
+    - name: Release 1.8 (LTS) nightly 
       uses: ./.github/actions/release-nightly
       with:
         goVersion: "1.16.x"

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -32,16 +32,16 @@ asciidoc:
   attributes:
     requires: "'util=camel-website-util,ck=xref:js/ck.js'"
     prerelease: true
-    camel-kamelets-version: 0.8.0 # Makefile KAMELET_CATALOG_REPO_BRANCH
-    camel-kamelets-docs-version: 0.8.x # Makefile KAMELET_CATALOG_REPO_BRANCH
-    camel-k-runtime-version: 1.13.0 # Makefile RUNTIME_VERSION
+    camel-kamelets-version: 0.10.0 # Makefile KAMELET_CATALOG_REPO_BRANCH
+    camel-kamelets-docs-version: 0.10.x # Makefile KAMELET_CATALOG_REPO_BRANCH
+    camel-k-runtime-version: 1.15.0 # Makefile RUNTIME_VERSION
     camel-api-versions: camel.apache.org/v1 camel.apache.org/v1alpha1 # Makefile BUNDLE_CAMEL_APIS
     # from camel-k-runtime parent pom:
-    camel-version: 3.16.0
-    camel-docs-version: 3.16.x
-    camel-quarkus-version: 2.8.0
-    camel-quarkus-docs-version: 2.8.x
-    quarkus-version: 2.8.0.Final
-    graalvm-version: 22.0.0
-    graalvm-docs-version: 22.0
+    camel-version: 3.18.0
+    camel-docs-version: 3.18.x
+    camel-quarkus-version: 2.11.0
+    camel-quarkus-docs-version: 2.11.x
+    quarkus-version: 2.11.3.Final
+    graalvm-version: 22.1.0
+    graalvm-docs-version: 22.1
 

--- a/release.adoc
+++ b/release.adoc
@@ -306,4 +306,6 @@ git push upstream main
 ```
 Where <new-version> represents the new version you want to bump and <replace-version> the version that was previously released.
 
-In case of a major or minor release, please update accordingly the `release` workflow in order to always have the latest 2 release branches and `main` running in a CI fashion. See https://github.com/apache/camel-k/pull/3607/commits/f835c978dcfbcadae99b0f8b2fbcd07f49adb3a1 for reference.
+In case of a major or minor release, please update accordingly the `release` workflow in order to always have the previous release branches, `main` and latest LTS running in a CI fashion. See https://github.com/apache/camel-k/pull/3607/commits/f835c978dcfbcadae99b0f8b2fbcd07f49adb3a1 for reference.
+
+You will also need to update the `docs/antora.yml` configuration in order to provide the proper versions for the upcoming release in `main` branch.


### PR DESCRIPTION
Some PR on `release-1.8.x` to follow up in order to update documentation on that branch.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore: enable latest LTS nightly
```
