### PR TITLE
fix: kustomize revert placeholder namespace

### DIFF
--- a/config/manifests/bases/camel-k.clusterserviceversion.yaml
+++ b/config/manifests/bases/camel-k.clusterserviceversion.yaml
@@ -32,6 +32,7 @@ metadata:
     repository: https://github.com/apache/camel-k
     support: Camel
   name: camel-k.v2.0.0
+  namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/config/rbac/openshift/operator-cluster-role-console-binding-openshift.yaml
+++ b/config/rbac/openshift/operator-cluster-role-console-binding-openshift.yaml
@@ -24,6 +24,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
+  namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: camel-k-operator-console-openshift

--- a/config/rbac/operator-cluster-role-binding-addressable-resolver.yaml
+++ b/config/rbac/operator-cluster-role-binding-addressable-resolver.yaml
@@ -24,6 +24,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
+  namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: camel-k-operator-bind-addressable-resolver

--- a/config/rbac/operator-cluster-role-binding-custom-resource-definitions.yaml
+++ b/config/rbac/operator-cluster-role-binding-custom-resource-definitions.yaml
@@ -24,6 +24,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
+  namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: camel-k-operator-custom-resource-definitions

--- a/config/rbac/operator-role-binding-local-registry.yaml
+++ b/config/rbac/operator-role-binding-local-registry.yaml
@@ -25,6 +25,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
+  namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: camel-k-operator-local-registry

--- a/install/Makefile
+++ b/install/Makefile
@@ -72,6 +72,7 @@ RBAC := $(CONFIG)/rbac
 RBAC_OS := $(RBAC)/openshift
 RBAC_GLOBAL := global
 OPERATOR := operator
+PLACEHOLDER := placeholder
 YAML := yaml
 
 # Fetch the latest image name - may override the original constant


### PR DESCRIPTION
Revert 2d726544168391c7052818def932caf1071bbe50 as it is required by Kustomize procedure

Closes #4142

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix: kustomize revert placeholder namespace
```
