### PR TITLE
feat(cli): Support build time dependencies for dependencies uploaded …

### DIFF
--- a/e2e/global/registry/files/classpath/Xslt.java
+++ b/e2e/global/registry/files/classpath/Xslt.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class Xslt extends RouteBuilder {
+
+  private final String XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<item>A</item>";
+
+  @Override
+  public void configure() throws Exception {
+    from("timer:tick?period=1s")
+      .setBody().constant(XML)
+      .to("xslt:xslt/cheese.xsl")
+      .to("log:info");
+  }
+}

--- a/e2e/global/registry/files/classpath/cheese.xsl
+++ b/e2e/global/registry/files/classpath/cheese.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<xsl:stylesheet
+        xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
+        version='1.0'>
+
+    <xsl:output method="xml" indent="yes" encoding="ISO-8859-1"/>
+
+    <xsl:template match="/">
+        <classpath-xsl subject="{/mail/subject}">
+            <cheese>
+                <xsl:apply-templates select="*|@*"/>
+            </cheese>
+        </classpath-xsl>
+    </xsl:template>
+
+    <xsl:template match="*">
+        <xsl:copy>
+            <xsl:copy-of select="attribute::*"/>
+            <xsl:apply-templates/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -77,7 +77,7 @@ import (
 	"github.com/apache/camel-k/pkg/util/watch"
 )
 
-const usageDependency = `A dependency that should be included, e.g., "-d camel:mail" for a Camel component, "-d mvn:org.my:app:1.0" for a Maven dependency, "-d http(s)://my-repo/my-dependency.jar|targetPath=<path>&registry=<registry_URL>&skipChecksums=<true>&skipPOM=<true>" for custom dependencies located on an http server or "file://localPath[?targetPath=<path>&registry=<registry_URL>&skipChecksums=<true>&skipPOM=<true>]" for local files (experimental)`
+const usageDependency = `A dependency that should be included, e.g., "-d camel:mail" for a Camel component, "-d mvn:org.my:app:1.0" for a Maven dependency, "-d http(s)://my-repo/my-dependency.jar|targetPath=<path>&registry=<registry_URL>&skipChecksums=<true>&skipPOM=<true>&classpath=<true>" for custom dependencies located on an http server or "file://localPath[?targetPath=<path>&registry=<registry_URL>&skipChecksums=<true>&skipPOM=<true>&classpath=<true>]" for local files`
 
 func newCmdRun(rootCmdOptions *RootCmdOptions) (*cobra.Command, *runCmdOptions) {
 	options := runCmdOptions{
@@ -974,6 +974,10 @@ func (o *runCmdOptions) skipPom() bool {
 	return o.RegistryOptions.Get("skipPOM") == "true"
 }
 
+func (o *runCmdOptions) classpath() bool {
+	return o.RegistryOptions.Get("classpath") == "true"
+}
+
 func (o *runCmdOptions) getTargetPath() string {
 	return o.RegistryOptions.Get("targetPath")
 }
@@ -1048,6 +1052,9 @@ func (o *runCmdOptions) uploadDependency(platform *v1.IntegrationPlatform, item 
 				return err
 			}
 			dependency := fmt.Sprintf("registry-mvn:%s:%s:%s:%s@%s", gav.GroupID, gav.ArtifactID, gav.Type, gav.Version, mountPath)
+			if o.classpath() {
+				dependency = fmt.Sprintf("%s@%s", dependency, "classpath")
+			}
 			o.PrintfVerboseOutf(cmd, "Added %s to the Integration's dependency list \n", dependency)
 			integration.Spec.AddDependency(dependency)
 			return o.uploadAsMavenArtifact(gav, path, platform, integration.Namespace, options, cmd)

--- a/pkg/util/camel/camel_dependencies.go
+++ b/pkg/util/camel/camel_dependencies.go
@@ -208,15 +208,20 @@ func addRegistryMavenDependency(project *maven.Project, dependency string) error
 	if err != nil {
 		return err
 	}
-	plugin := getOrCreateBuildPlugin(project, "com.googlecode.maven-download-plugin", "download-maven-plugin", "1.6.7")
+	plugin := getOrCreateBuildPlugin(project, "com.googlecode.maven-download-plugin", "download-maven-plugin", "1.6.8")
+	outputDirectory := "../context"
+	isClasspath := len(mapping) == 3 && mapping[2] == "classpath"
+	if isClasspath {
+		outputDirectory = "src/main/resources"
+	}
 	exec := maven.Execution{
 		ID:    fmt.Sprint(len(plugin.Executions)),
-		Phase: "package",
+		Phase: "validate",
 		Goals: []string{
 			"artifact",
 		},
 		Configuration: map[string]string{
-			"outputDirectory": path.Join("../context", filepath.Dir(outputFileRelativePath)),
+			"outputDirectory": path.Join(outputDirectory, filepath.Dir(outputFileRelativePath)),
 			"outputFileName":  filepath.Base(outputFileRelativePath),
 			"groupId":         gav.GroupID,
 			"artifactId":      gav.ArtifactID,


### PR DESCRIPTION
…to the Image Registry

<!-- Description -->
Some Camel Quarkus Extensions require resources to be present at build time. This adds the possibility to do so when uploading dependencies to the Image Registry by specifying `classpath=true` e.g:

```
kamel run route.java -d file://resource.dat?classpath=true
```

Thanks !


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
