### PR TITLE
Remove KEP cryptic message when installing

### DIFF
--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -299,7 +299,7 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 	}
 
 	if err = installNamespacedRoleBinding(ctx, c, collection, cfg.Namespace, "/rbac/operator-role-binding-local-registry.yaml"); err != nil {
-		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: the operator won't be able to detect a local image registry via KEP-1755")
+		fmt.Fprintln(cmd.ErrOrStderr(), "")
 	}
 
 	if cfg.Monitoring.Enabled {


### PR DESCRIPTION
<!-- Description -->


Solves #3829 

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
