### PR TITLE
fix(#3800): Add proper kamel CLI to image build on macOS

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -316,9 +316,6 @@ ifeq ($(shell uname -s 2>/dev/null || echo Unknown),Linux)
 else
 	go build $(GOFLAGS) -o kamel ./cmd/kamel/*.go
 endif
-ifeq ($(shell uname -m), arm64)
-	GOOS=linux GOARCH=arm64 go build $(GOFLAGS) -o kamel.linux.arm ./cmd/kamel/*.go
-endif
 
 build-resources:
 	./script/get_catalog.sh $(RUNTIME_VERSION) $(STAGING_RUNTIME_REPO)
@@ -402,7 +399,15 @@ maven-overlay:
 kamel-overlay:
 	@echo "####### Copying kamel CLI to output build directory..."
 	mkdir -p build/_output/bin
-	cp kamel build/_output/bin
+ifeq ($(shell uname -m), arm64)
+  GOOS=linux GOARCH=arm64 go build $(GOFLAGS) -o build/_output/bin/kamel ./cmd/kamel/*.go
+else ifneq ($(shell uname -s 2>/dev/null || echo Unknown),Linux)
+  GOOS=linux go build $(GOFLAGS) -o build/_output/bin/kamel ./cmd/kamel/*.go
+else
+	@{ \
+  cp kamel build/_output/bin \
+  }
+endif
 
 images: build kamel-overlay maven-overlay bundle-kamelets
 ifneq (,$(findstring SNAPSHOT,$(RUNTIME_VERSION)))
@@ -421,7 +426,7 @@ endif
 	docker buildx rm --all-inactive --force
 	docker buildx create --append --name builder
 ifeq ($(shell uname -m), x86_x64)
-    	docker buildx build --platform=linux/amd64 -t $(CUSTOM_IMAGE):$(CUSTOM_VERSION) -f build/Dockerfile.arch .
+  docker buildx build --platform=linux/amd64 -t $(CUSTOM_IMAGE):$(CUSTOM_VERSION) -f build/Dockerfile.arch .
 endif
 ifeq ($(shell uname -m), aarch64)
 	docker buildx build --platform=linux/arm64 -t $(CUSTOM_IMAGE):$(CUSTOM_VERSION) -f build/Dockerfile.arch .


### PR DESCRIPTION
Fixes #3800 

Make sure to add proper kamel CLI binary to Docker image when building on macOS