### PR TITLE
Revert "Allow to configure test namespace and operatorID"

### DIFF
--- a/e2e/common/cli/default.go
+++ b/e2e/common/cli/default.go
@@ -22,5 +22,5 @@ package cli
 
 import "github.com/apache/camel-k/v2/e2e/support"
 
-var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var ns = support.GetCIProcessID()
+var operatorID = support.GetCIProcessID()

--- a/e2e/common/config/default.go
+++ b/e2e/common/config/default.go
@@ -22,5 +22,5 @@ package config
 
 import "github.com/apache/camel-k/v2/e2e/support"
 
-var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var ns = support.GetCIProcessID()
+var operatorID = support.GetCIProcessID()

--- a/e2e/common/languages/default.go
+++ b/e2e/common/languages/default.go
@@ -22,5 +22,5 @@ package languages
 
 import "github.com/apache/camel-k/v2/e2e/support"
 
-var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var ns = support.GetCIProcessID()
+var operatorID = support.GetCIProcessID()

--- a/e2e/common/misc/default.go
+++ b/e2e/common/misc/default.go
@@ -22,5 +22,5 @@ package misc
 
 import "github.com/apache/camel-k/v2/e2e/support"
 
-var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var ns = support.GetCIProcessID()
+var operatorID = support.GetCIProcessID()

--- a/e2e/common/traits/default.go
+++ b/e2e/common/traits/default.go
@@ -22,5 +22,5 @@ package traits
 
 import "github.com/apache/camel-k/v2/e2e/support"
 
-var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var ns = support.GetCIProcessID()
+var operatorID = support.GetCIProcessID()

--- a/e2e/knative/default.go
+++ b/e2e/knative/default.go
@@ -22,5 +22,5 @@ package knative
 
 import "github.com/apache/camel-k/v2/e2e/support"
 
-var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var ns = support.GetCIProcessID()
+var operatorID = support.GetCIProcessID()


### PR DESCRIPTION
Reverts apache/camel-k#4286

It seems it is the cause of checks failure. Let's try if reverting bring back to green.