### PR TITLE
feat: automatic github actions bump 

### DIFF
--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -42,11 +42,11 @@ jobs:
       with:
         branch-ref: "release-1.10.x"
 
-  v1_8_x:
+  v1_11_x:
     if: github.repository == 'apache/camel-k'
     runs-on: ubuntu-20.04
     steps:
-    - name: Automatic updates on release-1.8.x
+    - name: Automatic updates on release-1.11.x
       uses: ./.github/actions/automatic-updates
       with:
-        branch-ref: "release-1.8.x"
+        branch-ref: "release-1.11.x"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,15 +57,15 @@ jobs:
         secretDockerHubPassword: ${{ secrets.TEST_DOCKER_HUB_PASSWORD }}
         secretGithubToken: ${{ secrets.GITHUB_TOKEN }}
 
-  v1_8_x:
+  v1_11_x:
     if: github.repository == 'apache/camel-k'
     runs-on: ubuntu-20.04
     steps:
-    - name: release-1.8.x nightly
+    - name: release-1.11.x nightly
       uses: ./.github/actions/release-nightly
       with:
-        branch-ref: "release-1.8.x"
-        goVersion: "1.16.x"
+        branch-ref: "release-1.11.x"
+        goVersion: "1.17.x"
         javaVersion: "11"
         secretE2ECluster: ${{ secrets.E2E_CLUSTER_CONFIG }}
         secretE2EKube: ${{ secrets.E2E_KUBE_CONFIG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     if: github.repository == 'apache/camel-k'
     runs-on: ubuntu-20.04
     steps:
-    - name: Release 1.10 nightly
+    - name: release-1.10.x nightly
       uses: ./.github/actions/release-nightly
       with:
         branch-ref: "release-1.10.x"
@@ -61,7 +61,7 @@ jobs:
     if: github.repository == 'apache/camel-k'
     runs-on: ubuntu-20.04
     steps:
-    - name: Release 1.8 nightly
+    - name: release-1.8.x nightly
       uses: ./.github/actions/release-nightly
       with:
         branch-ref: "release-1.8.x"

--- a/release.adoc
+++ b/release.adoc
@@ -320,6 +320,6 @@ git push upstream main
 ```
 Where <new-version> represents the new version you want to bump and <replace-version> the version that was previously released.
 
-In case of a major or minor release, please update accordingly the `release` workflow in order to always have the previous release branches, `main` and latest LTS running in a CI fashion. See https://github.com/apache/camel-k/pull/3607/commits/f835c978dcfbcadae99b0f8b2fbcd07f49adb3a1 for reference.
+Note: this action should also replace automatically the oldest nightly release Github Action with the newest one just created.
 
 You will also need to update the `docs/antora.yml` configuration in order to provide the proper versions for the upcoming release in `main` branch.

--- a/script/Makefile
+++ b/script/Makefile
@@ -140,6 +140,7 @@ bump-replace:
 	@sed -i 's/^LAST_RELEASED_VERSION ?= .*$//LAST_RELEASED_VERSION ?= $(LAST_RELEASED_VERSION)/' ./script/Makefile
 
 bump: bump-replace codegen bundle
+	./script/bump_actions.sh $(LAST_RELEASED_VERSION)
 
 # Generates the version file
 codegen:

--- a/script/bump_actions.sh
+++ b/script/bump_actions.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <Camel K version>"
+  exit 1
+fi
+
+location=$(dirname $0)
+version="$1"
+
+re="^([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)$"
+if ! [[ $version =~ $re ]]; then
+    echo "❗ argument must match semantic version: $version"
+    exit 1
+fi
+version_mm="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+
+new_release="v$(echo "$version_mm" | tr \. _)_x"
+new_release_branch="release-$version_mm.x"
+
+# pick the oldest release (we will replace it)
+oldest_release=$(yq '.jobs[] | key | select ( . !="main" )' $location/../.github/workflows/release.yml | sort | head -1)
+oldest_release_branch=$(yq ".jobs[\"$oldest_release\"].steps[0].with.branch-ref" $location/../.github/workflows/release.yml)
+echo "Swapping GH actions tasks from $oldest_release to $new_release, $oldest_release_branch to $new_release_branch"
+# Nightly release action
+sed -i "s/$oldest_release/$new_release/g" $location/../.github/workflows/release.yml
+sed -i "s/$oldest_release_branch/$new_release_branch/g" $location/../.github/workflows/release.yml
+# Automatic updates action
+sed -i "s/$oldest_release/$new_release/g" $location/../.github/workflows/automatic-updates.yml
+sed -i "s/$oldest_release_branch/$new_release_branch/g" $location/../.github/workflows/automatic-updates.yml


### PR DESCRIPTION
<!-- Description -->
With this PR we automate the replacement of the oldest release action (and any other automated github action) with the last released.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat: automatic github actions bump 
```
