### PR TITLE
[Backport-1.10.x] fix(#3657): Also use OPERATOR_ID EnvVar to obtain the operator id

### DIFF
--- a/docs/modules/ROOT/pages/contributing/local-development.adoc
+++ b/docs/modules/ROOT/pages/contributing/local-development.adoc
@@ -11,7 +11,7 @@ As soon as you build your operator locally you will ask yourself how to test it.
 * You can start with setting the environment variable ``WATCH_NAMESPACE`` with the namespace you'd like your operator to watch. You also need to specify the name of the operator, as you may have different operators running on the cluster.
 ----
 export WATCH_NAMESPACE=operator-test
-export KAMEL_OPERATOR_ID="camel-k-dev"
+export OPERATOR_ID="camel-k-dev"
 ----
 
 * The next step is to install an ``IntegrationPlatform`` on the cluster namespace. You probably need to tweak the registry parameters in order to be able to authenticate against an image repository (see below paragraph for local repository instructions). It's important to specify the target operator that will take care of this IntegrationPlatform (`-x` or `--operator-id` option).

--- a/docs/modules/ROOT/pages/installation/advanced/multi.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/multi.adoc
@@ -12,7 +12,7 @@ Operators must not contend the integration and the reconciliation because this w
 To avoid contention, Camel K uses an operator id for each operator. The operator id must be unique on the cluster and any custom resource (CR) is assigned to a specific operator using an annotation.
 The assigned operator will be responsible for the reconciliation of the annotated CR and explicitly manages the resource no matter where it lives.
 
-In detail, the Camel K operator supports the environment variable `KAMEL_OPERATOR_ID`. The value is an identifier that can be equal to any string (e.g. `KAMEL_OPERATOR_ID=operator-1`).
+In detail, the Camel K operator supports the environment variable `OPERATOR_ID`. The value is an identifier that can be equal to any string (e.g. `OPERATOR_ID=operator-1`).
 Once the operator is assigned with an identifier, it will *only reconcile* Camel K custom resources that are assigned to that ID (unannotated resources will be ignored as well).
 
 By default, the Camel K operator is using the id `camel-k`. When installing many operators the instances must use a different operator id.

--- a/pkg/util/defaults/defaults_support.go
+++ b/pkg/util/defaults/defaults_support.go
@@ -38,7 +38,7 @@ func InstallDefaultKamelets() bool {
 }
 
 func OperatorID() string {
-	return envOrDefault("", "KAMEL_OPERATOR_ID")
+	return envOrDefault("", "KAMEL_OPERATOR_ID", "OPERATOR_ID")
 }
 
 func boolEnvOrDefault(def bool, envs ...string) bool {


### PR DESCRIPTION
Manual backport of #3660 to 1.10.x 

The code base was using exclusively `KAMEL_OPERATOR_ID` as environment setting to identify the operator id. This caused problems after OLM based installation because `KAMEL_OPERATOR_ID` is not being used in this kind of installation. Simplify things by using also using `OPERATOR_ID` when obtaining an operator id from EnvVar settings. Still support `KAMEL_OPERATOR_ID` when installing via `kamel install` in order to overwrite the default id given in the CRDs.

**Release Note**
```release-note
Fix: Also use OPERATOR_ID EnvVar to obtain the operator id
```
