### PR TITLE
chore: gotestfmt is renamed to gotesttools/gotestfmt (1.10.x)

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -220,7 +220,7 @@ endif
 
 gotestfmt-install:
 ifeq (, $(shell command -v gotestfmt 2> /dev/null))
-	go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+	go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 endif
 
 test: do-build


### PR DESCRIPTION
<!-- Description -->

backport #3735


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
