### PR TITLE
fix(source): dataformat dependencies not resolved

### DIFF
--- a/pkg/apis/camel/v1/camelcatalog_types_support.go
+++ b/pkg/apis/camel/v1/camelcatalog_types_support.go
@@ -101,20 +101,20 @@ func (in *CamelArtifact) GetDependencyID() string {
 	}
 }
 
-func (in *CamelArtifact) GetConsumerDependencyIDs(schemeID string) (deps []string) {
+func (in *CamelArtifact) GetConsumerDependencyIDs(schemeID string) []string {
 	return in.getDependencyIDs(schemeID, consumerScheme)
 }
 
-func (in *CamelArtifact) GetProducerDependencyIDs(schemeID string) (deps []string) {
+func (in *CamelArtifact) GetProducerDependencyIDs(schemeID string) []string {
 	return in.getDependencyIDs(schemeID, producerScheme)
 }
 
-func (in *CamelArtifact) getDependencyIDs(schemeID string, scope func(CamelScheme) CamelSchemeScope) (deps []string) {
+func (in *CamelArtifact) getDependencyIDs(schemeID string, scope func(CamelScheme) CamelSchemeScope) []string {
 	ads := in.getDependencies(schemeID, scope)
 	if ads == nil {
-		return deps
+		return nil
 	}
-	deps = make([]string, 0, len(ads))
+	deps := make([]string, 0, len(ads))
 	for _, ad := range ads {
 		deps = append(deps, ad.GetDependencyID())
 	}

--- a/pkg/util/camel/camel_runtime_catalog.go
+++ b/pkg/util/camel/camel_runtime_catalog.go
@@ -186,9 +186,8 @@ func (c *RuntimeCatalog) DecodeComponent(uri string) (*v1.CamelArtifact, *v1.Cam
 		return nil, nil
 	}
 	uriStart := uriSplit[0]
-	scheme, ok := c.GetScheme(uriStart)
 	var schemeRef *v1.CamelScheme
-	if ok {
+	if scheme, ok := c.GetScheme(uriStart); ok {
 		schemeRef = &scheme
 	}
 	return c.GetArtifactByScheme(uriStart), schemeRef

--- a/pkg/util/source/inspector.go
+++ b/pkg/util/source/inspector.go
@@ -354,16 +354,15 @@ func (i *baseInspector) addDependencies(uri string, meta *Metadata, consumer boo
 	}
 
 	// some components require additional dependency resolution based on URI
-	if err := i.addDependenciesFromUri(uri, scheme, meta); err != nil {
+	if err := i.addDependenciesFromURI(uri, scheme, meta); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (i *baseInspector) addDependenciesFromUri(uri string, scheme *v1.CamelScheme, meta *Metadata) error {
-	switch scheme.ID {
-	case "dataformat":
+func (i *baseInspector) addDependenciesFromURI(uri string, scheme *v1.CamelScheme, meta *Metadata) error {
+	if scheme.ID == "dataformat" {
 		// dataformat:name:(marshal|unmarshal)[?options]
 		parts := strings.Split(uri, ":")
 		if len(parts) < 3 {

--- a/pkg/util/source/inspector_groovy_test.go
+++ b/pkg/util/source/inspector_groovy_test.go
@@ -106,12 +106,12 @@ func TestGroovyKamelet(t *testing.T) {
 	}
 }
 
-const groovyJsonEip = `
+const groovyJSONEip = `
 from("direct:start")
     .unmarshal().json()
 `
 
-const groovyJsonJacksonEip = `
+const groovyJSONJacksonEip = `
 from("direct:start")
     .unmarshal().json(JsonLibrary.Jackson)
 `
@@ -137,11 +137,11 @@ func TestGroovyDataFormat(t *testing.T) {
 		deps   []string
 	}{
 		{
-			source: groovyJsonEip,
+			source: groovyJSONEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{
-			source: groovyJsonJacksonEip,
+			source: groovyJSONJacksonEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{

--- a/pkg/util/source/inspector_java_script_test.go
+++ b/pkg/util/source/inspector_java_script_test.go
@@ -88,12 +88,12 @@ func TestJavaScriptKamelet(t *testing.T) {
 	}
 }
 
-const javaScriptJsonEip = `
+const javaScriptJSONEip = `
 from('direct:start')
     .unmarshal().json()
 `
 
-const javaScriptJsonJacksonEip = `
+const javaScriptJSONJacksonEip = `
 from('direct:start')
     .unmarshal().json(JsonLibrary.Jackson)
 `
@@ -119,11 +119,11 @@ func TestJavaScriptDataFormat(t *testing.T) {
 		deps   []string
 	}{
 		{
-			source: javaScriptJsonEip,
+			source: javaScriptJSONEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{
-			source: javaScriptJsonJacksonEip,
+			source: javaScriptJSONJacksonEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{

--- a/pkg/util/source/inspector_java_source_test.go
+++ b/pkg/util/source/inspector_java_source_test.go
@@ -21,25 +21,38 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/util/camel"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-const JavaSourceKameletEip = `
+func newTestJavaSourceInspector(t *testing.T) JavaSourceInspector {
+	t.Helper()
+
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
+
+	return JavaSourceInspector{
+		baseInspector: baseInspector{
+			catalog: catalog,
+		},
+	}
+}
+
+const javaSourceKameletEip = `
 from("direct:start")
-    .kamelet("foo/bar?baz=test")
+    .kamelet("foo/bar?baz=test");
 `
 
-const JavaSourceKameletEndpoint = `
+const javaSourceKameletEndpoint = `
 from("direct:start")
-    .to("kamelet:foo/bar?baz=test")
+    .to("kamelet:foo/bar?baz=test");
 `
 
-const JavaSourceWireTapEip = `
+const javaSourceWireTapEip = `
 from("direct:start")
-    .wireTap("kamelet:foo/bar?baz=test")
+    .wireTap("kamelet:foo/bar?baz=test");
 `
 
 func TestJavaSourceKamelet(t *testing.T) {
@@ -48,45 +61,94 @@ func TestJavaSourceKamelet(t *testing.T) {
 		kamelets []string
 	}{
 		{
-			source:   JavaSourceKameletEip,
+			source:   javaSourceKameletEip,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   JavaSourceKameletEndpoint,
+			source:   javaSourceKameletEndpoint,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   JavaSourceWireTapEip,
+			source:   javaSourceWireTapEip,
 			kamelets: []string{"foo/bar"},
 		},
 	}
 
+	inspector := newTestJavaSourceInspector(t)
 	for i := range tc {
 		test := tc[i]
 		t.Run(fmt.Sprintf("TestJavaSourceKamelet-%d", i), func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Content: test.source,
-				},
-			}
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				assert.True(t, meta.RequiredCapabilities.IsEmpty())
+				for _, k := range test.kamelets {
+					assert.Contains(t, meta.Kamelets, k)
+				}
+			})
+		})
+	}
+}
 
-			catalog, err := camel.DefaultCatalog()
-			assert.Nil(t, err)
+const javaSourceJsonEip = `
+from("direct:start")
+    .unmarshal().json();
+`
 
-			meta := NewMetadata()
-			inspector := JavaSourceInspector{
-				baseInspector: baseInspector{
-					catalog: catalog,
-				},
-			}
+const javaSourceJsonJacksonEip = `
+from("direct:start")
+    .unmarshal().json(JsonLibrary.Jackson);
+`
 
-			err = inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			assert.True(t, meta.RequiredCapabilities.IsEmpty())
+const javaSourceAvroEndpoint = `
+from("direct:start")
+    .to("dataformat:avro:marshal");
+`
 
-			for _, k := range test.kamelets {
-				assert.Contains(t, meta.Kamelets, k)
-			}
+const javaSourceJacksonEndpoint = `
+from("direct:start")
+    .to("dataformat:jackson:marshal");
+`
+
+const javaSourceProtobufEndpoint = `
+from("direct:start")
+    .to("dataformat:protobuf:marshal");
+`
+
+func TestJavaSourceDataFormat(t *testing.T) {
+	tc := []struct {
+		source string
+		deps   []string
+	}{
+		{
+			source: javaSourceJsonEip,
+			deps:   []string{"camel:jackson"},
+		},
+		{
+			source: javaSourceJsonJacksonEip,
+			deps:   []string{"camel:jackson"},
+		},
+		{
+			source: javaSourceAvroEndpoint,
+			deps:   []string{"camel:dataformat", "camel:avro"},
+		},
+		{
+			source: javaSourceJacksonEndpoint,
+			deps:   []string{"camel:dataformat", "camel:jackson"},
+		},
+		{
+			source: javaSourceProtobufEndpoint,
+			deps:   []string{"camel:dataformat", "camel:protobuf"},
+		},
+	}
+
+	inspector := newTestJavaSourceInspector(t)
+	for i := range tc {
+		test := tc[i]
+		t.Run(fmt.Sprintf("TestJavaSourceDataFormat-%d", i), func(t *testing.T) {
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				for _, d := range test.deps {
+					assert.Contains(t, meta.Dependencies.List(), d)
+				}
+			})
 		})
 	}
 }

--- a/pkg/util/source/inspector_java_source_test.go
+++ b/pkg/util/source/inspector_java_source_test.go
@@ -88,12 +88,12 @@ func TestJavaSourceKamelet(t *testing.T) {
 	}
 }
 
-const javaSourceJsonEip = `
+const javaSourceJSONEip = `
 from("direct:start")
     .unmarshal().json();
 `
 
-const javaSourceJsonJacksonEip = `
+const javaSourceJSONJacksonEip = `
 from("direct:start")
     .unmarshal().json(JsonLibrary.Jackson);
 `
@@ -119,11 +119,11 @@ func TestJavaSourceDataFormat(t *testing.T) {
 		deps   []string
 	}{
 		{
-			source: javaSourceJsonEip,
+			source: javaSourceJSONEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{
-			source: javaSourceJsonJacksonEip,
+			source: javaSourceJSONJacksonEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{

--- a/pkg/util/source/inspector_kotlin_test.go
+++ b/pkg/util/source/inspector_kotlin_test.go
@@ -88,12 +88,12 @@ func TestKotlinKamelet(t *testing.T) {
 	}
 }
 
-const kotlinJsonEip = `
+const kotlinJSONEip = `
 from("direct:start")
     .unmarshal().json()
 `
 
-const kotlinJsonJacksonEip = `
+const kotlinJSONJacksonEip = `
 from("direct:start")
     .unmarshal().json(JsonLibrary.Jackson)
 `
@@ -119,11 +119,11 @@ func TestKotlinDataFormat(t *testing.T) {
 		deps   []string
 	}{
 		{
-			source: kotlinJsonEip,
+			source: kotlinJSONEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{
-			source: kotlinJsonJacksonEip,
+			source: kotlinJSONJacksonEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{

--- a/pkg/util/source/inspector_kotlin_test.go
+++ b/pkg/util/source/inspector_kotlin_test.go
@@ -21,23 +21,36 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/util/camel"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-const KotlinKameletEip = `
+func newTestKotlinInspector(t *testing.T) KotlinInspector {
+	t.Helper()
+
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
+
+	return KotlinInspector{
+		baseInspector: baseInspector{
+			catalog: catalog,
+		},
+	}
+}
+
+const kotlinKameletEip = `
 from("direct:start")
     .kamelet("foo/bar?baz=test")
 `
 
-const KotlinKameletEndpoint = `
+const kotlinKameletEndpoint = `
 from("direct:start")
     .to("kamelet:foo/bar?baz=test")
 `
 
-const KotlinWireTapEip = `
+const kotlinWireTapEip = `
 from("direct:start")
     .wireTap("kamelet:foo/bar?baz=test")
 `
@@ -48,45 +61,94 @@ func TestKotlinKamelet(t *testing.T) {
 		kamelets []string
 	}{
 		{
-			source:   KotlinKameletEip,
+			source:   kotlinKameletEip,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   KotlinKameletEndpoint,
+			source:   kotlinKameletEndpoint,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   KotlinWireTapEip,
+			source:   kotlinWireTapEip,
 			kamelets: []string{"foo/bar"},
 		},
 	}
 
+	inspector := newTestKotlinInspector(t)
 	for i := range tc {
 		test := tc[i]
 		t.Run(fmt.Sprintf("TestKotlinKamelet-%d", i), func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Content: test.source,
-				},
-			}
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				assert.True(t, meta.RequiredCapabilities.IsEmpty())
+				for _, k := range test.kamelets {
+					assert.Contains(t, meta.Kamelets, k)
+				}
+			})
+		})
+	}
+}
 
-			catalog, err := camel.DefaultCatalog()
-			assert.Nil(t, err)
+const kotlinJsonEip = `
+from("direct:start")
+    .unmarshal().json()
+`
 
-			meta := NewMetadata()
-			inspector := KotlinInspector{
-				baseInspector: baseInspector{
-					catalog: catalog,
-				},
-			}
+const kotlinJsonJacksonEip = `
+from("direct:start")
+    .unmarshal().json(JsonLibrary.Jackson)
+`
 
-			err = inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			assert.True(t, meta.RequiredCapabilities.IsEmpty())
+const kotlinAvroEndpoint = `
+from("direct:start")
+    .to("dataformat:avro:marshal")
+`
 
-			for _, k := range test.kamelets {
-				assert.Contains(t, meta.Kamelets, k)
-			}
+const kotlinJacksonEndpoint = `
+from("direct:start")
+    .to("dataformat:jackson:marshal")
+`
+
+const kotlinProtobufEndpoint = `
+from("direct:start")
+    .to("dataformat:protobuf:marshal")
+`
+
+func TestKotlinDataFormat(t *testing.T) {
+	tc := []struct {
+		source string
+		deps   []string
+	}{
+		{
+			source: kotlinJsonEip,
+			deps:   []string{"camel:jackson"},
+		},
+		{
+			source: kotlinJsonJacksonEip,
+			deps:   []string{"camel:jackson"},
+		},
+		{
+			source: kotlinAvroEndpoint,
+			deps:   []string{"camel:dataformat", "camel:avro"},
+		},
+		{
+			source: kotlinJacksonEndpoint,
+			deps:   []string{"camel:dataformat", "camel:jackson"},
+		},
+		{
+			source: kotlinProtobufEndpoint,
+			deps:   []string{"camel:dataformat", "camel:protobuf"},
+		},
+	}
+
+	inspector := newTestKotlinInspector(t)
+	for i := range tc {
+		test := tc[i]
+		t.Run(fmt.Sprintf("TestKotlinDataFormat-%d", i), func(t *testing.T) {
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				for _, d := range test.deps {
+					assert.Contains(t, meta.Dependencies.List(), d)
+				}
+			})
 		})
 	}
 }

--- a/pkg/util/source/inspector_xml.go
+++ b/pkg/util/source/inspector_xml.go
@@ -19,6 +19,7 @@ package source
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strings"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
@@ -48,6 +49,16 @@ func (i XMLInspector) Extract(source v1.SourceSpec, meta *Metadata) error {
 				meta.RequiredCapabilities.Add(v1.CapabilityRest)
 			case "circuitBreaker":
 				meta.RequiredCapabilities.Add(v1.CapabilityCircuitBreaker)
+			case "json":
+				dataFormatID := defaultJSONDataFormat
+				for _, a := range se.Attr {
+					if a.Name.Local == "library" {
+						dataFormatID = strings.ToLower(fmt.Sprintf("%s", a.Value))
+					}
+				}
+				if dfDep := i.catalog.GetArtifactByDataFormat(dataFormatID); dfDep != nil {
+					meta.AddDependency(dfDep.GetDependencyID())
+				}
 			case "language":
 				for _, a := range se.Attr {
 					if a.Name.Local == "language" {

--- a/pkg/util/source/inspector_xml.go
+++ b/pkg/util/source/inspector_xml.go
@@ -19,7 +19,6 @@ package source
 
 import (
 	"encoding/xml"
-	"fmt"
 	"strings"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
@@ -53,7 +52,7 @@ func (i XMLInspector) Extract(source v1.SourceSpec, meta *Metadata) error {
 				dataFormatID := defaultJSONDataFormat
 				for _, a := range se.Attr {
 					if a.Name.Local == "library" {
-						dataFormatID = strings.ToLower(fmt.Sprintf("%s", a.Value))
+						dataFormatID = strings.ToLower(a.Value)
 					}
 				}
 				if dfDep := i.catalog.GetArtifactByDataFormat(dataFormatID); dfDep != nil {

--- a/pkg/util/source/inspector_xml_test.go
+++ b/pkg/util/source/inspector_xml_test.go
@@ -102,7 +102,7 @@ func TestXMLKamelet(t *testing.T) {
 	}
 }
 
-const xmlJsonEip = `
+const xmlJSONEip = `
 <camelContext xmlns="http://camel.apache.org/schema/spring">
   <route>
     <from uri="direct:start"/>
@@ -111,7 +111,7 @@ const xmlJsonEip = `
 </camelContext>
 `
 
-const xmlJsonJacksonEip = `
+const xmlJSONJacksonEip = `
 <camelContext xmlns="http://camel.apache.org/schema/spring">
   <route>
     <from uri="direct:start"/>
@@ -153,11 +153,11 @@ func TestXMLDataFormat(t *testing.T) {
 		deps   []string
 	}{
 		{
-			source: xmlJsonEip,
+			source: xmlJSONEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{
-			source: xmlJsonJacksonEip,
+			source: xmlJSONJacksonEip,
 			deps:   []string{"camel:jackson"},
 		},
 		{

--- a/pkg/util/source/inspector_xml_test.go
+++ b/pkg/util/source/inspector_xml_test.go
@@ -21,13 +21,26 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/util/camel"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-const XMLKameletEip = `
+func newTestXMLInspector(t *testing.T) XMLInspector {
+	t.Helper()
+
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
+
+	return XMLInspector{
+		baseInspector: baseInspector{
+			catalog: catalog,
+		},
+	}
+}
+
+const xmlKameletEip = `
 <camelContext xmlns="http://camel.apache.org/schema/spring">
   <route>
     <from uri="direct:start"/>
@@ -37,7 +50,7 @@ const XMLKameletEip = `
 </camelContext>
 `
 
-const XMLKameletEndpoint = `
+const xmlKameletEndpoint = `
 <camelContext xmlns="http://camel.apache.org/schema/spring">
   <route>
     <from uri="direct:start"/>
@@ -46,7 +59,7 @@ const XMLKameletEndpoint = `
 </camelContext>
 `
 
-const XMLWireTapEndpoint = `
+const xmlWireTapEndpoint = `
 <camelContext xmlns="http://camel.apache.org/schema/spring">
   <route>
     <from uri="direct:start"/>
@@ -61,45 +74,115 @@ func TestXMLKamelet(t *testing.T) {
 		kamelets []string
 	}{
 		{
-			source:   XMLKameletEip,
+			source:   xmlKameletEip,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   XMLKameletEndpoint,
+			source:   xmlKameletEndpoint,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   XMLWireTapEndpoint,
+			source:   xmlWireTapEndpoint,
 			kamelets: []string{"foo/bar"},
 		},
 	}
 
+	inspector := newTestXMLInspector(t)
 	for i := range tc {
 		test := tc[i]
 		t.Run(fmt.Sprintf("TestXMLKamelet-%d", i), func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Content: test.source,
-				},
-			}
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				assert.True(t, meta.RequiredCapabilities.IsEmpty())
 
-			catalog, err := camel.DefaultCatalog()
-			assert.Nil(t, err)
+				for _, k := range test.kamelets {
+					assert.Contains(t, meta.Kamelets, k)
+				}
+			})
+		})
+	}
+}
 
-			meta := NewMetadata()
-			inspector := XMLInspector{
-				baseInspector: baseInspector{
-					catalog: catalog,
-				},
-			}
+const xmlJsonEip = `
+<camelContext xmlns="http://camel.apache.org/schema/spring">
+  <route>
+    <from uri="direct:start"/>
+    <marshal><json/></marshal>
+  </route>
+</camelContext>
+`
 
-			err = inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			assert.True(t, meta.RequiredCapabilities.IsEmpty())
+const xmlJsonJacksonEip = `
+<camelContext xmlns="http://camel.apache.org/schema/spring">
+  <route>
+    <from uri="direct:start"/>
+    <marshal><json library="Jackson"/></marshal>
+  </route>
+</camelContext>
+`
 
-			for _, k := range test.kamelets {
-				assert.Contains(t, meta.Kamelets, k)
-			}
+const xmlAvroEndpoint = `
+<camelContext xmlns="http://camel.apache.org/schema/spring">
+  <route>
+    <from uri="direct:start"/>
+    <to uri="dataformat:avro:marshal"/>
+  </route>
+</camelContext>
+`
+
+const xmlJacksonEndpoint = `
+<camelContext xmlns="http://camel.apache.org/schema/spring">
+  <route>
+    <from uri="direct:start"/>
+    <to uri="dataformat:jackson:marshal"/>
+  </route>
+</camelContext>
+`
+
+const xmlProtobufEndpoint = `
+<camelContext xmlns="http://camel.apache.org/schema/spring">
+  <route>
+    <from uri="direct:start"/>
+    <to uri="dataformat:protobuf:marshal"/>
+  </route>
+</camelContext>
+`
+
+func TestXMLDataFormat(t *testing.T) {
+	tc := []struct {
+		source string
+		deps   []string
+	}{
+		{
+			source: xmlJsonEip,
+			deps:   []string{"camel:jackson"},
+		},
+		{
+			source: xmlJsonJacksonEip,
+			deps:   []string{"camel:jackson"},
+		},
+		{
+			source: xmlAvroEndpoint,
+			deps:   []string{"camel:dataformat", "camel:avro"},
+		},
+		{
+			source: xmlJacksonEndpoint,
+			deps:   []string{"camel:dataformat", "camel:jackson"},
+		},
+		{
+			source: xmlProtobufEndpoint,
+			deps:   []string{"camel:dataformat", "camel:protobuf"},
+		},
+	}
+
+	inspector := newTestXMLInspector(t)
+	for i := range tc {
+		test := tc[i]
+		t.Run(fmt.Sprintf("TestXMLDataFormat-%d", i), func(t *testing.T) {
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				for _, d := range test.deps {
+					assert.Contains(t, meta.Dependencies.List(), d)
+				}
+			})
 		})
 	}
 }

--- a/pkg/util/source/inspector_yaml.go
+++ b/pkg/util/source/inspector_yaml.go
@@ -69,9 +69,7 @@ func (i YAMLInspector) parseStep(key string, content interface{}, meta *Metadata
 		meta.RequiredCapabilities.Add(v1.CapabilityRest)
 	case "circuitBreaker":
 		meta.RequiredCapabilities.Add(v1.CapabilityCircuitBreaker)
-	case "unmarshal":
-		fallthrough
-	case "marshal":
+	case "marshal", "unmarshal":
 		if cm, ok := content.(map[interface{}]interface{}); ok {
 			if js, jsOk := cm["json"]; jsOk {
 				dataFormatID := defaultJSONDataFormat

--- a/pkg/util/source/inspector_yaml_test.go
+++ b/pkg/util/source/inspector_yaml_test.go
@@ -22,16 +22,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/pkg/util/camel"
 )
 
-func NewtestYAMLInspector(t *testing.T) YAMLInspector {
+func newTestYAMLInspector(t *testing.T) YAMLInspector {
 	t.Helper()
 
 	catalog, err := camel.DefaultCatalog()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	return YAMLInspector{
 		baseInspector: baseInspector{
@@ -40,7 +41,7 @@ func NewtestYAMLInspector(t *testing.T) YAMLInspector {
 	}
 }
 
-const YAMLRouteConsumer = `
+const yamlRouteConsumer = `
 - from:
     uri: knative:endpoint/default
     steps:
@@ -48,7 +49,7 @@ const YAMLRouteConsumer = `
           uri: "log:out"
 `
 
-const YAMLRouteProducer = `
+const yamlRouteProducer = `
 - from:
     uri: timer:tick
     steps:
@@ -56,7 +57,7 @@ const YAMLRouteProducer = `
           uri: knative:endpoint/service
 `
 
-const YAMLRouteTransformer = `
+const yamlRouteTransformer = `
 - from:
     uri: knative:channel/mychannel
     steps:
@@ -64,14 +65,14 @@ const YAMLRouteTransformer = `
           uri: knative:endpoint/service
 `
 
-const YAMLInvalid = `
+const yamlInvalid = `
 - from:
     uri: knative:endpoint/default
     steps:
       - "log:out"
 `
 
-const YAMLInDepthChannel = `
+const yamlInDepthChannel = `
 - from:
     uri: knative:channel/mychannel
     steps:
@@ -83,7 +84,7 @@ const YAMLInDepthChannel = `
                 uri: knative:endpoint/service
 `
 
-const YAMLWireTapKnativeEIP = `
+const yamlWireTapKnativeEIP = `
 - from:
     uri: knative:channel/mychannel
     parameters:
@@ -93,7 +94,7 @@ const YAMLWireTapKnativeEIP = `
           uri: knative:channel/mychannel
 `
 
-const YAMLWireTapJmsEIP = `
+const yamlWireTapJmsEIP = `
 - from:
     uri: knative:channel/mychannel
     parameters:
@@ -112,78 +113,69 @@ func TestYAMLDependencies(t *testing.T) {
 	}{
 		{
 			name:         "consumer",
-			source:       YAMLRouteConsumer,
+			source:       yamlRouteConsumer,
 			dependencies: []string{`camel:knative`},
 		},
 		{
 			name:         "producer",
-			source:       YAMLRouteProducer,
+			source:       yamlRouteProducer,
 			dependencies: []string{`camel:knative`},
 		},
 		{
 			name:   "transformer",
-			source: YAMLRouteTransformer,
+			source: yamlRouteTransformer,
 			dependencies: []string{
 				`camel:knative`,
 			},
 		},
 		{
 			name:   "invalid",
-			source: YAMLInvalid,
+			source: yamlInvalid,
 			dependencies: []string{
 				`camel:knative`,
 			},
 		},
 		{
 			name:   "in-depth",
-			source: YAMLInDepthChannel,
+			source: yamlInDepthChannel,
 			dependencies: []string{
 				`camel:knative`,
 			},
 		},
 		{
 			name:   "wire-tap-knative",
-			source: YAMLWireTapKnativeEIP,
+			source: yamlWireTapKnativeEIP,
 			dependencies: []string{
 				`camel:knative`,
 			},
 		},
 		{
 			name:   "wire-tap-jms",
-			source: YAMLWireTapJmsEIP,
+			source: yamlWireTapJmsEIP,
 			dependencies: []string{
 				`camel:knative`,
 				`camel:jms`,
 			},
 		},
 	}
+
+	inspector := newTestYAMLInspector(t)
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Name:    "route.yaml",
-					Content: test.source,
-				},
-				Language: v1.LanguageYaml,
-			}
-
-			meta := NewMetadata()
-			inspector := NewtestYAMLInspector(t)
-
-			err := inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			for _, dependency := range test.dependencies {
-				assert.Contains(t, meta.Dependencies.List(), dependency)
-			}
-			for _, missingDependency := range test.missingDependencies {
-				assert.NotContains(t, meta.Dependencies.List(), missingDependency)
-			}
+			assertExtractYAML(t, inspector, test.source, func(meta *Metadata) {
+				for _, dependency := range test.dependencies {
+					assert.Contains(t, meta.Dependencies.List(), dependency)
+				}
+				for _, missingDependency := range test.missingDependencies {
+					assert.NotContains(t, meta.Dependencies.List(), missingDependency)
+				}
+			})
 		})
 	}
 }
 
-const YAMLRestDSL = `
+const yamlRestDSL = `
 - rest:
     verb: "post"
     uri: "/api/flow"
@@ -204,7 +196,7 @@ const YAMLRestDSL = `
           uri: "log:out"
 `
 
-const YAMLRestDSLWithRoute = `
+const yamlRestDSLWithRoute = `
 - route:
     id: "flow"
     group: "routes"
@@ -229,30 +221,23 @@ const YAMLRestDSLWithRoute = `
 `
 
 func TestYAMLRestDSL(t *testing.T) {
-	for name, content := range map[string]string{"YAMLRestDSL": YAMLRestDSL, "YAMLRestDSLWithRoute": YAMLRestDSLWithRoute} {
+	inspector := newTestYAMLInspector(t)
+	for name, content := range map[string]string{
+		"yamlRestDSL":          yamlRestDSL,
+		"yamlRestDSLWithRoute": yamlRestDSLWithRoute,
+	} {
 		sourceContent := content
 		t.Run(name, func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Name:    "route.yaml",
-					Content: sourceContent,
-				},
-				Language: v1.LanguageYaml,
-			}
-
-			meta := NewMetadata()
-			inspector := NewtestYAMLInspector(t)
-
-			err := inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			assert.True(t, meta.RequiredCapabilities.Has(v1.CapabilityRest))
-			assert.True(t, meta.Dependencies.Has("camel:log"))
-			assert.True(t, meta.ExposesHTTPServices)
+			assertExtractYAML(t, inspector, sourceContent, func(meta *Metadata) {
+				assert.True(t, meta.RequiredCapabilities.Has(v1.CapabilityRest))
+				assert.True(t, meta.Dependencies.Has("camel:log"))
+				assert.True(t, meta.ExposesHTTPServices)
+			})
 		})
 	}
 }
 
-const YAMLFromDSL = `
+const yamlFromDSL = `
 - from:
     uri: "timer:tick"
     parameters:
@@ -265,7 +250,7 @@ const YAMLFromDSL = `
       - to: "log:info"
 `
 
-const YAMLFromDSLWithRoute = `
+const yamlFromDSLWithRoute = `
 - route:
     id: route1
     from:
@@ -281,30 +266,24 @@ const YAMLFromDSLWithRoute = `
 `
 
 func TestYAMLRouteAndFromEquivalence(t *testing.T) {
-	for name, content := range map[string]string{"YAMLFromDSL": YAMLFromDSL, "YAMLFromDSLWithRoute": YAMLFromDSLWithRoute} {
+	inspector := newTestYAMLInspector(t)
+	for name, content := range map[string]string{
+		"yamlFromDSL":          yamlFromDSL,
+		"yamlFromDSLWithRoute": yamlFromDSLWithRoute,
+	} {
 		sourceContent := content
 		t.Run(name, func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Name:    "route.yaml",
-					Content: sourceContent,
-				},
-				Language: v1.LanguageYaml,
-			}
-
-			meta := NewMetadata()
-			inspector := NewtestYAMLInspector(t)
-			err := inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			assert.Equal(t, meta.FromURIs, []string{"timer:tick?period=5000"})
-			assert.Equal(t, meta.ToURIs, []string{"log:info"})
-			assert.True(t, meta.Dependencies.Has("camel:log"))
-			assert.True(t, meta.Dependencies.Has("camel:timer"))
+			assertExtractYAML(t, inspector, sourceContent, func(meta *Metadata) {
+				assert.Equal(t, meta.FromURIs, []string{"timer:tick?period=5000"})
+				assert.Equal(t, meta.ToURIs, []string{"log:info"})
+				assert.True(t, meta.Dependencies.Has("camel:log"))
+				assert.True(t, meta.Dependencies.Has("camel:timer"))
+			})
 		})
 	}
 }
 
-const YAMLJSONMarshal = `
+const yamlJSONMarshal = `
 - from:
     uri: timer:tick
     steps:
@@ -312,7 +291,7 @@ const YAMLJSONMarshal = `
         json: {}
 `
 
-const YAMLJSONUnmarshal = `
+const yamlJSONUnmarshal = `
 - from:
     uri: timer:tick
     steps:
@@ -320,7 +299,7 @@ const YAMLJSONUnmarshal = `
         json: {}
 `
 
-const YAMLJSONGsonMarshal = `
+const yamlJSONGsonMarshal = `
 - from:
     uri: timer:tick
     steps:
@@ -329,7 +308,7 @@ const YAMLJSONGsonMarshal = `
           library: Gson
 `
 
-const YAMLJSONUnknownMarshal = `
+const yamlJSONUnknownMarshal = `
 - from:
     uri: timer:tick
     steps:
@@ -344,60 +323,106 @@ func TestYAMLJson(t *testing.T) {
 		dependency string
 	}{
 		{
-			source:     YAMLJSONMarshal,
+			source:     yamlJSONMarshal,
 			dependency: "camel:jackson",
 		},
 		{
-			source:     YAMLJSONUnmarshal,
+			source:     yamlJSONUnmarshal,
 			dependency: "camel:jackson",
 		},
 		{
-			source:     YAMLJSONGsonMarshal,
+			source:     yamlJSONGsonMarshal,
 			dependency: "camel:gson",
 		},
 		{
-			source:     YAMLJSONUnknownMarshal,
+			source:     yamlJSONUnknownMarshal,
 			dependency: "camel:timer",
 		},
 	}
 
+	inspector := newTestYAMLInspector(t)
 	for i := range tc {
 		test := tc[i]
 		t.Run(fmt.Sprintf("%s-%d", test.dependency, i), func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Name:    "route.yaml",
-					Content: test.source,
-				},
-				Language: v1.LanguageYaml,
-			}
-
-			meta := NewMetadata()
-			inspector := NewtestYAMLInspector(t)
-
-			err := inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			assert.True(t, meta.RequiredCapabilities.IsEmpty())
-			assert.Contains(t, meta.Dependencies.List(), test.dependency)
+			assertExtractYAML(t, inspector, test.source, func(meta *Metadata) {
+				assert.True(t, meta.RequiredCapabilities.IsEmpty())
+				assert.Contains(t, meta.Dependencies.List(), test.dependency)
+			})
 		})
 	}
 }
 
-const YAMLKameletEipNoID = `
+const yamlAvroEndpoint = `
+- from:
+    uri: direct:start
+    steps:
+    - to:
+        uri: dataformat:avro:marshal
+`
+
+const yamlJacksonEndpoint = `
+- from:
+    uri: direct:start
+    steps:
+    - to:
+        uri: dataformat:jackson:marshal
+`
+
+const yamlProtobufEndpoint = `
+- from:
+    uri: direct:start
+    steps:
+    - to:
+        uri: dataformat:protobuf:marshal
+`
+
+func TestYAMLDataFormat(t *testing.T) {
+	tc := []struct {
+		source string
+		deps   []string
+	}{
+		{
+			source: yamlAvroEndpoint,
+			deps:   []string{"camel:dataformat", "camel:avro"},
+		},
+		{
+			source: yamlJacksonEndpoint,
+			deps:   []string{"camel:dataformat", "camel:jackson"},
+		},
+		{
+			source: yamlProtobufEndpoint,
+			deps:   []string{"camel:dataformat", "camel:protobuf"},
+		},
+	}
+
+	inspector := newTestYAMLInspector(t)
+	for i := range tc {
+		test := tc[i]
+		t.Run(fmt.Sprintf("TestYAMLDataFormat-%d", i), func(t *testing.T) {
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				for _, d := range test.deps {
+					assert.Contains(t, meta.Dependencies.List(), d)
+				}
+			})
+		})
+	}
+}
+
+const yamlKameletEipNoID = `
 - from:
     uri: timer:tick
     steps:
     - kamelet: "foo"
 `
 
-const YAMLKameletEipInline = `
+const yamlKameletEipInline = `
 - from:
     uri: timer:tick
     steps:
     - kamelet: "foo/bar?baz=test"
 `
 
-const YAMLKameletEipMap = `
+const yamlKameletEipMap = `
 - from:
     uri: timer:tick
     steps:
@@ -406,7 +431,7 @@ const YAMLKameletEipMap = `
 `
 
 // #nosec G101
-const YAMLKameletEipMapWithParams = `
+const yamlKameletEipMapWithParams = `
 - from:
     uri: timer:tick
     steps:
@@ -416,7 +441,7 @@ const YAMLKameletEipMapWithParams = `
           baz:test
 `
 
-const YAMLKameletEndpoint = `
+const yamlKameletEndpoint = `
 - from:
     uri: timer:tick
     steps:
@@ -429,58 +454,42 @@ func TestYAMLKamelet(t *testing.T) {
 		kamelets []string
 	}{
 		{
-			source:   YAMLKameletEipNoID,
+			source:   yamlKameletEipNoID,
 			kamelets: []string{"foo"},
 		},
 		{
-			source:   YAMLKameletEipInline,
+			source:   yamlKameletEipInline,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   YAMLKameletEipMap,
+			source:   yamlKameletEipMap,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   YAMLKameletEipMapWithParams,
+			source:   yamlKameletEipMapWithParams,
 			kamelets: []string{"foo/bar"},
 		},
 		{
-			source:   YAMLKameletEndpoint,
+			source:   yamlKameletEndpoint,
 			kamelets: []string{"foo/bar"},
 		},
 	}
 
+	inspector := newTestYAMLInspector(t)
 	for i := range tc {
 		test := tc[i]
 		t.Run(fmt.Sprintf("TestYAMLKamelet-%d", i), func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Content: test.source,
-				},
-			}
-
-			catalog, err := camel.DefaultCatalog()
-			assert.Nil(t, err)
-
-			meta := NewMetadata()
-			inspector := YAMLInspector{
-				baseInspector: baseInspector{
-					catalog: catalog,
-				},
-			}
-
-			err = inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			assert.True(t, meta.RequiredCapabilities.IsEmpty())
-
-			for _, k := range test.kamelets {
-				assert.Contains(t, meta.Kamelets, k)
-			}
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				assert.True(t, meta.RequiredCapabilities.IsEmpty())
+				for _, k := range test.kamelets {
+					assert.Contains(t, meta.Kamelets, k)
+				}
+			})
 		})
 	}
 }
 
-const YAMLKameletExplicitParams = `
+const yamlKameletExplicitParams = `
 - from:
     uri: cron:tab
     parameters:
@@ -492,7 +501,7 @@ const YAMLKameletExplicitParams = `
           cloudEventsSpecVersion: "1.0"
 `
 
-const YAMLKameletExplicitNumericParams = `
+const yamlKameletExplicitNumericParams = `
 - from:
     uri: timer:tick
     parameters:
@@ -508,47 +517,31 @@ func TestYAMLExplicitParameters(t *testing.T) {
 		toURIs   []string
 	}{
 		{
-			source:   YAMLKameletExplicitParams,
+			source:   yamlKameletExplicitParams,
 			fromURIs: []string{"cron:tab?schedule=%2A+%2A+%2A+%2A+%3F"},
 			toURIs:   []string{"knative:channel/a?cloudEventsSpecVersion=1.0"},
 		},
 		{
-			source:   YAMLKameletExplicitNumericParams,
+			source:   yamlKameletExplicitNumericParams,
 			fromURIs: []string{"timer:tick?period=1000"},
 		},
 	}
 
+	inspector := newTestYAMLInspector(t)
 	for i := range tc {
 		test := tc[i]
 		t.Run(fmt.Sprintf("TestYAMLExplicitParameters-%d", i), func(t *testing.T) {
-			code := v1.SourceSpec{
-				DataSpec: v1.DataSpec{
-					Content: test.source,
-				},
-			}
-
-			catalog, err := camel.DefaultCatalog()
-			assert.Nil(t, err)
-
-			meta := NewMetadata()
-			inspector := YAMLInspector{
-				baseInspector: baseInspector{
-					catalog: catalog,
-				},
-			}
-
-			err = inspector.Extract(code, &meta)
-			assert.Nil(t, err)
-			assert.True(t, meta.RequiredCapabilities.IsEmpty())
-
-			assert.Len(t, meta.FromURIs, len(test.fromURIs))
-			for _, k := range test.fromURIs {
-				assert.Contains(t, meta.FromURIs, k)
-			}
-			assert.Len(t, meta.ToURIs, len(test.toURIs))
-			for _, k := range test.toURIs {
-				assert.Contains(t, meta.ToURIs, k)
-			}
+			assertExtract(t, inspector, test.source, func(meta *Metadata) {
+				assert.True(t, meta.RequiredCapabilities.IsEmpty())
+				assert.Len(t, meta.FromURIs, len(test.fromURIs))
+				for _, k := range test.fromURIs {
+					assert.Contains(t, meta.FromURIs, k)
+				}
+				assert.Len(t, meta.ToURIs, len(test.toURIs))
+				for _, k := range test.toURIs {
+					assert.Contains(t, meta.ToURIs, k)
+				}
+			})
 		})
 	}
 }

--- a/pkg/util/source/test_support.go
+++ b/pkg/util/source/test_support.go
@@ -1,0 +1,58 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"testing"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func assertExtract(t *testing.T, inspector Inspector, source string, assertFn func(meta *Metadata)) {
+	t.Helper()
+
+	srcSpec := v1.SourceSpec{
+		DataSpec: v1.DataSpec{
+			Content: source,
+		},
+	}
+	meta := NewMetadata()
+	err := inspector.Extract(srcSpec, &meta)
+	require.NoError(t, err)
+
+	assertFn(&meta)
+}
+
+func assertExtractYAML(t *testing.T, inspector YAMLInspector, source string, assertFn func(meta *Metadata)) {
+	t.Helper()
+
+	srcSpec := v1.SourceSpec{
+		DataSpec: v1.DataSpec{
+			Name:    "route.yaml",
+			Content: source,
+		},
+		Language: v1.LanguageYaml,
+	}
+	meta := NewMetadata()
+	err := inspector.Extract(srcSpec, &meta)
+	require.NoError(t, err)
+
+	assertFn(&meta)
+}


### PR DESCRIPTION
<!-- Description -->

This fixes an issue reported by @brunoNetId that Camel K doesn't resolve dataformat dependencies correctly unless doing explicitly `kamel run route.xml -d camel:jackson` for the following DSLs:
```xml
<to uri="dataformat:jackson:unmarshal"/>
```
```xml
<unmarshal>
  <json/>
</unmarshal>
```
```xml
<unmarshal>
  <json library="Jackson"/>
</unmarshal>
```

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(source): dataformat dependencies not resolved
```
