### PR TITLE
fix(e2e): increase commonwithcustominstall timeout

### DIFF
--- a/e2e/commonwithcustominstall/reset_test.go
+++ b/e2e/commonwithcustominstall/reset_test.go
@@ -37,7 +37,6 @@ func TestKamelReset(t *testing.T) {
 		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
 
 		t.Run("Reset the whole platform", func(t *testing.T) {
-
 			name := "yaml1"
 			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))

--- a/script/Makefile
+++ b/script/Makefile
@@ -276,7 +276,7 @@ test-common: do-build
 #
 test-common-with-custom-install: do-build
 	FAILED=0; STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)"; \
-	go test -timeout 60m -v ./e2e/commonwithcustominstall -tags=integration $(TEST_INSTALL_RUN) $(GOTESTFMT) || FAILED=1; \
+	go test -timeout 90m -v ./e2e/commonwithcustominstall -tags=integration $(TEST_INSTALL_RUN) $(GOTESTFMT) || FAILED=1; \
 	exit $${FAILED}
 
 #


### PR DESCRIPTION
Closes #4316

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): increase commonwithcustominstall timeout
```
