### PR TITLE
Fix get_catalog.sh when runtime is snapshot

### DIFF
--- a/script/get_catalog.sh
+++ b/script/get_catalog.sh
@@ -22,18 +22,26 @@ if [ "$#" -lt 1 ]; then
   echo "usage: $0 <Camel K runtime version> [<staging repository>]"
   exit 1
 fi
-
+runtime_version="$1"
 if [ -z $2 ]; then
-  mvn -q dependency:copy -Dartifact="org.apache.camel.k:camel-k-catalog:$1:yaml:catalog" -DoutputDirectory=${rootdir}/resources/
-  mv ${rootdir}/resources/camel-k-catalog-$1-catalog.yaml ${rootdir}/resources/camel-catalog-$1.yaml
+  mvn -q dependency:copy -Dartifact="org.apache.camel.k:camel-k-catalog:$runtime_version:yaml:catalog" -DoutputDirectory=${rootdir}/resources/
+  if [ -f "${rootdir}/resources/camel-k-catalog-${runtime_version}-catalog.yaml" ]; then
+      mv ${rootdir}/resources/camel-k-catalog-"${runtime_version}"-catalog.yaml ${rootdir}/resources/camel-catalog-"${runtime_version}".yaml
+  elif [[ $runtime_version == *"SNAPSHOT" ]]; then
+      # when using SNAPSHOT versions and a snapshot repository the downloaded artifact has a timestamp in place of the SNAPSHOT word
+      # we should replace this timestamp with the SNAPSHOT word
+      only_version=$(echo $runtime_version|sed 's/-SNAPSHOT//g')
+      cat_file=$(ls -lrt ${rootdir}/resources/camel-k-catalog-"${only_version}"*-catalog.yaml|tail -1|sed 's/.*resources\///g')
+      mv ${rootdir}/resources/$cat_file ${rootdir}/resources/camel-catalog-"${runtime_version}".yaml
+  fi
 else
   # TODO: fix this workaround to use the above mvn statement with the staging repository as well
   echo "INFO: extracting a catalog from staging repository $2"
-  wget -q $2/org/apache/camel/k/camel-k-catalog/$1/camel-k-catalog-$1-catalog.yaml -O ${rootdir}/resources/camel-catalog.yaml
+  wget -q $2/org/apache/camel/k/camel-k-catalog/$runtime_version/camel-k-catalog-$runtime_version-catalog.yaml -O ${rootdir}/resources/camel-catalog.yaml
 
   if [ -s ${rootdir}/resources/camel-catalog.yaml ]; then
     # the extracted catalog file is not empty
-    mv ${rootdir}/resources/camel-catalog.yaml ${rootdir}/resources/camel-catalog-$1.yaml
+    mv ${rootdir}/resources/camel-catalog.yaml ${rootdir}/resources/camel-catalog-$runtime_version.yaml
   else
     # the extracted catalog file is empty - some error in staging repository
     echo "WARNING: could not extract catalog from staging repository $2"


### PR DESCRIPTION
When the runtime is SNAPSHOT and uses a snapshot repository the downloaded artifact contains a timestamp which is not recognized when trying to move the file.

**Release Note**
```release-note
NONE
```
