### PR TITLE
olm_upgrade_test - use only major.minor.patch to verify csv in ik

### DIFF
--- a/e2e/namespace/upgrade/olm_upgrade_test.go
+++ b/e2e/namespace/upgrade/olm_upgrade_test.go
@@ -183,8 +183,10 @@ func TestOLMAutomaticUpgrade(t *testing.T) {
 			// Check the Integration version has been upgraded
 			Eventually(IntegrationVersion(ns, name)).Should(ContainSubstring(newIPVersionPrefix))
 
-			// Check the previous kit is not garbage collected
-			Eventually(Kits(ns, KitWithVersion(prevCSVVersion.String()))).Should(HaveLen(1))
+			// Check the previous kit is not garbage collected (skip Build - present in case of respin)
+			prevCSVVersionMajorMinorPatch := fmt.Sprintf("%d.%d.%d",
+				prevCSVVersion.Version.Major, prevCSVVersion.Version.Minor, prevCSVVersion.Version.Patch)
+			Eventually(Kits(ns, KitWithVersion(prevCSVVersionMajorMinorPatch))).Should(HaveLen(1))
 			// Check a new kit is created with the current version
 			Eventually(Kits(ns, KitWithVersion(defaults.Version)),
 				TestTimeoutMedium).Should(HaveLen(1))


### PR DESCRIPTION
<!-- Description -->
Backport the fix also to 1.10 upstream

