### PR TITLE
fix: reconciliation loops behaviors

### DIFF
--- a/e2e/global/common/traits/errored_trait_test.go
+++ b/e2e/global/common/traits/errored_trait_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package traits
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/apache/camel-k/e2e/support"
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+)
+
+func TestErroredTrait(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		operatorID := "camel-k-trait-errored"
+		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
+
+		t.Run("Integration trait should fail", func(t *testing.T) {
+			name := "it-errored"
+			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
+				"--name", name,
+				"-t", "kamelets.list=missing",
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPhase(ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
+			Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
+			Eventually(IntegrationCondition(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(And(
+				WithTransform(IntegrationConditionReason, Equal(v1.IntegrationConditionInitializationFailedReason)),
+				WithTransform(IntegrationConditionMessage, HavePrefix("error during trait customization")),
+			))
+		})
+
+		t.Run("KameletBinding trait should fail", func(t *testing.T) {
+			name := "kb-errored"
+			Expect(KamelBindWithID(operatorID, ns, "timer:foo", "log:bar",
+				"--name", name,
+				"-t", "kamelets.list=missing",
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPhase(ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
+			Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
+			Eventually(IntegrationCondition(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(And(
+				WithTransform(IntegrationConditionReason, Equal(v1.IntegrationConditionInitializationFailedReason)),
+				WithTransform(IntegrationConditionMessage, HavePrefix("error during trait customization")),
+			))
+		})
+
+		// Clean up
+		Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+	})
+}

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -996,6 +996,16 @@ func KameletBinding(ns string, name string) func() *v1alpha1.KameletBinding {
 	}
 }
 
+func KameletBindingPhase(ns string, name string) func() v1alpha1.KameletBindingPhase {
+	return func() v1alpha1.KameletBindingPhase {
+		klb := KameletBinding(ns, name)()
+		if klb == nil {
+			return ""
+		}
+		return klb.Status.Phase
+	}
+}
+
 func KameletBindingSpecReplicas(ns string, name string) func() *int32 {
 	return func() *int32 {
 		klb := KameletBinding(ns, name)()

--- a/pkg/apis/camel/v1alpha1/kamelet_binding_types.go
+++ b/pkg/apis/camel/v1alpha1/kamelet_binding_types.go
@@ -128,6 +128,8 @@ type KameletBindingConditionType string
 const (
 	// KameletBindingConditionReady --
 	KameletBindingConditionReady KameletBindingConditionType = "Ready"
+	// KameletBindingIntegrationConditionError is used to report the error on the generated Integration
+	KameletBindingIntegrationConditionError KameletBindingConditionType = "IntegrationError"
 )
 
 // KameletBindingPhase --

--- a/pkg/controller/kameletbinding/initialize.go
+++ b/pkg/controller/kameletbinding/initialize.go
@@ -52,7 +52,10 @@ func (action *initializeAction) CanHandle(kameletbinding *v1alpha1.KameletBindin
 func (action *initializeAction) Handle(ctx context.Context, kameletbinding *v1alpha1.KameletBinding) (*v1alpha1.KameletBinding, error) {
 	it, err := CreateIntegrationFor(ctx, action.client, kameletbinding)
 	if err != nil {
-		return nil, err
+		kameletbinding.Status.Phase = v1alpha1.KameletBindingPhaseError
+		kameletbinding.Status.SetErrorCondition(v1alpha1.KameletBindingIntegrationConditionError,
+			"Couldn't create an Integration custom resource", err)
+		return kameletbinding, err
 	}
 
 	if _, err := kubernetes.ReplaceResource(ctx, action.client, it); err != nil {

--- a/pkg/controller/kameletbinding/kamelet_binding_controller.go
+++ b/pkg/controller/kameletbinding/kamelet_binding_controller.go
@@ -19,7 +19,6 @@ package kameletbinding
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,6 +40,7 @@ import (
 
 	camelevent "github.com/apache/camel-k/pkg/event"
 	"github.com/apache/camel-k/pkg/platform"
+	"github.com/apache/camel-k/pkg/util/log"
 	"github.com/apache/camel-k/pkg/util/monitoring"
 )
 
@@ -180,7 +180,6 @@ func (r *ReconcileKameletBinding) Reconcile(ctx context.Context, request reconci
 		NewMonitorAction(),
 	}
 
-	var targetPhase v1alpha1.KameletBindingPhase
 	var err error
 
 	target := instance.DeepCopy()
@@ -193,30 +192,20 @@ func (r *ReconcileKameletBinding) Reconcile(ctx context.Context, request reconci
 		if a.CanHandle(target) {
 			targetLog.Infof("Invoking action %s", a.Name())
 
-			phaseFrom := target.Status.Phase
-
 			target, err = a.Handle(ctx, target)
 			if err != nil {
 				camelevent.NotifyKameletBindingError(ctx, r.client, r.recorder, &instance, target, err)
+				// Update the kameletbinding (mostly just to update its phase) if the new instance is returned
+				if target != nil {
+					_ = r.update(ctx, &instance, target, &targetLog)
+				}
 				return reconcile.Result{}, err
 			}
 
 			if target != nil {
-				target.Status.ObservedGeneration = instance.Generation
-
-				if err := r.client.Status().Patch(ctx, target, ctrl.MergeFrom(&instance)); err != nil {
+				if err := r.update(ctx, &instance, target, &targetLog); err != nil {
 					camelevent.NotifyKameletBindingError(ctx, r.client, r.recorder, &instance, target, err)
 					return reconcile.Result{}, err
-				}
-
-				targetPhase = target.Status.Phase
-
-				if targetPhase != phaseFrom {
-					targetLog.Info(
-						"state transition",
-						"phase-from", phaseFrom,
-						"phase-to", target.Status.Phase,
-					)
 				}
 			}
 
@@ -227,12 +216,24 @@ func (r *ReconcileKameletBinding) Reconcile(ctx context.Context, request reconci
 		}
 	}
 
-	if targetPhase == v1alpha1.KameletBindingPhaseReady {
-		return reconcile.Result{}, nil
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileKameletBinding) update(ctx context.Context, base *v1alpha1.KameletBinding, target *v1alpha1.KameletBinding, log *log.Logger) error {
+	target.Status.ObservedGeneration = base.Generation
+
+	if err := r.client.Status().Patch(ctx, target, ctrl.MergeFrom(base)); err != nil {
+		camelevent.NotifyKameletBindingError(ctx, r.client, r.recorder, base, target, err)
+		return err
 	}
 
-	// Requeue
-	return reconcile.Result{
-		RequeueAfter: 5 * time.Second,
-	}, nil
+	if target.Status.Phase != base.Status.Phase {
+		log.Info(
+			"state transition",
+			"phase-from", base.Status.Phase,
+			"phase-to", target.Status.Phase,
+		)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- Description -->
With this PR we aim to improve the reconciliation loop of Integrations and KameletBindings. The Integration now fails and report the error that may happen during the execution of traits. We also change the reconciliation loop for KameletBindings in order to detect any failure (failing traits, or wrong spec), report an error and stop the reconciliation loop.

Closes #3389
Closes #3010



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix: reconciliation loops behaviors
```
