### PR TITLE
fix(e2e): use generated API methods

### DIFF
--- a/e2e/global/common/scale_integration_test.go
+++ b/e2e/global/common/scale_integration_test.go
@@ -103,7 +103,7 @@ func TestIntegrationScale(t *testing.T) {
 			}}
 			payloadBytes, _ := json.Marshal(payload)
 
-			integrationScale, err = camel.CamelV1().Integrations(ns).PatchScale(TestContext, name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+			_, err = camel.CamelV1().Integrations(ns).Patch(TestContext, name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{}, "scale")
 			Expect(err).To(BeNil())
 
 			// Check the readiness condition is still truthy as down-scaling

--- a/e2e/global/common/scale_integration_test.go
+++ b/e2e/global/common/scale_integration_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package common
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -96,14 +95,9 @@ func TestIntegrationScale(t *testing.T) {
 			Expect(integrationScale.Spec.Replicas).To(BeNumerically("==", 2))
 			Expect(integrationScale.Status.Replicas).To(BeNumerically("==", 2))
 
-			payload := []PatchUInt32Value{{
-				Op:    "replace",
-				Path:  "/spec/replicas",
-				Value: 1,
-			}}
-			payloadBytes, _ := json.Marshal(payload)
-
-			_, err = camel.CamelV1().Integrations(ns).Patch(TestContext, name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{}, "scale")
+			// Setter
+			integrationScale.Spec.Replicas = 1
+			integrationScale, err = camel.CamelV1().Integrations(ns).UpdateScale(TestContext, name, integrationScale, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 
 			// Check the readiness condition is still truthy as down-scaling

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -102,13 +102,6 @@ var NoOlmOperatorImage string
 var TestContext context.Context
 var testClient client.Client
 
-//  patchUint32Value specifies a patch operation for a uint32.
-type PatchUInt32Value struct {
-	Op    string `json:"op"`
-	Path  string `json:"path"`
-	Value uint32 `json:"value"`
-}
-
 var testLocus *testing.T
 
 func setTestLocus(t *testing.T) {

--- a/pkg/client/camel/clientset/versioned/typed/camel/v1/fake/fake_integration.go
+++ b/pkg/client/camel/clientset/versioned/typed/camel/v1/fake/fake_integration.go
@@ -164,13 +164,3 @@ func (c *FakeIntegrations) UpdateScale(ctx context.Context, integrationName stri
 	}
 	return obj.(*autoscalingv1.Scale), err
 }
-
-func (c *FakeIntegrations) PatchScale(ctx context.Context, integrationName string, pt types.PatchType, data []byte, opts v1.PatchOptions) (result *autoscalingv1.Scale, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(integrationsResource, c.ns, integrationName, pt, data, "scale"), &autoscalingv1.Scale{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*autoscalingv1.Scale), err
-}

--- a/pkg/client/camel/clientset/versioned/typed/camel/v1/integration.go
+++ b/pkg/client/camel/clientset/versioned/typed/camel/v1/integration.go
@@ -51,7 +51,6 @@ type IntegrationInterface interface {
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Integration, err error)
 	GetScale(ctx context.Context, integrationName string, options metav1.GetOptions) (*autoscalingv1.Scale, error)
 	UpdateScale(ctx context.Context, integrationName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error)
-	PatchScale(ctx context.Context, integrationName string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *autoscalingv1.Scale, err error)
 
 	IntegrationExpansion
 }
@@ -224,21 +223,6 @@ func (c *integrations) UpdateScale(ctx context.Context, integrationName string, 
 		SubResource("scale").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// PatchScale takes the top resource name and the representation of a scale and patches it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *integrations) PatchScale(ctx context.Context, integrationName string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *autoscalingv1.Scale, err error) {
-	result = &autoscalingv1.Scale{}
-	err = c.client.Patch(pt).
-		Namespace(c.ns).
-		Resource("integrations").
-		Name(integrationName).
-		SubResource("scale").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
 		Do(ctx).
 		Into(result)
 	return


### PR DESCRIPTION
Closes #3818

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): use generated API methods
```
