### PR TITLE
fix: won't panic on error handler validation failure

### DIFF
--- a/pkg/apis/camel/v1alpha1/error_handler_types_support.go
+++ b/pkg/apis/camel/v1alpha1/error_handler_types_support.go
@@ -19,6 +19,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // +kubebuilder:object:generate=false
@@ -28,6 +29,7 @@ type ErrorHandler interface {
 	Type() ErrorHandlerType
 	Endpoint() *Endpoint
 	Configuration() (map[string]interface{}, error)
+	Validate() error
 }
 
 // baseErrorHandler is the base used for the Error Handler hierarchy
@@ -47,6 +49,11 @@ func (e baseErrorHandler) Endpoint() *Endpoint {
 // Configuration --
 func (e baseErrorHandler) Configuration() (map[string]interface{}, error) {
 	return nil, nil
+}
+
+// Validate --
+func (e baseErrorHandler) Validate() error {
+	return nil
 }
 
 // ErrorHandlerNone --
@@ -125,4 +132,12 @@ func (e ErrorHandlerSink) Configuration() (map[string]interface{}, error) {
 	properties[ErrorHandlerAppPropertiesPrefix] = "#class:org.apache.camel.builder.DeadLetterChannelBuilder"
 
 	return properties, err
+}
+
+// Validate --
+func (e ErrorHandlerSink) Validate() error {
+	if e.DLCEndpoint == nil {
+		return fmt.Errorf("Missing endpoint in Error Handler Sink")
+	}
+	return nil
 }

--- a/pkg/controller/kameletbinding/error_handler.go
+++ b/pkg/controller/kameletbinding/error_handler.go
@@ -79,8 +79,10 @@ func parseErrorHandler(rawMessage v1alpha1.RawMessage) (v1alpha1.ErrorHandler, e
 			return nil, errors.Errorf("Unknown error handler type %s", errHandlType)
 		}
 
-		err := json.Unmarshal(errHandlValue, dst)
-		if err != nil {
+		if err = json.Unmarshal(errHandlValue, dst); err != nil {
+			return nil, err
+		}
+		if err = dst.Validate(); err != nil {
 			return nil, err
 		}
 

--- a/pkg/controller/kameletbinding/error_handler_test.go
+++ b/pkg/controller/kameletbinding/error_handler_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package kameletbinding
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/apache/camel-k/v2/pkg/apis/camel/v1alpha1"
@@ -64,7 +63,6 @@ func TestParseErrorHandlerLogWithParametersDoesSucceed(t *testing.T) {
 }
 
 func TestParseErrorHandlerSinkDoesSucceed(t *testing.T) {
-	fmt.Println("Test")
 	sinkErrorHandler, err := parseErrorHandler(
 		[]byte(`{"sink": {"endpoint": {"uri": "someUri"}}}`),
 	)
@@ -100,4 +98,12 @@ func TestParseErrorHandlerSinkWithParametersDoesSucceed(t *testing.T) {
 	assert.Equal(t, v1alpha1.ErrorHandlerRefDefaultName, parameters[v1alpha1.ErrorHandlerRefName])
 	assert.Equal(t, "value1", parameters["camel.beans.defaultErrorHandler.param1"])
 	assert.Equal(t, "value2", parameters["camel.beans.defaultErrorHandler.param2"])
+}
+
+func TestParseErrorHandlerSinkFail(t *testing.T) {
+	_, err := parseErrorHandler(
+		[]byte(`{"sink": {"ref": {"uri": "someUri"}}}`),
+	)
+	assert.NotNil(t, err)
+	assert.Equal(t, "Missing endpoint in Error Handler Sink", err.Error())
 }


### PR DESCRIPTION
Introduced a validation for each kind of error handler.

With this PR we make sure that every error handler type is validated against the expected configuration. `Validate()` func need to be configured for each type according the logic required for it (in this case it seems only the `sink` requires some validation).

Closes #3586

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix: won't panic on error handler validation failure
```
