### PR TITLE
[release-1.10.x] fix(#3956): Add maven settings-security to maven command

### DIFF
--- a/pkg/util/maven/maven_command.go
+++ b/pkg/util/maven/maven_command.go
@@ -76,6 +76,13 @@ func (c *Command) Do(ctx context.Context) error {
 		args = append(args, "--settings", settingsPath)
 	}
 
+	settingsSecurityPath := path.Join(c.context.Path, "settings-security.xml")
+	if settingsSecurityExists, err := util.FileExists(settingsSecurityPath); err != nil {
+		return err
+	} else if settingsSecurityExists {
+		args = append(args, "-Dsettings.security="+settingsSecurityPath)
+	}
+
 	if !util.StringContainsPrefix(c.context.AdditionalArguments, "-Dmaven.artifact.threads") {
 		args = append(args, "-Dmaven.artifact.threads="+strconv.Itoa(runtime.GOMAXPROCS(0)))
 	}


### PR DESCRIPTION
Backport of PR #4099 on `release-1.10.x`

**Release Note**
```release-note
NONE
```
