### PR TITLE
fix(trait): trait error "camel-catalog already exists" during upgrade (1.10.x)

### DIFF
--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,8 +65,7 @@ func (t *camelTrait) Apply(e *Environment) error {
 	rv := t.determineRuntimeVersion(e)
 
 	if e.CamelCatalog == nil {
-		err := t.loadOrCreateCatalog(e, rv)
-		if err != nil {
+		if err := t.loadOrCreateCatalog(e, rv); err != nil {
 			return err
 		}
 	}
@@ -113,7 +113,8 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 		if exactVersionRegexp.MatchString(runtimeVersion) {
 			ctx, cancel := context.WithTimeout(e.Ctx, e.Platform.Status.Build.GetTimeout().Duration)
 			defer cancel()
-			catalog, err = camel.GenerateCatalog(ctx, e.Client, ns, e.Platform.Status.Build.Maven, runtime, []maven.Dependency{})
+			catalog, err = camel.GenerateCatalog(ctx, e.Client,
+				ns, e.Platform.Status.Build.Maven, runtime, []maven.Dependency{})
 			if err != nil {
 				return err
 			}
@@ -128,12 +129,22 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 			cx.Labels["camel.apache.org/runtime.provider"] = string(runtime.Provider)
 			cx.Labels["camel.apache.org/catalog.generated"] = True
 
-			err = e.Client.Create(e.Ctx, &cx)
-			if err != nil {
-				return errors.Wrapf(err, "unable to create catalog runtime=%s, provider=%s, name=%s",
-					runtime.Version,
-					runtime.Provider,
-					catalogName)
+			if err := e.Client.Create(e.Ctx, &cx); err != nil {
+				if k8serrors.IsAlreadyExists(err) {
+					// It's still possible that catalog wasn't yet found at the time of loading
+					// but then created in the background before the client tries to create it.
+					// In this case, simply try loading again and reuse the existing catalog.
+					catalog, err = camel.LoadCatalog(e.Ctx, e.Client, ns, runtime)
+					if err != nil {
+						// unexpected error
+						return errors.Wrapf(err, "catalog %q already exists but unable to load", catalogName)
+					}
+				} else {
+					return errors.Wrapf(err, "unable to create catalog runtime=%s, provider=%s, name=%s",
+						runtime.Version,
+						runtime.Provider,
+						catalogName)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Description -->

backport #3858


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
