### PR TITLE
feat(trait): dynamic configuration

### DIFF
--- a/docs/modules/traits/pages/traits.adoc
+++ b/docs/modules/traits/pages/traits.adoc
@@ -53,12 +53,47 @@ metadata:
 spec:
   traits:
     jvm:
-      configuration:
-        classpath: /path/to/my.jar
+      classpath: /path/to/my.jar
 ...
 ----
 
-The `.spec.traits` holds an array of traits, identified by their id (`jvm`, in this case). Then, the `.jvm.configuration.classpath` is the property we want to set. If you need to set a trait directly in the `Integration` spec, then, you should proceed in the way illustrated above.
+The `.spec.traits` holds an array of traits, identified by their id (`jvm`, in this case). Then, the `.jvm.classpath` is the property we want to set. If you need to set a trait directly in the `Integration` spec, then, you should proceed in the way illustrated above.
+
+=== Configure as an annotation
+
+When working directly with Integration specification, it may result handy to use a more compact approach than configuring the `.spec.traits`: we can use a special annotation instead:
+
+[source,yaml]
+----
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: my-integration
+  annotations:
+    trait.camel.apache.org/jvm.classpath: /path/to/my.jar
+...
+----
+
+When using this strategy you're having a higher degree of flexibility but you're losing the possibility to validate the type of data against the expected type (ie, trying to parse a string instead of a number).
+
+NOTE: if you need to specify an array of values, the syntax will be `trait.camel.apache.org/trait.conf: "[\"opt1\", \"opt2\", …​]"`
+
+=== Configure trait dynamically
+
+When using the trait annotation configuration you can benefit of its flexibility to use dynamic values stored in the cluster as `Configmap`:
+
+[source,yaml]
+----
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: my-integration
+  annotations:
+    trait.camel.apache.org/container.request-memory: {{configmap:my-cm/my-property}}
+...
+----
+
+This approach is very useful when you want to provide a specific configuration for your Integration based in the namespace where it's supposed to be executed (ie, you can have sensible value in a production and development environment). Just make sure the `Configmap` exists and has the expected values.
 
 [[traits-list]]
 == List of available traits

--- a/e2e/global/common/traits/environment_test.go
+++ b/e2e/global/common/traits/environment_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package traits
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/apache/camel-k/e2e/support"
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+)
+
+func TestEnvironmentTrait(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		operatorID := "camel-k-trait-environment"
+		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
+
+		t.Run("Run env var value from configmap", func(t *testing.T) {
+			var cmData = make(map[string]string)
+			cmData["env"] = "MY_ENV_VAR=Magicstring!"
+			CreatePlainTextConfigmap(ns, "cm", cmData)
+
+			name := "env"
+			Expect(KamelRunWithID(operatorID, ns, "files/Env.java",
+				"--annotation", "trait.camel.apache.org/environment.vars={{configmap:cm/env}}",
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
+			Eventually(IntegrationLogs(ns, name), TestTimeoutLong).Should(ContainSubstring("Magicstring!"))
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+	})
+}

--- a/e2e/global/common/traits/files/Env.java
+++ b/e2e/global/common/traits/files/Env.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class Env extends RouteBuilder {
+  @Override
+  public void configure() throws Exception {
+    from("timer:tick")
+        .log("${env:MY_ENV_VAR}");
+  }
+}

--- a/pkg/cmd/trait_support_test.go
+++ b/pkg/cmd/trait_support_test.go
@@ -1,0 +1,47 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	v1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/trait"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestConfigureStaticTraits(t *testing.T) {
+	traits := v1.Traits{}
+	c := trait.NewCatalog(nil)
+	options := []string{
+		"camel.runtime-version=1.2.3",
+		"container.port=1234",
+		"container.expose=true",
+		"container.image-pull-policy=Never",
+		"environment.vars=V1=X",
+		"environment.vars=V2=Y",
+	}
+	err := configureTraits(options, &traits, c)
+	assert.Nil(t, err)
+	assert.Equal(t, "1.2.3", traits.Camel.RuntimeVersion)
+	assert.Equal(t, 1234, traits.Container.Port)
+	assert.Equal(t, true, *traits.Container.Expose)
+	assert.Equal(t, corev1.PullNever, traits.Container.ImagePullPolicy)
+	assert.Equal(t, []string{"V1=X", "V2=Y"}, traits.Environment.Vars)
+}

--- a/pkg/trait/mount.go
+++ b/pkg/trait/mount.go
@@ -162,7 +162,7 @@ func (t *mountTrait) attachResource(e *Environment, conf *utilResource.Config) {
 		cm, err := kubernetes.GetUnstructured(e.Ctx, e.Client, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 			conf.Name(), e.Integration.Namespace)
 		if err == nil && cm != nil && cm.GetLabels()[kubernetes.ConfigMapAutogenLabel] == "true" {
-			refCm := kubernetes.NewConfigMap(e.Integration.Namespace, conf.Name(), "", "", "", nil)
+			refCm := kubernetes.NewConfigMap(e.Integration.Namespace, conf.Name(), "", nil, nil)
 			e.Resources.Add(refCm)
 		}
 	}

--- a/pkg/trait/openapi.go
+++ b/pkg/trait/openapi.go
@@ -106,7 +106,7 @@ func (t *openAPITrait) generateFromConfigmaps(e *Environment, tmpDir string) ([]
 		cm, err := kubernetes.GetUnstructured(e.Ctx, e.Client, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 			configmap, e.Integration.Namespace)
 		if err == nil && cm != nil && cm.GetLabels()[kubernetes.ConfigMapAutogenLabel] == "true" {
-			refCm := kubernetes.NewConfigMap(e.Integration.Namespace, configmap, "", "", "", nil)
+			refCm := kubernetes.NewConfigMap(e.Integration.Namespace, configmap, "", nil, nil)
 			e.Resources.Add(refCm)
 		}
 		// Iterate over each configmap key which may hold a different OpenAPI spec

--- a/pkg/util/kubernetes/factory.go
+++ b/pkg/util/kubernetes/factory.go
@@ -123,8 +123,7 @@ func NewResourceRequirements(reqs []string) (corev1.ResourceRequirements, error)
 }
 
 // NewConfigMap will create a ConfigMap.
-func NewConfigMap(namespace, cmName, originalFilename string, generatedKey string,
-	textData string, binaryData []byte) *corev1.ConfigMap {
+func NewConfigMap(namespace, cmName, originalFilename string, data map[string]string, binaryData map[string][]byte) *corev1.ConfigMap {
 	immutable := true
 	cm := corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -141,15 +140,11 @@ func NewConfigMap(namespace, cmName, originalFilename string, generatedKey strin
 		},
 		Immutable: &immutable,
 	}
-	if textData != "" {
-		cm.Data = map[string]string{
-			generatedKey: textData,
-		}
+	if data != nil {
+		cm.Data = data
 	}
 	if binaryData != nil {
-		cm.BinaryData = map[string][]byte{
-			generatedKey: binaryData,
-		}
+		cm.BinaryData = binaryData
 	}
 	return &cm
 }

--- a/pkg/util/resource/config.go
+++ b/pkg/util/resource/config.go
@@ -220,7 +220,11 @@ func ConvertFileToConfigmap(ctx context.Context, c client.Client, config *Config
 		config.resourceKey = filepath.Base(config.DestinationPath())
 	}
 	genCmName := fmt.Sprintf("cm-%s", hashFrom([]byte(filename), []byte(integrationName), []byte(content), rawContent))
-	cm := kubernetes.NewConfigMap(namespace, genCmName, filename, config.Key(), content, rawContent)
+	cm := kubernetes.NewConfigMap(
+		namespace, genCmName, filename,
+		map[string]string{config.Key(): content},
+		map[string][]byte{config.Key(): rawContent},
+	)
 	err := c.Create(ctx, cm)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {


### PR DESCRIPTION
<!-- Description -->
With this PR we enable the configuration of traits via Kubernetes Configmap. We can only provide this feature when defining the traits as annotation. I've tried to enable it for the generic use case but since we have a static type defined for each trait (ie, bool or int properties) the serialization to Integration and Trait type fail as we need to declare the configmap key to use, which is a string. We may revisit this in the future to make the Trait type flexible enough not to be forced to use its type, but in the while I think it's a good start.

Closes #3891 

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(trait): dynamic configuration
```
