### PR TITLE
chore(e2e): separate native-it and run it nightly

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -15,36 +15,14 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-name: install
+name: native
 
 env:
   TEST_CLUSTER: kind
 
 on:
-  pull_request:
-    branches:
-      - main
-      - "release-*"
-    paths-ignore:
-      - 'docs/**'
-      - 'proposals/**'
-      - '**.adoc'
-      - '**.md'
-      - 'KEYS'
-      - 'LICENSE'
-      - 'NOTICE'
-  push:
-    branches:
-      - main
-      - "release-*"
-    paths-ignore:
-      - 'docs/**'
-      - 'proposals/**'
-      - '**.adoc'
-      - '**.md'
-      - 'KEYS'
-      - 'LICENSE'
-      - 'NOTICE'
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       log-level:
@@ -70,7 +48,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  install-it:
+  native-it:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
@@ -84,11 +62,10 @@ jobs:
         ./.github/workflows/manual-exec-process-inputs.sh \
           -i "${{ github.event.inputs.pre-built-kamel-image }}" \
           -p "${{ github.event.inputs.skip-problematic }}" \
-          -q "${{ github.event.inputs.log-level }}" \
           -t "${{ github.event.inputs.test-filters }}"
 
     - name: Execute Tests
-      uses: ./.github/actions/e2e-install
+      uses: ./.github/actions/e2e-install-native
       with:
         cluster-config-data: ${{ secrets.E2E_CLUSTER_CONFIG }}
         cluster-kube-config-data: ${{ secrets.E2E_KUBE_CONFIG }}

--- a/e2e/global/builder/build_test.go
+++ b/e2e/global/builder/build_test.go
@@ -57,7 +57,7 @@ func TestKitKnativeFullBuild(t *testing.T) {
 }
 
 func TestKitTimerToLogFullNativeBuild(t *testing.T) {
-	doKitFullBuild(t, "timer-to-log", "4Gi", "15m0s", TestTimeoutVeryLong, kitOptions{
+	doKitFullBuild(t, "timer-to-log", "4Gi", "15m0s", TestTimeoutLong*3, kitOptions{
 		dependencies: []string{
 			"camel:timer", "camel:log",
 		},

--- a/e2e/namespace/native/native_binding_test.go
+++ b/e2e/namespace/native/native_binding_test.go
@@ -39,7 +39,7 @@ func TestNativeBinding(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
 		operatorID := "camel-k-native-binding"
 		Expect(KamelInstallWithID(operatorID, ns,
-			"--build-timeout", "60m0s",
+			"--build-timeout", "90m0s",
 			"--operator-resources", "limits.memory=4.5Gi",
 			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=3g",
 		).Execute()).To(Succeed())
@@ -80,8 +80,12 @@ func TestNativeBinding(t *testing.T) {
 				from, to,
 				map[string]string{"message": message}, map[string]string{})()).To(Succeed())
 
+			// ====================================
+			// !!! THE MOST TIME-CONSUMING PART !!!
+			// ====================================
 			Eventually(Kits(ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady)),
 				TestTimeoutVeryLong).Should(HaveLen(1))
+
 			nativeKit := Kits(ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady))()[0]
 			Eventually(IntegrationKit(ns, bindingName), TestTimeoutShort).Should(Equal(nativeKit.Name))
 

--- a/e2e/namespace/native/native_test.go
+++ b/e2e/namespace/native/native_test.go
@@ -37,7 +37,7 @@ func TestNativeIntegrations(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
 		operatorID := "camel-k-quarkus-native"
 		Expect(KamelInstallWithID(operatorID, ns,
-			"--build-timeout", "60m0s",
+			"--build-timeout", "90m0s",
 			"--operator-resources", "limits.memory=4.5Gi",
 			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=3g",
 		).Execute()).To(Succeed())
@@ -103,6 +103,9 @@ func TestNativeIntegrations(t *testing.T) {
 
 			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
+			// ====================================
+			// !!! THE MOST TIME-CONSUMING PART !!!
+			// ====================================
 			// Check the native Kit is ready
 			Eventually(Kits(ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady)),
 				TestTimeoutVeryLong).Should(HaveLen(1))

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -95,7 +95,7 @@ var TestTimeoutMedium = 5 * time.Minute
 var TestTimeoutLong = 10 * time.Minute
 
 // TestTimeoutVeryLong should be used only for testing native builds.
-var TestTimeoutVeryLong = 60 * time.Minute
+var TestTimeoutVeryLong = 90 * time.Minute
 
 var NoOlmOperatorImage string
 

--- a/script/Makefile
+++ b/script/Makefile
@@ -301,7 +301,7 @@ test-install: do-build
 
 test-quarkus-native: do-build
 	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" \
-	go test -timeout 130m -v ./e2e/namespace/native -tags=integration $(TEST_QUARKUS_RUN) -json 2>&1 | gotestfmt
+	go test -timeout 180m -v ./e2e/namespace/native -tags=integration $(TEST_QUARKUS_RUN) -json 2>&1 | gotestfmt
 
 test-upgrade: do-build
 	STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)" \


### PR DESCRIPTION
<!-- Description -->

Fix #3784


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
