### PR TITLE
fix(controller): Ready condition message not always taken from Camel Health Checks (1.10.x)

### DIFF
--- a/e2e/global/common/traits/files/NeverReady.java
+++ b/e2e/global/common/traits/files/NeverReady.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class NeverReady extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("timer:tick").id("never-ready")
+            .to("controlbus:route?routeId=never-ready&action=stop&async=true")
+            .setHeader("m").constant("string!")
+            .setBody().simple("Magic${header.m}")
+            .log("${body}");
+    }
+}

--- a/pkg/controller/integration/health.go
+++ b/pkg/controller/integration/health.go
@@ -30,28 +30,31 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type HealthCheckState string
+type HealthCheckStatus string
 
 const (
-	HealthCheckStateDown HealthCheckState = "DOWN"
-	HealthCheckStateUp   HealthCheckState = "UP"
+	HealthCheckStatusDown HealthCheckStatus = "DOWN"
+	HealthCheckStatusUp   HealthCheckStatus = "UP"
+
+	// The key used for propagating error details from Camel health to MicroProfile Health
+	// (See CAMEL-17138).
+	HealthCheckErrorMessage = "error.message"
 )
 
 type HealthCheck struct {
-	Status HealthCheckState      `json:"status,omitempty"`
+	Status HealthCheckStatus     `json:"status,omitempty"`
 	Checks []HealthCheckResponse `json:"checks,omitempty"`
 }
 
 type HealthCheckResponse struct {
 	Name   string                 `json:"name,omitempty"`
-	Status HealthCheckState       `json:"status,omitempty"`
+	Status HealthCheckStatus      `json:"status,omitempty"`
 	Data   map[string]interface{} `json:"data,omitempty"`
 }
 
 func NewHealthCheck(body []byte) (*HealthCheck, error) {
 	health := HealthCheck{}
-	err := json.Unmarshal(body, &health)
-	if err != nil {
+	if err := json.Unmarshal(body, &health); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/integration/health_test.go
+++ b/pkg/controller/integration/health_test.go
@@ -61,24 +61,24 @@ func TestNewHealthCheck(t *testing.T) {
 	`)
 	health, err := NewHealthCheck(body)
 	assert.NoError(t, err)
-	assert.Equal(t, HealthCheckStateDown, health.Status)
+	assert.Equal(t, HealthCheckStatusDown, health.Status)
 	assert.Len(t, health.Checks, 3)
 	assert.Equal(t, "camel-routes", health.Checks[0].Name)
-	assert.Equal(t, HealthCheckStateDown, health.Checks[0].Status)
+	assert.Equal(t, HealthCheckStatusDown, health.Checks[0].Status)
 	assert.True(t, reflect.DeepEqual(health.Checks[0].Data, map[string]interface{}{
 		"route.id":           "route1",
 		"route.context.name": "camel-1",
 		"route.status":       "Stopped",
 	}))
 	assert.Equal(t, "context", health.Checks[1].Name)
-	assert.Equal(t, HealthCheckStateUp, health.Checks[1].Status)
+	assert.Equal(t, HealthCheckStatusUp, health.Checks[1].Status)
 	assert.True(t, reflect.DeepEqual(health.Checks[1].Data, map[string]interface{}{
 		"context.name":    "camel-1",
 		"context.version": "3.16.0",
 		"context.status":  "Started",
 	}))
 	assert.Equal(t, "camel-consumers", health.Checks[2].Name)
-	assert.Equal(t, HealthCheckStateDown, health.Checks[2].Status)
+	assert.Equal(t, HealthCheckStatusDown, health.Checks[2].Status)
 	assert.True(t, reflect.DeepEqual(health.Checks[2].Data, map[string]interface{}{
 		"route.id":           "route1",
 		"route.context.name": "camel-1",

--- a/pkg/controller/integration/monitor.go
+++ b/pkg/controller/integration/monitor.go
@@ -237,7 +237,12 @@ func (action *monitorAction) updateIntegrationPhaseAndReadyCondition(
 		return err
 	}
 
+	readyPods, unreadyPods := filterPodsByReadyStatus(runningPods, controller.getPodSpec())
+
 	if done, err := controller.checkReadyCondition(ctx); done || err != nil {
+		// There may be pods that are not ready but still probable for getting error messages.
+		// Ignore returned error from probing as it's expected when the ctrl obj is not ready.
+		_ = action.probeReadiness(ctx, environment, integration, unreadyPods)
 		return err
 	}
 	if done := checkPodStatuses(integration, pendingPods, runningPods); done {
@@ -245,7 +250,6 @@ func (action *monitorAction) updateIntegrationPhaseAndReadyCondition(
 	}
 	integration.Status.Phase = v1.IntegrationPhaseRunning
 
-	readyPods, unreadyPods := filterPodsByReadyStatus(runningPods, controller.getPodSpec())
 	if done := controller.updateReadyCondition(readyPods); done {
 		return nil
 	}

--- a/pkg/controller/integration/monitor.go
+++ b/pkg/controller/integration/monitor.go
@@ -99,7 +99,8 @@ func (action *monitorAction) Handle(ctx context.Context, integration *v1.Integra
 	if !ok {
 		priority = "0"
 	}
-	withHigherPriority, err := labels.NewRequirement(v1.IntegrationKitPriorityLabel, selection.GreaterThan, []string{priority})
+	withHigherPriority, err := labels.NewRequirement(v1.IntegrationKitPriorityLabel,
+		selection.GreaterThan, []string{priority})
 	if err != nil {
 		return nil, err
 	}
@@ -159,8 +160,9 @@ func (action *monitorAction) Handle(ctx context.Context, integration *v1.Integra
 	if integration.Status.Phase == v1.IntegrationPhaseDeploying {
 		integration.Status.Phase = v1.IntegrationPhaseRunning
 	}
-	err = action.updateIntegrationPhaseAndReadyCondition(ctx, environment, integration, pendingPods.Items, runningPods.Items)
-	if err != nil {
+	if err = action.updateIntegrationPhaseAndReadyCondition(
+		ctx, environment, integration, pendingPods.Items, runningPods.Items,
+	); err != nil {
 		return nil, err
 	}
 
@@ -226,7 +228,10 @@ func getUpdatedController(env *trait.Environment, obj ctrl.Object) ctrl.Object {
 	})
 }
 
-func (action *monitorAction) updateIntegrationPhaseAndReadyCondition(ctx context.Context, environment *trait.Environment, integration *v1.Integration, pendingPods []corev1.Pod, runningPods []corev1.Pod) error {
+func (action *monitorAction) updateIntegrationPhaseAndReadyCondition(
+	ctx context.Context, environment *trait.Environment, integration *v1.Integration,
+	pendingPods []corev1.Pod, runningPods []corev1.Pod,
+) error {
 	controller, err := action.newController(environment, integration)
 	if err != nil {
 		return err
@@ -255,7 +260,9 @@ func checkPodStatuses(integration *v1.Integration, pendingPods []corev1.Pod, run
 	// Check Pods statuses
 	for _, pod := range pendingPods {
 		// Check the scheduled condition
-		if scheduled := kubernetes.GetPodCondition(pod, corev1.PodScheduled); scheduled != nil && scheduled.Status == corev1.ConditionFalse && scheduled.Reason == "Unschedulable" {
+		if scheduled := kubernetes.GetPodCondition(pod, corev1.PodScheduled); scheduled != nil &&
+			scheduled.Status == corev1.ConditionFalse &&
+			scheduled.Reason == "Unschedulable" {
 			integration.Status.Phase = v1.IntegrationPhaseError
 			setReadyConditionError(integration, scheduled.Message)
 			return true
@@ -372,7 +379,10 @@ func findIntegrationContainer(spec corev1.PodSpec) *corev1.Container {
 }
 
 // probeReadiness calls the readiness probes of the non-ready Pods directly to retrieve insights from the Camel runtime.
-func (action *monitorAction) probeReadiness(ctx context.Context, environment *trait.Environment, integration *v1.Integration, unreadyPods []corev1.Pod) error {
+func (action *monitorAction) probeReadiness(
+	ctx context.Context, environment *trait.Environment, integration *v1.Integration,
+	unreadyPods []corev1.Pod,
+) error {
 	var runtimeNotReadyMessages []string
 	for i := range unreadyPods {
 		pod := &unreadyPods[i]
@@ -389,11 +399,13 @@ func (action *monitorAction) probeReadiness(ctx context.Context, environment *tr
 				continue
 			}
 			if errors.Is(err, context.DeadlineExceeded) {
-				runtimeNotReadyMessages = append(runtimeNotReadyMessages, fmt.Sprintf("readiness probe timed out for Pod %s/%s", pod.Namespace, pod.Name))
+				runtimeNotReadyMessages = append(runtimeNotReadyMessages,
+					fmt.Sprintf("readiness probe timed out for Pod %s/%s", pod.Namespace, pod.Name))
 				continue
 			}
 			if !k8serrors.IsServiceUnavailable(err) {
-				runtimeNotReadyMessages = append(runtimeNotReadyMessages, fmt.Sprintf("readiness probe failed for Pod %s/%s: %s", pod.Namespace, pod.Name, err.Error()))
+				runtimeNotReadyMessages = append(runtimeNotReadyMessages,
+					fmt.Sprintf("readiness probe failed for Pod %s/%s: %s", pod.Namespace, pod.Name, err.Error()))
 				continue
 			}
 			health, err := NewHealthCheck(body)
@@ -407,7 +419,8 @@ func (action *monitorAction) probeReadiness(ctx context.Context, environment *tr
 				if _, ok := check.Data[runtimeHealthCheckErrorMessage]; ok {
 					integration.Status.Phase = v1.IntegrationPhaseError
 				}
-				runtimeNotReadyMessages = append(runtimeNotReadyMessages, fmt.Sprintf("Pod %s runtime is not ready: %s", pod.Name, check.Data))
+				runtimeNotReadyMessages = append(runtimeNotReadyMessages,
+					fmt.Sprintf("Pod %s runtime is not ready: %s", pod.Name, check.Data))
 			}
 		}
 	}

--- a/pkg/controller/integration/monitor_cronjob.go
+++ b/pkg/controller/integration/monitor_cronjob.go
@@ -59,8 +59,11 @@ func (c *cronJobController) checkReadyCondition(ctx context.Context) (bool, erro
 			t = c.lastCompletedJob.CreationTimestamp.Time
 		}
 		if c.lastCompletedJob != nil {
-			if failed := kubernetes.GetJobCondition(*c.lastCompletedJob, batchv1.JobFailed); failed != nil && failed.Status == corev1.ConditionTrue {
-				setReadyCondition(c.integration, corev1.ConditionFalse, v1.IntegrationConditionLastJobFailedReason, fmt.Sprintf("last job %s failed: %s", c.lastCompletedJob.Name, failed.Message))
+			if failed := kubernetes.GetJobCondition(*c.lastCompletedJob, batchv1.JobFailed); failed != nil &&
+				failed.Status == corev1.ConditionTrue {
+				setReadyCondition(c.integration, corev1.ConditionFalse,
+					v1.IntegrationConditionLastJobFailedReason,
+					fmt.Sprintf("last job %s failed: %s", c.lastCompletedJob.Name, failed.Message))
 				c.integration.Status.Phase = v1.IntegrationPhaseError
 				return true, nil
 			}
@@ -77,20 +80,27 @@ func (c *cronJobController) getPodSpec() corev1.PodSpec {
 func (c *cronJobController) updateReadyCondition(readyPods []corev1.Pod) bool {
 	switch {
 	case c.obj.Status.LastScheduleTime == nil:
-		setReadyCondition(c.integration, corev1.ConditionTrue, v1.IntegrationConditionCronJobCreatedReason, "cronjob created")
+		setReadyCondition(c.integration, corev1.ConditionTrue,
+			v1.IntegrationConditionCronJobCreatedReason, "cronjob created")
 		return true
 
 	case len(c.obj.Status.Active) > 0:
-		setReadyCondition(c.integration, corev1.ConditionTrue, v1.IntegrationConditionCronJobActiveReason, "cronjob active")
+		setReadyCondition(c.integration, corev1.ConditionTrue,
+			v1.IntegrationConditionCronJobActiveReason, "cronjob active")
 		return true
 
-	case c.obj.Spec.SuccessfulJobsHistoryLimit != nil && *c.obj.Spec.SuccessfulJobsHistoryLimit == 0 && c.obj.Spec.FailedJobsHistoryLimit != nil && *c.obj.Spec.FailedJobsHistoryLimit == 0:
-		setReadyCondition(c.integration, corev1.ConditionTrue, v1.IntegrationConditionCronJobCreatedReason, "no jobs history available")
+	case c.obj.Spec.SuccessfulJobsHistoryLimit != nil && *c.obj.Spec.SuccessfulJobsHistoryLimit == 0 &&
+		c.obj.Spec.FailedJobsHistoryLimit != nil && *c.obj.Spec.FailedJobsHistoryLimit == 0:
+		setReadyCondition(c.integration, corev1.ConditionTrue,
+			v1.IntegrationConditionCronJobCreatedReason, "no jobs history available")
 		return true
 
 	case c.lastCompletedJob != nil:
-		if complete := kubernetes.GetJobCondition(*c.lastCompletedJob, batchv1.JobComplete); complete != nil && complete.Status == corev1.ConditionTrue {
-			setReadyCondition(c.integration, corev1.ConditionTrue, v1.IntegrationConditionLastJobSucceededReason, fmt.Sprintf("last job %s completed successfully", c.lastCompletedJob.Name))
+		if complete := kubernetes.GetJobCondition(*c.lastCompletedJob, batchv1.JobComplete); complete != nil &&
+			complete.Status == corev1.ConditionTrue {
+			setReadyCondition(c.integration, corev1.ConditionTrue,
+				v1.IntegrationConditionLastJobSucceededReason,
+				fmt.Sprintf("last job %s completed successfully", c.lastCompletedJob.Name))
 			return true
 		}
 

--- a/pkg/controller/integration/monitor_deployment.go
+++ b/pkg/controller/integration/monitor_deployment.go
@@ -37,7 +37,9 @@ var _ controller = &deploymentController{}
 
 func (c *deploymentController) checkReadyCondition(ctx context.Context) (bool, error) {
 	// Check the Deployment progression
-	if progressing := kubernetes.GetDeploymentCondition(*c.obj, appsv1.DeploymentProgressing); progressing != nil && progressing.Status == corev1.ConditionFalse && progressing.Reason == "ProgressDeadlineExceeded" {
+	if progressing := kubernetes.GetDeploymentCondition(*c.obj, appsv1.DeploymentProgressing); progressing != nil &&
+		progressing.Status == corev1.ConditionFalse &&
+		progressing.Reason == "ProgressDeadlineExceeded" {
 		c.integration.Status.Phase = v1.IntegrationPhaseError
 		setReadyConditionError(c.integration, progressing.Message)
 		return true, nil

--- a/pkg/controller/integration/monitor_knative.go
+++ b/pkg/controller/integration/monitor_knative.go
@@ -37,7 +37,8 @@ var _ controller = &knativeServiceController{}
 
 func (c *knativeServiceController) checkReadyCondition(ctx context.Context) (bool, error) {
 	// Check the KnativeService conditions
-	if ready := kubernetes.GetKnativeServiceCondition(*c.obj, servingv1.ServiceConditionReady); ready.IsFalse() && ready.GetReason() == "RevisionFailed" {
+	if ready := kubernetes.GetKnativeServiceCondition(*c.obj, servingv1.ServiceConditionReady); ready.IsFalse() &&
+		ready.GetReason() == "RevisionFailed" {
 		c.integration.Status.Phase = v1.IntegrationPhaseError
 		setReadyConditionError(c.integration, ready.Message)
 		return true, nil

--- a/script/Makefile
+++ b/script/Makefile
@@ -75,7 +75,7 @@ OPM := opm
 # Used to push pre-release artifacts
 STAGING_IMAGE_NAME := docker.io/camelk/camel-k
 
-STAGING_RUNTIME_REPO := https://repository.apache.org/content/repositories/orgapachecamel-1495
+STAGING_RUNTIME_REPO :=
 
 # Define here the repo containing the default Kamelet catalog (if any)
 KAMELET_CATALOG_REPO := https://github.com/apache/camel-kamelets.git


### PR DESCRIPTION
<!-- Description -->

Backport #3814


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(controller): Ready condition message not always taken from Camel Health Checks
```
