### PR TITLE
[BACKPORT-1.10.x] fix(#3671): Fix native mode for KameletBinding

### DIFF
--- a/pkg/trait/quarkus.go
+++ b/pkg/trait/quarkus.go
@@ -20,6 +20,7 @@ package trait
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/rs/xid"
 
@@ -197,6 +198,13 @@ func (t *quarkusTrait) newIntegrationKit(e *Environment, packageType traitv1.Qua
 	if v, ok := integration.Annotations[v1.PlatformSelectorAnnotation]; ok {
 		v1.SetAnnotation(&kit.ObjectMeta, v1.PlatformSelectorAnnotation, v)
 	}
+
+	for k, v := range integration.Annotations {
+		if strings.HasPrefix(k, v1.TraitAnnotationPrefix) {
+			v1.SetAnnotation(&kit.ObjectMeta, k, v)
+		}
+	}
+
 	operatorID := defaults.OperatorID()
 	if operatorID != "" {
 		kit.SetOperatorID(operatorID)

--- a/pkg/trait/quarkus_test.go
+++ b/pkg/trait/quarkus_test.go
@@ -71,6 +71,24 @@ func TestApplyQuarkusTraitDefaultKitLayout(t *testing.T) {
 	assert.Equal(t, environment.IntegrationKits[0].Labels[v1.IntegrationKitLayoutLabel], v1.IntegrationKitLayoutFastJar)
 }
 
+func TestApplyQuarkusTraitAnnotationKitConfiguration(t *testing.T) {
+	quarkusTrait, environment := createNominalQuarkusTest()
+	environment.Integration.Status.Phase = v1.IntegrationPhaseBuildingKit
+
+	v1.SetAnnotation(&environment.Integration.ObjectMeta, v1.TraitAnnotationPrefix+"quarkus.foo", "camel-k")
+
+	configured, err := quarkusTrait.Configure(environment)
+	assert.True(t, configured)
+	assert.Nil(t, err)
+
+	err = quarkusTrait.Apply(environment)
+	assert.Nil(t, err)
+	assert.Len(t, environment.IntegrationKits, 1)
+	assert.Equal(t, v1.IntegrationKitLayoutFastJar, environment.IntegrationKits[0].Labels[v1.IntegrationKitLayoutLabel])
+	assert.Equal(t, "camel-k", environment.IntegrationKits[0].Annotations[v1.TraitAnnotationPrefix+"quarkus.foo"])
+
+}
+
 func createNominalQuarkusTest() (*quarkusTrait, *Environment) {
 	trait, _ := newQuarkusTrait().(*quarkusTrait)
 	trait.Enabled = pointer.Bool(true)


### PR DESCRIPTION
Manual backport of #3682 

Propagate annotation trait configuration from Integration to IntegrationKit. This makes sure that the kit matches the integration once the native build is done.

**Release Note**
```release-note
Fix: Quarkus native mode for KameletBinding
```
