### PR TITLE
feat(cli): Add namespace in command autocompletion bash

### DIFF
--- a/pkg/cmd/completion_bash.go
+++ b/pkg/cmd/completion_bash.go
@@ -93,13 +93,26 @@ __kamel_kubectl_get_servicebinding() {
     local kubectl_out
     local service_names
     local services_list
+    local namespace_condition
+    
+    if command -v awk &> /dev/null ; then
+        local namespace_config=$(${COMP_WORDS[0]} config --list | awk '/default-namespace/{print $2}')
+        if [ ! -z $namespace_config ]; then
+            namespace_condition=$(echo "--namespace ${namespace_config}")
+        fi
+    fi
+    
+    local namespace_flag=$(echo "${flaghash['-n']}${flaghash['--namespace']}")
+    if [ ! -z $namespace_flag ]; then
+        namespace_condition=$(echo "--namespace ${namespace_flag}")
+    fi
 
     template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
     template_gvkn="{{ range .items  }}{{ .kind  }}/{{ .apiVersion  }}/{{ .metadata.name }} {{ end }}" 
-    if kubectl_out=$(kubectl get -o template --template="${template}" crd -l service.binding/provisioned-service=true 2>/dev/null); then
+    if kubectl_out=$(kubectl get -o template --template="${template}" ${namespace_condition} crd -l service.binding/provisioned-service=true 2>/dev/null); then
         kubectl_out="${kubectl_out// /,}"
         service_names="${kubectl_out}servicebinding"
-        if kubectl_out=$(kubectl get -o template --template="${template_gvkn}" ${service_names} 2>/dev/null); then
+        if kubectl_out=$(kubectl get -o template --template="${template_gvkn}" ${namespace_condition} ${service_names} 2>/dev/null); then
             for resource in  $kubectl_out
             do
                name=$(echo ${resource} | cut -d'/' -f 4)
@@ -116,10 +129,23 @@ __kamel_kubectl_get_servicebinding() {
 __kamel_kubectl_get_configmap() {
     local template
     local kubectl_out
+    local namespace_condition
+    
+    if command -v awk &> /dev/null ; then
+        local namespace_config=$(${COMP_WORDS[0]} config --list | awk '/default-namespace/{print $2}')
+        if [ ! -z $namespace_config ]; then
+            namespace_condition=$(echo "--namespace ${namespace_config}")
+        fi
+    fi
+    
+    local namespace_flag=$(echo "${flaghash['-n']}${flaghash['--namespace']}")
+    if [ ! -z $namespace_flag ]; then
+        namespace_condition=$(echo "--namespace ${namespace_flag}")
+    fi
 
     template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
 
-    if kubectl_out=$(kubectl get -o template --template="${template}" configmap 2>/dev/null); then
+    if kubectl_out=$(kubectl get -o template --template="${template}" ${namespace_condition} configmap 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
     fi
 }
@@ -127,10 +153,23 @@ __kamel_kubectl_get_configmap() {
 __kamel_kubectl_get_secret() {
     local template
     local kubectl_out
+    local namespace_condition
+    
+    if command -v awk &> /dev/null ; then
+        local namespace_config=$(${COMP_WORDS[0]} config --list | awk '/default-namespace/{print $2}')
+        if [ ! -z $namespace_config ]; then
+            namespace_condition=$(echo "--namespace ${namespace_config}")
+        fi
+    fi
+    
+    local namespace_flag=$(echo "${flaghash['-n']}${flaghash['--namespace']}")
+    if [ ! -z $namespace_flag ]; then
+        namespace_condition=$(echo "--namespace ${namespace_flag}")
+    fi
 
     template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
 
-    if kubectl_out=$(kubectl get -o template --template="${template}" secret 2>/dev/null); then
+    if kubectl_out=$(kubectl get -o template --template="${template}" ${namespace_condition} secret 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
     fi
 }
@@ -138,10 +177,23 @@ __kamel_kubectl_get_secret() {
 __kamel_kubectl_get_integrations() {
     local template
     local kubectl_out
+    local namespace_condition
+    
+    if command -v awk &> /dev/null ; then
+        local namespace_config=$(${COMP_WORDS[0]} config --list | awk '/default-namespace/{print $2}')
+        if [ ! -z $namespace_config ]; then
+            namespace_condition=$(echo "--namespace ${namespace_config}")
+        fi
+    fi
+    
+    local namespace_flag=$(echo "${flaghash['-n']}${flaghash['--namespace']}")
+    if [ ! -z $namespace_flag ]; then
+        namespace_condition=$(echo "--namespace ${namespace_flag}")
+    fi
 
     template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
 
-    if kubectl_out=$(kubectl get -o template --template="${template}" integrations 2>/dev/null); then
+    if kubectl_out=$(kubectl get -o template --template="${template}" ${namespace_condition} integrations 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
     fi
 }
@@ -149,10 +201,23 @@ __kamel_kubectl_get_integrations() {
 __kamel_kubectl_get_integrationkits() {
     local template
     local kubectl_out
+    local namespace_condition
+    
+    if command -v awk &> /dev/null ; then
+        local namespace_config=$(${COMP_WORDS[0]} config --list | awk '/default-namespace/{print $2}')
+        if [ ! -z $namespace_config ]; then
+            namespace_condition=$(echo "--namespace ${namespace_config}")
+        fi
+    fi
+    
+    local namespace_flag=$(echo "${flaghash['-n']}${flaghash['--namespace']}")
+    if [ ! -z $namespace_flag ]; then
+        namespace_condition=$(echo "--namespace ${namespace_flag}")
+    fi
 
     template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
 
-    if kubectl_out=$(kubectl get -o template --template="${template}" integrationkits 2>/dev/null); then
+    if kubectl_out=$(kubectl get -o template --template="${template}" ${namespace_condition} integrationkits 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
     fi
 }
@@ -160,11 +225,24 @@ __kamel_kubectl_get_integrationkits() {
 __kamel_kubectl_get_non_platform_integrationkits() {
     local template
     local kubectl_out
+    local namespace_condition
+    
+    if command -v awk &> /dev/null ; then
+        local namespace_config=$(${COMP_WORDS[0]} config --list | awk '/default-namespace/{print $2}')
+        if [ ! -z $namespace_config ]; then
+            namespace_condition=$(echo "--namespace ${namespace_config}")
+        fi
+    fi
+    
+    local namespace_flag=$(echo "${flaghash['-n']}${flaghash['--namespace']}")
+    if [ ! -z $namespace_flag ]; then
+        namespace_condition=$(echo "--namespace ${namespace_flag}")
+    fi
 
     template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
     label_condition="camel.apache.org/kit.type!=platform"
 
-    if kubectl_out=$(kubectl get -l ${label_condition} -o template --template="${template}" integrationkits 2>/dev/null); then
+    if kubectl_out=$(kubectl get -l ${label_condition} -o template --template="${template}" ${namespace_condition} integrationkits 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
     fi
 }
@@ -179,10 +257,23 @@ __kamel_kubectl_get_known_integrationkits() {
 __kamel_kubectl_get_kamelets() {
     local template
     local kubectl_out
+    local namespace_condition
+    
+    if command -v awk &> /dev/null ; then
+        local namespace_config=$(${COMP_WORDS[0]} config --list | awk '/default-namespace/{print $2}')
+        if [ ! -z $namespace_config ]; then
+            namespace_condition=$(echo "--namespace ${namespace_config}")
+        fi
+    fi
+    
+    local namespace_flag=$(echo "${flaghash['-n']}${flaghash['--namespace']}")
+    if [ ! -z $namespace_flag ]; then
+        namespace_condition=$(echo "--namespace ${namespace_flag}")
+    fi
 
     template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
 
-    if kubectl_out=$(kubectl get -o template --template="${template}" kamelets 2>/dev/null); then
+    if kubectl_out=$(kubectl get -o template --template="${template}" ${namespace_condition} kamelets 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
     fi
 }
@@ -190,11 +281,24 @@ __kamel_kubectl_get_kamelets() {
 __kamel_kubectl_get_non_bundled_non_readonly_kamelets() {
     local template
     local kubectl_out
+    local namespace_condition
+    
+    if command -v awk &> /dev/null ; then
+        local namespace_config=$(${COMP_WORDS[0]} config --list | awk '/default-namespace/{print $2}')
+        if [ ! -z $namespace_config ]; then
+            namespace_condition=$(echo "--namespace ${namespace_config}")
+        fi
+    fi
+    
+    local namespace_flag=$(echo "${flaghash['-n']}${flaghash['--namespace']}")
+    if [ ! -z $namespace_flag ]; then
+        namespace_condition=$(echo "--namespace ${namespace_flag}")
+    fi
 
     template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
     label_conditions="camel.apache.org/kamelet.bundled=false,camel.apache.org/kamelet.readonly=false"
 
-    if kubectl_out=$(kubectl get -l ${label_conditions} -o template --template="${template}" kamelets 2>/dev/null); then
+    if kubectl_out=$(kubectl get -l ${label_conditions} -o template --template="${template}" ${namespace_condition} kamelets 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubectl_out}" -- "$cur" ) )
     fi
 }


### PR DESCRIPTION
Fixes #3922

## Motivation

Make the autocompletion internal `kubectl` command and the CLI `kamel` command as consistant as possible in regards of namespace declaration.

## Description

* retrieve the namespace flag from the current command
* retrieve the namespace config with the `kamel config --list` command only if awk is available
* apply the namespace to the kubectl autocompletion command : flag namespace > config namespace > no specified namespace

The generated completion script was tested on Linux Fedora OS bash. 

Closes: #3922

**Release Note**
```release-note
Use flag/config namespace for existing CLI completion kubectl commands
```
