### PR TITLE
fix(#3896): Fix dependency inspector supporting property placeholders

### DIFF
--- a/pkg/util/camel/camel_runtime_catalog.go
+++ b/pkg/util/camel/camel_runtime_catalog.go
@@ -179,7 +179,7 @@ func (c *RuntimeCatalog) VisitSchemes(visitor func(string, v1.CamelScheme) bool)
 	}
 }
 
-// DecodeComponent parses an URI and return a camel artifact and a scheme.
+// DecodeComponent parses the given URI and return a camel artifact and a scheme.
 func (c *RuntimeCatalog) DecodeComponent(uri string) (*v1.CamelArtifact, *v1.CamelScheme) {
 	uriSplit := strings.SplitN(uri, ":", 2)
 	if len(uriSplit) < 2 {
@@ -191,4 +191,20 @@ func (c *RuntimeCatalog) DecodeComponent(uri string) (*v1.CamelArtifact, *v1.Cam
 		schemeRef = &scheme
 	}
 	return c.GetArtifactByScheme(uriStart), schemeRef
+}
+
+// IsResolvable checks given URI for proper Camel format (e.g. resolvable scheme).
+func (c *RuntimeCatalog) IsResolvable(uri string) bool {
+	uriSplit := strings.SplitN(uri, ":", 2)
+
+	if len(uriSplit) == 0 {
+		return false
+	}
+
+	if scheme := uriSplit[0]; strings.HasPrefix(scheme, "{{") && strings.HasSuffix(scheme, "}}") {
+		// scheme is a property placeholder (e.g. {{url}}) which is not resolvable
+		return false
+	}
+
+	return true
 }

--- a/pkg/util/source/inspector.go
+++ b/pkg/util/source/inspector.go
@@ -336,7 +336,14 @@ func (i *baseInspector) discoverKamelets(meta *Metadata) {
 }
 
 func (i *baseInspector) addDependencies(uri string, meta *Metadata, consumer bool) error {
+	if !i.catalog.IsResolvable(uri) {
+		// ignore dependencies for given URI as it is not resolvable in this state
+		// (e.g. using a property placeholder such as {{url} or {{scheme}}:{{resource}})
+		return nil
+	}
+
 	candidateComp, scheme := i.catalog.DecodeComponent(uri)
+
 	if candidateComp == nil || scheme == nil {
 		return fmt.Errorf("component not found for uri %q in camel catalog runtime version %s",
 			uri, i.catalog.GetRuntimeVersion())

--- a/pkg/util/source/test_support.go
+++ b/pkg/util/source/test_support.go
@@ -56,3 +56,20 @@ func assertExtractYAML(t *testing.T, inspector YAMLInspector, source string, ass
 
 	assertFn(&meta)
 }
+
+func assertExtractYAMLError(t *testing.T, inspector YAMLInspector, source string, assertFn func(err error)) {
+	t.Helper()
+
+	srcSpec := v1.SourceSpec{
+		DataSpec: v1.DataSpec{
+			Name:    "route.yaml",
+			Content: source,
+		},
+		Language: v1.LanguageYaml,
+	}
+	meta := NewMetadata()
+	err := inspector.Extract(srcSpec, &meta)
+	require.Error(t, err)
+
+	assertFn(err)
+}


### PR DESCRIPTION
Do not raise errors during dependency inspection when using property placeholders in toURI. Fixes http-sink Kamelet

Fixes #3896 