### PR TITLE
Backport: Adds the default maven repositories if extra ones are added

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -440,7 +440,8 @@ func (o *installCmdOptions) install(cobraCmd *cobra.Command, _ []string) error {
 		}
 
 		if len(o.MavenRepositories) > 0 {
-			settings, err := maven.NewSettings(maven.Repositories(o.MavenRepositories...))
+			settings, err := maven.NewSettings(maven.Repositories(o.MavenRepositories...), maven.DefaultRepositories)
+
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- Description -->
Avoids the default maven repositories being removed from the maven settings by the new specified repositories

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note

When overriding the maven repository settings, the default repositories should still be retained to avoid losing the base
dependencies.

```