### PR TITLE
chore: Use global client discovery API to check Knative install

### DIFF
--- a/e2e/global/knative/knative_platform_test.go
+++ b/e2e/global/knative/knative_platform_test.go
@@ -40,7 +40,9 @@ import (
 
 func TestKnativePlatform(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
-		if !knative.IsEnabledInNamespace(TestContext, TestClient(), ns) {
+		installed, err := knative.IsInstalled(TestClient())
+		Expect(err).NotTo(HaveOccurred())
+		if !installed {
 			t.Error("Knative not installed in the cluster")
 			t.FailNow()
 		}

--- a/pkg/controller/kameletbinding/integration.go
+++ b/pkg/controller/kameletbinding/integration.go
@@ -249,7 +249,9 @@ func determineProfile(ctx context.Context, c client.Client, binding *v1alpha1.Ka
 			return pl.Spec.Profile, nil
 		}
 	}
-	if knative.IsEnabledInNamespace(ctx, c, binding.Namespace) {
+	if ok, err := knative.IsInstalled(c); err != nil {
+		return "", err
+	} else if ok {
 		return v1.TraitProfileKnative, nil
 	}
 	if pl != nil {

--- a/pkg/install/cluster.go
+++ b/pkg/install/cluster.go
@@ -201,7 +201,7 @@ func SetupClusterWideResourcesOrCollect(ctx context.Context, clientProvider clie
 		}
 	}
 
-	isKnative, err := knative.IsInstalled(ctx, c)
+	isKnative, err := knative.IsInstalled(c)
 	if err != nil {
 		return err
 	}

--- a/pkg/install/knative.go
+++ b/pkg/install/knative.go
@@ -35,7 +35,7 @@ const knativeAddressableResolverClusterRoleName = "addressable-resolver"
 // BindKnativeAddressableResolverClusterRole binds the Knative addressable resolver aggregated ClusterRole
 // to the operator ServiceAccount.
 func BindKnativeAddressableResolverClusterRole(ctx context.Context, c kubernetes.Interface, namespace string, operatorNamespace string) error {
-	if isKnative, err := knative.IsInstalled(ctx, c); err != nil {
+	if isKnative, err := knative.IsInstalled(c); err != nil {
 		return err
 	} else if !isKnative {
 		return nil

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -242,7 +242,7 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 	}
 
 	// Additionally, install Knative resources (roles and bindings)
-	isKnative, err := knative.IsInstalled(ctx, c)
+	isKnative, err := knative.IsInstalled(c)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/knative/enabled.go
+++ b/pkg/util/knative/enabled.go
@@ -18,48 +18,15 @@ limitations under the License.
 package knative
 
 import (
-	"context"
-
-	"github.com/apache/camel-k/pkg/client"
-	kubernetesutils "github.com/apache/camel-k/pkg/util/kubernetes"
-	"github.com/apache/camel-k/pkg/util/log"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+
+	util "github.com/apache/camel-k/pkg/util/kubernetes"
 )
 
-// IsEnabledInNamespace returns true if we can list some basic knative objects in the given namespace.
-//
-// This method can be used at operator level to check if knative resources can be accessed.
-func IsEnabledInNamespace(ctx context.Context, c client.Client, namespace string) bool {
-	dyn, err := dynamic.NewForConfig(c.GetConfig())
-	if err != nil {
-		log.Infof("could not create dynamic client to check knative installation in namespace %s, got error: %v", namespace, err)
-		return false
-	}
-	for _, kgv := range RequiredKinds {
-		_, err = dyn.Resource(schema.GroupVersionResource{
-			Group:    kgv.Group,
-			Version:  kgv.Version,
-			Resource: kgv.Resource,
-		}).Namespace(namespace).List(ctx, metav1.ListOptions{})
-
-		if err == nil {
-			return true
-		}
-	}
-
-	log.Infof("could not find any knative type in namespace %s, last error was: %v", namespace, err)
-	return false
-}
-
-// IsInstalled returns true if we are connected to a cluster with Knative installed
-//
-// This method should not be called from the operator, as it might require permissions that are not available.
-func IsInstalled(ctx context.Context, c kubernetes.Interface) (bool, error) {
-	// check some Knative APIs
+// IsInstalled returns true if we are connected to a cluster with Knative installed.
+func IsInstalled(c kubernetes.Interface) (bool, error) {
 	for _, api := range getRequiredKnativeGroupVersions() {
 		if installed, err := isInstalled(c, api); err != nil {
 			return false, err
@@ -72,7 +39,7 @@ func IsInstalled(ctx context.Context, c kubernetes.Interface) (bool, error) {
 
 func isInstalled(c kubernetes.Interface, api schema.GroupVersion) (bool, error) {
 	_, err := c.Discovery().ServerResourcesForGroupVersion(api.String())
-	if err != nil && (k8serrors.IsNotFound(err) || kubernetesutils.IsUnknownAPIError(err)) {
+	if err != nil && (k8serrors.IsNotFound(err) || util.IsUnknownAPIError(err)) {
 		return false, nil
 	} else if err != nil {
 		return false, err


### PR DESCRIPTION
This refactors the current logic to check whether Knative is installed, that is anyway debatable, so it uses the globally provided client. 

**Release Note**
```release-note
chore: Use global client discovery API to check Knative install
```
