### PR TITLE
feat(cli): provide useful info in kubectl CLI

### DIFF
--- a/addons/strimzi/duck/client/internalclientset/fake/register.go
+++ b/addons/strimzi/duck/client/internalclientset/fake/register.go
@@ -38,14 +38,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/addons/strimzi/duck/client/internalclientset/scheme/register.go
+++ b/addons/strimzi/duck/client/internalclientset/scheme/register.go
@@ -38,14 +38,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/config/crd/bases/camel.apache.org_camelcatalogs.yaml
+++ b/config/crd/bases/camel.apache.org_camelcatalogs.yaml
@@ -39,13 +39,17 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The Camel K Runtime version
+    - description: The Runtime provider
+      jsonPath: .spec.runtime.provider
+      name: Runtime Provider
+      type: string
+    - description: The Runtime version
       jsonPath: .spec.runtime.version
       name: Runtime Version
       type: string
-    - description: The Camel K Runtime provider
-      jsonPath: .spec.runtime.provider
-      name: Runtime Provider
+    - description: The Camel version
+      jsonPath: .spec.runtime.metadata.camel\.version
+      name: Runtime Camel Version
       type: string
     - description: The catalog phase
       jsonPath: .status.phase

--- a/config/crd/bases/camel.apache.org_integrationkits.yaml
+++ b/config/crd/bases/camel.apache.org_integrationkits.yaml
@@ -39,6 +39,10 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - description: The integration kit alias
+      jsonPath: .metadata.labels.camel\.apache\.org\/kit\.alias
+      name: Alias
+      type: string
     - description: The integration kit phase
       jsonPath: .status.phase
       name: Phase
@@ -46,6 +50,10 @@ spec:
     - description: The integration kit type
       jsonPath: .metadata.labels.camel\.apache\.org\/kit\.type
       name: Type
+      type: string
+    - description: The integration kit layout
+      jsonPath: .metadata.labels.camel\.apache\.org\/kit\.layout
+      name: Layout
       type: string
     - description: The integration kit image
       jsonPath: .status.image

--- a/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -43,6 +43,22 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: The default build strategy
+      jsonPath: .status.build.buildStrategy
+      name: Build strategy
+      type: string
+    - description: The default publish strategy
+      jsonPath: .status.build.publishStrategy
+      name: Publish strategy
+      type: string
+    - description: The container registry address
+      jsonPath: .status.build.registry.address
+      name: Registry address
+      type: string
+    - description: The default runtime version
+      jsonPath: .status.build.runtimeVersion
+      name: Default runtime
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/config/crd/bases/camel.apache.org_integrations.yaml
@@ -43,6 +43,14 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: The runtime version
+      jsonPath: .status.runtimeProvider
+      name: Runtime Provider
+      type: string
+    - description: The runtime provider
+      jsonPath: .status.runtimeVersion
+      name: Runtime Version
+      type: string
     - description: The integration kit
       jsonPath: .status.integrationKit.name
       name: Kit

--- a/helm/camel-k/crds/crd-camel-catalog.yaml
+++ b/helm/camel-k/crds/crd-camel-catalog.yaml
@@ -39,13 +39,17 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The Camel K Runtime version
+    - description: The Runtime provider
+      jsonPath: .spec.runtime.provider
+      name: Runtime Provider
+      type: string
+    - description: The Runtime version
       jsonPath: .spec.runtime.version
       name: Runtime Version
       type: string
-    - description: The Camel K Runtime provider
-      jsonPath: .spec.runtime.provider
-      name: Runtime Provider
+    - description: The Camel version
+      jsonPath: .spec.runtime.metadata.camel\.version
+      name: Runtime Camel Version
       type: string
     - description: The catalog phase
       jsonPath: .status.phase

--- a/helm/camel-k/crds/crd-integration-kit.yaml
+++ b/helm/camel-k/crds/crd-integration-kit.yaml
@@ -39,6 +39,10 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - description: The integration kit alias
+      jsonPath: .metadata.labels.camel\.apache\.org\/kit\.alias
+      name: Alias
+      type: string
     - description: The integration kit phase
       jsonPath: .status.phase
       name: Phase
@@ -46,6 +50,10 @@ spec:
     - description: The integration kit type
       jsonPath: .metadata.labels.camel\.apache\.org\/kit\.type
       name: Type
+      type: string
+    - description: The integration kit layout
+      jsonPath: .metadata.labels.camel\.apache\.org\/kit\.layout
+      name: Layout
       type: string
     - description: The integration kit image
       jsonPath: .status.image

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -43,6 +43,22 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: The default build strategy
+      jsonPath: .status.build.buildStrategy
+      name: Build strategy
+      type: string
+    - description: The default publish strategy
+      jsonPath: .status.build.publishStrategy
+      name: Publish strategy
+      type: string
+    - description: The container registry address
+      jsonPath: .status.build.registry.address
+      name: Registry address
+      type: string
+    - description: The default runtime version
+      jsonPath: .status.build.runtimeVersion
+      name: Default runtime
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -43,6 +43,14 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: The runtime version
+      jsonPath: .status.runtimeProvider
+      name: Runtime Provider
+      type: string
+    - description: The runtime provider
+      jsonPath: .status.runtimeVersion
+      name: Runtime Version
+      type: string
     - description: The integration kit
       jsonPath: .status.integrationKit.name
       name: Kit

--- a/pkg/apis/camel/v1/camelcatalog_types.go
+++ b/pkg/apis/camel/v1/camelcatalog_types.go
@@ -32,8 +32,9 @@ const (
 // +kubebuilder:resource:path=camelcatalogs,scope=Namespaced,shortName=cc,categories=kamel;camel
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="Runtime Version",type=string,JSONPath=`.spec.runtime.version`,description="The Camel K Runtime version"
-// +kubebuilder:printcolumn:name="Runtime Provider",type=string,JSONPath=`.spec.runtime.provider`,description="The Camel K Runtime provider"
+// +kubebuilder:printcolumn:name="Runtime Provider",type=string,JSONPath=`.spec.runtime.provider`,description="The Runtime provider"
+// +kubebuilder:printcolumn:name="Runtime Version",type=string,JSONPath=`.spec.runtime.version`,description="The Runtime version"
+// +kubebuilder:printcolumn:name="Runtime Camel Version",type=string,JSONPath=`.spec.runtime.metadata.camel\.version`,description="The Camel version"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The catalog phase"
 
 // CamelCatalog represents the languages, components, data formats and capabilities enabled on a given runtime provider. The catalog may be statically generated.

--- a/pkg/apis/camel/v1/integration_types.go
+++ b/pkg/apis/camel/v1/integration_types.go
@@ -34,6 +34,8 @@ import (
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The integration phase"
+// +kubebuilder:printcolumn:name="Runtime Provider",type=string,JSONPath=`.status.runtimeProvider`,description="The runtime version"
+// +kubebuilder:printcolumn:name="Runtime Version",type=string,JSONPath=`.status.runtimeVersion`,description="The runtime provider"
 // +kubebuilder:printcolumn:name="Kit",type=string,JSONPath=`.status.integrationKit.name`,description="The integration kit"
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`,description="The number of pods"
 

--- a/pkg/apis/camel/v1/integrationkit_types.go
+++ b/pkg/apis/camel/v1/integrationkit_types.go
@@ -32,8 +32,10 @@ import (
 // +kubebuilder:resource:path=integrationkits,scope=Namespaced,shortName=ik,categories=kamel;camel
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Alias",type=string,JSONPath=`.metadata.labels.camel\.apache\.org\/kit\.alias`,description="The integration kit alias"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The integration kit phase"
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.metadata.labels.camel\.apache\.org\/kit\.type`,description="The integration kit type"
+// +kubebuilder:printcolumn:name="Layout",type=string,JSONPath=`.metadata.labels.camel\.apache\.org\/kit\.layout`,description="The integration kit layout"
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.status.image`,description="The integration kit image"
 
 // IntegrationKit defines a container image and additional configuration needed to run an `Integration`.

--- a/pkg/apis/camel/v1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1/integrationplatform_types.go
@@ -68,6 +68,10 @@ type IntegrationPlatformStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The integration platform phase"
+// +kubebuilder:printcolumn:name="Build strategy",type=string,JSONPath=`.status.build.buildStrategy`,description="The default build strategy"
+// +kubebuilder:printcolumn:name="Publish strategy",type=string,JSONPath=`.status.build.publishStrategy`,description="The default publish strategy"
+// +kubebuilder:printcolumn:name="Registry address",type=string,JSONPath=`.status.build.registry.address`,description="The container registry address"
+// +kubebuilder:printcolumn:name="Default runtime",type=string,JSONPath=`.status.build.runtimeVersion`,description="The default runtime version"
 
 // IntegrationPlatform is the resource used to drive the Camel K operator behavior.
 // It defines the behavior of all Custom Resources (`IntegrationKit`, `Integration`, `Kamelet`) in the given namespace.

--- a/pkg/client/camel/clientset/versioned/fake/register.go
+++ b/pkg/client/camel/clientset/versioned/fake/register.go
@@ -40,14 +40,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/camel/clientset/versioned/scheme/register.go
+++ b/pkg/client/camel/clientset/versioned/scheme/register.go
@@ -40,14 +40,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.


### PR DESCRIPTION
With this PR we are exposing some useful information by default int kube CLI:

```
squake:~/workspace/camel-k [main]$ kubectl get it
NAME   PHASE     RUNTIME PROVIDER   RUNTIME VERSION   KIT                        REPLICAS
test   Running   quarkus            3.20.1-SNAPSHOT   kit-ch596vsqgf4s73emsj6g   1
squake:~/workspace/camel-k [main]$ kubectl get ik
NAME                       ALIAS            PHASE   TYPE       LAYOUT     IMAGE
kit-ch596vsqgf4s73emsj6g   my-awesome-kit   Ready   platform   fast-jar   10.100.175.64/default/camel-k-kit-ch596vsqgf4s73emsj6g@sha256:33fe9888322e13543e62f8c2618772821d34a1899efaa80c25f2d98309ca3c2e
squake:~/workspace/camel-k [main]$ kubectl get ip
NAME      PHASE   BUILD STRATEGY   PUBLISH STRATEGY   REGISTRY ADDRESS   DEFAULT RUNTIME
camel-k   Ready   pod              Spectrum           10.100.175.64      2.16.0-SNAPSHOT
squake:~/workspace/camel-k [main]$ kubectl get camelcatalog
NAME                            RUNTIME PROVIDER   RUNTIME VERSION   RUNTIME CAMEL VERSION   PHASE
camel-catalog-2.16.0-snapshot   quarkus            2.16.0-SNAPSHOT   3.20.1                  Ready
```

Alias in kit is an annotation that the end user can customize updating the CR with any value he choose.

Closes #4205
Closes #4172

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cli): provide useful info in kubectl CLI
```
