### PR TITLE
 feat: switch to eclipse-temurin:11 as runtime base image (1.11.x)

### DIFF
--- a/.github/actions/kamel-prepare-env/action.yml
+++ b/.github/actions/kamel-prepare-env/action.yml
@@ -51,10 +51,11 @@ runs:
         df -h
 
     - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+      uses: actions/setup-java@v3
       if: ${{ env.ENV_PREPARED != 'true' }}
       with:
-        version: "11"
+        java-version: '11'
+        distribution: 'temurin'
 
     - name: Set Go
       uses: actions/setup-go@v2 # Version 2 adds GOBIN to PATH

--- a/e2e/namespace/upgrade/cli_upgrade_test.go
+++ b/e2e/namespace/upgrade/cli_upgrade_test.go
@@ -51,7 +51,7 @@ func TestOperatorUpgrade(t *testing.T) {
 		Expect(os.Setenv("KAMEL_BIN", kamel)).To(Succeed())
 
 		// Should both install the CRDs and kamel in the given namespace
-		Expect(Kamel("install", "-n", ns, "--olm=false", "--force").Execute()).To(Succeed())
+		Expect(Kamel("install", "-n", ns, "--olm=false", "--force", "--base-image", defaults.BaseImage()).Execute()).To(Succeed())
 
 		// Check the operator pod is running
 		Eventually(OperatorPodPhase(ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
@@ -75,7 +75,7 @@ func TestOperatorUpgrade(t *testing.T) {
 		Expect(os.Setenv("KAMEL_BIN", "")).To(Succeed())
 
 		// Upgrade the operator by installing the current version
-		Expect(KamelInstall(ns, "--olm=false", "--force", "--operator-image", image).Execute()).To(Succeed())
+		Expect(KamelInstall(ns, "--olm=false", "--force", "--operator-image", image, "--base-image", defaults.BaseImage()).Execute()).To(Succeed())
 
 		// Check the operator image is the current built one
 		Eventually(OperatorImage(ns)).Should(Equal(image))

--- a/e2e/namespace/upgrade/olm_upgrade_test.go
+++ b/e2e/namespace/upgrade/olm_upgrade_test.go
@@ -90,6 +90,7 @@ func TestOLMAutomaticUpgrade(t *testing.T) {
 			"--olm=true",
 			"--olm-source", catalogSourceName,
 			"--olm-source-namespace", ns,
+			"--base-image", defaults.BaseImage(),
 		}
 
 		if prevUpdateChannel != "" {

--- a/pkg/util/defaults/defaults.go
+++ b/pkg/util/defaults/defaults.go
@@ -35,7 +35,7 @@ const (
 	KanikoVersion = "0.17.1"
 
 	// baseImage --
-	baseImage = "docker.io/adoptopenjdk/openjdk11:slim"
+	baseImage = "docker.io/eclipse-temurin:11"
 
 	// LocalRepository --
 	LocalRepository = "/tmp/artifacts/m2"

--- a/script/Makefile
+++ b/script/Makefile
@@ -25,7 +25,7 @@ CODEGEN_VERSION := v0.23.5
 OPERATOR_SDK_VERSION := v1.16.0
 KUSTOMIZE_VERSION := v4.1.2
 OPM_VERSION := v1.24.0
-BASE_IMAGE := docker.io/adoptopenjdk/openjdk11:slim
+BASE_IMAGE := docker.io/eclipse-temurin:11
 LOCAL_REPOSITORY := /tmp/artifacts/m2
 IMAGE_NAME ?= docker.io/apache/camel-k
 


### PR DESCRIPTION
- feat: use eclipse-temurin:11 as runtime base image
- workaround: force eclipse-temurin:11 as runtime base image for upgrade tests
- feat: use eclipse temurin as java distribution for github actions

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
