### PR TITLE
fix(#3988): Fix flaky E2E test on operator multi tenancy

### DIFF
--- a/e2e/namespace/install/operator_id_filtering_test.go
+++ b/e2e/namespace/install/operator_id_filtering_test.go
@@ -81,8 +81,7 @@ func TestOperatorIDFiltering(t *testing.T) {
 					RegisterTestingT(t)
 
 					Expect(AssignIntegrationToOperator(ns, "moving", operator2)).To(Succeed())
-					Eventually(IntegrationPhase(ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
-					Expect(Kamel("rebuild", "-n", ns, "moving").Execute()).To(Succeed())
+					Eventually(IntegrationPhase(ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseBuildingKit))
 					Eventually(IntegrationPhase(ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
 					Eventually(IntegrationPodPhase(ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 					Eventually(IntegrationLogs(ns, "moving"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))


### PR DESCRIPTION
- Fix TestOperatorIDFiltering/Operators_can_handoff_scoped_integrations
- Just set new operator ID, there is no need to explicitly rebuild the integration
- Avoid race condition between rebuild command and the operator ID update
- Due to race conditions the test sometimes failed with concurrent resource modification error