### PR TITLE
fix(service): Create k8s service when knative-service trait is disabled

### DIFF
--- a/e2e/global/knative/files/http_out.groovy
+++ b/e2e/global/knative/files/http_out.groovy
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+from("rest:get:hello/")
+      .transform().simple("Hello");

--- a/e2e/global/knative/knative_test.go
+++ b/e2e/global/knative/knative_test.go
@@ -107,6 +107,21 @@ func TestKnative(t *testing.T) {
 
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
+
+		t.Run("Knative-service disabled", func(t *testing.T) {
+			Expect(KamelRunWithID(operatorID, ns, "files/http_out.groovy", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			Eventually(Service(ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
+			Consistently(KnativeService(ns, "http-out"), TestTimeoutShort).Should(BeNil())
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("Knative-service priority", func(t *testing.T) {
+			Expect(KamelRunWithID(operatorID, ns, "files/http_out.groovy").Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			Eventually(KnativeService(ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
 	})
 }
 

--- a/pkg/trait/service.go
+++ b/pkg/trait/service.go
@@ -43,12 +43,6 @@ func newServiceTrait() Trait {
 	}
 }
 
-// IsAllowedInProfile overrides default.
-func (t *serviceTrait) IsAllowedInProfile(profile v1.TraitProfile) bool {
-	return profile.Equal(v1.TraitProfileKubernetes) ||
-		profile.Equal(v1.TraitProfileOpenShift)
-}
-
 func (t *serviceTrait) Configure(e *Environment) (bool, error) {
 	if e.Integration == nil || !pointer.BoolDeref(t.Enabled, true) {
 		if e.Integration != nil {
@@ -61,6 +55,15 @@ func (t *serviceTrait) Configure(e *Environment) (bool, error) {
 		}
 
 		return false, nil
+	}
+
+	// in case the knative-service and service trait are enabled, the knative-service has priority
+	// then this service is disabled
+	if e.GetTrait(knativeServiceTraitID) != nil {
+		knativeServiceTrait, _ := e.GetTrait(knativeServiceTraitID).(*knativeServiceTrait)
+		if pointer.BoolDeref(knativeServiceTrait.Enabled, true) {
+			return false, nil
+		}
 	}
 
 	if !e.IntegrationInRunningPhases() {


### PR DESCRIPTION
https://github.com/apache/camel-k/issues/3849

When knative-service and k8s service traits are enabled, the priority is to use knative-service in knative profile

**Release Note**
```release-note
NONE
```
