### PR TITLE
chore: Fix tests on macOS aarch64

### DIFF
--- a/pkg/util/command_test.go
+++ b/pkg/util/command_test.go
@@ -45,17 +45,16 @@ var (
 )
 
 func TestRunAndLog(t *testing.T) {
-	cmd := exec.CommandContext(context.Background(), "/usr/bin/date")
+	cmd := exec.CommandContext(context.Background(), "date")
 	err := RunAndLog(context.Background(), cmd, loggerInfo, loggerError)
 
 	assert.Nil(t, err)
 }
 
-// Let's comment this because the Error logging might be different on different Linux distribution
-/*func TestRunAndLogInvalid(t *testing.T) {
-	cmd := exec.CommandContext(context.Background(), "/usr/bin/date", "-dsa")
+func TestRunAndLogInvalid(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "date", "-dsa")
 	err := RunAndLog(context.Background(), cmd, loggerInfo, loggerError)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, "/usr/bin/date: invalid date ‘sa’: exit status 1", err.Error())
-}*/
+	assert.ErrorContains(t, err, "exit status 1")
+}

--- a/pkg/util/maven/maven_log_test.go
+++ b/pkg/util/maven/maven_log_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestRunAndLogErrorMvn(t *testing.T) {
-	cmd := exec.CommandContext(context.Background(), "/usr/bin/mvn", "package")
+	cmd := exec.CommandContext(context.Background(), "mvn", "package")
 	err := util.RunAndLog(context.Background(), cmd, mavenLogHandler, mavenLogHandler)
 
 	assert.NotNil(t, err)


### PR DESCRIPTION
`/usr/bin/data` and `/usr/bin/mvn` does not exist on macOS aarch64 environment

Instead assume both binaries being part of the PATH