### PR TITLE
feat(build): parse cmd execution for errors

### DIFF
--- a/pkg/util/command_test.go
+++ b/pkg/util/command_test.go
@@ -1,0 +1,60 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	loggerInfo = func(s string) string {
+		fmt.Println("OUT:", s)
+		if strings.Contains(s, "invalid") {
+			return s
+		}
+		return ""
+	}
+	loggerError = func(s string) string {
+		fmt.Println("ERR:", s)
+		if strings.Contains(s, "invalid") {
+			return s
+		}
+		return ""
+	}
+)
+
+func TestRunAndLog(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/usr/bin/date")
+	err := RunAndLog(context.Background(), cmd, loggerInfo, loggerError)
+
+	assert.Nil(t, err)
+}
+
+func TestRunAndLogInvalid(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/usr/bin/date", "-dsa")
+	err := RunAndLog(context.Background(), cmd, loggerInfo, loggerError)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "/usr/bin/date: invalid date ‘sa’: exit status 1", err.Error())
+}

--- a/pkg/util/jvm/keystore.go
+++ b/pkg/util/jvm/keystore.go
@@ -33,8 +33,8 @@ import (
 var (
 	logger = log.WithName("keytool")
 
-	loggerInfo  = func(s string) { logger.Info(s) }
-	loggerError = func(s string) { logger.Error(nil, s) }
+	loggerInfo  = func(s string) string { logger.Info(s); return "" }
+	loggerError = func(s string) string { logger.Error(nil, s); return "" }
 )
 
 func GenerateKeystore(ctx context.Context, keystoreDir, keystoreName, keystorePass string, data [][]byte) error {

--- a/pkg/util/maven/maven_log_test.go
+++ b/pkg/util/maven/maven_log_test.go
@@ -1,0 +1,35 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maven
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/apache/camel-k/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunAndLogErrorMvn(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/usr/bin/mvn", "package")
+	err := util.RunAndLog(context.Background(), cmd, mavenLogHandler, mavenLogHandler)
+
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "[ERROR] The goal you specified requires a project to execute but there is no POM in this directory")
+}


### PR DESCRIPTION
With this PR we introduce the possibility to parse any external command call output in order to use it for more meaningful error messages to be reported to the final user. In particular we'll collect the first error message line in the `mvn` execution used during build and add to the error in order to be eventually reported in the `IntegrationKit` error status.

Closes #3779

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(build): parse cmd execution for errors
```
