### PR TITLE
chore(doc): Update Monitoring documentation for micrometer

### DIFF
--- a/docs/modules/ROOT/pages/observability/monitoring/integration.adoc
+++ b/docs/modules/ROOT/pages/observability/monitoring/integration.adoc
@@ -38,17 +38,19 @@ spec:
 ----
 <1> Activates the Prometheus trait at the platform level
 
-The Camel Quarkus MicroProfile Metrics extension is responsible for collecting and exposing metrics in the https://github.com/OpenObservability/OpenMetrics[OpenMetrics] text format.
+The Camel Quarkus Micrometer Metrics extension is responsible for collecting and exposing metrics in the https://github.com/OpenObservability/OpenMetrics[OpenMetrics] text format.
 
-The MicroProfile Metrics extension registers and exposes the following metrics out-of-the-box:
+The Micrometer Metrics extension registers and exposes the following metrics out-of-the-box:
 
-* https://github.com/eclipse/microprofile-metrics/blob/master/spec/src/main/asciidoc/required-metrics.adoc#required-metrics[JVM and operating system related metrics]
+* Basic JVM and operating system related metrics
+* xref:components::micrometer-component.adoc[Camel related metrics]
+
 
 It is possible to extend this set of metrics by using either, or both:
 
-* The MicroProfile Metrics component
+* The Micrometer Metrics component
 
-* The https://github.com/eclipse/microprofile-metrics/blob/master/spec/src/main/asciidoc/app-programming-model.adoc#annotations[MicroProfile Metrics annotations], in external dependencies
+* The https://quarkus.io/guides/micrometer#does-micrometer-support-annotations[Micrometer Quarkus Metrics annotations]
 
 == Discovery
 
@@ -71,9 +73,9 @@ $ kamel run -t prometheus.pod-monitor=false ...
 
 More information can be found in the xref:traits:prometheus.adoc[Prometheus trait] documentation.
 
-The Prometheus Operator https://github.com/coreos/prometheus-operator/blob/v0.38.0/Documentation/user-guides/getting-started.md#related-resources[getting started] guide documents the discovery mechanism, as well as the relationship between the operator resources.
+The Prometheus Operator https://prometheus-operator.dev/docs/user-guides/getting-started/[getting started] guide documents the discovery mechanism, as well as the relationship between the operator resources.
 
-In case your integration metrics are not discovered, you may want to rely on https://github.com/coreos/prometheus-operator/blob/v0.38.0/Documentation/troubleshooting.md#troubleshooting-servicemonitor-changes[Troubleshooting `ServiceMonitor` changes], which also applies to `PodMonitor` resources troubleshooting.
+In case your integration metrics are not discovered, you may want to rely on https://prometheus-operator.dev/docs/operator/troubleshooting/#troubleshooting-servicemonitor-changes[Troubleshooting `ServiceMonitor` changes], which also applies to `PodMonitor` resources troubleshooting.
 
 == Alerting
 
@@ -100,5 +102,5 @@ spec:
 EOF
 ----
 
-More information can be found in the Prometheus Operator https://github.com/coreos/prometheus-operator/blob/v0.38.0/Documentation/user-guides/alerting.md[Alerting] user guide.
-You can also find more details in https://docs.openshift.com/container-platform/4.4/monitoring/monitoring-your-own-services.html#creating-alerting-rules_monitoring-your-own-services[Creating alerting rules] from the OpenShift documentation.
+More information can be found in the Prometheus Operator https://prometheus-operator.dev/docs/user-guides/alerting/[Alerting] user guide.
+You can also find more details in https://docs.openshift.com/container-platform/4.12/monitoring/managing-alerts.html#creating-alerting-rules-for-user-defined-projects_managing-alerts[Creating alerting rules] from the OpenShift documentation.

--- a/docs/modules/ROOT/pages/observability/monitoring/operator.adoc
+++ b/docs/modules/ROOT/pages/observability/monitoring/operator.adoc
@@ -95,9 +95,9 @@ spec:
 <1> The labels must match the `podMonitorSelector` field from the `Prometheus` resource
 <2> This label selector matches the Camel K operator Deployment labels
 
-The Prometheus Operator https://github.com/coreos/prometheus-operator/blob/v0.38.0/Documentation/user-guides/getting-started.md#related-resources[getting started] guide documents the discovery mechanism, as well as the relationship between the operator resources.
+The Prometheus Operator https://prometheus-operator.dev/docs/user-guides/getting-started/[getting started] guide documents the discovery mechanism, as well as the relationship between the operator resources.
 
-In case your operator metrics are not discovered, you may want to rely on https://github.com/coreos/prometheus-operator/blob/v0.38.0/Documentation/troubleshooting.md#troubleshooting-servicemonitor-changes[Troubleshooting `ServiceMonitor` changes], which also applies to `PodMonitor` resources troubleshooting.
+In case your operator metrics are not discovered, you may want to rely on https://prometheus-operator.dev/docs/operator/troubleshooting/#troubleshooting-servicemonitor-changes[Troubleshooting `ServiceMonitor` changes], which also applies to `PodMonitor` resources troubleshooting.
 
 [[alerting]]
 == Alerting
@@ -172,5 +172,5 @@ spec:
               for {{ $labels.job }} have their first time to readiness above 1m.
 ----
 
-More information can be found in the Prometheus Operator https://github.com/coreos/prometheus-operator/blob/v0.38.0/Documentation/user-guides/alerting.md[Alerting] user guide.
-You can also find more details in https://docs.openshift.com/container-platform/4.4/monitoring/monitoring-your-own-services.html#creating-alerting-rules_monitoring-your-own-services[Creating alerting rules] from the OpenShift documentation.
+More information can be found in the Prometheus Operator https://prometheus-operator.dev/docs/user-guides/alerting/[Alerting] user guide.
+You can also find more details in https://docs.openshift.com/container-platform/4.12/monitoring/managing-alerts.html#creating-alerting-rules-for-user-defined-projects_managing-alerts[Creating alerting rules] from the OpenShift documentation.


### PR DESCRIPTION
 Update Monitoring documentation to fit the migration of prometheus trait from microprofile to micrometer

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(doc): Monitoring doc with prometheus/micrometer
```
