### PR TITLE
fix(cli): Remove CamelCatalogs CR on kamel uninstall

### DIFF
--- a/e2e/install/cli/uninstall_test.go
+++ b/e2e/install/cli/uninstall_test.go
@@ -62,6 +62,7 @@ func TestBasicUninstall(t *testing.T) {
 		Eventually(Configmap(ns, "camel-k-maven-settings")).Should(BeNil())
 		Eventually(OperatorPod(ns), TestTimeoutMedium).Should(BeNil())
 		Eventually(KameletList(ns), TestTimeoutMedium).Should(BeEmpty())
+		Eventually(CamelCatalogList(ns), TestTimeoutMedium).Should(BeEmpty())
 	})
 }
 
@@ -136,5 +137,19 @@ func TestUninstallSkipKamelets(t *testing.T) {
 		// on uninstall it should remove everything except kamelets
 		Expect(Kamel("uninstall", "-n", ns, "--skip-crd", "--skip-cluster-roles", "--skip-kamelets").Execute()).To(Succeed())
 		Eventually(KameletList(ns)).ShouldNot(BeEmpty())
+	})
+}
+
+func TestUninstallSkipCamelCatalogs(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		// a successful new installation
+		operatorID := fmt.Sprintf("camel-k-%s", ns)
+		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
+		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
+		Eventually(CamelCatalogList(ns)).ShouldNot(BeEmpty())
+		// on uninstall it should remove everything except camel catalogs
+		Expect(Kamel("uninstall", "-n", ns, "--skip-crd", "--skip-cluster-roles", "--skip-camel-catalogs").Execute()).To(Succeed())
+		Eventually(CamelCatalogList(ns)).ShouldNot(BeEmpty())
+
 	})
 }

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1700,6 +1700,16 @@ func CamelCatalogImage(ns, name string) func() string {
 	}
 }
 
+func CamelCatalogList(ns string) func() []v1.CamelCatalog {
+	return func() []v1.CamelCatalog {
+		lst := v1.NewCamelCatalogList()
+		if err := TestClient().List(TestContext, &lst, ctrl.InNamespace(ns)); err != nil {
+			failTest(err)
+		}
+		return lst.Items
+	}
+}
+
 func DeletePlatform(ns string) func() bool {
 	return func() bool {
 		pl := Platform(ns)()


### PR DESCRIPTION
Fixes #4160 

## Motivation

When using `kamel uninstall` command the CamelCatalogs CR are not removed from the cluster. When an operator with the same Runtime is installed, it is already considered as Ready so the builder image container is not builded again with the code from the operator.

## Description

Remove all the CamelCatalogs in the namespace of the operator on `kamel uninstall call` and add a `skip-camel-catalogs` flag.


**Release Note**
```release-note
Fix(cli): Remove CamelCatalogs CR on kamel uninstall
```
