### PR TITLE
prometheus trait fully tested as in CI, the version of OCP is 4.x

### DIFF
--- a/e2e/global/common/traits/prometheus_test.go
+++ b/e2e/global/common/traits/prometheus_test.go
@@ -46,20 +46,17 @@ func TestPrometheusTrait(t *testing.T) {
 		ocp, err := openshift.IsOpenShift(TestClient())
 		assert.Nil(t, err)
 
-		// Do not create PodMonitor for the time being as CI test runs on OCP 3.11
-		createPodMonitor := false
-
 		operatorID := "camel-k-trait-prometheus"
 		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
 
-		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
-			"-t", "prometheus.enabled=true",
-			"-t", fmt.Sprintf("prometheus.pod-monitor=%v", createPodMonitor)).Execute()).To(Succeed())
-		Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		Eventually(IntegrationConditionStatus(ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		Eventually(IntegrationLogs(ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-
 		t.Run("Metrics endpoint works", func(t *testing.T) {
+			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
+				"-t", "prometheus.enabled=true",
+				"-t", "prometheus.pod-monitor=true").Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationConditionStatus(ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+
 			pod := IntegrationPod(ns, "java")
 			response, err := TestClient().CoreV1().RESTClient().Get().
 				AbsPath(fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/proxy/q/metrics", ns, pod().Name)).DoRaw(TestContext)
@@ -67,16 +64,41 @@ func TestPrometheusTrait(t *testing.T) {
 				assert.Fail(t, err.Error())
 			}
 			assert.Contains(t, string(response), "camel.route.exchanges.total")
+
+			if ocp {
+				t.Run("PodMonitor is created", func(t *testing.T) {
+					sm := podMonitor(ns, "java")
+					Eventually(sm, TestTimeoutShort).ShouldNot(BeNil())
+
+					t.Run("PodMonitor has default label", func(t *testing.T) {
+						Expect(sm().GetLabels()["camel.apache.org/integration"]).To(Equal("java"))
+					})
+				})
+			}
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
-		if ocp && createPodMonitor {
-			t.Run("PodMonitor is created", func(t *testing.T) {
-				sm := podMonitor(ns, "java")
-				Eventually(sm, TestTimeoutShort).ShouldNot(BeNil())
+		if ocp {
+			t.Run("Pod monitor custom label is added", func(t *testing.T) {
+				Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
+					"-t", "prometheus.enabled=true",
+					"-t", "prometheus.pod-monitor-labels=mylabelname=mylabelvalue").Execute()).To(Succeed())
+				Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				Eventually(IntegrationConditionStatus(ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+				Eventually(IntegrationLogs(ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+
+				t.Run("PodMonitor is created", func(t *testing.T) {
+					sm := podMonitor(ns, "java")
+					Eventually(sm, TestTimeoutShort).ShouldNot(BeNil())
+					t.Run("PodMonitor has custom label", func(t *testing.T) {
+						Expect(sm().GetLabels()["mylabelname"]).To(Equal("mylabelvalue"))
+					})
+				})
+
+				Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 			})
 		}
 
-		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }
 


### PR DESCRIPTION
The prometheus traits now are fully tested as it's possible to run the test on OCP 4.x.
In the trait `pod-monitor` now the default label is checked.
The test for the trait `pod-monitor-labels` has been added checking in the `PodMonitor` the presence of the specified label.
