### PR TITLE
chore(build): upgrade Maven and ubi-quarkus-mandrel base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,9 +15,9 @@
 
 FROM quay.io/quarkus/ubi-quarkus-mandrel:21.3.0.0-Final-java11
 
-ARG MAVEN_VERSION="3.8.4"
+ARG MAVEN_VERSION="3.8.6"
 ARG MAVEN_HOME="/usr/share/maven"
-ARG SHA="a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8"
+ARG SHA="f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26"
 ARG BASE_URL="https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 USER 0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/quarkus/ubi-quarkus-mandrel:21.3.0.0-Final-java11
+FROM quay.io/quarkus/ubi-quarkus-mandrel:22.2.0.0-Final-java11
 
 ARG MAVEN_VERSION="3.8.6"
 ARG MAVEN_HOME="/usr/share/maven"


### PR DESCRIPTION
<!-- Description -->

Trying to address #3817. But we might need to downgrade to `ubi-quarkus-native-image:22.2.0-java11` for camel-k-runtime as well.
https://github.com/apache/camel-k-runtime/blob/main/pom.xml#L47

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(build): upgrade base image to ubi-quarkus-mandrel:22.2.0.0-Final-java11
chore(build): upgrade Maven to 3.8.6
```
