### PR TITLE
chore(test): don't install kamelet catalog

### DIFF
--- a/e2e/global/common/scale_binding_test.go
+++ b/e2e/global/common/scale_binding_test.go
@@ -51,7 +51,7 @@ func TestKameletBindingScale(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
 		name := "binding"
 		operatorID := "camel-k-kamelet-scale"
-		Expect(KamelInstallWithID(operatorID, ns, "-w").Execute()).To(Succeed())
+		Expect(KamelInstallWithIDAndKameletCatalog(operatorID, ns, "-w").Execute()).To(Succeed())
 		Expect(KamelBindWithID(operatorID, ns, "timer-source?message=HelloBinding", "log-sink", "--name", name).Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/namespace/install/cli/bind_test.go
+++ b/e2e/namespace/install/cli/bind_test.go
@@ -35,7 +35,7 @@ import (
 func TestKamelCLIBind(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
 		operatorID := "camel-k-cli-bind"
-		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
+		Expect(KamelInstallWithIDAndKameletCatalog(operatorID, ns).Execute()).To(Succeed())
 		Expect(CreateTimerKamelet(ns, "test-timer-source")()).To(Succeed())
 
 		t.Run("bind timer to log", func(t *testing.T) {

--- a/e2e/namespace/install/cli/uninstall_test.go
+++ b/e2e/namespace/install/cli/uninstall_test.go
@@ -51,8 +51,8 @@ func TestBasicUninstall(t *testing.T) {
 		}
 
 		if !uninstallViaOLM {
-		Eventually(Role(ns)).Should(BeNil())
-		Eventually(RoleBinding(ns)).Should(BeNil())
+			Eventually(Role(ns)).Should(BeNil())
+			Eventually(RoleBinding(ns)).Should(BeNil())
 			Eventually(ServiceAccount(ns, "camel-k-operator")).Should(BeNil())
 		} else {
 			Eventually(Role(ns)).ShouldNot(BeNil())
@@ -130,7 +130,7 @@ func TestUninstallSkipKamelets(t *testing.T) {
 	WithNewTestNamespace(t, func(ns string) {
 		// a successful new installation
 		operatorID := fmt.Sprintf("camel-k-%s", ns)
-		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
+		Expect(KamelInstallWithIDAndKameletCatalog(operatorID, ns).Execute()).To(Succeed())
 		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
 		Eventually(KameletList(ns)).ShouldNot(BeEmpty())
 		// on uninstall it should remove everything except kamelets

--- a/e2e/namespace/install/operator_id_filtering_test.go
+++ b/e2e/namespace/install/operator_id_filtering_test.go
@@ -53,11 +53,11 @@ func TestOperatorIDFiltering(t *testing.T) {
 		WithNewTestNamespace(t, func(nsop1 string) {
 			WithNewTestNamespace(t, func(nsop2 string) {
 				operator1 := "operator-1"
-				Expect(KamelInstallWithID(operator1, nsop1, "--global", "--force").Execute()).To(Succeed())
+				Expect(KamelInstallWithIDAndKameletCatalog(operator1, nsop1, "--global", "--force").Execute()).To(Succeed())
 				Eventually(PlatformPhase(nsop1), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 				operator2 := "operator-2"
-				Expect(KamelInstallWithID(operator2, nsop2, "--global", "--force").Execute()).To(Succeed())
+				Expect(KamelInstallWithIDAndKameletCatalog(operator2, nsop2, "--global", "--force").Execute()).To(Succeed())
 				Eventually(PlatformPhase(nsop2), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 				t.Run("Operators ignore non-scoped integrations", func(t *testing.T) {

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -228,10 +228,14 @@ func KamelInstall(namespace string, args ...string) *cobra.Command {
 }
 
 func KamelInstallWithID(operatorID string, namespace string, args ...string) *cobra.Command {
-	return KamelInstallWithContext(TestContext, operatorID, namespace, args...)
+	return kamelInstallWithContext(TestContext, operatorID, namespace, true, args...)
 }
 
-func KamelInstallWithContext(ctx context.Context, operatorID string, namespace string, args ...string) *cobra.Command {
+func KamelInstallWithIDAndKameletCatalog(operatorID string, namespace string, args ...string) *cobra.Command {
+	return kamelInstallWithContext(TestContext, operatorID, namespace, false, args...)
+}
+
+func kamelInstallWithContext(ctx context.Context, operatorID string, namespace string, skipKameletCatalog bool, args ...string) *cobra.Command {
 	var installArgs []string
 
 	globalTest := os.Getenv("CAMEL_K_FORCE_GLOBAL_TEST") == "true"
@@ -250,10 +254,7 @@ func KamelInstallWithContext(ctx context.Context, operatorID string, namespace s
 		installArgs = []string{"install", "-n", namespace, "--operator-id", operatorID}
 	}
 
-	// Default behavior, we don't install Kamelet catalog to spare resources
-	// They need to be installed on purpose if required to be tested
-	enableKamelets := os.Getenv("CAMEL_K_TEST_KAMELET_CATALOG_INSTALL") == "true"
-	if !enableKamelets {
+	if skipKameletCatalog {
 		installArgs = append(installArgs, "--operator-env-vars", "KAMEL_INSTALL_DEFAULT_KAMELETS=false")
 	}
 

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -250,6 +250,13 @@ func KamelInstallWithContext(ctx context.Context, operatorID string, namespace s
 		installArgs = []string{"install", "-n", namespace, "--operator-id", operatorID}
 	}
 
+	// Default behavior, we don't install Kamelet catalog to spare resources
+	// They need to be installed on purpose if required to be tested
+	enableKamelets := os.Getenv("CAMEL_K_TEST_KAMELET_CATALOG_INSTALL") == "true"
+	if !enableKamelets {
+		installArgs = append(installArgs, "--operator-env-vars", "KAMEL_INSTALL_DEFAULT_KAMELETS=false")
+	}
+
 	logLevel := os.Getenv("CAMEL_K_TEST_LOG_LEVEL")
 	if len(logLevel) > 0 {
 		fmt.Printf("Setting log-level to %s\n", logLevel)


### PR DESCRIPTION
as a default. They are required only in some test.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(test): don't install kamelet catalog
```
