### PR TITLE
fix(ci): revert usage of TEST_CLUSTER

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@
 name: release
 
 env:
+  TEST_CLUSTER: kind
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:


### PR DESCRIPTION
Although not used by `main` release step, it is still required by `v_10` and `v_11` release steps, so, it cannot be removed.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
