### PR TITLE
fix: upgrade configuration docs to reflect the last release 1.10.3

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -31,14 +31,14 @@ asciidoc:
     requires: "'util=camel-website-util,ck=xref:js/ck.js'"
     lts: LTS
     prerelease: false
-    camel-kamelets-version: 0.9.1 # Makefile KAMELET_CATALOG_REPO_BRANCH
+    camel-kamelets-version: 0.9.3 # Makefile KAMELET_CATALOG_REPO_BRANCH
     camel-kamelets-docs-version: 0.9.x # Makefile KAMELET_CATALOG_REPO_BRANCH
-    camel-k-runtime-version: 1.15.1 # Makefile RUNTIME_VERSION
+    camel-k-runtime-version: 1.15.2 # Makefile RUNTIME_VERSION
     camel-api-versions: camel.apache.org/v1 camel.apache.org/v1alpha1 # Makefile BUNDLE_CAMEL_APIS
     # from camel-k-runtime parent pom:
     camel-version: 3.18.2
     camel-docs-version: 3.18.x
-    camel-quarkus-version: 2.13.0
+    camel-quarkus-version: 2.13.1
     camel-quarkus-docs-version: 2.13.x
     quarkus-version: 2.13.0.Final
     graalvm-version: 22.1.0


### PR DESCRIPTION
Refs: #3852

Update dependencies versions configuration for documentation to match those of the 1.10.3 release.


**Release Note**
```release-note
NONE
```
