### PR TITLE
fix: Always uninstall IntegrationPlatform resources

### DIFF
--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -466,7 +466,7 @@ func (o *uninstallCmdOptions) uninstallServiceAccounts(ctx context.Context, c cl
 }
 
 func (o *uninstallCmdOptions) uninstallIntegrationPlatform(ctx context.Context, c client.Client) error {
-	integrationPlatforms, err := c.CamelV1().IntegrationPlatforms(o.Namespace).List(ctx, defaultListOptions)
+	integrationPlatforms, err := c.CamelV1().IntegrationPlatforms(o.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Make sure to remove IntegrationPlatform resources from operator namespace on uninstall
- Do not filter on label "app=camel-k" when removing IntegrationPlatform resources

**Release Note**
```release-note
fix: Always uninstall IntegrationPlatform resources
```
