### PR TITLE
chore(e2e): clean up OCP3 guards

### DIFF
--- a/e2e/global/builder/build_test.go
+++ b/e2e/global/builder/build_test.go
@@ -57,11 +57,6 @@ func TestKitKnativeFullBuild(t *testing.T) {
 }
 
 func TestKitTimerToLogFullNativeBuild(t *testing.T) {
-	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
-		t.Skip("INFO: Skipping test as known to never pass on OCP3")
-		return
-	}
-
 	doKitFullBuild(t, "timer-to-log", "4Gi", "15m0s", TestTimeoutVeryLong, kitOptions{
 		dependencies: []string{
 			"camel:timer", "camel:log",

--- a/e2e/namespace/install/kustomize/operator_test.go
+++ b/e2e/namespace/install/kustomize/operator_test.go
@@ -31,21 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOcp3CrdError(t *testing.T) {
-	if os.Getenv("CAMEL_K_CLUSTER_OCP3") != "true" {
-		t.Skip("INFO: Skipping test as only applicable to OCP3")
-	}
-
-	WithNewTestNamespace(t, func(ns string) {
-		ExecMakeError(t, Make("setup-cluster", fmt.Sprintf("NAMESPACE=%s", ns)))
-	})
-}
-
 func TestBasicOperator(t *testing.T) {
-	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
-		t.Skip("INFO: Skipping test as not supported on OCP3")
-	}
-
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed
@@ -64,10 +50,6 @@ func TestBasicOperator(t *testing.T) {
 }
 
 func TestAlternativeImageOperator(t *testing.T) {
-	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
-		t.Skip("INFO: Skipping test as not supported on OCP3")
-	}
-
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed
@@ -90,10 +72,6 @@ func TestAlternativeImageOperator(t *testing.T) {
 }
 
 func TestGlobalOperator(t *testing.T) {
-	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
-		t.Skip("INFO: Skipping test as not supported on OCP3")
-	}
-
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed

--- a/e2e/namespace/install/kustomize/setup_test.go
+++ b/e2e/namespace/install/kustomize/setup_test.go
@@ -32,10 +32,6 @@ import (
 )
 
 func TestBasicSetup(t *testing.T) {
-	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
-		t.Skip("INFO: Skipping test as not supported on OCP3")
-	}
-
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed
@@ -65,10 +61,6 @@ func TestBasicSetup(t *testing.T) {
 }
 
 func TestGlobalSetup(t *testing.T) {
-	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
-		t.Skip("INFO: Skipping test as not supported on OCP3")
-	}
-
 	os.Setenv("MAKE_DIR", "../../../../install")
 
 	// Ensure no CRDs are already installed

--- a/e2e/namespace/native/native_test.go
+++ b/e2e/namespace/native/native_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package native
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -35,11 +34,6 @@ import (
 )
 
 func TestNativeIntegrations(t *testing.T) {
-	if os.Getenv("CAMEL_K_CLUSTER_OCP3") == "true" {
-		t.Skip("INFO: Skipping test as known to never pass on OCP3")
-		return
-	}
-
 	WithNewTestNamespace(t, func(ns string) {
 		operatorID := "camel-k-quarkus-native"
 		Expect(KamelInstallWithID(operatorID, ns,


### PR DESCRIPTION
<!-- Description -->

Since we've been doing without the `openshift` CI for some time, let's remove the OCP3 guards in E2E tests.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
