### PR TITLE
[backport 1.10.x] fix(ci): github rate limit and shell in update action

### DIFF
--- a/.github/actions/automatic-updates/action.yml
+++ b/.github/actions/automatic-updates/action.yml
@@ -32,6 +32,7 @@ runs:
         token: ${{ inputs.secretGithubToken }}
         release_branch: ${{ inputs.branch-ref }}
     - name: Commit changelog
+      shell: bash
       env:
         CI_USER: "github-actions[bot]"
         CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
@@ -40,6 +41,7 @@ runs:
         git config --local user.name "$CI_USER"
         git add CHANGELOG.md && git commit -m 'chore: changelog automatic update' && echo "changelog=1" >> $GITHUB_ENV || echo "No changes to CHANGELOG"
     - name: Run refresh actions and commit
+      shell: bash
       env:
         CI_USER: "github-actions[bot]"
         CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
@@ -48,6 +50,7 @@ runs:
         make update-docs
         git add -A && git commit -m 'chore: nightly resource refresh' && echo "refresh=1" >> $GITHUB_ENV || echo "No changes to make update-docs"
     - name: Push changes
+      shell: bash
       if: env.changelog == 1 || env.refresh == 1
       env:
         CI_USER: "github-actions[bot]"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@
 
 name: build
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -19,6 +19,7 @@ name: builder
 
 env:
   TEST_CLUSTER: kind
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
   pull_request:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -19,6 +19,7 @@ name: common
 
 env:
   TEST_CLUSTER: kind
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
   pull_request:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -19,6 +19,7 @@ name: install
 
 env:
   TEST_CLUSTER: kind
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
   pull_request:

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -19,6 +19,7 @@ name: knative
 
 env:
   TEST_CLUSTER: kind
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
   pull_request:

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -17,6 +17,9 @@
 
 name: local
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -17,6 +17,9 @@
 
 name: openshift
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -19,6 +19,7 @@ name: upgrade
 
 env:
   TEST_CLUSTER: kind
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
   pull_request:


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
