### PR TITLE
chore(cli): Remove dead code on completion for context flag

### DIFF
--- a/pkg/cmd/completion_bash.go
+++ b/pkg/cmd/completion_bash.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 
 	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/platform"
 	"github.com/apache/camel-k/pkg/trait"
 	"github.com/apache/camel-k/pkg/util/camel"
 )
@@ -168,13 +167,6 @@ __kamel_kubectl_get_non_platform_integrationkits() {
         COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
     fi
 }
-
-__kamel_kubectl_get_known_integrationkits() {
-    local type_list="` + strings.Join(platform.GetKitsNames(), " ") + `"
-    COMPREPLY=( $( compgen -W "${type_list}" -- "$cur") )
-    compopt -o nospace
-}
-
 
 __kamel_kubectl_get_kamelets() {
     local template

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -153,15 +153,6 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *installCmdO
 	// save
 	cmd.Flags().Bool("save", false, "Save the install parameters into the default kamel configuration file (kamel-config.yaml)")
 
-	// completion support
-	configureBashAnnotationForFlag(
-		&cmd,
-		"context",
-		map[string][]string{
-			cobra.BashCompCustom: {"__kamel_kubectl_get_known_integrationcontexts"},
-		},
-	)
-
 	return &cmd, &options
 }
 


### PR DESCRIPTION
`--context` flag was replaced by `--kit` flag (#726) then `kit` flag was removed from `kamel install` command (#1609) therefore its completion code is no longer used.