### PR TITLE
feat(cli): Update Kamel bind step index in properties to start at 1 instead of 0

### DIFF
--- a/pkg/cmd/bind.go
+++ b/pkg/cmd/bind.go
@@ -56,7 +56,7 @@ func newCmdBind(rootCmdOptions *RootCmdOptions) (*cobra.Command, *bindCmdOptions
 	cmd.Flags().String("error-handler", "", `Add error handler (none|log|sink:<endpoint>). Sink endpoints are expected in the format "[[apigroup/]version:]kind:[namespace/]name", plain Camel URIs or Kamelet name.`)
 	cmd.Flags().String("name", "", "Name for the binding")
 	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml")
-	cmd.Flags().StringArrayP("property", "p", nil, `Add a binding property in the form of "source.<key>=<value>", "sink.<key>=<value>", "error-handler.<key>=<value>" or "step-<n>.<key>=<value>"`)
+	cmd.Flags().StringArrayP("property", "p", nil, `Add a binding property in the form of "source.<key>=<value>", "sink.<key>=<value>", "error-handler.<key>=<value>" or "step-<n>.<key>=<value> where <n> is the step order starting from 1"`)
 	cmd.Flags().Bool("skip-checks", false, "Do not verify the binding for compliance with Kamelets and other Kubernetes resources")
 	cmd.Flags().StringArray("step", nil, `Add binding steps as Kubernetes resources. Endpoints are expected in the format "[[apigroup/]version:]kind:[namespace/]name", plain Camel URIs or Kamelet name.`)
 	cmd.Flags().StringArrayP("trait", "t", nil, `Add a trait to the corresponding Integration.`)
@@ -210,7 +210,8 @@ func (o *bindCmdOptions) run(cmd *cobra.Command, args []string) error {
 	if len(o.Steps) > 0 {
 		binding.Spec.Steps = make([]v1alpha1.Endpoint, 0)
 		for idx, stepDesc := range o.Steps {
-			stepKey := fmt.Sprintf("%s%d", stepKeyPrefix, idx)
+			stepIndex := idx + 1
+			stepKey := fmt.Sprintf("%s%d", stepKeyPrefix, stepIndex)
 			step, err := o.decode(stepDesc, stepKey)
 			if err != nil {
 				return err

--- a/pkg/cmd/bind_test.go
+++ b/pkg/cmd/bind_test.go
@@ -206,8 +206,8 @@ func TestBindSteps(t *testing.T) {
 	buildCmdOptions, bindCmd, _ := initializeBindCmdOptions(t)
 	output, err := test.ExecuteCommand(bindCmd, cmdBind, "my:src", "my:dst", "-o", "yaml",
 		"--step", "dst:step1", "--step", "src:step2",
-		"-p", "step-0.var1=my-step1-var1", "-p", "step-0.var2=my-step1-var2",
-		"-p", "step-1.var1=my-step2-var1", "-p", "step-1.var2=my-step2-var2")
+		"-p", "step-1.var1=my-step1-var1", "-p", "step-1.var2=my-step1-var2",
+		"-p", "step-2.var1=my-step2-var1", "-p", "step-2.var2=my-step2-var2")
 	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
 
 	assert.Nil(t, err)

--- a/pkg/cmd/bind_test.go
+++ b/pkg/cmd/bind_test.go
@@ -201,3 +201,37 @@ spec:
 status: {}
 `, output)
 }
+
+func TestBindSteps(t *testing.T) {
+	buildCmdOptions, bindCmd, _ := initializeBindCmdOptions(t)
+	output, err := test.ExecuteCommand(bindCmd, cmdBind, "my:src", "my:dst", "-o", "yaml",
+		"--step", "dst:step1", "--step", "src:step2",
+		"-p", "step-0.var1=my-step1-var1", "-p", "step-0.var2=my-step1-var2",
+		"-p", "step-1.var1=my-step2-var1", "-p", "step-1.var2=my-step2-var2")
+	assert.Equal(t, "yaml", buildCmdOptions.OutputFormat)
+
+	assert.Nil(t, err)
+	assert.Equal(t, `apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  annotations:
+    camel.apache.org/operator.id: camel-k
+  creationTimestamp: null
+  name: my-to-my
+spec:
+  sink:
+    uri: my:dst
+  source:
+    uri: my:src
+  steps:
+  - properties:
+      var1: my-step1-var1
+      var2: my-step1-var2
+    uri: dst:step1
+  - properties:
+      var1: my-step2-var1
+      var2: my-step2-var2
+    uri: src:step2
+status: {}
+`, output)
+}


### PR DESCRIPTION
fixes #2586

## Motivation

The `kamel bind` command  uses 0 index start for the definition of step properties : 
```sh
kamel bind ... --step my-step-1 --step my-step-2 -p step-0.my-key=value1 -p step-1.my-key=value2
```

Having an index start at 1 is more user friendly : 
```shell
kamel bind ... --step my-step-1 --step my-step-2 -p step-1.my-key=value1 -p step-2.my-key=value2
```
## Modifications

* Modify the transformation from command to spec for steps in biding command code
* Add a unit test on step values


**Release Note**
```release-note
feat(cli): Update Kamel bind step index in properties to start at 1 instead of 0
```
