### PR TITLE
[backport 1.10.x] fix(core): move to policy/v1

### DIFF
--- a/e2e/global/common/traits/pdb_test.go
+++ b/e2e/global/common/traits/pdb_test.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 
 	corev1 "k8s.io/api/core/v1"
-	policy "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -109,7 +109,7 @@ func TestPodDisruptionBudgetTrait(t *testing.T) {
 		// Eviction attempt
 		pods := IntegrationPods(ns, name)()
 		Expect(pods).To(HaveLen(2))
-		err := TestClient().CoreV1().Pods(ns).Evict(TestContext, &policy.Eviction{
+		err := TestClient().CoreV1().Pods(ns).EvictV1(TestContext, &policyv1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: pods[0].Name,
 			},
@@ -141,7 +141,7 @@ func TestPodDisruptionBudgetTrait(t *testing.T) {
 
 		pods = IntegrationPods(ns, name)()
 		Expect(pods).To(HaveLen(3))
-		Expect(TestClient().CoreV1().Pods(ns).Evict(TestContext, &policy.Eviction{
+		Expect(TestClient().CoreV1().Pods(ns).EvictV1(TestContext, &policyv1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: pods[0].Name,
 			},
@@ -152,11 +152,11 @@ func TestPodDisruptionBudgetTrait(t *testing.T) {
 	})
 }
 
-func podDisruptionBudget(ns string, name string) func() *policy.PodDisruptionBudget {
-	return func() *policy.PodDisruptionBudget {
-		pdb := policy.PodDisruptionBudget{
+func podDisruptionBudget(ns string, name string) func() *policyv1.PodDisruptionBudget {
+	return func() *policyv1.PodDisruptionBudget {
+		pdb := policyv1.PodDisruptionBudget{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: policy.SchemeGroupVersion.String(),
+				APIVersion: policyv1.SchemeGroupVersion.String(),
 				Kind:       "PodDisruptionBudget",
 			},
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/trait/pdb.go
+++ b/pkg/trait/pdb.go
@@ -20,7 +20,7 @@ package trait
 import (
 	"fmt"
 
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
@@ -72,18 +72,18 @@ func (t *pdbTrait) Apply(e *Environment) error {
 	return nil
 }
 
-func (t *pdbTrait) podDisruptionBudgetFor(integration *v1.Integration) *v1beta1.PodDisruptionBudget {
-	pdb := &v1beta1.PodDisruptionBudget{
+func (t *pdbTrait) podDisruptionBudgetFor(integration *v1.Integration) *policyv1.PodDisruptionBudget {
+	pdb := &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
-			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			APIVersion: policyv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      integration.Name,
 			Namespace: integration.Namespace,
 			Labels:    integration.Labels,
 		},
-		Spec: v1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					v1.IntegrationLabel: integration.Name,

--- a/pkg/trait/pdb_test.go
+++ b/pkg/trait/pdb_test.go
@@ -24,7 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -73,7 +73,7 @@ func TestPdbIsCreatedWithMinAvailable(t *testing.T) {
 	assert.Equal(t, int32(2), pdb.Spec.MinAvailable.IntVal)
 }
 
-func pdbCreatedCheck(t *testing.T, pdbTrait *pdbTrait, environment *Environment) *v1beta1.PodDisruptionBudget {
+func pdbCreatedCheck(t *testing.T, pdbTrait *pdbTrait, environment *Environment) *policyv1.PodDisruptionBudget {
 	t.Helper()
 
 	err := pdbTrait.Apply(environment)
@@ -87,9 +87,9 @@ func pdbCreatedCheck(t *testing.T, pdbTrait *pdbTrait, environment *Environment)
 	return pdb
 }
 
-func findPdb(resources *kubernetes.Collection) *v1beta1.PodDisruptionBudget {
+func findPdb(resources *kubernetes.Collection) *policyv1.PodDisruptionBudget {
 	for _, a := range resources.Items() {
-		if pdb, ok := a.(*v1beta1.PodDisruptionBudget); ok {
+		if pdb, ok := a.(*policyv1.PodDisruptionBudget); ok {
 			return pdb
 		}
 	}


### PR DESCRIPTION
Closes #3840

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(core): move to policy/v1
```
