### PR TITLE
chore(test) : TestRunAndLog to pass on mac os

### DIFF
--- a/pkg/util/command_test.go
+++ b/pkg/util/command_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,17 +29,11 @@ import (
 var (
 	loggerInfo = func(s string) string {
 		fmt.Println("OUT:", s)
-		if strings.Contains(s, "invalid") {
-			return s
-		}
-		return ""
+		return s
 	}
 	loggerError = func(s string) string {
 		fmt.Println("ERR:", s)
-		if strings.Contains(s, "invalid") {
-			return s
-		}
-		return ""
+		return s
 	}
 )
 
@@ -52,9 +45,9 @@ func TestRunAndLog(t *testing.T) {
 }
 
 func TestRunAndLogInvalid(t *testing.T) {
-	cmd := exec.CommandContext(context.Background(), "date", "-dsa")
+	cmd := exec.CommandContext(context.Background(), "go", "help", "dsa")
 	err := RunAndLog(context.Background(), cmd, loggerInfo, loggerError)
 
 	assert.NotNil(t, err)
-	assert.ErrorContains(t, err, "exit status 1")
+	assert.Equal(t, "go help dsa: unknown help topic. Run 'go help'.: exit status 2", err.Error())
 }


### PR DESCRIPTION
* Fix: #3813

Signed-off-by: yugo-horie <u5.horie@gmail.com>

<!-- Description -->

#3813 

We divided the test case each OS.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
TestRunAndLog to pass both linux and MacOS
```
