### PR TITLE
[BACKPORT-1.9.x] fix(#3671): Fix native mode for KameletBinding

### DIFF
--- a/pkg/trait/quarkus.go
+++ b/pkg/trait/quarkus.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/rs/xid"
 
@@ -270,6 +271,16 @@ func (t *quarkusTrait) newIntegrationKit(e *Environment, packageType quarkusPack
 	if v, ok := integration.Annotations[v1.PlatformSelectorAnnotation]; ok {
 		kit.Annotations[v1.PlatformSelectorAnnotation] = v
 	}
+
+	if kit.GetAnnotations() == nil {
+		kit.SetAnnotations(make(map[string]string))
+	}
+	for k, v := range integration.Annotations {
+		if strings.HasPrefix(k, v1.TraitAnnotationPrefix) {
+			kit.GetAnnotations()[k] = v
+		}
+	}
+
 	operatorID := defaults.OperatorID()
 	if operatorID != "" {
 		kit.Annotations[v1.OperatorIDAnnotation] = operatorID

--- a/pkg/trait/quarkus_test.go
+++ b/pkg/trait/quarkus_test.go
@@ -69,6 +69,27 @@ func TestApplyQuarkusTraitDefaultKitLayout(t *testing.T) {
 	assert.Equal(t, environment.IntegrationKits[0].Labels[v1.IntegrationKitLayoutLabel], v1.IntegrationKitLayoutFastJar)
 }
 
+func TestApplyQuarkusTraitAnnotationKitConfiguration(t *testing.T) {
+	quarkusTrait, environment := createNominalQuarkusTest()
+	environment.Integration.Status.Phase = v1.IntegrationPhaseBuildingKit
+
+	if environment.Integration.GetAnnotations() == nil {
+		environment.Integration.SetAnnotations(make(map[string]string))
+	}
+	environment.Integration.GetAnnotations()[v1.TraitAnnotationPrefix+"quarkus.foo"] = "camel-k"
+
+	configured, err := quarkusTrait.Configure(environment)
+	assert.True(t, configured)
+	assert.Nil(t, err)
+
+	err = quarkusTrait.Apply(environment)
+	assert.Nil(t, err)
+	assert.Len(t, environment.IntegrationKits, 1)
+	assert.Equal(t, v1.IntegrationKitLayoutFastJar, environment.IntegrationKits[0].Labels[v1.IntegrationKitLayoutLabel])
+	assert.Equal(t, "camel-k", environment.IntegrationKits[0].Annotations[v1.TraitAnnotationPrefix+"quarkus.foo"])
+
+}
+
 func createNominalQuarkusTest() (*quarkusTrait, *Environment) {
 	trait, _ := newQuarkusTrait().(*quarkusTrait)
 	trait.Enabled = BoolP(true)


### PR DESCRIPTION
Manual backport of #3682 

Propagate annotation trait configuration from Integration to IntegrationKit. This makes sure that the kit matches the integration once the native build is done.

**Release Note**
```release-note
Fix: Quarkus native mode for KameletBinding
```
