### PR TITLE
[Backport 1.10.x] fix(cmd): promote should load catalog from k8s

### DIFF
--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -344,7 +344,11 @@ func toPropertyMap(src interface{}) (map[string]interface{}, error) {
 }
 
 func (o *promoteCmdOptions) listKamelets(c client.Client, it *v1.Integration) ([]string, error) {
-	catalog, err := camel.DefaultCatalog()
+	runtime := v1.RuntimeSpec{
+		Version:  it.Status.RuntimeVersion,
+		Provider: v1.RuntimeProviderQuarkus,
+	}
+	catalog, err := camel.LoadCatalog(o.Context, c, o.Namespace, runtime)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
