### PR TITLE
fix(#4044): Fix Kamelet utils version in e2e tests

### DIFF
--- a/e2e/yaks/common/kamelet-data-types/event-sink.kamelet.yaml
+++ b/e2e/yaks/common/kamelet-data-types/event-sink.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
         description: The data type to convert incoming events to
         type: string
   dependencies:
-    - github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT
+    - github:apache.camel-kamelets:camel-kamelets-utils:3.x-SNAPSHOT
     - "camel:core"
     - "camel:kamelet"
   template:

--- a/e2e/yaks/common/kamelet-data-types/event-source.kamelet.yaml
+++ b/e2e/yaks/common/kamelet-data-types/event-source.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
         description: The data type of produced events
         type: string
   dependencies:
-    - github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT
+    - github:apache.camel-kamelets:camel-kamelets-utils:3.x-SNAPSHOT
     - "camel:core"
     - "camel:kamelet"
   template:


### PR DESCRIPTION
- Apache Camel Kamelets catalog main branch has moved to Camel 4
- Use 3.x branch instead to fix Jitpack dependency resolving