### PR TITLE
chore(cmd): don't warn if rolebinding exists

### DIFF
--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -345,7 +345,9 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 	}
 
 	if err = installNamespacedRoleBinding(ctx, c, collection, cfg.Namespace, "/rbac/operator-role-binding-local-registry.yaml"); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: the operator may not be able to detect a local image registry (%s)\n", err.Error())
+		if !k8serrors.IsAlreadyExists(err) {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: the operator may not be able to detect a local image registry (%s)\n", err.Error())
+		}
 	}
 
 	if cfg.Monitoring.Enabled {


### PR DESCRIPTION
<!-- Description -->

Enhance #4251 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(cmd): don't warn if rolebinding exists
```
