### PR TITLE
fix(e2e): increase build timeout for native build tests: 40m -> 60m

### DIFF
--- a/e2e/namespace/native/native_binding_test.go
+++ b/e2e/namespace/native/native_binding_test.go
@@ -39,7 +39,7 @@ func TestNativeBinding(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
 		operatorID := "camel-k-native-binding"
 		Expect(KamelInstallWithID(operatorID, ns,
-			"--build-timeout", "40m0s",
+			"--build-timeout", "60m0s",
 			"--operator-resources", "limits.memory=4.5Gi",
 			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=3g",
 		).Execute()).To(Succeed())

--- a/e2e/namespace/native/native_test.go
+++ b/e2e/namespace/native/native_test.go
@@ -43,7 +43,7 @@ func TestNativeIntegrations(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
 		operatorID := "camel-k-quarkus-native"
 		Expect(KamelInstallWithID(operatorID, ns,
-			"--build-timeout", "40m0s",
+			"--build-timeout", "60m0s",
 			"--operator-resources", "limits.memory=4.5Gi",
 			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=3g",
 		).Execute()).To(Succeed())

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -95,7 +95,7 @@ var TestTimeoutMedium = 5 * time.Minute
 var TestTimeoutLong = 10 * time.Minute
 
 // TestTimeoutVeryLong should be used only for testing native builds.
-var TestTimeoutVeryLong = 40 * time.Minute
+var TestTimeoutVeryLong = 60 * time.Minute
 
 var NoOlmOperatorImage string
 

--- a/script/Makefile
+++ b/script/Makefile
@@ -300,7 +300,7 @@ test-install: do-build
 
 test-quarkus-native: do-build
 	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" \
-	go test -timeout 90m -v ./e2e/namespace/native -tags=integration $(TEST_QUARKUS_RUN) -json 2>&1 | gotestfmt
+	go test -timeout 130m -v ./e2e/namespace/native -tags=integration $(TEST_QUARKUS_RUN) -json 2>&1 | gotestfmt
 
 test-upgrade: do-build
 	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" \


### PR DESCRIPTION
<!-- Description -->

Fix #3773. This should also fix the `native-it` failures with pull req #3764.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
