### PR TITLE
Ref #4150: Add the installation guide for Docker Desktop

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,7 @@
 * xref:installation/installation.adoc[Installation]
 ** Kubernetes Platform
 *** xref:installation/platform/minikube.adoc[Minikube]
+*** xref:installation/platform/docker-desktop.adoc[Docker Desktop]
 *** xref:installation/platform/crc.adoc[CRC]
 *** xref:installation/platform/digitalocean.adoc[DigitalOcean]
 *** xref:installation/platform/gke.adoc[GKE]

--- a/docs/modules/ROOT/pages/installation/installation.adoc
+++ b/docs/modules/ROOT/pages/installation/installation.adoc
@@ -55,7 +55,7 @@ Camel K is also available in Operator Hub:
 $ kubectl create -f https://operatorhub.io/install/camel-k.yaml
 ```
 
-You will need to OLM framework to be propely installed in your cluster. More instructions on the https://operatorhub.io/operator/camel-k[Camel K Operator Hub] page.
+You will need to OLM framework to be properly installed in your cluster. More instructions on the https://operatorhub.io/operator/camel-k[Camel K Operator Hub] page.
 
 As an alternative, you can also use the `kamel` CLI to perform the same installation:
 
@@ -90,6 +90,7 @@ Camel K installation is usually straightforward, but for certain cluster types y
 
 - xref:installation/platform/openshift.adoc[OpenShift]
 - xref:installation/platform/minikube.adoc[Minikube]
+- xref:installation/platform/docker-desktop.adoc[Docker Desktop]
 - xref:installation/platform/kind.adoc[Kind]
 - xref:installation/platform/crc.adoc[Red Hat CodeReady Containers (CRC)]
 - xref:installation/platform/gke.adoc[Google Kubernetes Engine (GKE)]

--- a/docs/modules/ROOT/pages/installation/platform/docker-desktop.adoc
+++ b/docs/modules/ROOT/pages/installation/platform/docker-desktop.adoc
@@ -1,0 +1,31 @@
+[[installation-on-docker-desktop]]
+= Installing Camel K on Docker Desktop
+
+You can run Camel K integrations on plain Kubernetes using Docker Desktop, for that an external registry is needed and Kubernetes must be enabled.
+
+First, enable Kubernetes by following the instructions in the https://docs.docker.com/desktop/kubernetes/#enable-kubernetes[official documentation page].
+
+Once Kubernetes is up and running, a registry can be started locally using the command:
+```
+docker run -d -p 5000:5000 --restart=always --name registry registry:2
+```
+
+As it is meant for development purpose only, the registry has not been configured to be secured. To allow Kubernetes to pull images from
+our unsecured registry, the address `host.docker.internal:5000` (corresponding to the address of the registry from a container
+https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host[see for more details]) needs to be
+added to the `insecure-registries` by following the instructions in the https://docs.docker.com/registry/insecure/#deploy-a-plain-http-registry[official documentation page].
+
+
+An example of `daemon.json` with the expected configuration:
+```
+{
+    "insecure-registries": ["host.docker.internal:5000"]
+}
+```
+
+Once the configuration changed, the Docker daemon must be restarted to take the modification into account.
+
+Finally, you can install the Camel-K operator with the insecure registry properly configured thanks to the next command:
+```
+kamel install --registry host.docker.internal:5000 --registry-insecure true
+```

--- a/docs/modules/ROOT/pages/installation/registry/registry.adoc
+++ b/docs/modules/ROOT/pages/installation/registry/registry.adoc
@@ -7,8 +7,9 @@ A **default registry** is present in all the following supported installations:
 
 * **OpenShift**: all OpenShift installations (including CRC and real clusters) provide an internal container registry that is used for the S2I (source to image)
   feature. Camel K is able to leverage that registry.
-* **Minikube**: Minikube comes with a "registry addon" that can be enabled upon installation (see xref:installation/platform/minikube.adoc[install guide for Minikube ]). Camel K automatically detects the address of the registry and configures
+* **Minikube**: Minikube comes with a "registry addon" that can be enabled upon installation (see xref:installation/platform/minikube.adoc[install guide for Minikube]). Camel K automatically detects the address of the registry and configures
   it on the `IntegrationPlatform` when using the CLI (on `kamel install`).
+* **Docker Desktop**: Docker provides an https://github.com/distribution/distribution[open source Docker Registry] that can be started upon installation (see xref:installation/platform/docker-desktop.adoc[install guide for Docker Desktop]).
 
 Other platforms do not provide a default container registry and need to be configured accordingly.
 


### PR DESCRIPTION
fixes #4150 

## Motivation

Some issues are raised due to a misconfiguration when using Docker Desktop because there is no guide to install Camel-K on this particular environment.

## Modifications:

* Add a specific installation guide for Docker Desktop