### PR TITLE
feat(cli): Add autocomplete on integrations, kits, kamelets commands

### DIFF
--- a/pkg/cmd/completion_bash.go
+++ b/pkg/cmd/completion_bash.go
@@ -175,6 +175,30 @@ __kamel_kubectl_get_known_integrationkits() {
     compopt -o nospace
 }
 
+
+__kamel_kubectl_get_kamelets() {
+    local template
+    local kubectl_out
+
+    template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
+
+    if kubectl_out=$(kubectl get -o template --template="${template}" kamelets 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
+    fi
+}
+
+__kamel_kubectl_get_non_bundled_non_readonly_kamelets() {
+    local template
+    local kubectl_out
+
+    template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
+    label_conditions="camel.apache.org/kamelet.bundled=false,camel.apache.org/kamelet.readonly=false"
+
+    if kubectl_out=$(kubectl get -l ${label_conditions} -o template --template="${template}" kamelets 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
+    fi
+}
+
 __custom_func() {
     case ${last_command} in
         kamel_describe_integration)
@@ -185,6 +209,10 @@ __custom_func() {
             __kamel_kubectl_get_integrationkits
             return
             ;;
+        kamel_describe_kamelet)
+            __kamel_kubectl_get_kamelets
+            return
+            ;;
         kamel_delete)
             __kamel_kubectl_get_integrations
             return
@@ -193,8 +221,20 @@ __custom_func() {
             __kamel_kubectl_get_integrations
             return
             ;;
+        kamel_get)
+            __kamel_kubectl_get_integrations
+            return
+            ;;
         kamel_kit_delete)
             __kamel_kubectl_get_non_platform_integrationkits
+            return
+            ;;
+        kamel_kit_get)
+            __kamel_kubectl_get_integrationkits
+            return
+            ;;
+        kamel_kamelet_delete)
+            __kamel_kubectl_get_non_bundled_non_readonly_kamelets
             return
             ;;
         *)


### PR DESCRIPTION
Fixes #3628

## Motivation

Adding some completion on CLI basic commands to improve its usability through bash completion.

## Description

The completion uses `kubectl` commands to retrieve the results.

* `kamel get` autocomplete on integrations
*`kamel delete` autocomplete on integrations (no modification made)
* `kamel get kit` autocomplete on all kits
* `kamel delete kit` still autocomplete on non-platform kits (no modification made)
* `kamel kamelet delete` autocomplete on non-readonly and non-bundled kamelets (this is the command behavior)
* `kamel describe kamelet` autocomplete on all kamelets

Pre-existing limit : the completion never use the value of the namespace flag even if it is provided, it always use the kubectl config context namespace. For `kamel -n usernamespace get <TAB>`, completion runs  `kamel get `. None of the completion use the namespace flag.


**Release Note**
```release-note
feat(cli): Enable CLI completion for integration, kit, kamelet names
```
