### PR TITLE
feat(ci): scrape latest CK runtime available

### DIFF
--- a/.github/actions/automatic-updates/action.yml
+++ b/.github/actions/automatic-updates/action.yml
@@ -55,6 +55,7 @@ runs:
       run: |
         make generate
         make update-docs
+        make update-default-ck-runtime
         git add -A && git commit -m 'chore: nightly resource refresh' && echo "refresh=1" >> $GITHUB_ENV || echo "No changes to make update-docs"
     - name: Push changes
       shell: bash

--- a/script/Makefile
+++ b/script/Makefile
@@ -143,6 +143,9 @@ default: build
 update-docs: build-resources
 	./script/update_docs.sh
 
+update-default-ck-runtime:
+	./script/update_defaults_ck_runtime.sh
+
 bump-replace:
 	@# Bump version and replace with the variables provided by the user
 	@sed -i 's/^VERSION ?= .*$//VERSION ?= $(VERSION)/' ./script/Makefile

--- a/script/update_default_ck_runtime.sh
+++ b/script/update_default_ck_runtime.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+set -e
+
+location=$(dirname $0)
+
+git clone --depth 1 https://github.com/apache/camel-k-runtime.git /tmp/camel-k-runtime
+ck_runtime_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -f /tmp/camel-k-runtime/pom.xml)
+echo "INFO: last Camel K runtime version set at $ck_runtime_version"
+sed -i "s/^RUNTIME_VERSION := .*$/RUNTIME_VERSION := $ck_runtime_version/" $location/Makefile
+rm -rf /tmp/camel-k-runtime/


### PR DESCRIPTION
<!-- Description -->

This PR will automate the setting of Camel K Runtime dependency, taking last one available.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(ci): scrape latest CK runtime available
```
