### PR TITLE
fix(e2e): Stabilize YAKS E2E tests

### DIFF
--- a/e2e/yaks/common/kamelet-beans/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-beans/yaks-config.yaml
@@ -22,6 +22,8 @@ pre:
 - name: installation
   run: |
     kubectl apply -f beans-source.kamelet.yaml -n $YAKS_NAMESPACE
+    
+    kubectl wait kamelet beans-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
 post:
   - name: print dump
     if: env:CI=true && failure()

--- a/e2e/yaks/common/kamelet-binding-autoload/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-autoload/yaks-config.yaml
@@ -25,6 +25,8 @@ pre:
     kubectl apply -f secret-specific.yaml -n $YAKS_NAMESPACE
 
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
+    
+    kubectl wait kamelet timer-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
 post:
   - name: print dump
     if: env:CI=true && failure()

--- a/e2e/yaks/common/kamelet-binding-broker/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-broker/yaks-config.yaml
@@ -25,6 +25,9 @@ pre:
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f logger-sink.kamelet.yaml -n $YAKS_NAMESPACE
 
+    kubectl wait kamelet timer-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+    kubectl wait kamelet logger-sink --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+
     kubectl apply -f timer-source-binding.yaml -n $YAKS_NAMESPACE
     kubectl apply -f logger-sink-binding.yaml -n $YAKS_NAMESPACE
     kubectl wait kameletbinding timer-source-binding --for=condition=Ready --timeout=15m -n $YAKS_NAMESPACE

--- a/e2e/yaks/common/kamelet-binding-http/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-http/yaks-config.yaml
@@ -23,6 +23,8 @@ pre:
   run: |
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
 
+    kubectl wait kamelet timer-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+
     kamel run display.groovy -w -n $YAKS_NAMESPACE
     cat timer-source-binding-display.yaml | sed  's/{namespace}/'"${YAKS_NAMESPACE}"'/' | kubectl apply -n $YAKS_NAMESPACE -f -
     kubectl wait kameletbinding timer-source-binding-display --for=condition=Ready --timeout=15m -n $YAKS_NAMESPACE

--- a/e2e/yaks/common/kamelet-binding-property-encoding/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding-property-encoding/yaks-config.yaml
@@ -22,6 +22,9 @@ pre:
 - name: installation
   run: |
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
+    
+    kubectl wait kamelet timer-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+
     kubectl apply -f properties-binding.yaml -n $YAKS_NAMESPACE
 post:
   - name: print dump

--- a/e2e/yaks/common/kamelet-binding/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-binding/yaks-config.yaml
@@ -26,6 +26,9 @@ pre:
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f logger-sink.kamelet.yaml -n $YAKS_NAMESPACE
 
+    kubectl wait kamelet timer-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+    kubectl wait kamelet logger-sink --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+
     kubectl apply -f timer-source-binding.yaml -n $YAKS_NAMESPACE
     kubectl apply -f logger-sink-binding.yaml -n $YAKS_NAMESPACE
 

--- a/e2e/yaks/common/kamelet-data-types/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-data-types/yaks-config.yaml
@@ -37,6 +37,10 @@ pre:
     kubectl apply -f event-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f event-sink.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f data-type-action.kamelet.yaml -n $YAKS_NAMESPACE
+    
+    kubectl wait kamelet event-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+    kubectl wait kamelet event-sink --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+    kubectl wait kamelet data-type-action --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
 post:
   - name: print dump
     if: env:CI=true && failure()

--- a/e2e/yaks/common/kamelet-steps/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet-steps/yaks-config.yaml
@@ -23,6 +23,10 @@ pre:
   run: |
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f prefix-action.kamelet.yaml -n $YAKS_NAMESPACE
+    
+    kubectl wait kamelet timer-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+    kubectl wait kamelet prefix-action --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+    
     kubectl apply -f steps-binding.yaml -n $YAKS_NAMESPACE
 
     kubectl wait kameletbinding steps-binding --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE

--- a/e2e/yaks/common/kamelet/yaks-config.yaml
+++ b/e2e/yaks/common/kamelet/yaks-config.yaml
@@ -24,6 +24,9 @@ pre:
     kubectl apply -f timer-source.kamelet.yaml -n $YAKS_NAMESPACE
     kubectl apply -f echo-sink.kamelet.yaml -n $YAKS_NAMESPACE
 
+    kubectl wait kamelet timer-source --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+    kubectl wait kamelet echo-sink --for=condition=Ready --timeout=10m -n $YAKS_NAMESPACE
+
     kamel run source-sink.groovy -w -n $YAKS_NAMESPACE
 post:
   - name: print dump


### PR DESCRIPTION
- Wait for custom Kamelets to be in ready state to avoid test errors due to slow operator reconciliation loops
- Avoids Kamelet not found errors