### PR TITLE
fix(cmd): refactor install cmd to remove maintidx lint

### DIFF
--- a/pkg/install/cluster.go
+++ b/pkg/install/cluster.go
@@ -40,7 +40,10 @@ import (
 )
 
 // nolint: maintidx // TODO: refactor the code
-func SetupClusterWideResourcesOrCollect(ctx context.Context, clientProvider client.Provider, collection *kubernetes.Collection, clusterType string, force bool) error {
+func SetupClusterWideResourcesOrCollect(
+	ctx context.Context, clientProvider client.Provider,
+	collection *kubernetes.Collection, clusterType string, force bool,
+) error {
 	// Get a client to install the CRD
 	c, err := clientProvider.Get()
 	if err != nil {
@@ -48,23 +51,22 @@ func SetupClusterWideResourcesOrCollect(ctx context.Context, clientProvider clie
 	}
 
 	isAPIExtensionsV1 := true
-	_, err = c.Discovery().ServerResourcesForGroupVersion("apiextensions.k8s.io/v1")
-	if err != nil && k8serrors.IsNotFound(err) {
-		isAPIExtensionsV1 = false
-	} else if err != nil {
-		return err
+	if _, err := c.Discovery().ServerResourcesForGroupVersion("apiextensions.k8s.io/v1"); err != nil {
+		if k8serrors.IsNotFound(err) {
+			isAPIExtensionsV1 = false
+		} else {
+			return err
+		}
 	}
 
 	// Convert the CRD to apiextensions.k8s.io/v1beta1 in case v1 is not available.
 	// This is mainly required to support OpenShift 3, and older versions of Kubernetes.
 	// It can be removed as soon as these versions are not supported anymore.
-	err = apiextensionsv1.AddToScheme(c.GetScheme())
-	if err != nil {
+	if err := apiextensionsv1.AddToScheme(c.GetScheme()); err != nil {
 		return err
 	}
 	if !isAPIExtensionsV1 {
-		err = apiextensionsv1beta1.AddToScheme(c.GetScheme())
-		if err != nil {
+		if err := apiextensionsv1beta1.AddToScheme(c.GetScheme()); err != nil {
 			return err
 		}
 	}
@@ -114,37 +116,44 @@ func SetupClusterWideResourcesOrCollect(ctx context.Context, clientProvider clie
 	}
 
 	// Install CRD for Integration Platform (if needed)
-	if err := installCRD(ctx, c, "IntegrationPlatform", "v1", "camel.apache.org_integrationplatforms.yaml", downgradeToCRDv1beta1, collection, force); err != nil {
+	if err := installCRD(ctx, c, "IntegrationPlatform", "v1", "camel.apache.org_integrationplatforms.yaml",
+		downgradeToCRDv1beta1, collection, force); err != nil {
 		return err
 	}
 
 	// Install CRD for Integration Kit (if needed)
-	if err := installCRD(ctx, c, "IntegrationKit", "v1", "camel.apache.org_integrationkits.yaml", downgradeToCRDv1beta1, collection, force); err != nil {
+	if err := installCRD(ctx, c, "IntegrationKit", "v1", "camel.apache.org_integrationkits.yaml",
+		downgradeToCRDv1beta1, collection, force); err != nil {
 		return err
 	}
 
 	// Install CRD for Integration (if needed)
-	if err := installCRD(ctx, c, "Integration", "v1", "camel.apache.org_integrations.yaml", downgradeToCRDv1beta1, collection, force); err != nil {
+	if err := installCRD(ctx, c, "Integration", "v1", "camel.apache.org_integrations.yaml",
+		downgradeToCRDv1beta1, collection, force); err != nil {
 		return err
 	}
 
 	// Install CRD for Camel Catalog (if needed)
-	if err := installCRD(ctx, c, "CamelCatalog", "v1", "camel.apache.org_camelcatalogs.yaml", downgradeToCRDv1beta1, collection, force); err != nil {
+	if err := installCRD(ctx, c, "CamelCatalog", "v1", "camel.apache.org_camelcatalogs.yaml",
+		downgradeToCRDv1beta1, collection, force); err != nil {
 		return err
 	}
 
 	// Install CRD for Build (if needed)
-	if err := installCRD(ctx, c, "Build", "v1", "camel.apache.org_builds.yaml", downgradeToCRDv1beta1, collection, force); err != nil {
+	if err := installCRD(ctx, c, "Build", "v1", "camel.apache.org_builds.yaml",
+		downgradeToCRDv1beta1, collection, force); err != nil {
 		return err
 	}
 
 	// Install CRD for Kamelet (if needed)
-	if err := installCRD(ctx, c, "Kamelet", "v1alpha1", "camel.apache.org_kamelets.yaml", downgradeToCRDv1beta1, collection, force); err != nil {
+	if err := installCRD(ctx, c, "Kamelet", "v1alpha1", "camel.apache.org_kamelets.yaml",
+		downgradeToCRDv1beta1, collection, force); err != nil {
 		return err
 	}
 
 	// Install CRD for KameletBinding (if needed)
-	if err := installCRD(ctx, c, "KameletBinding", "v1alpha1", "camel.apache.org_kameletbindings.yaml", downgradeToCRDv1beta1, collection, force); err != nil {
+	if err := installCRD(ctx, c, "KameletBinding", "v1alpha1", "camel.apache.org_kameletbindings.yaml",
+		downgradeToCRDv1beta1, collection, force); err != nil {
 		return err
 	}
 
@@ -173,7 +182,8 @@ func SetupClusterWideResourcesOrCollect(ctx context.Context, clientProvider clie
 		return err
 	}
 	if !ok {
-		if err := installResource(ctx, c, collection, "/rbac/operator-cluster-role-custom-resource-definitions.yaml"); err != nil {
+		if err := installResource(ctx, c, collection,
+			"/rbac/operator-cluster-role-custom-resource-definitions.yaml"); err != nil {
 			return err
 		}
 	}
@@ -237,7 +247,9 @@ func WaitForAllCrdInstallation(ctx context.Context, clientProvider client.Provid
 		}
 		// Check after 2 seconds if not expired
 		if time.Now().After(deadline) {
-			return errors.New("cannot check CRD installation after " + strconv.FormatInt(timeout.Nanoseconds()/1000000000, 10) + " seconds")
+			return fmt.Errorf(
+				"cannot check CRD installation after %s seconds",
+				strconv.FormatInt(timeout.Nanoseconds()/1000000000, 10))
 		}
 		time.Sleep(2 * time.Second)
 	}
@@ -292,7 +304,10 @@ func isCrdInstalled(c client.Client, kind string, version string) (bool, error) 
 	return false, nil
 }
 
-func installCRD(ctx context.Context, c client.Client, kind string, version string, resourceName string, converter ResourceCustomizer, collection *kubernetes.Collection, force bool) error {
+func installCRD(
+	ctx context.Context, c client.Client, kind string, version string, resourceName string,
+	converter ResourceCustomizer, collection *kubernetes.Collection, force bool,
+) error {
 	content, err := resources.ResourceAsString("/crd/bases/" + resourceName)
 	if err != nil {
 		return err

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -509,9 +509,11 @@ func installLeaseBindings(ctx context.Context, c client.Client, namespace string
 	)
 }
 
-// NewPlatform --
-// nolint: lll
-func NewPlatform(ctx context.Context, c client.Client, clusterType string, skipRegistrySetup bool, registry v1.RegistrySpec, operatorID string) (*v1.IntegrationPlatform, error) {
+// NewPlatform creates a new IntegrationPlatform instance.
+func NewPlatform(
+	ctx context.Context, c client.Client,
+	clusterType string, skipRegistrySetup bool, registry v1.RegistrySpec, operatorID string,
+) (*v1.IntegrationPlatform, error) {
 	isOpenShift, err := isOpenShift(c, clusterType)
 	if err != nil {
 		return nil, err

--- a/pkg/util/olm/available.go
+++ b/pkg/util/olm/available.go
@@ -31,7 +31,7 @@ import (
 	kubernetesutils "github.com/apache/camel-k/pkg/util/kubernetes"
 )
 
-// IsAPIAvailable returns true if we are connected to a cluster with OLM installed
+// IsAPIAvailable returns true if we are connected to a cluster with OLM installed.
 //
 // This method should not be called from the operator, as it might require permissions that are not available.
 func IsAPIAvailable(ctx context.Context, c kubernetes.Interface, namespace string) (bool, error) {


### PR DESCRIPTION
<!-- Description -->

To promote the Kustomize installation method, I'm checking the feature parity between the two methods. In order to make the task easier, I first refactored the `install` cmd. As a side product, I was able to remove two `// nolint: maintidx` comments.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
