### PR TITLE
feat(cli): Make add-repo and remove-repo compatible with a global operator

### DIFF
--- a/e2e/namespace/install/cli/files/TimerCustomKameletIntegration.java
+++ b/e2e/namespace/install/cli/files/TimerCustomKameletIntegration.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.Exception;
+import java.lang.Override;
+import org.apache.camel.builder.RouteBuilder;
+
+public class TimerCustomKameletIntegration extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("kamelet:timer-custom-source?message=hello%20world")
+            .to("log:info");
+    }
+}

--- a/e2e/namespace/install/cli/kamelet_test.go
+++ b/e2e/namespace/install/cli/kamelet_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/apache/camel-k/e2e/support"
+)
+
+func TestKameletFromCustomRepository(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		operatorID := operatorID(ns)
+		installWithID(ns)
+
+		kameletName := "timer-custom-source"
+		removeKamelet(kameletName, ns)
+
+		Eventually(Kamelet(kameletName, ns)).Should(BeNil())
+
+		// Add the custom repository
+		Expect(Kamel("kamelet", "add-repo", "github:apache/camel-k/e2e/global/common/files/kamelets", "-n", ns, "-x", operatorID).Execute()).To(Succeed())
+
+		Expect(KamelRunWithID(operatorID, ns, "files/TimerCustomKameletIntegration.java").Execute()).To(Succeed())
+		Eventually(IntegrationPodPhase(ns, "timer-custom-kamelet-integration"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+
+		Eventually(IntegrationLogs(ns, "timer-custom-kamelet-integration")).Should(ContainSubstring("hello world"))
+
+		// Remove the custom repository
+		Expect(Kamel("kamelet", "remove-repo", "github:apache/camel-k/e2e/global/common/files/kamelets", "-n", ns, "-x", operatorID).Execute()).To(Succeed())
+	})
+}
+
+func removeKamelet(name string, ns string) {
+	kamelet := Kamelet(name, ns)()
+	TestClient().Delete(TestContext, kamelet)
+}

--- a/pkg/cmd/kamelet.go
+++ b/pkg/cmd/kamelet.go
@@ -31,6 +31,7 @@ func newCmdKamelet(rootCmdOptions *RootCmdOptions) *cobra.Command {
 	cmd.AddCommand(cmdOnly(newKameletGetCmd(rootCmdOptions)))
 	cmd.AddCommand(cmdOnly(newKameletDeleteCmd(rootCmdOptions)))
 	cmd.AddCommand(cmdOnly(newKameletAddRepoCmd(rootCmdOptions)))
+	cmd.AddCommand(cmdOnly(newKameletRemoveRepoCmd(rootCmdOptions)))
 
 	return &cmd
 }

--- a/pkg/cmd/kamelet_remove_repo.go
+++ b/pkg/cmd/kamelet_remove_repo.go
@@ -1,0 +1,98 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/spf13/cobra"
+)
+
+func newKameletRemoveRepoCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kameletRemoveRepoCommandOptions) {
+	options := kameletRemoveRepoCommandOptions{
+		kameletUpdateRepoCommandOptions: &kameletUpdateRepoCommandOptions{
+			RootCmdOptions: rootCmdOptions,
+		},
+	}
+
+	cmd := cobra.Command{
+		Use:     "remove-repo github:owner/repo[/path_to_kamelets_folder][@version] ...",
+		Short:   "Remove a Kamelet repository",
+		Long:    `Remove a Kamelet repository.`,
+		PreRunE: decode(&options),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.validate(args); err != nil {
+				return err
+			}
+			return options.run(cmd, args)
+		},
+	}
+
+	cmd.Flags().StringP("operator-id", "x", "", "Id of the Operator to update. If not set, the active primary Integration Platform is updated.")
+
+	return &cmd, &options
+}
+
+type kameletRemoveRepoCommandOptions struct {
+	*kameletUpdateRepoCommandOptions
+}
+
+func (o *kameletRemoveRepoCommandOptions) validate(args []string) error {
+	if len(args) == 0 {
+		return errors.New("at least one Kamelet repository is expected")
+	}
+	return nil
+}
+
+func (o *kameletRemoveRepoCommandOptions) run(cmd *cobra.Command, args []string) error {
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return err
+	}
+	var platform *v1.IntegrationPlatform
+	if o.OperatorID == "" {
+		platform, err = o.findIntegrationPlatorm(cmd, c)
+	} else {
+		platform, err = o.getIntegrationPlatorm(cmd, c)
+	}
+	if err != nil {
+		return err
+	} else if platform == nil {
+		return nil
+	}
+	for _, uri := range args {
+		i, err := getURIIndex(uri, platform.Spec.Kamelet.Repositories)
+		if err != nil {
+			return err
+		}
+		platform.Spec.Kamelet.Repositories[i] = platform.Spec.Kamelet.Repositories[len(platform.Spec.Kamelet.Repositories)-1]
+		platform.Spec.Kamelet.Repositories = platform.Spec.Kamelet.Repositories[:len(platform.Spec.Kamelet.Repositories)-1]
+	}
+	return c.Update(o.Context, platform)
+}
+
+func getURIIndex(uri string, repositories []v1.IntegrationPlatformKameletRepositorySpec) (int, error) {
+	for i, repo := range repositories {
+		if repo.URI == uri {
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf("non existing Kamelet repository uri %s", uri)
+}

--- a/pkg/cmd/kamelet_remove_repo_test.go
+++ b/pkg/cmd/kamelet_remove_repo_test.go
@@ -1,0 +1,86 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/util/test"
+)
+
+const cmdKameletRemoveRepo = "remove-repo"
+
+// nolint: unparam
+func initializeKameletRemoveRepoCmdOptions(t *testing.T) (*kameletRemoveRepoCommandOptions, *cobra.Command, RootCmdOptions) {
+	t.Helper()
+
+	options, rootCmd := kamelTestPreAddCommandInit()
+	kameletRemoveRepoCommandOptions := addTestKameletRemoveRepoCmd(*options, rootCmd)
+	kamelTestPostAddCommandInit(t, rootCmd)
+
+	return kameletRemoveRepoCommandOptions, rootCmd, *options
+}
+
+func addTestKameletRemoveRepoCmd(options RootCmdOptions, rootCmd *cobra.Command) *kameletRemoveRepoCommandOptions {
+	// Add a testing version of kamelet remove-repo Command
+	kameletRemoveRepoCmd, kameletRemoveRepoOptions := newKameletRemoveRepoCmd(&options)
+	kameletRemoveRepoCmd.RunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	kameletRemoveRepoCmd.PostRunE = func(c *cobra.Command, args []string) error {
+		return nil
+	}
+	kameletRemoveRepoCmd.Args = test.ArbitraryArgs
+	rootCmd.AddCommand(kameletRemoveRepoCmd)
+	return kameletRemoveRepoOptions
+}
+
+func TestKameletRemoveRepoNoFlag(t *testing.T) {
+	_, rootCmd, _ := initializeKameletRemoveRepoCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdKameletRemoveRepo, "foo")
+	assert.Nil(t, err)
+}
+
+func TestKameletRemoveRepoNonExistingFlag(t *testing.T) {
+	_, rootCmd, _ := initializeKameletRemoveRepoCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdKameletRemoveRepo, "--nonExistingFlag", "foo")
+	assert.NotNil(t, err)
+}
+
+func TestKameletRemoveRepoURINotFoundEmpty(t *testing.T) {
+	repositories := []v1.IntegrationPlatformKameletRepositorySpec{}
+	_, err := getURIIndex("foo", repositories)
+	assert.NotNil(t, err)
+}
+
+func TestKameletRemoveRepoURINotFoundNotEmpty(t *testing.T) {
+	repositories := []v1.IntegrationPlatformKameletRepositorySpec{{URI: "github:foo/bar"}}
+	_, err := getURIIndex("foo", repositories)
+	assert.NotNil(t, err)
+}
+
+func TestKameletRemoveRepoURIFound(t *testing.T) {
+	repositories := []v1.IntegrationPlatformKameletRepositorySpec{{URI: "github:foo/bar1"}, {URI: "github:foo/bar2"}, {URI: "github:foo/bar3"}}
+	i, err := getURIIndex("github:foo/bar2", repositories)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, i)
+}


### PR DESCRIPTION
fixes #3667 

## Motivation

The subcommand `add-repo` is not compatible with a global operator as it is now, it should be reviewed to propose a way to use it in case a global operator is used.

## Modifications:

* Add the subcommand `remove-repo` to be able to remove a repository in order to be able to clean up the Integration Platform used for the e2e test
* Update the active primary IntegrationPlaform of the namespace when the operator id is not set 


**Release Note**
```release-note
feat(cli): Make add-repo and remove-repo compatible with a global operator
```
