### PR TITLE
chore(dep): Remove archived github.com/pkg/errors dependency

### DIFF
--- a/addons/keda/keda_test.go
+++ b/addons/keda/keda_test.go
@@ -20,6 +20,7 @@ package keda
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/apache/camel-k/v2/addons/keda/duck/v1alpha1"
@@ -29,7 +30,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/test"
-	"github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -438,7 +439,7 @@ func getSecret(e *trait.Environment) *corev1.Secret {
 func createBasicTestEnvironment(resources ...runtime.Object) *trait.Environment {
 	fakeClient, err := test.NewFakeClient(resources...)
 	if err != nil {
-		panic(errors.Wrap(err, "could not create fake client"))
+		panic(fmt.Errorf("could not create fake client: %w", err))
 	}
 
 	var it *camelv1.Integration

--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -5522,9 +5522,9 @@ in order to save resources when the integration does not need to be executed.
 Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 
 The rules for using a Kubernetes CronJob are the following:
-- `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
-- `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
-  `cron:tab?schedule=0/2$\{plus}*\{plus}*\{plus}*\{plus}?` or `quartz:trigger?cron=0\{plus}0/2\{plus}*\{plus}*\{plus}*\{plus}?`.
+  - `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
+  - `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
+    `cron:tab?schedule=0/2$\{plus}*\{plus}*\{plus}*\{plus}?` or `quartz:trigger?cron=0\{plus}0/2\{plus}*\{plus}*\{plus}*\{plus}?`.
 
 
 [cols="2,2a",options="header"]

--- a/docs/modules/traits/pages/cron.adoc
+++ b/docs/modules/traits/pages/cron.adoc
@@ -11,9 +11,9 @@ in order to save resources when the integration does not need to be executed.
 Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 
 The rules for using a Kubernetes CronJob are the following:
-- `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
-- `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
-  `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?` or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.
+  - `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
+  - `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
+    `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?` or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.
 
 
 This trait is available in the following profiles: **Kubernetes, Knative, OpenShift**.

--- a/e2e/common/cli/default.go
+++ b/e2e/common/cli/default.go
@@ -23,4 +23,4 @@ package cli
 import "github.com/apache/camel-k/v2/e2e/support"
 
 var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID", support.GetCIProcessID())

--- a/e2e/common/config/default.go
+++ b/e2e/common/config/default.go
@@ -23,4 +23,4 @@ package config
 import "github.com/apache/camel-k/v2/e2e/support"
 
 var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID", support.GetCIProcessID())

--- a/e2e/common/languages/default.go
+++ b/e2e/common/languages/default.go
@@ -23,4 +23,4 @@ package languages
 import "github.com/apache/camel-k/v2/e2e/support"
 
 var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID", support.GetCIProcessID())

--- a/e2e/common/misc/client_test.go
+++ b/e2e/common/misc/client_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
-	"github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/client/camel/clientset/versioned"
 	. "github.com/onsi/gomega"
 )

--- a/e2e/common/misc/default.go
+++ b/e2e/common/misc/default.go
@@ -23,4 +23,4 @@ package misc
 import "github.com/apache/camel-k/v2/e2e/support"
 
 var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID", support.GetCIProcessID())

--- a/e2e/common/misc/kamelet_binding_test.go
+++ b/e2e/common/misc/kamelet_binding_test.go
@@ -30,7 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
-	"github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 )
 

--- a/e2e/common/misc/kamelet_binding_with_image_test.go
+++ b/e2e/common/misc/kamelet_binding_with_image_test.go
@@ -31,7 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
-	"github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 )
 
 func TestPipeWithImage(t *testing.T) {

--- a/e2e/common/misc/kamelet_update_test.go
+++ b/e2e/common/misc/kamelet_update_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
-	"github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 )
 
 const customLabel = "custom-label"

--- a/e2e/common/traits/default.go
+++ b/e2e/common/traits/default.go
@@ -23,4 +23,4 @@ package traits
 import "github.com/apache/camel-k/v2/e2e/support"
 
 var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID", support.GetCIProcessID())

--- a/e2e/common/traits/deployment_test.go
+++ b/e2e/common/traits/deployment_test.go
@@ -23,8 +23,9 @@ limitations under the License.
 package traits
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
 	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/e2e/common/traits/errored_trait_test.go
+++ b/e2e/common/traits/errored_trait_test.go
@@ -30,7 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
-	"github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 )
 
 func TestErroredTrait(t *testing.T) {

--- a/e2e/common/traits/health_test.go
+++ b/e2e/common/traits/health_test.go
@@ -25,10 +25,11 @@ package traits
 import (
 	"encoding/json"
 	"fmt"
-	camelv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"strings"
 	"testing"
 	"time"
+
+	camelv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 
 	. "github.com/onsi/gomega"
 

--- a/e2e/common/traits/pdb_test.go
+++ b/e2e/common/traits/pdb_test.go
@@ -31,7 +31,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -102,7 +102,7 @@ func TestPodDisruptionBudgetTrait(t *testing.T) {
 			Name: pods[0].Name,
 		},
 	})
-	Expect(err).To(MatchError(&errors.StatusError{
+	Expect(err).To(MatchError(&k8serrors.StatusError{
 		ErrStatus: metav1.Status{
 			Status:  "Failure",
 			Message: "Cannot evict pod as it would violate the pod's disruption budget.",
@@ -152,7 +152,7 @@ func podDisruptionBudget(ns string, name string) func() *policyv1.PodDisruptionB
 			},
 		}
 		err := TestClient().Get(TestContext, ctrl.ObjectKeyFromObject(&pdb), &pdb)
-		if err != nil && errors.IsNotFound(err) {
+		if err != nil && k8serrors.IsNotFound(err) {
 			return nil
 		} else if err != nil {
 			panic(err)

--- a/e2e/common/traits/prometheus_test.go
+++ b/e2e/common/traits/prometheus_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -83,7 +83,7 @@ func podMonitor(ns string, name string) func() *monitoringv1.PodMonitor {
 			Name:      name,
 		}
 		err := TestClient().Get(TestContext, key, &pm)
-		if err != nil && errors.IsNotFound(err) {
+		if err != nil && k8serrors.IsNotFound(err) {
 			return nil
 		} else if err != nil {
 			panic(err)

--- a/e2e/commonwithcustominstall/debug_test.go
+++ b/e2e/commonwithcustominstall/debug_test.go
@@ -25,12 +25,13 @@ package commonwithcustominstall
 import (
 	"context"
 	"fmt"
-	. "github.com/apache/camel-k/v2/e2e/support"
-	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 	"net"
 	"testing"
 	"time"
+
+	. "github.com/apache/camel-k/v2/e2e/support"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestKamelCLIDebug(t *testing.T) {

--- a/e2e/commonwithcustominstall/platform_traits_test.go
+++ b/e2e/commonwithcustominstall/platform_traits_test.go
@@ -74,4 +74,3 @@ func TestTraitOnIntegrationPlatform(t *testing.T) {
 		})
 	})
 }
-

--- a/e2e/knative/default.go
+++ b/e2e/knative/default.go
@@ -23,4 +23,4 @@ package knative
 import "github.com/apache/camel-k/v2/e2e/support"
 
 var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.GetCIProcessID())
-var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID",support.GetCIProcessID())
+var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID", support.GetCIProcessID())

--- a/e2e/knative/knative_platform_test.go
+++ b/e2e/knative/knative_platform_test.go
@@ -33,7 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
-	"github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/util/dsl"
 	"github.com/apache/camel-k/v2/pkg/util/knative"
 )

--- a/e2e/knative/openapi_test.go
+++ b/e2e/knative/openapi_test.go
@@ -23,9 +23,10 @@ limitations under the License.
 package knative
 
 import (
+	"testing"
+
 	. "github.com/apache/camel-k/v2/e2e/support"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestOpenAPIService(t *testing.T) {

--- a/e2e/support/csv.go
+++ b/e2e/support/csv.go
@@ -29,7 +29,7 @@ import (
 	"unsafe"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
@@ -97,7 +97,7 @@ func CatalogSource(ns, name string) func() *olm.CatalogSource {
 				Name:      name,
 			},
 		}
-		if err := TestClient().Get(TestContext, ctrl.ObjectKeyFromObject(cs), cs); err != nil && errors.IsNotFound(err) {
+		if err := TestClient().Get(TestContext, ctrl.ObjectKeyFromObject(cs), cs); err != nil && k8serrors.IsNotFound(err) {
 			return nil
 		} else if err != nil {
 			log.Errorf(err, "Error while retrieving CatalogSource %s", name)
@@ -119,7 +119,7 @@ func CatalogSourcePhase(ns, name string) func() string {
 func CatalogSourcePod(ns, csName string) func() *corev1.Pod {
 	return func() *corev1.Pod {
 		podList, err := TestClient().CoreV1().Pods(ns).List(TestContext, metav1.ListOptions{})
-		if err != nil && errors.IsNotFound(err) {
+		if err != nil && k8serrors.IsNotFound(err) {
 			return nil
 		} else if err != nil {
 			panic(err)

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -27,6 +27,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -44,7 +45,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -348,7 +349,7 @@ func verifyGlobalOperator() error {
 
 	oppod := OperatorPod(opns)()
 	if oppod == nil {
-		return fmt.Errorf("No operator pod detected in namespace %s. Operator install is a pre-requisite of the test", opns)
+		return fmt.Errorf("no operator pod detected in namespace %s. Operator install is a pre-requisite of the test", opns)
 	}
 
 	return nil

--- a/e2e/support/test_util.go
+++ b/e2e/support/test_util.go
@@ -23,10 +23,11 @@ limitations under the License.
 package support
 
 import (
+	"os"
+
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
-	"os"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/openshift/api v3.9.1-0.20190927182313-d4a64ec2cbd8+incompatible
 	github.com/operator-framework/api v0.13.0
 	github.com/otiai10/copy v1.9.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.60.0
 	github.com/prometheus/client_golang v1.15.1
 	github.com/prometheus/client_model v0.4.0
@@ -136,6 +135,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/opencontainers/runc v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect

--- a/pkg/apis/camel/v1/trait/cron.go
+++ b/pkg/apis/camel/v1/trait/cron.go
@@ -27,9 +27,9 @@ package trait
 // Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 //
 // The rules for using a Kubernetes CronJob are the following:
-// - `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
-// - `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
-//   `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?` or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.
+//   - `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
+//   - `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
+//     `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?` or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.
 //
 // +camel-k:trait=cron.
 type CronTrait struct {

--- a/pkg/client/apply.go
+++ b/pkg/client/apply.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -27,7 +28,7 @@ import (
 
 	"github.com/apache/camel-k/v2/pkg/util/log"
 	"github.com/apache/camel-k/v2/pkg/util/patch"
-	"github.com/pkg/errors"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,12 +18,13 @@ limitations under the License.
 package client
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	user "github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/scale"
 

--- a/pkg/cmd/debug.go
+++ b/pkg/cmd/debug.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -28,7 +29,7 @@ import (
 	camelv1 "github.com/apache/camel-k/v2/pkg/client/camel/clientset/versioned/typed/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	k8slog "github.com/apache/camel-k/v2/pkg/util/kubernetes/log"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/cmd/local/container.go
+++ b/pkg/cmd/local/container.go
@@ -19,6 +19,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/apache/camel-k/v2/pkg/util"
 	"github.com/apache/camel-k/v2/pkg/util/docker"
-	"github.com/pkg/errors"
 )
 
 // Local Docker file system management functions.
@@ -110,7 +110,7 @@ func buildBaseImage(ctx context.Context, stdout, stderr io.Writer) error {
 
 	// Run the command.
 	if err := cmd.Run(); err != nil {
-		return errors.Errorf("base image containerization did not run successfully: %v", err)
+		return fmt.Errorf("base image containerization did not run successfully: %w", err)
 	}
 
 	return nil
@@ -206,7 +206,7 @@ func buildIntegrationImage(ctx context.Context, image string, stdout, stderr io.
 
 	// Run the command.
 	if err := cmd.Run(); err != nil {
-		return errors.Errorf("integration image containerization did not run successfully: %v", err)
+		return fmt.Errorf("integration image containerization did not run successfully: %w", err)
 	}
 
 	return nil
@@ -239,7 +239,7 @@ func RunIntegrationImage(ctx context.Context, image string, stdout, stderr io.Wr
 
 	// Run the command.
 	if err := cmd.Run(); err != nil {
-		return errors.Errorf("integration image did not run successfully: %v", err)
+		return fmt.Errorf("integration image did not run successfully: %w", err)
 	}
 
 	return nil

--- a/pkg/cmd/local/local.go
+++ b/pkg/cmd/local/local.go
@@ -20,13 +20,13 @@ package local
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/scylladb/go-set/strset"
 	"github.com/spf13/cobra"
 
@@ -52,7 +52,7 @@ func GetDependencies(ctx context.Context, cmd *cobra.Command, srcs, userDependen
 	// Fetch existing catalog or create new one if one does not already exist
 	catalog, err := CreateCamelCatalog(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create Camel catalog")
+		return nil, fmt.Errorf("failed to create Camel catalog: %w", err)
 	}
 
 	// Validate user-provided dependencies against Camel catalog
@@ -61,7 +61,7 @@ func GetDependencies(ctx context.Context, cmd *cobra.Command, srcs, userDependen
 	// Get top-level dependencies from sources
 	dependencies, err := getTopLevelDependencies(ctx, catalog, srcs)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to resolve dependencies from source")
+		return nil, fmt.Errorf("failed to resolve dependencies from source: %w", err)
 	}
 
 	// Add additional user-provided dependencies
@@ -77,7 +77,7 @@ func GetDependencies(ctx context.Context, cmd *cobra.Command, srcs, userDependen
 
 		dependencies, err = getTransitiveDependencies(ctx, catalog, dependencies, repositories)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to compute transitive dependencies")
+			return nil, fmt.Errorf("failed to compute transitive dependencies: %w", err)
 		}
 	}
 
@@ -278,7 +278,7 @@ func printDependencies(format string, dependencies []string, cmd *cobra.Command)
 		}
 		fmt.Fprint(cmd.OutOrStdout(), string(data))
 	default:
-		return errors.Errorf("unknown output format: %s", format)
+		return fmt.Errorf("unknown output format: %s", format)
 	}
 	return nil
 }
@@ -353,7 +353,7 @@ func validatePropertyFile(fileName string) error {
 	}
 
 	if file, err := os.Stat(fileName); err != nil {
-		return errors.Wrapf(err, "unable to access property file %s", fileName)
+		return fmt.Errorf("unable to access property file %s: %w", fileName, err)
 	} else if file.IsDir() {
 		return fmt.Errorf("property file %s is a directory", fileName)
 	}

--- a/pkg/cmd/local_build.go
+++ b/pkg/cmd/local_build.go
@@ -18,9 +18,9 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/apache/camel-k/v2/pkg/cmd/local"

--- a/pkg/cmd/local_run.go
+++ b/pkg/cmd/local_run.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -25,7 +26,7 @@ import (
 
 	"github.com/apache/camel-k/v2/pkg/cmd/local"
 	"github.com/apache/camel-k/v2/pkg/util"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 )
 
@@ -123,7 +124,7 @@ func (o *localRunCmdOptions) validate(args []string) error {
 		if ok, err := util.DirectoryExists(o.IntegrationDirectory); err != nil {
 			return err
 		} else if !ok {
-			return errors.Errorf("integration directory %q does not exist", o.IntegrationDirectory)
+			return fmt.Errorf("integration directory %q does not exist", o.IntegrationDirectory)
 		}
 	}
 

--- a/pkg/cmd/modeline.go
+++ b/pkg/cmd/modeline.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -26,7 +27,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/cmd/source"
 	"github.com/apache/camel-k/v2/pkg/util"
 	"github.com/apache/camel-k/v2/pkg/util/modeline"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -129,7 +130,7 @@ func createKamelWithModelineCommand(ctx context.Context, args []string) (*cobra.
 
 	opts, err := extractModelineOptions(ctx, files, rootCmd)
 	if err != nil {
-		return rootCmd, nil, errors.Wrap(err, "cannot read sources")
+		return rootCmd, nil, fmt.Errorf("cannot read sources: %w", err)
 	}
 
 	// Extract list of property/trait names already specified by the user.
@@ -196,7 +197,7 @@ func extractModelineOptions(ctx context.Context, sources []string, cmd *cobra.Co
 
 	resolvedSources, err := source.Resolve(ctx, sources, false, cmd)
 	if err != nil {
-		return opts, errors.Wrap(err, "failed to resolve sources")
+		return opts, fmt.Errorf("failed to resolve sources: %w", err)
 	}
 
 	for _, resolvedSource := range resolvedSources {
@@ -219,7 +220,7 @@ func extractModelineOptions(ctx context.Context, sources []string, cmd *cobra.Co
 func extractModelineOptionsFromSource(resolvedSource source.Source) ([]modeline.Option, error) {
 	ops, err := modeline.Parse(resolvedSource.Name, resolvedSource.Content)
 	if err != nil {
-		return ops, errors.Wrapf(err, "cannot process file %s", resolvedSource.Location)
+		return ops, fmt.Errorf("cannot process file %s: %w", resolvedSource.Location, err)
 	}
 	for i, o := range ops {
 		if disallowedOptions[o.Name] {

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 
 	"go.uber.org/automaxprocs/maxprocs"
@@ -271,7 +270,7 @@ func findOrCreateIntegrationPlatform(ctx context.Context, c client.Client, opera
 
 		// Make sure that IntegrationPlatform installed in operator namespace can be seen by others
 		if err := install.IntegrationPlatformViewerRole(ctx, c, operatorNamespace); err != nil && !k8serrors.IsAlreadyExists(err) {
-			return errors.Wrap(err, "Error while installing global IntegrationPlatform viewer role")
+			return fmt.Errorf("error while installing global IntegrationPlatform viewer role: %w", err)
 		}
 	} else {
 		return err

--- a/pkg/cmd/rebuild.go
+++ b/pkg/cmd/rebuild.go
@@ -18,9 +18,9 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -94,7 +94,7 @@ func (o *rebuildCmdOptions) run(cmd *cobra.Command, args []string) error {
 func (o *rebuildCmdOptions) listAllIntegrations(c client.Client) ([]v1.Integration, error) {
 	list := v1.NewIntegrationList()
 	if err := c.List(o.Context, &list, k8sclient.InNamespace(o.Namespace)); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("could not retrieve integrations from namespace %s", o.Namespace))
+		return nil, fmt.Errorf("could not retrieve integrations from namespace %s: %w", o.Namespace, err)
 	}
 	return list.Items, nil
 }
@@ -108,7 +108,7 @@ func (o *rebuildCmdOptions) getIntegrations(c client.Client, names []string) ([]
 			Namespace: o.Namespace,
 		}
 		if err := c.Get(o.Context, key, &it); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("could not find integration %s in namespace %s", it.Name, o.Namespace))
+			return nil, fmt.Errorf("could not find integration %s in namespace %s: %w", it.Name, o.Namespace, err)
 		}
 		ints = append(ints, it)
 	}
@@ -120,7 +120,7 @@ func (o *rebuildCmdOptions) rebuildIntegrations(c k8sclient.StatusClient, integr
 		it := i
 		it.Status = v1.IntegrationStatus{}
 		if err := c.Status().Update(o.Context, &it); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("could not rebuild integration %s in namespace %s", it.Name, o.Namespace))
+			return fmt.Errorf("could not rebuild integration %s in namespace %s: %w", it.Name, o.Namespace, err)
 		}
 	}
 	return nil

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -18,12 +18,13 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/apis/camel/v1alpha1"
 	"github.com/apache/camel-k/v2/pkg/client"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,7 +105,7 @@ func (o *resetCmdOptions) reset(cmd *cobra.Command, _ []string) {
 func (o *resetCmdOptions) deleteAllIntegrations(c client.Client) (int, error) {
 	list := v1.NewIntegrationList()
 	if err := c.List(o.Context, &list, k8sclient.InNamespace(o.Namespace)); err != nil {
-		return 0, errors.Wrap(err, fmt.Sprintf("could not retrieve integrations from namespace %s", o.Namespace))
+		return 0, fmt.Errorf("could not retrieve integrations from namespace %s: %w", o.Namespace, err)
 	}
 	for _, i := range list.Items {
 		it := i
@@ -113,7 +114,7 @@ func (o *resetCmdOptions) deleteAllIntegrations(c client.Client) (int, error) {
 			continue
 		}
 		if err := c.Delete(o.Context, &it); err != nil {
-			return 0, errors.Wrap(err, fmt.Sprintf("could not delete integration %s from namespace %s", it.Name, it.Namespace))
+			return 0, fmt.Errorf("could not delete integration %s from namespace %s: %w", it.Name, it.Namespace, err)
 		}
 	}
 	return len(list.Items), nil
@@ -122,12 +123,12 @@ func (o *resetCmdOptions) deleteAllIntegrations(c client.Client) (int, error) {
 func (o *resetCmdOptions) deleteAllIntegrationKits(c client.Client) (int, error) {
 	list := v1.NewIntegrationKitList()
 	if err := c.List(o.Context, &list, k8sclient.InNamespace(o.Namespace)); err != nil {
-		return 0, errors.Wrap(err, fmt.Sprintf("could not retrieve integration Kits from namespace %s", o.Namespace))
+		return 0, fmt.Errorf("could not retrieve integration Kits from namespace %s: %w", o.Namespace, err)
 	}
 	for _, i := range list.Items {
 		kit := i
 		if err := c.Delete(o.Context, &kit); err != nil {
-			return 0, errors.Wrap(err, fmt.Sprintf("could not delete integration kit %s from namespace %s", kit.Name, kit.Namespace))
+			return 0, fmt.Errorf("could not delete integration kit %s from namespace %s: %w", kit.Name, kit.Namespace, err)
 		}
 	}
 	return len(list.Items), nil
@@ -136,12 +137,12 @@ func (o *resetCmdOptions) deleteAllIntegrationKits(c client.Client) (int, error)
 func (o *resetCmdOptions) deleteAllPipes(c client.Client) (int, error) {
 	list := v1.NewPipeList()
 	if err := c.List(o.Context, &list, k8sclient.InNamespace(o.Namespace)); err != nil {
-		return 0, errors.Wrap(err, fmt.Sprintf("could not retrieve Pipes from namespace %s", o.Namespace))
+		return 0, fmt.Errorf("could not retrieve Pipes from namespace %s: %w", o.Namespace, err)
 	}
 	for _, i := range list.Items {
 		klb := i
 		if err := c.Delete(o.Context, &klb); err != nil {
-			return 0, errors.Wrap(err, fmt.Sprintf("could not delete Pipe %s from namespace %s", klb.Name, klb.Namespace))
+			return 0, fmt.Errorf("could not delete Pipe %s from namespace %s: %w", klb.Name, klb.Namespace, err)
 		}
 	}
 	return len(list.Items), nil
@@ -151,12 +152,12 @@ func (o *resetCmdOptions) deleteAllPipes(c client.Client) (int, error) {
 func (o *resetCmdOptions) deleteAllKameletBindings(c client.Client) (int, error) {
 	list := v1alpha1.NewKameletBindingList()
 	if err := c.List(o.Context, &list, k8sclient.InNamespace(o.Namespace)); err != nil {
-		return 0, errors.Wrap(err, fmt.Sprintf("could not retrieve KameletBindings from namespace %s", o.Namespace))
+		return 0, fmt.Errorf("could not retrieve KameletBindings from namespace %s: %w", o.Namespace, err)
 	}
 	for _, i := range list.Items {
 		klb := i
 		if err := c.Delete(o.Context, &klb); err != nil {
-			return 0, errors.Wrap(err, fmt.Sprintf("could not delete KameletBinding %s from namespace %s", klb.Name, klb.Namespace))
+			return 0, fmt.Errorf("could not delete KameletBinding %s from namespace %s: %w", klb.Name, klb.Namespace, err)
 		}
 	}
 	return len(list.Items), nil
@@ -165,7 +166,7 @@ func (o *resetCmdOptions) deleteAllKameletBindings(c client.Client) (int, error)
 func (o *resetCmdOptions) resetIntegrationPlatform(c client.Client) error {
 	list := v1.NewIntegrationPlatformList()
 	if err := c.List(o.Context, &list, k8sclient.InNamespace(o.Namespace)); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("could not retrieve integration platform from namespace %s", o.Namespace))
+		return fmt.Errorf("could not retrieve integration platform from namespace %s: %w", o.Namespace, err)
 	}
 	if len(list.Items) > 1 {
 		return fmt.Errorf("expected 1 integration platform in the namespace, found: %d", len(list.Items))

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -19,11 +19,11 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -180,14 +180,14 @@ func (command *RootCmdOptions) preRun(cmd *cobra.Command, _ []string) error {
 	if !isOfflineCommand(cmd) {
 		c, err := command.GetCmdClient()
 		if err != nil {
-			return errors.Wrap(err, "cannot get command client")
+			return fmt.Errorf("cannot get command client: %w", err)
 		}
 		if command.Namespace == "" {
 			current := viper.GetString("kamel.config.default-namespace")
 			if current == "" {
 				defaultNS, err := c.GetCurrentNamespace(command.KubeConfig)
 				if err != nil {
-					return errors.Wrap(err, "cannot get current namespace")
+					return fmt.Errorf("cannot get current namespace: %w", err)
 				}
 				current = defaultNS
 			}

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -524,7 +524,7 @@ func TestRunValidateArgs(t *testing.T) {
 	args = []string{"missing_file"}
 	err = runCmdOptions.validateArgs(rootCmd, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "One of the provided sources is not reachable: missing file or unsupported scheme in missing_file", err.Error())
+	assert.Equal(t, "one of the provided sources is not reachable: missing file or unsupported scheme in missing_file", err.Error())
 }
 
 func TestResolvePodTemplate(t *testing.T) {

--- a/pkg/cmd/source/source.go
+++ b/pkg/cmd/source/source.go
@@ -32,7 +32,6 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/google/go-github/v32/github"
-	"github.com/pkg/errors"
 )
 
 // Source represents the source file of an Integration.
@@ -202,9 +201,9 @@ func resolveGist(ctx context.Context, location string, compress bool, cmd *cobra
 // resolveLocal resolves a source from the local file system.
 func resolveLocal(location string, compress bool) (Source, error) {
 	if _, err := os.Stat(location); err != nil && os.IsNotExist(err) {
-		return Source{}, errors.Wrapf(err, "file %s does not exist", location)
+		return Source{}, fmt.Errorf("file %s does not exist: %w", location, err)
 	} else if err != nil {
-		return Source{}, errors.Wrapf(err, "error while accessing file %s", location)
+		return Source{}, fmt.Errorf("error while accessing file %s: %w", location, err)
 	}
 
 	answer, err := newSource(location, compress, func() ([]byte, error) {

--- a/pkg/cmd/source/util.go
+++ b/pkg/cmd/source/util.go
@@ -23,8 +23,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -52,7 +50,7 @@ func IsLocalAndFileExists(uri string) (bool, error) {
 		}
 
 		// If it is a different error (ie, permission denied) we should report it back
-		return false, errors.Wrap(err, fmt.Sprintf("file system error while looking for %s", uri))
+		return false, fmt.Errorf("file system error while looking for %s: %w", uri, err)
 	}
 
 	return !info.IsDir(), nil

--- a/pkg/cmd/uninstall.go
+++ b/pkg/cmd/uninstall.go
@@ -19,10 +19,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -137,7 +137,7 @@ func (o *uninstallCmdOptions) uninstall(cmd *cobra.Command, _ []string) error {
 	if o.OlmEnabled {
 		var err error
 		if uninstallViaOLM, err = olm.IsAPIAvailable(o.Context, c, o.Namespace); err != nil {
-			return errors.Wrap(err, "error while checking OLM availability. Run with '--olm=false' to skip this check")
+			return fmt.Errorf("error while checking OLM availability. Run with '--olm=false' to skip this check: %w", err)
 		}
 
 		if uninstallViaOLM {
@@ -169,7 +169,7 @@ func (o *uninstallCmdOptions) uninstall(cmd *cobra.Command, _ []string) error {
 				defer cancel()
 				err := watch.WaitPodToTerminate(tctx, c, pod)
 				if err != nil {
-					return errors.Wrap(err, "error while waiting the operator pod to terminate gracefully")
+					return fmt.Errorf("error while waiting the operator pod to terminate gracefully: %w", err)
 				}
 			}
 		}

--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
@@ -121,7 +121,7 @@ func (r *reconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 	var instance v1.Build
 
 	if err := r.client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue

--- a/pkg/controller/build/build_pod.go
+++ b/pkg/controller/build/build_pod.go
@@ -19,13 +19,12 @@ package build
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/build/initialize_pod.go
+++ b/pkg/controller/build/initialize_pod.go
@@ -19,10 +19,9 @@ package build
 
 import (
 	"context"
+	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/pkg/errors"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 )
@@ -51,7 +50,7 @@ func (action *initializePodAction) CanHandle(build *v1.Build) bool {
 // Handle handles the builds.
 func (action *initializePodAction) Handle(ctx context.Context, build *v1.Build) (*v1.Build, error) {
 	if err := deleteBuilderPod(ctx, action.client, build); err != nil {
-		return nil, errors.Wrap(err, "cannot delete build pod")
+		return nil, fmt.Errorf("cannot delete build pod: %w", err)
 	}
 
 	pod, err := getBuilderPod(ctx, action.reader, build)

--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -20,6 +20,7 @@ package build
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -31,8 +32,6 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/pkg/errors"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/platform"
@@ -92,7 +91,7 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 			}
 
 			if err = action.client.Create(ctx, pod); err != nil {
-				return nil, errors.Wrap(err, "cannot create build pod")
+				return nil, fmt.Errorf("cannot create build pod: %w", err)
 			}
 
 		case v1.BuildPhaseRunning:

--- a/pkg/controller/catalog/catalog_controller.go
+++ b/pkg/controller/catalog/catalog_controller.go
@@ -22,7 +22,7 @@ import (
 	goruntime "runtime"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
@@ -126,7 +126,7 @@ func (r *reconcileCatalog) Reconcile(ctx context.Context, request reconcile.Requ
 	var instance v1.CamelCatalog
 
 	if err := r.client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup
 			// logic use finalizers.

--- a/pkg/controller/integration/integration_controller.go
+++ b/pkg/controller/integration/integration_controller.go
@@ -23,8 +23,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/pkg/errors"
-
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -64,7 +62,7 @@ func Add(ctx context.Context, mgr manager.Manager, c client.Client) error {
 		})
 
 	if err != nil {
-		return errors.Wrapf(err, "unable to set up field indexer for status.phase")
+		return fmt.Errorf("unable to set up field indexer for status.phase: %w", err)
 	}
 
 	return add(ctx, mgr, c, newReconciler(mgr, c))

--- a/pkg/controller/integration/kits.go
+++ b/pkg/controller/integration/kits.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 
@@ -38,7 +38,7 @@ import (
 
 func lookupKitsForIntegration(ctx context.Context, c ctrl.Reader, integration *v1.Integration, options ...ctrl.ListOption) ([]v1.IntegrationKit, error) {
 	pl, err := platform.GetForResource(ctx, c, integration)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return nil, err
 	}
 

--- a/pkg/controller/integrationkit/build.go
+++ b/pkg/controller/integrationkit/build.go
@@ -19,12 +19,12 @@ package integrationkit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
-	"github.com/pkg/errors"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +120,7 @@ func (action *buildAction) handleBuildSubmitted(ctx context.Context, kit *v1.Int
 			if pvc, err := kubernetes.LookupPersistentVolumeClaim(env.Ctx, env.Client, builderPodNamespace, defaults.DefaultPVC); pvc != nil || err != nil {
 				err = platform.CreateBuilderServiceAccount(env.Ctx, env.Client, env.Platform)
 				if err != nil {
-					return nil, errors.Wrap(err, "Error while creating Camel K Builder service account")
+					return nil, fmt.Errorf("error while creating Camel K Builder service account: %w", err)
 				}
 			} else {
 				// Fallback to Routine strategy
@@ -157,12 +157,12 @@ func (action *buildAction) handleBuildSubmitted(ctx context.Context, kit *v1.Int
 
 		err = action.client.Delete(ctx, build)
 		if err != nil && !k8serrors.IsNotFound(err) {
-			return nil, errors.Wrap(err, "cannot delete build")
+			return nil, fmt.Errorf("cannot delete build: %w", err)
 		}
 
 		err = action.client.Create(ctx, build)
 		if err != nil {
-			return nil, errors.Wrap(err, "cannot create build")
+			return nil, fmt.Errorf("cannot create build: %w", err)
 		}
 	}
 

--- a/pkg/controller/integrationkit/initialize.go
+++ b/pkg/controller/integrationkit/initialize.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/trait"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // NewInitializeAction creates a new initialization handling action for the kit.
@@ -65,7 +65,7 @@ func (action *initializeAction) Handle(ctx context.Context, kit *v1.IntegrationK
 		)
 
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				// If the catalog is not available, likely it was required to be created
 				// by Integration trait, so we'll need to wait for it the be available
 				kit.Status.Phase = v1.IntegrationKitPhaseWaitingForCatalog

--- a/pkg/controller/integrationkit/integrationkit_controller.go
+++ b/pkg/controller/integrationkit/integrationkit_controller.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -208,7 +208,7 @@ func (r *reconcileIntegrationKit) Reconcile(ctx context.Context, request reconci
 
 	// Fetch the IntegrationKit instance
 	if err := r.client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue

--- a/pkg/controller/integrationplatform/integrationplatform_controller.go
+++ b/pkg/controller/integrationplatform/integrationplatform_controller.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
@@ -135,7 +135,7 @@ func (r *reconcileIntegrationPlatform) Reconcile(ctx context.Context, request re
 	var instance v1.IntegrationPlatform
 
 	if err := r.client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup
 			// logic use finalizers.

--- a/pkg/controller/integrationplatform/kaniko_cache.go
+++ b/pkg/controller/integrationplatform/kaniko_cache.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,12 +108,12 @@ func createKanikoCacheWarmerPod(ctx context.Context, client client.Client, platf
 
 	err := client.Delete(ctx, &pod)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrap(err, "cannot delete Kaniko warmer pod")
+		return fmt.Errorf("cannot delete Kaniko warmer pod: %w", err)
 	}
 
 	err = client.Create(ctx, &pod)
 	if err != nil {
-		return errors.Wrap(err, "cannot create Kaniko warmer pod")
+		return fmt.Errorf("cannot create Kaniko warmer pod: %w", err)
 	}
 
 	return nil

--- a/pkg/controller/kamelet/kamelet_controller.go
+++ b/pkg/controller/kamelet/kamelet_controller.go
@@ -22,7 +22,7 @@ import (
 	goruntime "runtime"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
@@ -127,7 +127,7 @@ func (r *reconcileKamelet) Reconcile(ctx context.Context, request reconcile.Requ
 	var instance v1.Kamelet
 
 	if err := r.client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup
 			// logic use finalizers.

--- a/pkg/controller/kameletbinding/initialize.go
+++ b/pkg/controller/kameletbinding/initialize.go
@@ -19,6 +19,7 @@ package kameletbinding
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	v1alpha1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1alpha1"
@@ -27,7 +28,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/platform"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/patch"
-	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +61,7 @@ func (action *initializeAction) Handle(ctx context.Context, binding *v1alpha1.Ka
 	}
 
 	if _, err := kubernetes.ReplaceResource(ctx, action.client, it); err != nil {
-		return nil, errors.Wrap(err, "could not create integration for KameletBinding")
+		return nil, fmt.Errorf("could not create integration for KameletBinding: %w", err)
 	}
 
 	// propagate Kamelet icon (best effort)

--- a/pkg/controller/kameletbinding/kameletbinding_controller.go
+++ b/pkg/controller/kameletbinding/kameletbinding_controller.go
@@ -20,7 +20,7 @@ package kameletbinding
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
@@ -157,7 +157,7 @@ func (r *ReconcileKameletBinding) Reconcile(ctx context.Context, request reconci
 	var instance v1alpha1.KameletBinding
 
 	if err := r.client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup
 			// logic use finalizers.

--- a/pkg/controller/kameletbinding/monitor.go
+++ b/pkg/controller/kameletbinding/monitor.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -72,7 +70,7 @@ func (action *monitorAction) Handle(ctx context.Context, binding *v1alpha1.Kamel
 		)
 		return target, nil
 	} else if err != nil {
-		return nil, errors.Wrapf(err, "could not load integration for Binding %q", binding.Name)
+		return nil, fmt.Errorf("could not load integration for Binding %q: %w", binding.Name, err)
 	}
 
 	operatorIDChanged := v1.GetOperatorIDAnnotation(binding) != "" &&

--- a/pkg/controller/pipe/initialize.go
+++ b/pkg/controller/pipe/initialize.go
@@ -19,6 +19,7 @@ package pipe
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -27,7 +28,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/platform"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/patch"
-	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +61,7 @@ func (action *initializeAction) Handle(ctx context.Context, binding *v1.Pipe) (*
 	}
 
 	if _, err := kubernetes.ReplaceResource(ctx, action.client, it); err != nil {
-		return nil, errors.Wrap(err, "could not create integration forPipe")
+		return nil, fmt.Errorf("could not create integration forPipe: %w", err)
 	}
 
 	// propagate Kamelet icon (best effort)

--- a/pkg/controller/pipe/integration.go
+++ b/pkg/controller/pipe/integration.go
@@ -20,9 +20,8 @@ package pipe
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
-
-	"github.com/pkg/errors"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,16 +105,16 @@ func CreateIntegrationFor(ctx context.Context, c client.Client, binding *v1.Pipe
 
 	from, err := bindings.Translate(bindingContext, endpointTypeSourceContext, binding.Spec.Source)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not determine source URI")
+		return nil, fmt.Errorf("could not determine source URI: %w", err)
 	}
 	to, err := bindings.Translate(bindingContext, endpointTypeSinkContext, binding.Spec.Sink)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not determine sink URI")
+		return nil, fmt.Errorf("could not determine sink URI: %w", err)
 	}
 	// error handler is optional
 	errorHandler, err := maybeErrorHandler(binding.Spec.ErrorHandler, bindingContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not determine error handler")
+		return nil, fmt.Errorf("could not determine error handler: %w", err)
 	}
 
 	steps := make([]*bindings.Binding, 0, len(binding.Spec.Steps))
@@ -126,20 +125,20 @@ func CreateIntegrationFor(ctx context.Context, c client.Client, binding *v1.Pipe
 			Position: &position,
 		}, step)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not determine URI for step %d", idx)
+			return nil, fmt.Errorf("could not determine URI for step %d: %w", idx, err)
 		}
 		steps = append(steps, stepBinding)
 	}
 
 	if to.Step == nil && to.URI == "" {
-		return nil, errors.Errorf("illegal step definition for sink step: either Step or URI should be provided")
+		return nil, fmt.Errorf("illegal step definition for sink step: either Step or URI should be provided")
 	}
 	if from.URI == "" {
-		return nil, errors.Errorf("illegal step definition for source step: URI should be provided")
+		return nil, fmt.Errorf("illegal step definition for source step: URI should be provided")
 	}
 	for index, step := range steps {
 		if step.Step == nil && step.URI == "" {
-			return nil, errors.Errorf("illegal step definition for step %d: either Step or URI should be provided", index)
+			return nil, fmt.Errorf("illegal step definition for step %d: either Step or URI should be provided", index)
 		}
 	}
 
@@ -239,7 +238,7 @@ func determineProfile(ctx context.Context, c client.Client, binding *v1.Pipe) (v
 	}
 	pl, err := platform.GetForResource(ctx, c, binding)
 	if err != nil && !k8serrors.IsNotFound(err) {
-		return "", errors.Wrap(err, "error while retrieving the integration platform")
+		return "", fmt.Errorf("error while retrieving the integration platform: %w", err)
 	}
 	if pl != nil {
 		if pl.Status.Profile != "" {

--- a/pkg/controller/pipe/monitor.go
+++ b/pkg/controller/pipe/monitor.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,7 +69,7 @@ func (action *monitorAction) Handle(ctx context.Context, binding *v1.Pipe) (*v1.
 		)
 		return target, nil
 	} else if err != nil {
-		return nil, errors.Wrapf(err, "could not load integration for Pipe %q", binding.Name)
+		return nil, fmt.Errorf("could not load integration for Pipe %q: %w", binding.Name, err)
 	}
 
 	operatorIDChanged := v1.GetOperatorIDAnnotation(binding) != "" &&

--- a/pkg/controller/pipe/pipe_controller.go
+++ b/pkg/controller/pipe/pipe_controller.go
@@ -20,7 +20,7 @@ package pipe
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
@@ -157,7 +157,7 @@ func (r *ReconcilePipe) Reconcile(ctx context.Context, request reconcile.Request
 	var instance v1.Pipe
 
 	if err := r.client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup
 			// logic use finalizers.

--- a/pkg/install/cluster.go
+++ b/pkg/install/cluster.go
@@ -35,7 +35,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/resources"
 	"github.com/apache/camel-k/v2/pkg/util/knative"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
-	pkgerr "github.com/pkg/errors"
+
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -291,42 +291,42 @@ func WaitForAllCrdInstallation(ctx context.Context, clientProvider client.Provid
 
 func areAllCrdInstalled(c client.Client) (int, error) {
 	if ok, err := isCrdInstalled(c, "IntegrationPlatform", "v1"); err != nil {
-		return 1, pkgerr.Wrap(err, "Error installing IntegrationPlatform CRDs")
+		return 1, fmt.Errorf("error installing IntegrationPlatform CRDs: %w", err)
 	} else if !ok {
 		return 1, nil
 	}
 	if ok, err := isCrdInstalled(c, "IntegrationKit", "v1"); err != nil {
-		return 2, pkgerr.Wrap(err, "Error installing IntegrationKit CRDs")
+		return 2, fmt.Errorf("error installing IntegrationKit CRDs: %w", err)
 	} else if !ok {
 		return 2, nil
 	}
 	if ok, err := isCrdInstalled(c, "Integration", "v1"); err != nil {
-		return 3, pkgerr.Wrap(err, "Error installing Integration CRDs")
+		return 3, fmt.Errorf("error installing Integration CRDs: %w", err)
 	} else if !ok {
 		return 3, nil
 	}
 	if ok, err := isCrdInstalled(c, "CamelCatalog", "v1"); err != nil {
-		return 4, pkgerr.Wrap(err, "Error installing CamelCatalog CRDs")
+		return 4, fmt.Errorf("error installing CamelCatalog CRDs: %w", err)
 	} else if !ok {
 		return 4, nil
 	}
 	if ok, err := isCrdInstalled(c, "Build", "v1"); err != nil {
-		return 5, pkgerr.Wrap(err, "Error installing Build CRDs")
+		return 5, fmt.Errorf("error installing Build CRDs: %w", err)
 	} else if !ok {
 		return 5, nil
 	}
 	if ok, err := isCrdInstalled(c, "Kamelet", "v1"); err != nil {
-		return 6, pkgerr.Wrap(err, "Error installing Kamelet CRDs")
+		return 6, fmt.Errorf("error installing Kamelet CRDs: %w", err)
 	} else if !ok {
 		return 6, nil
 	}
 	if ok, err := isCrdInstalled(c, "KameletBinding", "v1alpha1"); err != nil {
-		return 7, pkgerr.Wrap(err, "Error installing KameletBindings CRDs")
+		return 7, fmt.Errorf("error installing KameletBindings CRDs: %w", err)
 	} else if !ok {
 		return 7, nil
 	}
 	if ok, err := isCrdInstalled(c, "Pipe", "v1"); err != nil {
-		return 8, pkgerr.Wrap(err, "Error installing Pipe CRDs")
+		return 8, fmt.Errorf("error installing Pipe CRDs: %w", err)
 	} else if !ok {
 		return 8, nil
 	}

--- a/pkg/install/kamelets.go
+++ b/pkg/install/kamelets.go
@@ -30,7 +30,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	gerrors "github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,7 +103,7 @@ func KameletCatalog(ctx context.Context, c client.Client, namespace string) erro
 						err = nil
 					} else {
 						// Unexpected error occurred
-						err = gerrors.Wrap(err, "Unexpected error occurred whilst validating kamelet")
+						err = fmt.Errorf("unexpected error occurred whilst validating kamelet: %w", err)
 						log.Error(err, "Error occurred whilst loading kamelets")
 					}
 				} else {

--- a/pkg/install/openshift.go
+++ b/pkg/install/openshift.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Masterminds/semver"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -80,7 +80,7 @@ func OpenShiftConsoleDownloadLink(ctx context.Context, c client.Client) error {
 	existing := &console.ConsoleCLIDownload{}
 	err = c.Get(ctx, types.NamespacedName{Name: KamelCLIDownloadName}, existing)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			existing = nil
 		} else {
 			return err
@@ -104,7 +104,7 @@ func OpenShiftConsoleDownloadLink(ctx context.Context, c client.Client) error {
 			// Else delete the older version
 			err = c.Delete(ctx, existing)
 			if err != nil {
-				if errors.IsForbidden(err) {
+				if k8serrors.IsForbidden(err) {
 					// Let's just skip the ConsoleCLIDownload resource creation
 					return nil
 				}

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -19,10 +19,10 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -355,7 +355,8 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 			switch {
 			case k8serrors.IsForbidden(err):
 				fmt.Fprintln(cmd.ErrOrStderr(), "Warning: the creation of monitoring resources is not allowed. Try installing as cluster-admin to allow the creation of monitoring resources.")
-			case meta.IsNoMatchError(errors.Cause(err)):
+				// TU to check ?
+			case meta.IsNoMatchError(errors.Unwrap(err)):
 				fmt.Fprintln(cmd.ErrOrStderr(), "Warning: the creation of the monitoring resources failed: ", err)
 			default:
 				return err
@@ -415,7 +416,7 @@ func installNamespacedRoleBinding(ctx context.Context, c client.Client, collecti
 		return err
 	}
 	if yaml == "" {
-		return errors.Errorf("resource file %v not found", path)
+		return fmt.Errorf("resource file %v not found", path)
 	}
 	obj, err := kubernetes.LoadResourceFromYaml(c.GetScheme(), yaml)
 	if err != nil {
@@ -466,7 +467,7 @@ func installClusterRoleBinding(ctx context.Context, c client.Client, collection 
 
 		existing = nil
 		if content == "" {
-			return errors.Errorf("resource file %v not found", path)
+			return fmt.Errorf("resource file %v not found", path)
 		}
 
 		obj, err := kubernetes.LoadResourceFromYaml(c.GetScheme(), content)

--- a/pkg/kamelet/initialize.go
+++ b/pkg/kamelet/initialize.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -88,7 +87,7 @@ func recomputeProperties(kamelet *v1.Kamelet) error {
 			d := json.NewDecoder(bytes.NewReader(v.Default.RawMessage))
 			d.UseNumber()
 			if err := d.Decode(&val); err != nil {
-				return errors.Wrapf(err, "cannot decode default value for property %q", k)
+				return fmt.Errorf("cannot decode default value for property %q: %w", k, err)
 			}
 			defValue = fmt.Sprintf("%v", val)
 		}

--- a/pkg/platform/defaults.go
+++ b/pkg/platform/defaults.go
@@ -19,11 +19,10 @@ package platform
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -94,7 +93,7 @@ func ConfigureDefaults(ctx context.Context, c client.Client, p *v1.IntegrationPl
 
 	if p.Status.Build.BuildStrategy == v1.BuildStrategyPod {
 		if err := CreateBuilderServiceAccount(ctx, c, p); err != nil {
-			return errors.Wrap(err, "cannot ensure service account is present")
+			return fmt.Errorf("cannot ensure service account is present: %w", err)
 		}
 	}
 

--- a/pkg/resources/resources_support.go
+++ b/pkg/resources/resources_support.go
@@ -19,6 +19,7 @@ package resources
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -28,14 +29,12 @@ import (
 	"text/template"
 
 	"github.com/apache/camel-k/v2/pkg/util"
-
-	"github.com/pkg/errors"
 )
 
 //
-//go:generate go run ../../cmd/util/vfs-gen resources config
-//
 // ResourceAsString returns the named resource content as string.
+//
+//go:generate go run ../../cmd/util/vfs-gen resources config
 func ResourceAsString(name string) (string, error) {
 	data, err := Resource(name)
 	return string(data), err
@@ -51,13 +50,13 @@ func Resource(name string) ([]byte, error) {
 
 	file, err := openAsset(name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot access resource file %s", name)
+		return nil, fmt.Errorf("cannot access resource file %s: %w", name, err)
 	}
 
 	data, err := io.ReadAll(file)
 	if err != nil {
 		_ = file.Close()
-		return nil, errors.Wrapf(err, "cannot access resource file %s", name)
+		return nil, fmt.Errorf("cannot access resource file %s: %w", name, err)
 	}
 
 	return data, file.Close()
@@ -124,7 +123,7 @@ func Resources(dirName string) ([]string, error) {
 			return nil, nil
 		}
 
-		return nil, errors.Wrapf(err, "error while listing resource files %s", dirName)
+		return nil, fmt.Errorf("error while listing resource files %s: %w", dirName, err)
 	}
 
 	info, err := dir.Stat()
@@ -133,13 +132,13 @@ func Resources(dirName string) ([]string, error) {
 	}
 	if !info.IsDir() {
 		util.CloseQuietly(dir)
-		return nil, errors.Wrapf(err, "location %s is not a directory", dirName)
+		return nil, fmt.Errorf("location %s is not a directory: %w", dirName, err)
 	}
 
 	files, err := dir.Readdir(-1)
 	if err != nil {
 		util.CloseQuietly(dir)
-		return nil, errors.Wrapf(err, "error while listing files on directory %s", dirName)
+		return nil, fmt.Errorf("error while listing files on directory %s: %w", dirName, err)
 	}
 
 	var res []string

--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -19,11 +19,10 @@ package trait
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -149,13 +148,14 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 					catalog, err = camel.LoadCatalog(e.Ctx, e.Client, ns, runtime)
 					if err != nil {
 						// unexpected error
-						return errors.Wrapf(err, "catalog %q already exists but unable to load", catalogName)
+						return fmt.Errorf("catalog %q already exists but unable to load: %w", catalogName, err)
 					}
 				} else {
-					return errors.Wrapf(err, "unable to create catalog runtime=%s, provider=%s, name=%s",
+					return fmt.Errorf("unable to create catalog runtime=%s, provider=%s, name=%s: %w",
 						runtime.Version,
 						runtime.Provider,
-						catalogName)
+						catalogName, err)
+
 				}
 			}
 		}

--- a/pkg/trait/init.go
+++ b/pkg/trait/init.go
@@ -18,9 +18,8 @@ limitations under the License.
 package trait
 
 import (
+	"errors"
 	"sort"
-
-	"github.com/pkg/errors"
 
 	"k8s.io/utils/pointer"
 

--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/scylladb/go-set/strset"
 
 	infp "gopkg.in/inf.v0"
@@ -87,7 +86,7 @@ func (t *jvmTrait) Apply(e *Environment) error {
 		ns := e.Integration.GetIntegrationKitNamespace(e.Platform)
 		k := v1.NewIntegrationKit(ns, name)
 		if err := t.Client.Get(e.Ctx, ctrl.ObjectKeyFromObject(k), k); err != nil {
-			return errors.Wrapf(err, "unable to find integration kit %s/%s, %s", ns, name, err)
+			return fmt.Errorf("unable to find integration kit %s/%s, %s: %w", ns, name, err, err)
 		}
 		kit = k
 	}

--- a/pkg/trait/openapi.go
+++ b/pkg/trait/openapi.go
@@ -19,13 +19,12 @@ package trait
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -132,7 +131,7 @@ func (t *openAPITrait) generateFromDataSpecs(e *Environment, tmpDir string, spec
 		generatedSourceName := strings.TrimSuffix(resource.Name, filepath.Ext(resource.Name)) + ".xml"
 		// Generate configmap or reuse existing one
 		if err := t.generateOpenAPIConfigMap(e, resource, tmpDir, generatedContentName); err != nil {
-			return nil, errors.Wrapf(err, "cannot generate configmap for openapi resource %s", resource.Name)
+			return nil, fmt.Errorf("cannot generate configmap for openapi resource %s: %w", resource.Name, err)
 		}
 		if e.Integration.Status.GeneratedSources != nil {
 			// Filter out the previously generated source

--- a/pkg/trait/pull_secret.go
+++ b/pkg/trait/pull_secret.go
@@ -20,8 +20,6 @@ package trait
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,7 +108,7 @@ func (t *pullSecretTrait) delegateImagePuller(e *Environment) error {
 	// (different from the integration namespace when delegation is enabled).
 	rb := t.newImagePullerRoleBinding(e)
 	if _, err := kubernetes.ReplaceResource(e.Ctx, e.Client, rb); err != nil {
-		return errors.Wrap(err, "error during the creation of the system:image-puller delegating role binding")
+		return fmt.Errorf("error during the creation of the system:image-puller delegating role binding: %w", err)
 	}
 	return nil
 }

--- a/pkg/trait/trait.go
+++ b/pkg/trait/trait.go
@@ -19,8 +19,8 @@ package trait
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,7 +46,7 @@ func Apply(ctx context.Context, c client.Client, integration *v1.Integration, ki
 
 	environment, err := newEnvironment(ctx, c, integration, kit)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating trait environment")
+		return nil, fmt.Errorf("error creating trait environment: %w", err)
 	}
 
 	catalog := NewCatalog(c)
@@ -56,14 +56,14 @@ func Apply(ctx context.Context, c client.Client, integration *v1.Integration, ki
 
 	// invoke the trait framework to determine the needed resources
 	if err := catalog.apply(environment); err != nil {
-		return nil, errors.Wrap(err, "error during trait customization")
+		return nil, fmt.Errorf("error during trait customization: %w", err)
 	}
 
 	// execute post actions registered by traits
 	for _, postAction := range environment.PostActions {
 		err := postAction(environment)
 		if err != nil {
-			return nil, errors.Wrap(err, "error executing post actions")
+			return nil, fmt.Errorf("error executing post actions: %w", err)
 		}
 	}
 

--- a/pkg/trait/trait_catalog.go
+++ b/pkg/trait/trait_catalog.go
@@ -18,12 +18,13 @@ limitations under the License.
 package trait
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
 
 	"github.com/fatih/structs"
-	"github.com/pkg/errors"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/client"
@@ -119,7 +120,7 @@ func (c *Catalog) apply(environment *Environment) error {
 			for _, processor := range environment.PostStepProcessors {
 				err := processor(environment)
 				if err != nil {
-					return errors.Wrap(err, "error executing post step action")
+					return fmt.Errorf("error executing post step action: %w", err)
 				}
 			}
 		}
@@ -138,7 +139,7 @@ func (c *Catalog) apply(environment *Environment) error {
 	for _, processor := range environment.PostProcessors {
 		err := processor(environment)
 		if err != nil {
-			return errors.Wrap(err, "error executing post processor")
+			return fmt.Errorf("error executing post processor: %w", err)
 		}
 	}
 

--- a/pkg/trait/trait_configure.go
+++ b/pkg/trait/trait_configure.go
@@ -19,12 +19,12 @@ package trait
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/util"
@@ -170,7 +170,7 @@ func configureTrait(id string, config map[string]interface{}, trait interface{})
 			if v, ok := data.(string); ok && strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]") {
 				var value interface{}
 				if err := json.Unmarshal([]byte(v), &value); err != nil {
-					return nil, errors.Wrap(err, "could not decode JSON array for configuring trait property")
+					return nil, fmt.Errorf("could not decode JSON array for configuring trait property: %w", err)
 				}
 				return value, nil
 			}
@@ -189,7 +189,7 @@ func configureTrait(id string, config map[string]interface{}, trait interface{})
 		},
 	)
 	if err != nil {
-		return errors.Wrapf(err, "error while decoding trait configuration %q", id)
+		return fmt.Errorf("error while decoding trait configuration %q: %w", id, err)
 	}
 
 	return decoder.Decode(config)

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -25,8 +25,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -377,7 +375,7 @@ func (e *Environment) computeApplicationProperties() (*corev1.ConfigMap, error) 
 	// application properties
 	applicationProperties, err := property.EncodePropertyFile(e.ApplicationProperties)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not compute application properties")
+		return nil, fmt.Errorf("could not compute application properties: %w", err)
 	}
 
 	if applicationProperties != "" {

--- a/pkg/trait/util.go
+++ b/pkg/trait/util.go
@@ -20,13 +20,13 @@ package trait
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/scylladb/go-set/strset"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -312,7 +312,7 @@ func MigrateLegacyConfiguration(trait map[string]interface{}) error {
 		}
 		delete(trait, "configuration")
 	} else {
-		return errors.Errorf(`unexpected type for "configuration" field: %v`, reflect.TypeOf(trait["configuration"]))
+		return fmt.Errorf(`unexpected type for "configuration" field: %v`, reflect.TypeOf(trait["configuration"]))
 	}
 
 	return nil

--- a/pkg/util/command.go
+++ b/pkg/util/command.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os/exec"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -49,7 +48,7 @@ func RunAndLog(ctx context.Context, cmd *exec.Cmd, stdOutF func(string) string, 
 		scanOutMsg = scan(stdOut, stdOutF)
 		scanErrMsg = scan(stdErr, stdErrF)
 
-		return errors.Wrapf(err, formatErr(scanOutMsg, scanErrMsg))
+		return fmt.Errorf(formatErr(scanOutMsg, scanErrMsg)+": %w", err)
 	}
 	g, _ := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -61,10 +60,10 @@ func RunAndLog(ctx context.Context, cmd *exec.Cmd, stdOutF func(string) string, 
 		return nil
 	})
 	if err = g.Wait(); err != nil {
-		return errors.Wrapf(err, formatErr(scanOutMsg, scanErrMsg))
+		return fmt.Errorf(formatErr(scanOutMsg, scanErrMsg)+": %w", err)
 	}
 	if err = cmd.Wait(); err != nil {
-		return errors.Wrapf(err, formatErr(scanOutMsg, scanErrMsg))
+		return fmt.Errorf(formatErr(scanOutMsg, scanErrMsg)+": %w", err)
 	}
 
 	return nil

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -18,13 +18,13 @@ limitations under the License.
 package docker
 
 import (
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/apache/camel-k/v2/pkg/util"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
-	"github.com/pkg/errors"
 )
 
 // CreateBaseImageDockerFile --.

--- a/pkg/util/kubernetes/discovery.go
+++ b/pkg/util/kubernetes/discovery.go
@@ -18,14 +18,14 @@ limitations under the License.
 package kubernetes
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 )
 
 func IsAPIResourceInstalled(c kubernetes.Interface, groupVersion string, kind string) (bool, error) {
 	resources, err := c.Discovery().ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err

--- a/pkg/util/kubernetes/log/pod_scraper.go
+++ b/pkg/util/kubernetes/log/pod_scraper.go
@@ -20,13 +20,14 @@ package log
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 	"time"
 
 	"go.uber.org/multierr"
 
 	klog "github.com/apache/camel-k/v2/pkg/util/log"
-	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/util/kubernetes/replace.go
+++ b/pkg/util/kubernetes/replace.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,7 +56,7 @@ func ReplaceResource(ctx context.Context, c client.Client, res ctrl.Object) (boo
 		err = c.Update(ctx, res)
 	}
 	if err != nil {
-		return replaced, errors.Wrap(err, "could not create or replace "+findResourceDetails(res))
+		return replaced, fmt.Errorf("could not create or replace "+findResourceDetails(res)+": %w", err)
 	}
 	return replaced, nil
 }

--- a/pkg/util/kubernetes/resolver.go
+++ b/pkg/util/kubernetes/resolver.go
@@ -23,7 +23,7 @@ import (
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/util/gzip"
-	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	controller "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -85,7 +85,7 @@ func Resolve(data *v1.DataSpec, mapLookup func(string) (*corev1.ConfigMap, error
 		var uncompressed []byte
 		var err error
 		if uncompressed, err = gzip.UncompressBase64(cnt); err != nil {
-			return errors.Wrap(err, "error while uncompressing data")
+			return fmt.Errorf("error while uncompressing data: %w", err)
 		}
 		data.Compression = false
 		data.Content = string(uncompressed)

--- a/pkg/util/maven/maven_command.go
+++ b/pkg/util/maven/maven_command.go
@@ -19,6 +19,7 @@ package maven
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,8 +29,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/apache/camel-k/v2/pkg/util"
 	"github.com/apache/camel-k/v2/pkg/util/log"

--- a/pkg/util/olm/operator.go
+++ b/pkg/util/olm/operator.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/cmd/set/env"
 
@@ -182,19 +180,19 @@ func Install(ctx context.Context, client client.Client, namespace string, global
 	// Additional configuration
 	err = maybeSetTolerations(&sub, tolerations)
 	if err != nil {
-		return false, errors.Wrap(err, "could not set tolerations")
+		return false, fmt.Errorf("could not set tolerations: %w", err)
 	}
 	err = maybeSetNodeSelectors(&sub, nodeSelectors)
 	if err != nil {
-		return false, errors.Wrap(err, "could not set node selectors")
+		return false, fmt.Errorf("could not set node selectors: %w", err)
 	}
 	err = maybeSetResourcesRequirements(&sub, resourcesRequirements)
 	if err != nil {
-		return false, errors.Wrap(err, "could not set resources requirements")
+		return false, fmt.Errorf("could not set resources requirements: %w", err)
 	}
 	err = maybeSetEnvVars(&sub, envVars)
 	if err != nil {
-		return false, errors.Wrap(err, "could not set environment variables")
+		return false, fmt.Errorf("could not set environment variables: %w", err)
 	}
 
 	if collection != nil {
@@ -221,9 +219,10 @@ func Install(ctx context.Context, client client.Client, namespace string, global
 			if collection != nil {
 				collection.Add(group)
 			} else if err := client.Create(ctx, group); err != nil {
-				return false, errors.Wrap(err, fmt.Sprintf("namespace %s has no operator group defined and "+
+				return false, fmt.Errorf("namespace %s has no operator group defined and "+
 					"current user is not able to create it. "+
-					"Make sure you have the right roles to install operators from OLM", namespace))
+					"Make sure you have the right roles to install operators from OLM"+": %w", namespace, err)
+
 			}
 		}
 	}

--- a/pkg/util/openshift/openshift.go
+++ b/pkg/util/openshift/openshift.go
@@ -18,14 +18,14 @@ limitations under the License.
 package openshift
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 )
 
 // IsOpenShift returns true if we are connected to a OpenShift cluster.
 func IsOpenShift(client kubernetes.Interface) (bool, error) {
 	_, err := client.Discovery().ServerResourcesForGroupVersion("image.openshift.io/v1")
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8serrors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
 		return false, err

--- a/pkg/util/property/property.go
+++ b/pkg/util/property/property.go
@@ -19,10 +19,10 @@ package property
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/magiconair/properties"
-	"github.com/pkg/errors"
 )
 
 // EncodePropertyFileEntry converts the given key/value pair into a .properties file entry.
@@ -48,7 +48,7 @@ func EncodePropertyFile(sourceProperties map[string]string) (string, error) {
 	buf := new(bytes.Buffer)
 	_, err := props.Write(buf, properties.UTF8)
 	if err != nil {
-		return "", errors.Wrapf(err, "could not compute application properties")
+		return "", fmt.Errorf("could not compute application properties: %w", err)
 	}
 	return buf.String(), nil
 }

--- a/pkg/util/reference/reference.go
+++ b/pkg/util/reference/reference.go
@@ -18,6 +18,7 @@ limitations under the License.
 package reference
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -25,7 +26,7 @@ import (
 	"unicode"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
-	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
@@ -105,11 +106,11 @@ func (c *Converter) PropertiesFromString(str string) (map[string]string, error) 
 			}
 			k, errkey := url.QueryUnescape(kv[0])
 			if errkey != nil {
-				return nil, errors.Wrapf(errkey, "cannot unescape key %q", kv[0])
+				return nil, fmt.Errorf("cannot unescape key %q: %w", kv[0], errkey)
 			}
 			v, errval := url.QueryUnescape(kv[1])
 			if errval != nil {
-				return nil, errors.Wrapf(errval, "cannot unescape value %q", kv[1])
+				return nil, fmt.Errorf("cannot unescape value %q: %w", kv[1], errval)
 			}
 			res[k] = v
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -38,7 +39,6 @@ import (
 
 	yaml2 "gopkg.in/yaml.v2"
 
-	"github.com/pkg/errors"
 	"github.com/scylladb/go-set/strset"
 )
 
@@ -490,7 +490,7 @@ func MapToYAML(src map[string]interface{}) ([]byte, error) {
 func WriteToFile(filePath string, fileContents string) error {
 	err := os.WriteFile(filePath, []byte(fileContents), 0o400)
 	if err != nil {
-		return errors.Errorf("error writing file: %v", filePath)
+		return fmt.Errorf("error writing file: %v", filePath)
 	}
 
 	return nil
@@ -499,11 +499,11 @@ func WriteToFile(filePath string, fileContents string) error {
 func GetEnvironmentVariable(variable string) (string, error) {
 	value, isPresent := os.LookupEnv(variable)
 	if !isPresent {
-		return "", errors.Errorf("environment variable %v does not exist", variable)
+		return "", fmt.Errorf("environment variable %v does not exist", variable)
 	}
 
 	if value == "" {
-		return "", errors.Errorf("environment variable %v is not set", variable)
+		return "", fmt.Errorf("environment variable %v is not set", variable)
 	}
 
 	return value, nil
@@ -615,18 +615,18 @@ func WriteFileWithContent(filePath string, content []byte) error {
 	// Create dir if not present
 	err := os.MkdirAll(fileDir, 0o700)
 	if err != nil {
-		return errors.Wrap(err, "could not create dir for file "+filePath)
+		return fmt.Errorf("could not create dir for file "+filePath+": %w", err)
 	}
 
 	// Create file
 	file, err := os.Create(filePath)
 	if err != nil {
-		return errors.Wrap(err, "could not create file "+filePath)
+		return fmt.Errorf("could not create file "+filePath+": %w", err)
 	}
 
 	_, err = file.Write(content)
 	if err != nil {
-		err = errors.Wrap(err, "could not write to file "+filePath)
+		err = fmt.Errorf("could not write to file "+filePath+": %w", err)
 	}
 
 	return Close(err, file)
@@ -713,7 +713,7 @@ func NavigateConfigTree(current interface{}, nodes []string) (interface{}, error
 		}
 		pos, err := strconv.Atoi(nodes[0][1 : len(nodes[0])-1])
 		if err != nil {
-			return nil, errors.Wrapf(err, "value %q inside brackets is not numeric", nodes[0])
+			return nil, fmt.Errorf("value %q inside brackets is not numeric: %w", nodes[0], err)
 		}
 		var next interface{}
 		if len(*c) > pos && (*c)[pos] != nil {


### PR DESCRIPTION
Ref #4326

## Motivation

The github.com/pkg/errors dependency has been archived and golang provides ways to replace it.

## Description

* process used: https://xdg.me/rewriting-go-with-ast-transformation/
* some helping tooling: https://github.com/xdg-go/go-rewrap-errors

Principal manual adaptations : k8serrors, errors.Cause

Note: It is still an sub-dependency from other projects.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Remove archived github.com/pkg/errors as direct dependency
```
