### PR TITLE
[Backport 1.12.x] fix(operator): do not panic if cannot set GOMAXPROCS

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -126,7 +126,9 @@ func Run(healthPort, monitoringPort int32, leaderElection bool, leaderElectionID
 	klog.SetLogger(log.AsLogger())
 
 	_, err := maxprocs.Set(maxprocs.Logger(func(f string, a ...interface{}) { log.Info(fmt.Sprintf(f, a)) }))
-	exitOnError(err, "failed to set GOMAXPROCS from cgroups")
+	if err != nil {
+		log.Error(err, "failed to set GOMAXPROCS from cgroups")
+	}
 
 	printVersion()
 


### PR DESCRIPTION
Closes #4299

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(operator): do not panic if cannot set GOMAXPROCS
```
