### PR TITLE
feat(e2e): Set a more reasonable default for gomega eventually's polling interval

### DIFF
--- a/e2e/support/gomega_support.go
+++ b/e2e/support/gomega_support.go
@@ -1,0 +1,57 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package support
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	eventuallyTimeoutEnvVarName           = "E2E_DEFAULT_EVENTUALLY_TIMEOUT"
+	eventuallyPollingIntervalEnvVarName   = "E2E_DEFAULT_EVENTUALLY_POLLING_INTERVAL"
+	consistentlyDurationEnvVarName        = "E2E_DEFAULT_CONSISTENTLY_DURATION"
+	consistentlyPollingIntervalEnvVarName = "E2E_DEFAULT_CONSISTENTLY_POLLING_INTERVAL"
+)
+
+func init() {
+	SetDefaultEventuallyTimeout(durationFromEnv(eventuallyTimeoutEnvVarName, time.Second))
+	SetDefaultEventuallyPollingInterval(durationFromEnv(eventuallyPollingIntervalEnvVarName, 500*time.Millisecond))
+	SetDefaultConsistentlyDuration(durationFromEnv(consistentlyDurationEnvVarName, 100*time.Millisecond))
+	SetDefaultConsistentlyPollingInterval(durationFromEnv(consistentlyPollingIntervalEnvVarName, 500*time.Millisecond))
+}
+
+func durationFromEnv(key string, defaultDuration time.Duration) time.Duration {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultDuration
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		panic(fmt.Sprintf("Expected a duration when using %s!  Parse error %v", key, err))
+	}
+	return duration
+}

--- a/e2e/support/test_util.go
+++ b/e2e/support/test_util.go
@@ -25,10 +25,13 @@ package support
 import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"os"
-
 	"github.com/onsi/gomega/types"
+	"os"
 )
+
+func init() {
+
+}
 
 func EqualP(expected interface{}) types.GomegaMatcher {
 	return PointTo(Equal(expected))


### PR DESCRIPTION
Fixes #3992

This commit set a more reasonable default for gomega inetrnal timeout
and poll interval used for e2e testing.

The defaults are:
- **EventuallyTimeout** is set to 1s (not changed)
- **EventuallyPollingInterval** is set to 500ms
- **ConsistentlyDuration** is set to 100ms (not changed)
- **EventuallyPollingInterval** is set to 500ms

Values can be configured via env vars:
- E2E_DEFAULT_EVENTUALLY_TIMEOUT
- E2E_DEFAULT_EVENTUALLY_POLLING_INTERVAL
- E2E_DEFAULT_CONSISTENTLY_DURATION
- E2E_DEFAULT_CONSISTENTLY_POLLING_INTERVAL

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
