### PR TITLE
[Backport 1.12.x] fix(cmd): compatibility check when not a semver

### DIFF
--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -183,6 +183,9 @@ func operatorVersion(ctx context.Context, c client.Client, namespace string) (st
 }
 
 func compatibleVersions(aVersion, bVersion string, cmd *cobra.Command) bool {
+	if aVersion == bVersion {
+		return true
+	}
 	a, err := semver.NewVersion(aVersion)
 	if err != nil {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Could not parse '"+aVersion+"' (error:", err.Error()+")")

--- a/pkg/cmd/version_test.go
+++ b/pkg/cmd/version_test.go
@@ -86,3 +86,9 @@ func TestCompatibleVersions(t *testing.T) {
 	assert.Equal(t, false, compatibleVersions("1.3.0", "dsadsa", rootCmd))
 	assert.Equal(t, false, compatibleVersions("dsadsa", "1.3.4", rootCmd))
 }
+
+func TestCompatibleVersionsNonSemver(t *testing.T) {
+	_, rootCmd, _ := initializeVersionCmdOptions(t)
+	assert.Equal(t, true, compatibleVersions("1.3.0.special-version", "1.3.0.special-version", rootCmd))
+	assert.Equal(t, false, compatibleVersions("1.3.1.special-version", "1.3.0.special-version", rootCmd))
+}


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cmd): compatibility check when not a semver
```
