### PR TITLE
chore(e2e): segregate flaky tests from common,install ITs

### DIFF
--- a/.github/actions/e2e-common/action.yml
+++ b/.github/actions/e2e-common/action.yml
@@ -25,6 +25,10 @@ inputs:
   cluster-kube-config-data:
     description: 'Base16 encoded kube config - required for custom cluster type only'
     required: false
+  test-flaky:
+    description: 'Whether to run flaky or stable tests'
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -83,7 +87,7 @@ runs:
       image-namespace: ${{ steps.config-cluster.outputs.cluster-image-namespace }}
       image-registry-host: ${{ steps.config-cluster.outputs.cluster-image-registry-pull-host }}
       image-name: ${{ steps.build-kamel.outputs.build-binary-local-image-name }}
-      image-registry-insecure: ${{steps.config-cluster.outputs.cluster-image-registry-insecure }}
+      image-registry-insecure: ${{ steps.config-cluster.outputs.cluster-image-registry-insecure }}
       image-version: ${{ steps.build-kamel.outputs.build-binary-local-image-version }}
 
   - id: install-global-operator
@@ -97,7 +101,7 @@ runs:
       image-namespace: ${{ steps.config-cluster.outputs.cluster-image-namespace }}
       image-registry-host: ${{ steps.config-cluster.outputs.cluster-image-registry-pull-host }}
       image-name: ${{ steps.build-kamel.outputs.build-binary-local-image-name }}
-      image-registry-insecure: ${{steps.config-cluster.outputs.cluster-image-registry-insecure }}
+      image-registry-insecure: ${{ steps.config-cluster.outputs.cluster-image-registry-insecure }}
       image-version: ${{ steps.build-kamel.outputs.build-binary-local-image-version }}
 
   - id: report-problematic
@@ -106,21 +110,44 @@ runs:
     with:
       test-suite: global/common
 
-  - id: run-it
-    name: Run IT
+  - id: run-stable-it
+    name: Run IT (Stable)
+    if: ${{ inputs.test-flaky == 'false' }}
     shell: bash
     run: |
       ./.github/actions/e2e-common/exec-tests.sh \
         -b "${{ steps.config-cluster.outputs.cluster-catalog-source-name }}" \
         -c "${{ steps.config-cluster.outputs.cluster-catalog-source-namespace }}" \
+        -f "${{ inputs.test-flaky }}" \
         -g "${{ steps.config-cluster.outputs.cluster-global-operator-namespace }}" \
         -i "${{ steps.config-cluster.outputs.cluster-image-namespace }}" \
         -l "${{ steps.config-cluster.outputs.cluster-image-registry-pull-host }}" \
         -n "${{ steps.build-kamel.outputs.build-binary-local-image-name }}" \
         -q "${{ env.CAMEL_K_LOG_LEVEL }}" \
-        -s "${{steps.config-cluster.outputs.cluster-image-registry-insecure }}" \
+        -s "${{ steps.config-cluster.outputs.cluster-image-registry-insecure }}" \
         -v "${{ steps.build-kamel.outputs.build-binary-local-image-version }}" \
         -x "${{ env.CAMEL_K_TEST_SAVE_FAILED_TEST_NAMESPACE }}"
+
+  - id: run-flaky-it
+    name: Run IT (Flaky)
+    if: ${{ inputs.test-flaky == 'true' }}
+    uses: ./.github/actions/retry
+    with:
+      timeout_minutes: 90
+      max_attempts: 3
+      command: |
+        ./.github/actions/e2e-common/exec-tests.sh \
+          -b "${{ steps.config-cluster.outputs.cluster-catalog-source-name }}" \
+          -c "${{ steps.config-cluster.outputs.cluster-catalog-source-namespace }}" \
+          -f "${{ inputs.test-flaky }}" \
+          -g "${{ steps.config-cluster.outputs.cluster-global-operator-namespace }}" \
+          -i "${{ steps.config-cluster.outputs.cluster-image-namespace }}" \
+          -l "${{ steps.config-cluster.outputs.cluster-image-registry-pull-host }}" \
+          -n "${{ steps.build-kamel.outputs.build-binary-local-image-name }}" \
+          -q "${{ env.CAMEL_K_LOG_LEVEL }}" \
+          -s "${{ steps.config-cluster.outputs.cluster-image-registry-insecure }}" \
+          -v "${{ steps.build-kamel.outputs.build-binary-local-image-version }}" \
+          -x "${{ env.CAMEL_K_TEST_SAVE_FAILED_TEST_NAMESPACE }}"
 
   - name: Cleanup
     uses: ./.github/actions/kamel-cleanup

--- a/.github/actions/e2e-install/action.yml
+++ b/.github/actions/e2e-install/action.yml
@@ -25,6 +25,10 @@ inputs:
   cluster-kube-config-data:
     description: 'Base16 encoded kube config - required for custom cluster type only'
     required: false
+  test-flaky:
+    description: 'Whether to run flaky or stable tests'
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -84,7 +88,7 @@ runs:
       image-namespace: ${{ steps.config-cluster.outputs.cluster-image-namespace }}
       image-registry-host: ${{ steps.config-cluster.outputs.cluster-image-registry-pull-host }}
       image-name: ${{ steps.build-kamel.outputs.build-binary-local-image-name }}
-      image-registry-insecure: ${{steps.config-cluster.outputs.cluster-image-registry-insecure }}
+      image-registry-insecure: ${{ steps.config-cluster.outputs.cluster-image-registry-insecure }}
       image-version: ${{ steps.build-kamel.outputs.build-binary-local-image-version }}
 
   - id: report-problematic
@@ -93,20 +97,42 @@ runs:
     with:
       test-suite: namespace/install
 
-  - id: run-it
-    name: Run IT
+  - id: run-stable-it
+    name: Run IT (Stable)
+    if: ${{ inputs.test-flaky == 'false' }}
     shell: bash
     run: |
       ./.github/actions/e2e-install/exec-tests.sh \
         -b "${{ steps.config-cluster.outputs.cluster-catalog-source-name }}" \
         -c "${{ steps.config-cluster.outputs.cluster-catalog-source-namespace }}" \
+        -f "${{ inputs.test-flaky }}" \
         -i "${{ steps.config-cluster.outputs.cluster-image-namespace }}" \
         -l "${{ steps.config-cluster.outputs.cluster-image-registry-pull-host }}" \
         -n "${{ steps.build-kamel.outputs.build-binary-local-image-name }}" \
         -q "${{ env.CAMEL_K_LOG_LEVEL }}" \
-        -s "${{steps.config-cluster.outputs.cluster-image-registry-insecure }}" \
+        -s "${{ steps.config-cluster.outputs.cluster-image-registry-insecure }}" \
         -v "${{ steps.build-kamel.outputs.build-binary-local-image-version }}" \
         -x "${{ env.CAMEL_K_TEST_SAVE_FAILED_TEST_NAMESPACE }}"
+
+  - id: run-flaky-it
+    name: Run IT (Flaky)
+    if: ${{ inputs.test-flaky == 'true' }}
+    uses: ./.github/actions/retry
+    with:
+      timeout_minutes: 90
+      max_attempts: 3
+      command: |
+        ./.github/actions/e2e-install/exec-tests.sh \
+          -b "${{ steps.config-cluster.outputs.cluster-catalog-source-name }}" \
+          -c "${{ steps.config-cluster.outputs.cluster-catalog-source-namespace }}" \
+          -f "${{ inputs.test-flaky }}" \
+          -i "${{ steps.config-cluster.outputs.cluster-image-namespace }}" \
+          -l "${{ steps.config-cluster.outputs.cluster-image-registry-pull-host }}" \
+          -n "${{ steps.build-kamel.outputs.build-binary-local-image-name }}" \
+          -q "${{ env.CAMEL_K_LOG_LEVEL }}" \
+          -s "${{ steps.config-cluster.outputs.cluster-image-registry-insecure }}" \
+          -v "${{ steps.build-kamel.outputs.build-binary-local-image-version }}" \
+          -x "${{ env.CAMEL_K_TEST_SAVE_FAILED_TEST_NAMESPACE }}"
 
   - name: Cleanup
     uses: ./.github/actions/kamel-cleanup

--- a/.github/actions/e2e-install/exec-tests.sh
+++ b/.github/actions/e2e-install/exec-tests.sh
@@ -25,13 +25,16 @@
 
 set -e
 
-while getopts ":b:c:i:l:n:q:s:v:x:" opt; do
+while getopts ":b:c:f:i:l:n:q:s:v:x:" opt; do
   case "${opt}" in
     b)
       BUILD_CATALOG_SOURCE_NAME=${OPTARG}
       ;;
     c)
       BUILD_CATALOG_SOURCE_NAMESPACE=${OPTARG}
+      ;;
+    f)
+      TEST_FLAKY=${OPTARG}
       ;;
     i)
       IMAGE_NAMESPACE=${OPTARG}
@@ -124,4 +127,8 @@ export CAMEL_K_TEST_IMAGE_VERSION=${CUSTOM_VERSION}
 export CAMEL_K_TEST_SAVE_FAILED_TEST_NAMESPACE=${SAVE_FAILED_TEST_NS}
 
 # Then run integration tests
-DO_TEST_PREBUILD=false make test-install
+if [ "${TEST_FLAKY}" == "false" ]; then
+  DO_TEST_PREBUILD=false make test-install
+else
+  DO_TEST_PREBUILD=false make test-install-flaky
+fi

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -56,7 +56,7 @@ on:
       skip-problematic:
         description: 'Whether tests marked as problematic should be skipped - false by default (sets CAMEL_K_TEST_SKIP_PROBLEMATIC)'
         required: false
-        default: false
+        default: 'false'
       test-filters:
         description: |
           List of comma-separated key/value pairs to filter the tests in this test suite:
@@ -72,9 +72,7 @@ concurrency:
 
 jobs:
   common-it:
-
     runs-on: ubuntu-20.04
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -95,3 +93,27 @@ jobs:
       with:
         cluster-config-data: ${{ secrets.E2E_CLUSTER_CONFIG }}
         cluster-kube-config-data: ${{ secrets.E2E_KUBE_CONFIG }}
+
+  flaky-it:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+        submodules: recursive
+    - name: Convert input parameters to env vars
+      shell: bash
+      run: |
+        ./.github/workflows/manual-exec-process-inputs.sh \
+          -i "${{ github.event.inputs.pre-built-kamel-image }}" \
+          -p "${{ github.event.inputs.skip-problematic }}" \
+          -q "${{ github.event.inputs.log-level }}" \
+          -t "${{ github.event.inputs.test-filters }}"
+
+    - name: Execute Tests
+      uses: ./.github/actions/e2e-common
+      with:
+        cluster-config-data: ${{ secrets.E2E_CLUSTER_CONFIG }}
+        cluster-kube-config-data: ${{ secrets.E2E_KUBE_CONFIG }}
+        test-flaky: 'true'

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -56,7 +56,7 @@ on:
       skip-problematic:
         description: 'Whether tests marked as problematic should be skipped - false by default (sets CAMEL_K_TEST_SKIP_PROBLEMATIC)'
         required: false
-        default: false
+        default: 'false'
       test-filters:
         description: |
           List of comma-separated key/value pairs to filter the tests in this test suite:
@@ -92,3 +92,27 @@ jobs:
       with:
         cluster-config-data: ${{ secrets.E2E_CLUSTER_CONFIG }}
         cluster-kube-config-data: ${{ secrets.E2E_KUBE_CONFIG }}
+
+  flaky-it:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+        submodules: recursive
+    - name: Convert input parameters to env vars
+      shell: bash
+      run: |
+        ./.github/workflows/manual-exec-process-inputs.sh \
+          -i "${{ github.event.inputs.pre-built-kamel-image }}" \
+          -p "${{ github.event.inputs.skip-problematic }}" \
+          -q "${{ github.event.inputs.log-level }}" \
+          -t "${{ github.event.inputs.test-filters }}"
+
+    - name: Execute Tests
+      uses: ./.github/actions/e2e-install
+      with:
+        cluster-config-data: ${{ secrets.E2E_CLUSTER_CONFIG }}
+        cluster-kube-config-data: ${{ secrets.E2E_KUBE_CONFIG }}
+        test-flaky: 'true'

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,6 @@
 [submodule ".github/actions/changelog"]
 	path = .github/actions/changelog
 	url = https://github.com/CharMixer/auto-changelog-action
-	
+[submodule ".github/actions/retry"]
+	path = .github/actions/retry
+	url = https://github.com/nick-fields/retry.git

--- a/e2e/global/common/build/incremental_build_test.go
+++ b/e2e/global/common/build/incremental_build_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/build/maven_ca_secret_test.go
+++ b/e2e/global/common/build/maven_ca_secret_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/build/maven_repository_test.go
+++ b/e2e/global/common/build/maven_repository_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/client_test.go
+++ b/e2e/global/common/client_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/config/config_test.go
+++ b/e2e/global/common/config/config_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/cron_test.go
+++ b/e2e/global/common/cron_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/integration_fail_test.go
+++ b/e2e/global/common/integration_fail_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/kamelet_binding_test.go
+++ b/e2e/global/common/kamelet_binding_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/kamelet_binding_with_image_test.go
+++ b/e2e/global/common/kamelet_binding_with_image_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && flaky
+// +build integration,flaky
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/kamelet_test.go
+++ b/e2e/global/common/kamelet_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/kamelet_update_test.go
+++ b/e2e/global/common/kamelet_update_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/languages/groovy_test.go
+++ b/e2e/global/common/languages/groovy_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/languages/java_test.go
+++ b/e2e/global/common/languages/java_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/languages/js_test.go
+++ b/e2e/global/common/languages/js_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/languages/kotlin_test.go
+++ b/e2e/global/common/languages/kotlin_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/languages/polyglot_test.go
+++ b/e2e/global/common/languages/polyglot_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/languages/xml_test.go
+++ b/e2e/global/common/languages/xml_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/languages/yaml_test.go
+++ b/e2e/global/common/languages/yaml_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/operator_metrics_test.go
+++ b/e2e/global/common/operator_metrics_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/platformless_run_test.go
+++ b/e2e/global/common/platformless_run_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/reset_test.go
+++ b/e2e/global/common/reset_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/rest_test.go
+++ b/e2e/global/common/rest_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/scale_binding_test.go
+++ b/e2e/global/common/scale_binding_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/scale_integration_test.go
+++ b/e2e/global/common/scale_integration_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/secondary_platform_test.go
+++ b/e2e/global/common/secondary_platform_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/structured_logs_test.go
+++ b/e2e/global/common/structured_logs_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/tekton_test.go
+++ b/e2e/global/common/tekton_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/affinity_test.go
+++ b/e2e/global/common/traits/affinity_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/deployment_test.go
+++ b/e2e/global/common/traits/deployment_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 
@@ -23,8 +23,9 @@ limitations under the License.
 package traits
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
 	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/e2e/global/common/traits/error_handler_test.go
+++ b/e2e/global/common/traits/error_handler_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/health_test.go
+++ b/e2e/global/common/traits/health_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/istio_test.go
+++ b/e2e/global/common/traits/istio_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/jolokia_test.go
+++ b/e2e/global/common/traits/jolokia_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/jvm_test.go
+++ b/e2e/global/common/traits/jvm_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/master_test.go
+++ b/e2e/global/common/traits/master_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/openapi_test.go
+++ b/e2e/global/common/traits/openapi_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/pdb_test.go
+++ b/e2e/global/common/traits/pdb_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/pod_test.go
+++ b/e2e/global/common/traits/pod_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/prometheus_test.go
+++ b/e2e/global/common/traits/prometheus_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/pull_secret_test.go
+++ b/e2e/global/common/traits/pull_secret_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/route_test.go
+++ b/e2e/global/common/traits/route_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/service_test.go
+++ b/e2e/global/common/traits/service_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && flaky
+// +build integration,flaky
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/global/common/traits/toleration_test.go
+++ b/e2e/global/common/traits/toleration_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/bind_test.go
+++ b/e2e/namespace/install/cli/bind_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/config_test.go
+++ b/e2e/namespace/install/cli/config_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/debug_test.go
+++ b/e2e/namespace/install/cli/debug_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 
@@ -24,12 +24,13 @@ package common
 
 import (
 	"context"
-	. "github.com/apache/camel-k/e2e/support"
-	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 	"net"
 	"testing"
 	"time"
+
+	. "github.com/apache/camel-k/e2e/support"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestKamelCLIDebug(t *testing.T) {

--- a/e2e/namespace/install/cli/delete_test.go
+++ b/e2e/namespace/install/cli/delete_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/describe_test.go
+++ b/e2e/namespace/install/cli/describe_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/dev_mode_test.go
+++ b/e2e/namespace/install/cli/dev_mode_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/dump_test.go
+++ b/e2e/namespace/install/cli/dump_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/duplicate_parameters_test.go
+++ b/e2e/namespace/install/cli/duplicate_parameters_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/get_test.go
+++ b/e2e/namespace/install/cli/get_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/global_kamelet_test.go
+++ b/e2e/namespace/install/cli/global_kamelet_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/global_test.go
+++ b/e2e/namespace/install/cli/global_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/help_test.go
+++ b/e2e/namespace/install/cli/help_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/install_test.go
+++ b/e2e/namespace/install/cli/install_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/kamelet_test.go
+++ b/e2e/namespace/install/cli/kamelet_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/log_test.go
+++ b/e2e/namespace/install/cli/log_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/offline_commands_test.go
+++ b/e2e/namespace/install/cli/offline_commands_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/promote_test.go
+++ b/e2e/namespace/install/cli/promote_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/run_test.go
+++ b/e2e/namespace/install/cli/run_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/cli/uninstall_test.go
+++ b/e2e/namespace/install/cli/uninstall_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 
@@ -51,8 +51,8 @@ func TestBasicUninstall(t *testing.T) {
 		}
 
 		if !uninstallViaOLM {
-		Eventually(Role(ns)).Should(BeNil())
-		Eventually(RoleBinding(ns)).Should(BeNil())
+			Eventually(Role(ns)).Should(BeNil())
+			Eventually(RoleBinding(ns)).Should(BeNil())
 			Eventually(ServiceAccount(ns, "camel-k-operator")).Should(BeNil())
 		} else {
 			Eventually(Role(ns)).ShouldNot(BeNil())

--- a/e2e/namespace/install/cli/version_test.go
+++ b/e2e/namespace/install/cli/version_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/environment_test.go
+++ b/e2e/namespace/install/environment_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/kustomize/operator_test.go
+++ b/e2e/namespace/install/kustomize/operator_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && flaky
+// +build integration,flaky
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/kustomize/setup_test.go
+++ b/e2e/namespace/install/kustomize/setup_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && flaky
+// +build integration,flaky
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/maven_http_proxy_test.go
+++ b/e2e/namespace/install/maven_http_proxy_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && stable
+// +build integration,stable
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/e2e/namespace/install/operator_id_filtering_test.go
+++ b/e2e/namespace/install/operator_id_filtering_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration && flaky
+// +build integration,flaky
 
 // To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
 

--- a/script/Makefile
+++ b/script/Makefile
@@ -258,11 +258,20 @@ test-fmt: do-build
 #
 test-integration: do-build
 	FAILED=0; STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)"; \
-	go test -timeout 90m -v ./e2e/global/common -tags=integration $(TEST_INTEGRATION_COMMON_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
-	go test -timeout 90m -v ./e2e/global/common/build -tags=integration $(TEST_INTEGRATION_COMMON_BUILD_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
-	go test -timeout 90m -v ./e2e/global/common/config -tags=integration $(TEST_INTEGRATION_COMMON_CONFIG_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
-	go test -timeout 90m -v ./e2e/global/common/languages -tags=integration $(TEST_INTEGRATION_COMMON_LANG_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
-	go test -timeout 90m -v ./e2e/global/common/traits -tags=integration $(TEST_INTEGRATION_COMMON_TRAITS_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common -tags=integration,stable $(TEST_INTEGRATION_COMMON_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common/build -tags=integration,stable $(TEST_INTEGRATION_COMMON_BUILD_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common/config -tags=integration,stable $(TEST_INTEGRATION_COMMON_CONFIG_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common/languages -tags=integration,stable $(TEST_INTEGRATION_COMMON_LANG_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common/traits -tags=integration,stable $(TEST_INTEGRATION_COMMON_TRAITS_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	exit $${FAILED}
+
+test-integration-flaky: do-build
+	FAILED=0; STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)"; \
+	go test -timeout 90m -v ./e2e/global/common -tags=integration,flaky $(TEST_INTEGRATION_COMMON_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common/build -tags=integration,flaky $(TEST_INTEGRATION_COMMON_BUILD_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common/config -tags=integration,flaky $(TEST_INTEGRATION_COMMON_CONFIG_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common/languages -tags=integration,flaky $(TEST_INTEGRATION_COMMON_LANG_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/global/common/traits -tags=integration,flaky $(TEST_INTEGRATION_COMMON_TRAITS_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
 	exit $${FAILED}
 
 test-knative: do-build
@@ -294,9 +303,16 @@ test-registry-maven-wagon: do-build
 
 test-install: do-build
 	FAILED=0; STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)"; \
-	go test -timeout 90m -v ./e2e/namespace/install/ -tags=integration $(TEST_INSTALL_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
-	go test -timeout 90m -v ./e2e/namespace/install/cli -tags=integration $(TEST_INSTALL_CLI_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
-	go test -timeout 90m -v ./e2e/namespace/install/kustomize -tags=integration $(TEST_INSTALL_KUSTOMIZE_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/namespace/install/ -tags=integration,stable $(TEST_INSTALL_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/namespace/install/cli -tags=integration,stable $(TEST_INSTALL_CLI_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/namespace/install/kustomize -tags=integration,stable $(TEST_INSTALL_KUSTOMIZE_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	exit $${FAILED}
+
+test-install-flaky: do-build
+	FAILED=0; STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)"; \
+	go test -timeout 90m -v ./e2e/namespace/install/ -tags=integration,flaky $(TEST_INSTALL_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/namespace/install/cli -tags=integration,flaky $(TEST_INSTALL_CLI_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
+	go test -timeout 90m -v ./e2e/namespace/install/kustomize -tags=integration,flaky $(TEST_INSTALL_KUSTOMIZE_RUN) -json 2>&1 | gotestfmt || FAILED=1; \
 	exit $${FAILED}
 
 test-quarkus-native: do-build


### PR DESCRIPTION
<!-- Description -->

This is a step further for making our E2E more reilable. It marks known flaky tests from common and install E2E, and separate the workflow jobs from the rest of the stable ones.

From this on, we annotate this go build tag as default to integration tests in `e2e/global/common` and `e2e/namespace/install`:
```
//go:build integration && stable
// +build integration,stable
```
And when we observe some test is flaky, change the tag as follows:
```
//go:build integration && flaky
// +build integration,flaky
```
This way the stable and flaky tests are run separately in different jobs at GitHub workflows. The reasoning is that the stable ones rarely fail at random whereas the flaky ones frequently do. Seperating the jobs let us enable to retry only the flaky ones and avoid rerunning the majority of innocent tests.

Furthermore, the `flaky-it` jobs use the [retry action](https://github.com/nick-fields/retry) to rerun the tests at most 3 times, which makes the workflows yet more reliable (hopefully).

For now, it only makes sense to apply this to `common` and `install` E2E as they are the most bulky ones.

@squakez @phantomjinx Please review and let me know if you like this direction or not.
