### PR TITLE
change(helm): logLevel configuration enabled

### DIFF
--- a/helm/camel-k/templates/operator.yaml
+++ b/helm/camel-k/templates/operator.yaml
@@ -50,6 +50,8 @@ spec:
               {{- else }}
               value: ""
               {{- end }}
+            - name: LOG_LEVEL
+              value: {{ .Values.operator.logLevel }}
             - name: OPERATOR_NAME
               value: camel-k
             - name: POD_NAME

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -28,6 +28,7 @@ operator:
   resources: {}
   securityContext: {}
   tolerations: []
+  logLevel: "info"
 
 platform:
   build:


### PR DESCRIPTION
<!-- Description -->

Configuration of Log Level in Helm chart


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
operator log level made configurable
```
