### PR TITLE
Added support for multi-arch building of Operator image

### DIFF
--- a/.github/actions/kamel-build-binary/action.yml
+++ b/.github/actions/kamel-build-binary/action.yml
@@ -32,6 +32,9 @@ inputs:
   make-rules:
     description: 'Override the default make rules'
     required: false
+  image-platforms:
+    description: 'Comma-separated list of platforms eg linux/amd64,linux/arm64'
+    required: false
 
 runs:
   using: "composite"
@@ -45,6 +48,7 @@ runs:
           -l "${{ inputs.image-registry-pull-host }}" \
           -m "${{ inputs.make-rules }}" \
           -s "${{ inputs.image-registry-push-host }}" \
+          -p "${{ inputs.image-platforms }}" \
           -x "${{ env.DEBUG_USE_EXISTING_IMAGE }}"
 
 outputs:

--- a/.github/actions/kamel-build-binary/build-binary.sh
+++ b/.github/actions/kamel-build-binary/build-binary.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-while getopts ":i:l:m:s:x:" opt; do
+while getopts ":i:l:m:s:p:x:" opt; do
   case "${opt}" in
     i)
       IMAGE_NAMESPACE=${OPTARG}
@@ -38,6 +38,9 @@ while getopts ":i:l:m:s:x:" opt; do
       ;;
     s)
       REGISTRY_PUSH_HOST=${OPTARG}
+      ;;
+    p)
+      BUILD_PLATFORMS=${OPTARG}
       ;;
     x)
       DEBUG_USE_EXISTING_IMAGE=${OPTARG}
@@ -83,6 +86,10 @@ else
 
   echo "Build Kamel from source"
 
+  if [ -n "${BUILD_PLATFORMS}" ]; then
+    export BUILD_PLATFORMS
+  fi
+  
   RULES="PACKAGE_ARTIFACTS_STRATEGY=download build images"
   if [ -n "${MAKE_RULES}" ]; then
     RULES=" ${MAKE_RULES} "

--- a/.github/actions/kamel-build/action.yml
+++ b/.github/actions/kamel-build/action.yml
@@ -42,6 +42,9 @@ inputs:
   catalog-source-namespace:
     description: 'Namespace in which to install the catalog source for the bundle (if required)'
     required: false
+  image-platforms:
+    description: 'Comma-separated list of platforms eg linux/amd64,linux/arm64'
+    required: false
 
 runs:
   using: "composite"
@@ -54,6 +57,7 @@ runs:
         image-registry-pull-host: ${{ inputs.image-registry-pull-host }}
         image-namespace: ${{ inputs.image-namespace }}
         make-rules: ${{ inputs.make-rules }}
+        image-platforms: ${{ inputs.image-platforms }}
 
     #
     # By default do not build the image bundle

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/quarkus/ubi-quarkus-mandrel:22.2.0.0-Final-java11
+FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.2.0.0-Final-java11
 
 ARG MAVEN_VERSION="3.8.6"
 ARG MAVEN_HOME="/usr/share/maven"

--- a/build/buildkitd.toml
+++ b/build/buildkitd.toml
@@ -1,0 +1,6 @@
+insecure-entitlements = [ "network.host", "security.insecure"]
+
+[registry."kind-registry:5000"]
+  http = true
+  insecure = true
+  

--- a/script/Makefile
+++ b/script/Makefile
@@ -29,6 +29,8 @@ OPM_VERSION := v1.24.0
 BASE_IMAGE := docker.io/adoptopenjdk/openjdk11:slim
 LOCAL_REPOSITORY := /tmp/artifacts/m2
 IMAGE_NAME ?= docker.io/apache/camel-k
+BUILD_PLATFORMS ?= linux/amd64,linux/arm64
+CURRENT_ENV_PLATFORM ?= linux/amd64
 
 #
 # Situations when user wants to override
@@ -408,9 +410,15 @@ images: build kamel-overlay maven-overlay bundle-kamelets
 ifneq (,$(findstring SNAPSHOT,$(RUNTIME_VERSION)))
 	./script/package_maven_artifacts.sh -s "$(STAGING_RUNTIME_REPO)" -d "$(CAMEL_K_RUNTIME_DIR)" $(RUNTIME_VERSION)
 endif
-	@echo "####### Building Camel K operator container image..."
+	@echo "####### Building Camel K operator container image (single) for multi architectures..."
 	mkdir -p build/_maven_output
-	docker build -t $(CUSTOM_IMAGE):$(CUSTOM_VERSION) -f build/Dockerfile .
+	docker buildx rm --all-inactive --force
+	docker run --rm --privileged tonistiigi/binfmt:latest --install all
+	docker buildx create --name builder --use --driver-opt network=host --config build/buildkitd.toml
+	docker buildx build --platform $(BUILD_PLATFORMS) -t $(CUSTOM_IMAGE):$(CUSTOM_VERSION) -f build/Dockerfile .
+	# load only the curreny system platform as docker local storage doesnt support multi-arch images (yet)
+	# https://github.com/docker/buildx/issues/59
+	docker buildx build --load --platform $(CURRENT_ENV_PLATFORM) -t $(CUSTOM_IMAGE):$(CUSTOM_VERSION) -f build/Dockerfile .
 
 images-arch: build kamel-overlay maven-overlay bundle-kamelets
 ifneq (,$(findstring SNAPSHOT,$(RUNTIME_VERSION)))
@@ -431,11 +439,11 @@ ifeq ($(shell uname -m), arm64)
 endif
 
 images-push:
-	docker push $(CUSTOM_IMAGE):$(CUSTOM_VERSION)
+	docker buildx build --push --platform $(BUILD_PLATFORMS) -t $(CUSTOM_IMAGE):$(CUSTOM_VERSION) -f build/Dockerfile .
 
 images-push-staging:
 	docker tag $(CUSTOM_IMAGE):$(CUSTOM_VERSION) $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)
-	docker push $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)
+	docker buildx build --push --platform $(BUILD_PLATFORMS) -t $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION) -f build/Dockerfile .
 
 get-image:
 	@echo $(CUSTOM_IMAGE)


### PR DESCRIPTION
<!-- Description -->
Adds multi-arch support in the Camel-K Operator docker image. 
- Parameterized (defaults to amd64 + arm64)
- Uses the `ubi-quarkus-mandrel-builder-image` base instead of the `ubi-quarkus-mandrel` one

Fixes #1238 ; This should allow the Operator image to run natively on Apple Sillicon and other arm64 based processors.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Camel-K Operator Container Image is now available in multi-arch flavour; support for linux/amd64 and linux/arm64.
```
