### PR TITLE
fix(e2e): Kamelets tag compatibility with 3.19

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -84,7 +84,7 @@ STAGING_RUNTIME_REPO :=
 # Kamelets options
 INSTALL_DEFAULT_KAMELETS ?= true
 KAMELET_CATALOG_REPO := https://github.com/apache/camel-kamelets.git
-KAMELET_CATALOG_REPO_TAG := main
+KAMELET_CATALOG_REPO_TAG := 0.10.x
 
 # When performing integration tests, it is not necessary to always execute build, especially
 # in e2e tests when lots of tests are being executed sequentially & the build has already taken place.


### PR DESCRIPTION
Close #3957

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
