### PR TITLE
chore: ignore resources.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ config/**/*.gen.json
 
 # Fabric8 CRDs
 java/target
+pkg/resources/resources.go


### PR DESCRIPTION
The file is autogenerated at each build, and is a source of conflict. We better ignore.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore: ignore resources.go
```
