### PR TITLE
[backport] fix(cli): don't verify operator

### DIFF
--- a/pkg/cmd/bind.go
+++ b/pkg/cmd/bind.go
@@ -236,7 +236,7 @@ func (o *bindCmdOptions) run(cmd *cobra.Command, args []string) error {
 		binding.Annotations = make(map[string]string)
 	}
 
-	if o.OperatorID != "" {
+	if !isOfflineCommand(cmd) && o.OperatorID != "" {
 		if err := verifyOperatorID(o.Context, client, o.OperatorID, cmd.OutOrStdout()); err != nil {
 			if o.Force {
 				o.PrintfVerboseErrf(cmd, "%s, use --force option or make sure to use a proper operator id", err.Error())

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -623,7 +623,7 @@ func (o *runCmdOptions) applyAnnotations(cmd *cobra.Command, c client.Client, it
 		it.Annotations = make(map[string]string)
 	}
 
-	if o.OperatorID != "" {
+	if !isOfflineCommand(cmd) && o.OperatorID != "" {
 		if err := verifyOperatorID(o.Context, c, o.OperatorID, cmd.OutOrStdout()); err != nil {
 			if o.Force {
 				o.PrintfVerboseErrf(cmd, "%s, use --force option or make sure to use a proper operator id", err.Error())


### PR DESCRIPTION
when in offline mode

Closes #3662

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): don't verify operator when in offline mode
```
