### PR TITLE
Fix #3869: Update Saga Example

### DIFF
--- a/examples/saga/Flight.java
+++ b/examples/saga/Flight.java
@@ -31,7 +31,9 @@ public class Flight extends RouteBuilder {
 
 		rest("/api").post("/flight/buy")
 			.param().type(RestParamType.header).name("id").required(true).endParam()
-			.route()
+			.to("direct:buy");
+
+		from("direct:buy")
 			.saga()
 				.propagation(SagaPropagation.MANDATORY)
 				.option("id", header("id"))

--- a/examples/saga/Payment.java
+++ b/examples/saga/Payment.java
@@ -31,7 +31,9 @@ public class Payment extends RouteBuilder {
 		rest("/api/").post("/pay")
                     .param().type(RestParamType.query).name("type").required(true).endParam()
                     .param().type(RestParamType.header).name("id").required(true).endParam()
-                    .route()
+                    .to("direct:pay");
+
+		from("direct:pay")
                     .saga()
                         .propagation(SagaPropagation.MANDATORY)
                         .option("id", header("id"))

--- a/examples/saga/README.md
+++ b/examples/saga/README.md
@@ -22,7 +22,7 @@ kamel run -d camel:lra Train.java
 
 * Start the saga application
 ```
-kamel run -d camel:lra Saga.java
+kamel run -d camel:lra -d camel:direct Saga.java
 ```
 
 Then you can use ```kamel logs saga``` to check the output of the transactions.

--- a/examples/saga/Train.java
+++ b/examples/saga/Train.java
@@ -31,7 +31,9 @@ public class Train extends RouteBuilder {
 
 		rest("/api/").post("/train/buy/seat")
                     .param().type(RestParamType.header).name("id").required(true).endParam()
-                    .route()
+                    .to("direct:buySeat");
+
+		from("direct:buySeat")
                     .saga()
                         .propagation(SagaPropagation.SUPPORTS)
                         .option("id", header("id"))


### PR DESCRIPTION
Fix for #3869.

Update REST services to no longer use [unsupported embedded routes](https://camel.apache.org/manual/camel-3x-upgrade-guide-3_16.html#_removed_support_for_embedded_routes).

Update Readme to to run the Saga route with `-d camel:direct` and include the direct component dependency.
