### PR TITLE
fix(ctrl): use builtin command kill

### DIFF
--- a/e2e/commonwithcustominstall/builder_test.go
+++ b/e2e/commonwithcustominstall/builder_test.go
@@ -25,9 +25,11 @@ package commonwithcustominstall
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -49,6 +51,46 @@ func TestBuilderPodFallback(t *testing.T) {
 			Eventually(IntegrationLogs(ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 			Eventually(Logs(ns, OperatorPod(ns)().Name, corev1.PodLogOptions{})).Should(ContainSubstring(`the operator was installed with an ephemeral storage, builder \"pod\" strategy is not supported: using \"routine\" build strategy as a fallback.`))
+		})
+	})
+}
+
+func TestBuilderTimeout(t *testing.T) {
+	WithNewTestNamespace(t, func(ns string) {
+		operatorID := fmt.Sprintf("camel-k-%s", ns)
+		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
+		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
+		Eventually(Platform(ns)).ShouldNot(BeNil())
+		Eventually(PlatformConditionStatus(ns, v1.IntegrationPlatformConditionReady), TestTimeoutShort).
+			Should(Equal(corev1.ConditionTrue))
+
+		pl := Platform(ns)()
+		// set a short timeout to simulate the build timeout
+		pl.Spec.Build.Timeout = &metav1.Duration{
+			Duration: 10 * time.Second,
+		}
+		TestClient().Update(TestContext, pl)
+		Eventually(Platform(ns)).ShouldNot(BeNil())
+		Eventually(PlatformTimeout(ns)).Should(Equal(
+			&metav1.Duration{
+				Duration: 10 * time.Second,
+			},
+		))
+
+		t.Run("run yaml", func(t *testing.T) {
+			name := "yaml"
+			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			// As the build hits timeout, it keeps trying building
+			Eventually(IntegrationPhase(ns, name)).Should(Equal(v1.IntegrationPhaseBuildingKit))
+			integrationKitName := IntegrationKit(ns, name)()
+			builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
+			Eventually(BuilderPodPhase(ns, builderKitName)).Should(Equal(corev1.PodPending))
+			Eventually(BuildPhase(ns, integrationKitName)).Should(Equal(v1.BuildPhaseRunning))
+			// After a few minutes (5 max retries), this has to be in error state
+			Eventually(BuildPhase(ns, integrationKitName), TestTimeoutMedium).Should(Equal(v1.BuildPhaseError))
+			Eventually(IntegrationPhase(ns, name), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseError))
+			Eventually(BuildFailureRecovery(ns, integrationKitName), TestTimeoutMedium).Should(Equal(5))
+			Eventually(BuilderPodPhase(ns, builderKitName), TestTimeoutMedium).Should(Equal(corev1.PodFailed))
 		})
 	})
 }

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1374,6 +1374,16 @@ func BuilderPod(ns string, name string) func() *corev1.Pod {
 	}
 }
 
+func BuilderPodPhase(ns string, name string) func() corev1.PodPhase {
+	return func() corev1.PodPhase {
+		pod := BuilderPod(ns, name)()
+		if pod == nil {
+			return ""
+		}
+		return pod.Status.Phase
+	}
+}
+
 func BuilderPodsCount(ns string) func() int {
 	return func() int {
 		lst := corev1.PodList{
@@ -1590,6 +1600,16 @@ func BuildPhase(ns, name string) func() v1.BuildPhase {
 	}
 }
 
+func BuildFailureRecovery(ns, name string) func() int {
+	return func() int {
+		build := Build(ns, name)()
+		if build != nil {
+			return build.Status.Failure.Recovery.Attempt
+		}
+		return 0
+	}
+}
+
 func HasPlatform(ns string) func() bool {
 	return func() bool {
 		lst := v1.NewIntegrationPlatformList()
@@ -1786,6 +1806,16 @@ func PlatformBuildCatalogToolTimeout(ns string) func() *metav1.Duration {
 			return &metav1.Duration{}
 		}
 		return p.Status.Build.BuildCatalogToolTimeout
+	}
+}
+
+func PlatformTimeout(ns string) func() *metav1.Duration {
+	return func() *metav1.Duration {
+		p := Platform(ns)()
+		if p == nil {
+			return &metav1.Duration{}
+		}
+		return p.Status.Build.Timeout
 	}
 }
 

--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -216,7 +216,7 @@ func (action *monitorPodAction) sigterm(pod *corev1.Pod) error {
 
 		r.VersionedParams(&corev1.PodExecOptions{
 			Container: container.Name,
-			Command:   []string{"kill", "-SIGTERM", "1"},
+			Command:   []string{"/bin/bash", "-c", "kill -SIGTERM 1"},
 			Stdout:    true,
 			Stderr:    true,
 			TTY:       false,


### PR DESCRIPTION
The builder Pods may not have a /bin/kill command, but do have a builtin shell kill command available.

Closes #4241

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ctrl): use builtin command kill
```
