### PR TITLE
fix(controller): Ready condition message not always taken from Camel Health Checks

### DIFF
--- a/e2e/global/common/traits/files/NeverReady.java
+++ b/e2e/global/common/traits/files/NeverReady.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class NeverReady extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("timer:tick").id("never-ready")
+            .to("controlbus:route?routeId=never-ready&action=stop&async=true")
+            .setHeader("m").constant("string!")
+            .setBody().simple("Magic${header.m}")
+            .log("${body}");
+    }
+}

--- a/pkg/controller/integration/health.go
+++ b/pkg/controller/integration/health.go
@@ -30,28 +30,31 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type HealthCheckState string
+type HealthCheckStatus string
 
 const (
-	HealthCheckStateDown HealthCheckState = "DOWN"
-	HealthCheckStateUp   HealthCheckState = "UP"
+	HealthCheckStatusDown HealthCheckStatus = "DOWN"
+	HealthCheckStatusUp   HealthCheckStatus = "UP"
+
+	// The key used for propagating error details from Camel health to MicroProfile Health
+	// (See CAMEL-17138).
+	HealthCheckErrorMessage = "error.message"
 )
 
 type HealthCheck struct {
-	Status HealthCheckState      `json:"status,omitempty"`
+	Status HealthCheckStatus     `json:"status,omitempty"`
 	Checks []HealthCheckResponse `json:"checks,omitempty"`
 }
 
 type HealthCheckResponse struct {
 	Name   string                 `json:"name,omitempty"`
-	Status HealthCheckState       `json:"status,omitempty"`
+	Status HealthCheckStatus      `json:"status,omitempty"`
 	Data   map[string]interface{} `json:"data,omitempty"`
 }
 
 func NewHealthCheck(body []byte) (*HealthCheck, error) {
 	health := HealthCheck{}
-	err := json.Unmarshal(body, &health)
-	if err != nil {
+	if err := json.Unmarshal(body, &health); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/integration/health_test.go
+++ b/pkg/controller/integration/health_test.go
@@ -61,24 +61,24 @@ func TestNewHealthCheck(t *testing.T) {
 	`)
 	health, err := NewHealthCheck(body)
 	assert.NoError(t, err)
-	assert.Equal(t, HealthCheckStateDown, health.Status)
+	assert.Equal(t, HealthCheckStatusDown, health.Status)
 	assert.Len(t, health.Checks, 3)
 	assert.Equal(t, "camel-routes", health.Checks[0].Name)
-	assert.Equal(t, HealthCheckStateDown, health.Checks[0].Status)
+	assert.Equal(t, HealthCheckStatusDown, health.Checks[0].Status)
 	assert.True(t, reflect.DeepEqual(health.Checks[0].Data, map[string]interface{}{
 		"route.id":           "route1",
 		"route.context.name": "camel-1",
 		"route.status":       "Stopped",
 	}))
 	assert.Equal(t, "context", health.Checks[1].Name)
-	assert.Equal(t, HealthCheckStateUp, health.Checks[1].Status)
+	assert.Equal(t, HealthCheckStatusUp, health.Checks[1].Status)
 	assert.True(t, reflect.DeepEqual(health.Checks[1].Data, map[string]interface{}{
 		"context.name":    "camel-1",
 		"context.version": "3.16.0",
 		"context.status":  "Started",
 	}))
 	assert.Equal(t, "camel-consumers", health.Checks[2].Name)
-	assert.Equal(t, HealthCheckStateDown, health.Checks[2].Status)
+	assert.Equal(t, HealthCheckStatusDown, health.Checks[2].Status)
 	assert.True(t, reflect.DeepEqual(health.Checks[2].Data, map[string]interface{}{
 		"route.id":           "route1",
 		"route.context.name": "camel-1",

--- a/pkg/controller/integration/monitor.go
+++ b/pkg/controller/integration/monitor.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -40,9 +41,6 @@ import (
 	"github.com/apache/camel-k/pkg/util/digest"
 	"github.com/apache/camel-k/pkg/util/kubernetes"
 )
-
-// The key used for propagating error details from Camel health to MicroProfile Health (See CAMEL-17138).
-const runtimeHealthCheckErrorMessage = "error.message"
 
 func NewMonitorAction() Action {
 	return &monitorAction{}
@@ -454,10 +452,10 @@ func (action *monitorAction) probeReadiness(
 				return err
 			}
 			for _, check := range health.Checks {
-				if check.Status == HealthCheckStateUp {
+				if check.Status == HealthCheckStatusUp {
 					continue
 				}
-				if _, ok := check.Data[runtimeHealthCheckErrorMessage]; ok {
+				if _, ok := check.Data[HealthCheckErrorMessage]; ok {
 					integration.Status.Phase = v1.IntegrationPhaseError
 				}
 				runtimeNotReadyMessages = append(runtimeNotReadyMessages,
@@ -470,7 +468,8 @@ func (action *monitorAction) probeReadiness(
 		if integration.Status.Phase == v1.IntegrationPhaseError {
 			reason = v1.IntegrationConditionErrorReason
 		}
-		integration.SetReadyCondition(corev1.ConditionFalse, reason, fmt.Sprintf("%s", runtimeNotReadyMessages))
+		message := fmt.Sprintf("[%s]", strings.Join(runtimeNotReadyMessages, ", "))
+		integration.SetReadyCondition(corev1.ConditionFalse, reason, message)
 	}
 
 	return nil

--- a/pkg/controller/integration/monitor_cronjob.go
+++ b/pkg/controller/integration/monitor_cronjob.go
@@ -59,7 +59,8 @@ func (c *cronJobController) checkReadyCondition(ctx context.Context) (bool, erro
 			t = c.lastCompletedJob.CreationTimestamp.Time
 		}
 		if c.lastCompletedJob != nil {
-			if failed := kubernetes.GetJobCondition(*c.lastCompletedJob, batchv1.JobFailed); failed != nil && failed.Status == corev1.ConditionTrue {
+			if failed := kubernetes.GetJobCondition(*c.lastCompletedJob, batchv1.JobFailed); failed != nil &&
+				failed.Status == corev1.ConditionTrue {
 				c.integration.SetReadyCondition(corev1.ConditionFalse,
 					v1.IntegrationConditionLastJobFailedReason,
 					fmt.Sprintf("last job %s failed: %s", c.lastCompletedJob.Name, failed.Message))
@@ -88,13 +89,15 @@ func (c *cronJobController) updateReadyCondition(readyPods []corev1.Pod) bool {
 			v1.IntegrationConditionCronJobActiveReason, "cronjob active")
 		return true
 
-	case c.obj.Spec.SuccessfulJobsHistoryLimit != nil && *c.obj.Spec.SuccessfulJobsHistoryLimit == 0 && c.obj.Spec.FailedJobsHistoryLimit != nil && *c.obj.Spec.FailedJobsHistoryLimit == 0:
+	case c.obj.Spec.SuccessfulJobsHistoryLimit != nil && *c.obj.Spec.SuccessfulJobsHistoryLimit == 0 &&
+		c.obj.Spec.FailedJobsHistoryLimit != nil && *c.obj.Spec.FailedJobsHistoryLimit == 0:
 		c.integration.SetReadyCondition(corev1.ConditionTrue,
 			v1.IntegrationConditionCronJobCreatedReason, "no jobs history available")
 		return true
 
 	case c.lastCompletedJob != nil:
-		if complete := kubernetes.GetJobCondition(*c.lastCompletedJob, batchv1.JobComplete); complete != nil && complete.Status == corev1.ConditionTrue {
+		if complete := kubernetes.GetJobCondition(*c.lastCompletedJob, batchv1.JobComplete); complete != nil &&
+			complete.Status == corev1.ConditionTrue {
 			c.integration.SetReadyCondition(corev1.ConditionTrue,
 				v1.IntegrationConditionLastJobSucceededReason,
 				fmt.Sprintf("last job %s completed successfully", c.lastCompletedJob.Name))

--- a/pkg/controller/integration/monitor_deployment.go
+++ b/pkg/controller/integration/monitor_deployment.go
@@ -37,7 +37,9 @@ var _ controller = &deploymentController{}
 
 func (c *deploymentController) checkReadyCondition(ctx context.Context) (bool, error) {
 	// Check the Deployment progression
-	if progressing := kubernetes.GetDeploymentCondition(*c.obj, appsv1.DeploymentProgressing); progressing != nil && progressing.Status == corev1.ConditionFalse && progressing.Reason == "ProgressDeadlineExceeded" {
+	if progressing := kubernetes.GetDeploymentCondition(*c.obj, appsv1.DeploymentProgressing); progressing != nil &&
+		progressing.Status == corev1.ConditionFalse &&
+		progressing.Reason == "ProgressDeadlineExceeded" {
 		c.integration.Status.Phase = v1.IntegrationPhaseError
 		c.integration.SetReadyConditionError(progressing.Message)
 		return true, nil

--- a/pkg/controller/integration/monitor_knative.go
+++ b/pkg/controller/integration/monitor_knative.go
@@ -37,7 +37,8 @@ var _ controller = &knativeServiceController{}
 
 func (c *knativeServiceController) checkReadyCondition(ctx context.Context) (bool, error) {
 	// Check the KnativeService conditions
-	if ready := kubernetes.GetKnativeServiceCondition(*c.obj, servingv1.ServiceConditionReady); ready.IsFalse() && ready.GetReason() == "RevisionFailed" {
+	if ready := kubernetes.GetKnativeServiceCondition(*c.obj, servingv1.ServiceConditionReady); ready.IsFalse() &&
+		ready.GetReason() == "RevisionFailed" {
 		c.integration.Status.Phase = v1.IntegrationPhaseError
 		c.integration.SetReadyConditionError(ready.Message)
 		return true, nil


### PR DESCRIPTION
<!-- Description -->

Fix #3761

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(controller): Ready condition message not always taken from Camel Health Checks
```
