### PR TITLE
fix(test): temporary remove env var

### DIFF
--- a/e2e/namespace/install/cli/run_test.go
+++ b/e2e/namespace/install/cli/run_test.go
@@ -76,6 +76,10 @@ func TestKamelCLIRun(t *testing.T) {
 				Eventually(DeleteIntegrations(ns), TestTimeoutLong).Should(Equal(0))
 			})
 
+			// GIST does not like GITHUB_TOKEN apparently, we must temporary remove it
+			os.Setenv("GITHUB_TOKEN_TMP", os.Getenv("GITHUB_TOKEN"))
+			os.Setenv("GITHUB_TOKEN", "")
+
 			t.Run("Gist (ID)", func(t *testing.T) {
 				name := "github-gist-id"
 				Expect(KamelRunWithID(operatorID, ns, "--name", name,
@@ -99,6 +103,10 @@ func TestKamelCLIRun(t *testing.T) {
 				Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Tick!"))
 				Eventually(DeleteIntegrations(ns), TestTimeoutLong).Should(Equal(0))
 			})
+
+			// Revert GITHUB TOKEN
+			os.Setenv("GITHUB_TOKEN", os.Getenv("GITHUB_TOKEN_TMP"))
+			os.Setenv("GITHUB_TOKEN_TMP", "")
 
 			// Clean up
 			Eventually(DeleteIntegrations(ns), TestTimeoutLong).Should(Equal(0))

--- a/e2e/namespace/install/cli/run_test.go
+++ b/e2e/namespace/install/cli/run_test.go
@@ -78,7 +78,7 @@ func TestKamelCLIRun(t *testing.T) {
 
 			// GIST does not like GITHUB_TOKEN apparently, we must temporary remove it
 			os.Setenv("GITHUB_TOKEN_TMP", os.Getenv("GITHUB_TOKEN"))
-			os.Setenv("GITHUB_TOKEN", "")
+			os.Unsetenv("GITHUB_TOKEN")
 
 			t.Run("Gist (ID)", func(t *testing.T) {
 				name := "github-gist-id"
@@ -106,7 +106,7 @@ func TestKamelCLIRun(t *testing.T) {
 
 			// Revert GITHUB TOKEN
 			os.Setenv("GITHUB_TOKEN", os.Getenv("GITHUB_TOKEN_TMP"))
-			os.Setenv("GITHUB_TOKEN_TMP", "")
+			os.Unsetenv("GITHUB_TOKEN_TMP")
 
 			// Clean up
 			Eventually(DeleteIntegrations(ns), TestTimeoutLong).Should(Equal(0))


### PR DESCRIPTION
I cannot come up with a better solution. If the execution is sequential, temporary removing the environment variable should be fine.

Close #3952

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(test): temporary remove env var
```
