### PR TITLE
[backport 1.10] chore(ci): move native into nigtly release wf

### DIFF
--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -31,13 +31,13 @@ inputs:
   secretDockerHubUser:
     required: true
   secretDockerHubPassword:
-    required: true    
+    required: true
   secretGithubToken:
     required: true
 
 runs:
   using: "composite"
-  
+
   steps:
     - name: Set up JDK ${{ inputs.javaVersion }}
       uses: actions/setup-java@v2
@@ -48,8 +48,13 @@ runs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ inputs.goVersion }}
-    - name: Smoke tests
+    - name: Common smoke tests
       uses: ./.github/actions/e2e-common
+      with:
+        cluster-config-data: ${{ inputs.secretE2ECluster }}
+        cluster-kube-config-data: ${{ inputs.secretE2EKube }}
+    - name: Native smoke tests
+      uses: ./.github/actions/e2e-install-native
       with:
         cluster-config-data: ${{ inputs.secretE2ECluster }}
         cluster-kube-config-data: ${{ inputs.secretE2EKube }}
@@ -101,7 +106,7 @@ runs:
       with:
         artifacts: "./camel-k-client*.tar.gz"
         body: |
-          Apache Camel K ${{ env.VERSION }} build for testing (unstable). This nightly release is using 
+          Apache Camel K ${{ env.VERSION }} build for testing (unstable). This nightly release is using
           an **unsupported** operator image published as `${{ env.IMAGE_NAME }}:${{ env.VERSION }}`
 
           To test it, download the client for your OS and run:
@@ -109,7 +114,7 @@ runs:
           ```
           kamel install --olm=false --maven-repository=${{ env.MAVEN_REPOSITORY }}
           ```
-          
+
           NOTE: last updated on ${{ env.UPD_DATE }}
         token: ${{ inputs.secretGithubToken }}
         draft: false


### PR DESCRIPTION
Running `native-it` as nightly smoke test looks great on `main` branch (less than 1 hour running):

📦 github.com/apache/camel-k/e2e/namespace/native
✅ TestNativeBinding (12m28.67s)
✅ TestNativeBinding/kamelet_binding_with_native_build (9m0.12s)
✅ TestNativeBinding/warm_up_before_native_build_testing (3m14.21s)
✅ TestNativeIntegrations (12m14.6s)
✅ TestNativeIntegrations/automatic_rollout_deployment_from_fast-jar_to_native_kit (8m47.86s)
✅ TestNativeIntegrations/unsupported_integration_source_language (870ms)
✅ TestNativeIntegrations/warm_up_before_native_build_testing (3m11.3s)

With this PR we enable the same on `release-1.10` branch.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
