### PR TITLE
Improve error reporting in case of knative is required but not installed

### DIFF
--- a/pkg/apis/camel/v1/integration_types.go
+++ b/pkg/apis/camel/v1/integration_types.go
@@ -164,6 +164,8 @@ const (
 	IntegrationConditionServiceAvailable IntegrationConditionType = "ServiceAvailable"
 	// IntegrationConditionKnativeServiceAvailable --
 	IntegrationConditionKnativeServiceAvailable IntegrationConditionType = "KnativeServiceAvailable"
+	// IntegrationConditionKnativeAvailable --
+	IntegrationConditionKnativeAvailable IntegrationConditionType = "KnativeAvailable"
 	// IntegrationConditionCronJobAvailable --
 	IntegrationConditionCronJobAvailable IntegrationConditionType = "CronJobAvailable"
 	// IntegrationConditionExposureAvailable --
@@ -203,6 +205,8 @@ const (
 	IntegrationConditionKnativeServiceAvailableReason string = "KnativeServiceAvailable"
 	// IntegrationConditionKnativeServiceNotAvailableReason --
 	IntegrationConditionKnativeServiceNotAvailableReason string = "KnativeServiceNotAvailable"
+	// IntegrationConditionKnativeNotInstalledReason --
+	IntegrationConditionKnativeNotInstalledReason string = "KnativeNotInstalled"
 	// IntegrationConditionCronJobAvailableReason --
 	IntegrationConditionCronJobAvailableReason string = "CronJobAvailableReason"
 	// IntegrationConditionCronJobNotAvailableReason --

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 )
 
 func TestBuilderTraitNotAppliedBecauseOfNilKit(t *testing.T) {
@@ -106,11 +107,12 @@ func createBuilderTestEnv(cluster v1.IntegrationPlatformCluster, strategy v1.Int
 	if err != nil {
 		panic(err)
 	}
-
+	client, _ := test.NewFakeClient()
 	res := &Environment{
 		Ctx:          context.TODO(),
 		CamelCatalog: c,
 		Catalog:      NewCatalog(nil),
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",

--- a/pkg/trait/container.go
+++ b/pkg/trait/container.go
@@ -18,6 +18,7 @@ limitations under the License.
 package trait
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/digest"
 	"github.com/apache/camel-k/v2/pkg/util/envvar"
+	"github.com/apache/camel-k/v2/pkg/util/knative"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 )
 
@@ -72,6 +74,27 @@ func (t *containerTrait) Configure(e *Environment) (bool, error) {
 
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
 		return false, nil
+	}
+
+	knativeInstalled, _ := knative.IsInstalled(e.Client)
+	if e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !knativeInstalled {
+		hasKnativeEndpoint, err := containsEndpoint("knative", e, t.Client)
+		if err != nil {
+			return false, err
+		}
+
+		if hasKnativeEndpoint {
+			// fail fast the integration as there is no knative installed in the cluster
+			t.L.ForIntegration(e.Integration).Infof("Integration %s/%s contains knative endpoint that cannot run, as knative is not installed in the cluster.", e.Integration.Namespace, e.Integration.Name)
+			err := errors.New("integration cannot run, as knative is not installed in the cluster")
+			e.Integration.Status.SetCondition(
+				v1.IntegrationConditionKnativeAvailable,
+				corev1.ConditionFalse,
+				v1.IntegrationConditionKnativeNotInstalledReason,
+				err.Error())
+			e.Integration.Status.Phase = v1.IntegrationPhaseError
+			return false, err
+		}
 	}
 
 	if pointer.BoolDeref(t.Auto, true) {

--- a/pkg/trait/container_probes_test.go
+++ b/pkg/trait/container_probes_test.go
@@ -29,6 +29,7 @@ import (
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 )
 
 func newTestProbesEnv(t *testing.T, integration *v1.Integration) Environment {
@@ -38,11 +39,13 @@ func newTestProbesEnv(t *testing.T, integration *v1.Integration) Environment {
 	assert.Nil(t, err)
 	assert.NotNil(t, catalog)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	return Environment{
 		Catalog:      traitCatalog,
 		CamelCatalog: catalog,
+		Client:       client,
 		Platform: &v1.IntegrationPlatform{
 			Status: v1.IntegrationPlatformStatus{
 				Phase: v1.IntegrationPlatformPhaseReady,

--- a/pkg/trait/cron_test.go
+++ b/pkg/trait/cron_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 )
 
 func TestCronFromURI(t *testing.T) {
@@ -225,11 +226,13 @@ func TestCronDeps(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -298,11 +301,13 @@ func TestCronDepsFallback(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -376,11 +381,13 @@ func TestCronWithActiveDeadline(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -457,11 +464,13 @@ func TestCronWithBackoffLimit(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",

--- a/pkg/trait/deployment.go
+++ b/pkg/trait/deployment.go
@@ -45,6 +45,7 @@ func newDeploymentTrait() Trait {
 }
 
 func (t *deploymentTrait) Configure(e *Environment) (bool, error) {
+
 	if !e.IntegrationInRunningPhases() {
 		return false, nil
 	}

--- a/pkg/trait/deployment_test.go
+++ b/pkg/trait/deployment_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/test"
 )
@@ -265,10 +266,17 @@ func createNominalDeploymentTest() (*deploymentTrait, *Environment) {
 		},
 	})
 
+	// disable the knative service api
+	fakeClient := trait.Client.(*test.FakeClient) //nolint
+	fakeClient.DisableAPIGroupDiscovery("serving.knative.dev/v1")
+
 	replicas := int32(3)
+	catalog, _ := camel.QuarkusCatalog()
 
 	environment := &Environment{
-		Catalog: NewCatalog(nil),
+		CamelCatalog: catalog,
+		Catalog:      NewCatalog(nil),
+		Client:       trait.Client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "integration-name",

--- a/pkg/trait/environment_test.go
+++ b/pkg/trait/environment_test.go
@@ -31,6 +31,7 @@ import (
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 )
 
 func TestDefaultEnvironment(t *testing.T) {
@@ -195,9 +196,11 @@ func NewEnvironmentTestCatalog() *Catalog {
 }
 
 func mockEnvironment(catalog *camel.RuntimeCatalog) Environment {
+	fakeClient, _ := test.NewFakeClient()
 	return Environment{
 		CamelCatalog: catalog,
 		Catalog:      NewCatalog(nil),
+		Client:       fakeClient,
 		Integration: &v1.Integration{
 			Status: v1.IntegrationStatus{
 				Phase: v1.IntegrationPhaseDeploying,

--- a/pkg/trait/istio_test.go
+++ b/pkg/trait/istio_test.go
@@ -33,17 +33,19 @@ import (
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 )
 
 func NewIstioTestEnv(t *testing.T, d *appsv1.Deployment, s *serving.Service, enabled bool) Environment {
 	t.Helper()
-
+	client, _ := test.NewFakeClient()
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
 	env := Environment{
 		Catalog:      NewEnvironmentTestCatalog(),
 		CamelCatalog: catalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			Status: v1.IntegrationStatus{
 				Phase: v1.IntegrationPhaseDeploying,

--- a/pkg/trait/knative_service_test.go
+++ b/pkg/trait/knative_service_test.go
@@ -48,6 +48,7 @@ func TestKnativeService(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	require.NoError(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	compressedRoute, err := gzip.CompressBase64([]byte(`from("platform-http:test").log("hello")`))
@@ -56,6 +57,7 @@ func TestKnativeService(t *testing.T) {
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      KnativeServiceTestName,
@@ -184,11 +186,13 @@ func TestKnativeServiceWithCustomContainerName(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	require.NoError(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      KnativeServiceTestName,
@@ -265,11 +269,13 @@ func TestKnativeServiceWithResr(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	require.NoError(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      KnativeServiceTestName,
@@ -367,11 +373,13 @@ func createKnativeServiceTestEnvironment(t *testing.T, trait *traitv1.KnativeSer
 	catalog, err := camel.DefaultCatalog()
 	require.NoError(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	environment := &Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      KnativeServiceTestName,

--- a/pkg/trait/knative_test.go
+++ b/pkg/trait/knative_test.go
@@ -355,6 +355,7 @@ func TestKnativePlatformHttpDependencies(t *testing.T) {
 func NewFakeEnvironment(t *testing.T, source v1.SourceSpec) Environment {
 	t.Helper()
 
+	client, _ := NewFakeClient("ns")
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
@@ -363,6 +364,7 @@ func NewFakeEnvironment(t *testing.T, source v1.SourceSpec) Environment {
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",

--- a/pkg/trait/logging_test.go
+++ b/pkg/trait/logging_test.go
@@ -31,11 +31,13 @@ import (
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 )
 
 func createLoggingTestEnv(t *testing.T, color bool, json bool, jsonPrettyPrint bool, logLevel string, logFormat string) *Environment {
 	t.Helper()
 
+	client, _ := test.NewFakeClient()
 	c, err := camel.DefaultCatalog()
 	if err != nil {
 		panic(err)
@@ -45,6 +47,7 @@ func createLoggingTestEnv(t *testing.T, color bool, json bool, jsonPrettyPrint b
 		Ctx:          context.TODO(),
 		CamelCatalog: c,
 		Catalog:      NewCatalog(nil),
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",

--- a/pkg/trait/route_test.go
+++ b/pkg/trait/route_test.go
@@ -141,6 +141,7 @@ func createTestRouteEnvironment(t *testing.T, name string) *Environment {
 	res := &Environment{
 		CamelCatalog: catalog,
 		Catalog:      NewCatalog(client),
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/pkg/trait/service_test.go
+++ b/pkg/trait/service_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/gzip"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 )
 
 const (
@@ -43,6 +44,7 @@ func TestServiceWithDefaults(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	compressedRoute, err := gzip.CompressBase64([]byte(`from("netty-http:test").log("hello")`))
@@ -51,6 +53,7 @@ func TestServiceWithDefaults(t *testing.T) {
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ServiceTestName,
@@ -140,6 +143,7 @@ func TestService(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	compressedRoute, err := gzip.CompressBase64([]byte(`from("netty-http:test").log("hello")`))
@@ -148,6 +152,7 @@ func TestService(t *testing.T) {
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ServiceTestName,
@@ -245,11 +250,13 @@ func TestServiceWithCustomContainerName(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ServiceTestName,
@@ -322,6 +329,7 @@ func TestServiceWithNodePort(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	compressedRoute, err := gzip.CompressBase64([]byte(`from("netty-http:test").log("hello")`))
@@ -330,6 +338,7 @@ func TestServiceWithNodePort(t *testing.T) {
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ServiceTestName,
@@ -415,6 +424,7 @@ func TestServiceWithKnativeServiceEnabled(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	compressedRoute, err := gzip.CompressBase64([]byte(`from("netty-http:test").log("hello")`))
@@ -423,6 +433,7 @@ func TestServiceWithKnativeServiceEnabled(t *testing.T) {
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ServiceTestName,
@@ -489,6 +500,7 @@ func TestServicesWithKnativeProfile(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	compressedRoute, err := gzip.CompressBase64([]byte(`from("netty-http:test").log("hello")`))
@@ -497,6 +509,7 @@ func TestServicesWithKnativeProfile(t *testing.T) {
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ServiceTestName,
@@ -551,6 +564,7 @@ func TestServiceWithKnativeServiceDisabledInIntegrationPlatform(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
+	client, _ := test.NewFakeClient()
 	traitCatalog := NewCatalog(nil)
 
 	compressedRoute, err := gzip.CompressBase64([]byte(`from("netty-http:test").log("hello")`))
@@ -559,6 +573,7 @@ func TestServiceWithKnativeServiceDisabledInIntegrationPlatform(t *testing.T) {
 	environment := Environment{
 		CamelCatalog: catalog,
 		Catalog:      traitCatalog,
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ServiceTestName,

--- a/pkg/trait/trait_test.go
+++ b/pkg/trait/trait_test.go
@@ -34,6 +34,7 @@ import (
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 )
 
 const (
@@ -492,12 +493,14 @@ func processTestEnv(t *testing.T, env *Environment) *kubernetes.Collection {
 func createTestEnv(t *testing.T, cluster v1.IntegrationPlatformCluster, script string) *Environment {
 	t.Helper()
 
+	client, _ := test.NewFakeClient()
 	catalog, err := camel.DefaultCatalog()
 	assert.Nil(t, err)
 
 	res := &Environment{
 		CamelCatalog: catalog,
 		Catalog:      NewCatalog(nil),
+		Client:       client,
 		Integration: &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      TestDeploymentName,

--- a/pkg/util/test/client.go
+++ b/pkg/util/test/client.go
@@ -28,6 +28,7 @@ import (
 	fakecamelclientset "github.com/apache/camel-k/v2/pkg/client/camel/clientset/versioned/fake"
 	camelv1 "github.com/apache/camel-k/v2/pkg/client/camel/clientset/versioned/typed/camel/v1"
 	camelv1alpha1 "github.com/apache/camel-k/v2/pkg/client/camel/clientset/versioned/typed/camel/v1alpha1"
+	"github.com/apache/camel-k/v2/pkg/util"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,8 +122,9 @@ func filterObjects(scheme *runtime.Scheme, input []runtime.Object, filter func(g
 type FakeClient struct {
 	controller.Client
 	kubernetes.Interface
-	camel  camel.Interface
-	scales *fakescale.FakeScaleClient
+	camel          camel.Interface
+	scales         *fakescale.FakeScaleClient
+	disabledGroups []string
 }
 
 func (c *FakeClient) CamelV1() camelv1.CamelV1Interface {
@@ -151,9 +153,14 @@ func (c *FakeClient) Patch(ctx context.Context, obj controller.Object, patch con
 	return c.Create(ctx, obj)
 }
 
+func (c *FakeClient) DisableAPIGroupDiscovery(group string) {
+	c.disabledGroups = append(c.disabledGroups, group)
+}
+
 func (c *FakeClient) Discovery() discovery.DiscoveryInterface {
 	return &FakeDiscovery{
 		DiscoveryInterface: c.Interface.Discovery(),
+		disabledGroups:     c.disabledGroups,
 	}
 }
 
@@ -169,6 +176,7 @@ func (c *FakeClient) ScalesClient() (scale.ScalesGetter, error) {
 
 type FakeDiscovery struct {
 	discovery.DiscoveryInterface
+	disabledGroups []string
 }
 
 func (f *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
@@ -177,6 +185,13 @@ func (f *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 		return nil, k8serrors.NewNotFound(schema.GroupResource{
 			Group: "image.openshift.io",
 		}, "")
+	}
+
+	// used in util/knative/enabled.go to verify if knative is installed
+	if groupVersion == "serving.knative.dev/v1" && !util.StringSliceExists(f.disabledGroups, groupVersion) {
+		return &metav1.APIResourceList{
+			GroupVersion: "serving.knative.dev/v1",
+		}, nil
 	}
 	return f.DiscoveryInterface.ServerResourcesForGroupVersion(groupVersion)
 }


### PR DESCRIPTION
Fix https://github.com/apache/camel-k/issues/3803

The knative check, required the `Client` object in `Environment` for various tests.

**Release Note**
```release-note
Fix: Improve error reporting in case of knative is required but not installed
```
