### PR TITLE
fix(#4336): Restrict Knative binding provider execution for v1alpha1

### DIFF
--- a/pkg/util/bindings/knative_ref.go
+++ b/pkg/util/bindings/knative_ref.go
@@ -150,6 +150,17 @@ func (k V1alpha1KnativeRefBindingProvider) Translate(ctx V1alpha1BindingContext,
 		return nil, nil
 	}
 
+	if ok, err := isKnownKnativeResource(e.Ref); !ok {
+		// only operates on known Knative endpoint resources (e.g. channels, brokers)
+		return nil, err
+	}
+
+	if knativeInstalled, _ := knative.IsInstalled(ctx.Client); !knativeInstalled {
+		// works only when Knative is installed
+		return nil, fmt.Errorf("integration referencing Knative endpoint '%s' that cannot run, "+
+			"because Knative is not installed on the cluster", e.Ref.Name)
+	}
+
 	serviceType, err := knative.GetServiceType(*e.Ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Also restrict v1alpha1 binding provider
- Only run the binding provider when Knative is installed on the cluster
- Only run the binding provider when referencing a known Knative resource (e.g. broker, channel, service)