### PR TITLE
fix(cmd): run does not expand camel properties

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -744,7 +744,7 @@ func convertToTrait(value, traitParameter string) string {
 }
 
 func (o *runCmdOptions) applyProperties(c client.Client, items []string, traitName string) error {
-	if items == nil || len(items) == 0 {
+	if len(items) == 0 {
 		return nil
 	}
 	props, err := o.mergePropertiesWithPrecedence(c, items)

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -709,3 +709,67 @@ func TestIntegrationServiceAccountName(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, output, "serviceAccountName: my-service-account")
 }
+
+func TestFileProperties(t *testing.T) {
+	var tmpFile1 *os.File
+	var err error
+	if tmpFile1, err = os.CreateTemp("", "camel-k-*.properties"); err != nil {
+		t.Error(err)
+	}
+
+	assert.Nil(t, tmpFile1.Close())
+	assert.Nil(t, os.WriteFile(tmpFile1.Name(), []byte(`
+	key=${value}
+	#key2=value2
+	my.key=value
+	`), 0o400))
+
+	var tmpFile *os.File
+	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+		t.Error(err)
+	}
+
+	assert.Nil(t, tmpFile.Close())
+	assert.Nil(t, os.WriteFile(tmpFile.Name(), []byte(TestSrcContent), 0o400))
+	_, runCmd, _ := initializeRunCmdOptionsWithOutput(t)
+	output, err := test.ExecuteCommand(runCmd, cmdRun, tmpFile.Name(),
+		"-p", "file:"+tmpFile1.Name(),
+		"-o", "yaml",
+	)
+	assert.Nil(t, err)
+	assert.NotContains(t, output, "#key2")
+	assert.Contains(t, output, "my.key = value")
+	assert.Contains(t, output, "key = ${value}")
+}
+
+func TestPropertyShouldNotExpand(t *testing.T) {
+	var tmpFile1 *os.File
+	var err error
+	if tmpFile1, err = os.CreateTemp("", "camel-k-*.properties"); err != nil {
+		t.Error(err)
+	}
+
+	assert.Nil(t, tmpFile1.Close())
+	assert.Nil(t, os.WriteFile(tmpFile1.Name(), []byte(`
+	key=${value}
+	`), 0o400))
+
+	var tmpFile *os.File
+	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+		t.Error(err)
+	}
+
+	assert.Nil(t, tmpFile.Close())
+	assert.Nil(t, os.WriteFile(tmpFile.Name(), []byte(TestSrcContent), 0o400))
+	_, runCmd, _ := initializeRunCmdOptionsWithOutput(t)
+	output, err := test.ExecuteCommand(runCmd, cmdRun, tmpFile.Name(),
+		"-o", "yaml",
+		"-p", "runtimeProp=${value}",
+		"--build-property", "buildProp=${value}",
+		"-p", "file:"+tmpFile1.Name(),
+	)
+	assert.Nil(t, err)
+	assert.Contains(t, output, "runtimeProp = ${value}")
+	assert.Contains(t, output, "buildProp = ${value}")
+	assert.Contains(t, output, "key = ${value}")
+}


### PR DESCRIPTION
Closes #4163

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cmd): run does not expand camel properties
```
