### PR TITLE
fix: Add proper app label on default integration platform

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -258,6 +258,7 @@ func findOrCreateIntegrationPlatform(ctx context.Context, c client.Client, opera
 		if defaultPlatform.Labels == nil {
 			defaultPlatform.Labels = make(map[string]string)
 		}
+		defaultPlatform.Labels["app"] = "camel-k"
 		defaultPlatform.Labels["camel.apache.org/platform.generated"] = "true"
 
 		if operatorID != "" {

--- a/pkg/trait/platform.go
+++ b/pkg/trait/platform.go
@@ -132,6 +132,7 @@ func (t *platformTrait) getOrCreatePlatform(e *Environment) (*v1.IntegrationPlat
 		if defaultPlatform.Labels == nil {
 			defaultPlatform.Labels = make(map[string]string)
 		}
+		defaultPlatform.Labels["app"] = "camel-k"
 		defaultPlatform.Labels["camel.apache.org/platform.generated"] = True
 		// Cascade the operator id in charge to reconcile the Integration
 		if v1.GetOperatorIDAnnotation(e.Integration) != "" {

--- a/pkg/trait/platform_test.go
+++ b/pkg/trait/platform_test.go
@@ -109,7 +109,7 @@ func TestPlatformTraitCreatesDefaultPlatform(t *testing.T) {
 	assert.Equal(t, v1.IntegrationPhaseWaitingForPlatform, e.Integration.Status.Phase)
 	assert.Equal(t, 1, len(e.Resources.Items()))
 	defPlatform := v1.NewIntegrationPlatform("ns1", platform.DefaultPlatformName)
-	defPlatform.Labels = map[string]string{"camel.apache.org/platform.generated": True}
+	defPlatform.Labels = map[string]string{"app": "camel-k", "camel.apache.org/platform.generated": True}
 	assert.Contains(t, e.Resources.Items(), &defPlatform)
 }
 


### PR DESCRIPTION
Make sure to add `app=camel-k` label on the default integration platform created by the operator