### PR TITLE
chore: Restrict nightly coverage workflow execution

### DIFF
--- a/.github/workflows/nightly-coverage.yml
+++ b/.github/workflows/nightly-coverage.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'apache/camel-k'
     runs-on: ubuntu-20.04
     name: Update Coverage Badge
     steps:


### PR DESCRIPTION
- Only run workflow on GitHub repository 'apache/camel-k'
- Avoids merge conflicts on forked repositories