### PR TITLE
chore: add test-fmt make target

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -230,6 +230,13 @@ test: do-build
 	cd pkg/client/camel && go test ./...
 	cd pkg/kamelet/repository && go test ./...
 
+test-fmt: do-build
+	@echo "####### Running unit test..."
+	go test -v ./... -json 2>&1 | gotestfmt
+	cd pkg/apis/camel && go test -v ./... -json 2>&1 | gotestfmt
+	cd pkg/client/camel && go test -v ./... -json 2>&1 | gotestfmt
+	cd pkg/kamelet/repository && go test -v ./... -json 2>&1 | gotestfmt
+
 #
 # Integration tests are located either as global or namespace
 # global:    tests can be executed using a pre-installed global operator


### PR DESCRIPTION
<!-- Description -->

This is a small addition to Makefile. Since the output can be verbose I'd prefer to separate the main build (`make test`) from this `make test-fmt`. Anyone who wants to look into the local test failures can run `make test-fmt`.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
