### PR TITLE
fix(#3956): Add maven settings-security.xml to maven command

### DIFF
--- a/pkg/util/maven/maven_command.go
+++ b/pkg/util/maven/maven_command.go
@@ -76,6 +76,13 @@ func (c *Command) Do(ctx context.Context) error {
 		args = append(args, "--settings", settingsPath)
 	}
 
+	settingsSecurityPath := filepath.Join(c.context.Path, "settings-security.xml")
+	if settingsSecurityExists, err := util.FileExists(settingsSecurityPath); err != nil {
+		return err
+	} else if settingsSecurityExists {
+		args = append(args, "-Dsettings.security="+settingsSecurityPath)
+	}
+
 	if !util.StringContainsPrefix(c.context.AdditionalArguments, "-Dmaven.artifact.threads") {
 		args = append(args, "-Dmaven.artifact.threads="+strconv.Itoa(runtime.GOMAXPROCS(0)))
 	}


### PR DESCRIPTION
Resolves: #3956 

## Description

In case the settings-security.xml file is declared in the integration platform as [described in the documentation](https://camel.apache.org/camel-k/next/configuration/maven.html#maven-settings-security) it needs to be explicitly specified as part of the maven commands, else maven default to `${user.home}/.m2/settings-security.xml` instead of `/tmp/kit-xxxx/maven/settings-security.xml`.


**Release Note**
```release-note
fix: Add maven settings-security.xml to maven command
```
