### PR TITLE
chore(deps): ignore only k8s dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,44 +18,14 @@
 version: 2
 updates:
   - directory: "/"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     package-ecosystem: "gomod"
     schedule:
       interval: "daily"
     allow:
-      - dependency-name: "github.com/Masterminds/semver"
-      - dependency-name: "github.com/container-tools/spectrum"
-      - dependency-name: "github.com/fatih/structs"
-      - dependency-name: "github.com/gertd/go-pluralize"
-      - dependency-name: "github.com/go-logr/logr"
-      - dependency-name: "github.com/golangplus/testing"
-      - dependency-name: "github.com/google/go-github/v32"
-      - dependency-name: "github.com/google/uuid"
-      - dependency-name: "github.com/jpillora/backoff"
-      - dependency-name: "github.com/magiconair/properties"
-      - dependency-name: "github.com/mitchellh/go-homedir"
-      - dependency-name: "github.com/mitchellh/mapstructure"
-      - dependency-name: "github.com/onsi/gomega"
-      - dependency-name: "github.com/operator-framework/api"
-      - dependency-name: "github.com/pkg/errors"
-      - dependency-name: "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
-      - dependency-name: "github.com/prometheus/client_golang"
-      - dependency-name: "github.com/prometheus/client_model"
-      - dependency-name: "github.com/prometheus/common"
-      - dependency-name: "github.com/radovskyb/watcher"
-      - dependency-name: "github.com/redhat-developer/service-binding-operator"
-      - dependency-name: "github.com/rs/xid"
-      - dependency-name: "github.com/scylladb/go-set"
-      - dependency-name: "github.com/shurcooL/httpfs"
-      - dependency-name: "github.com/shurcooL/vfsgen"
-      - dependency-name: "github.com/sirupsen/logrus"
-      - dependency-name: "github.com/spf13/cobra"
-      - dependency-name: "github.com/spf13/pflag"
-      - dependency-name: "github.com/spf13/viper"
-      - dependency-name: "github.com/stoewer/go-strcase"
-      - dependency-name: "github.com/stretchr/testify"
-      - dependency-name: "go.uber.org/multierr"
-      - dependency-name: "go.uber.org/zap"
-      - dependency-name: "golang.org/x/oauth2"
-      - dependency-name: "gopkg.in/inf.v0"
-      - dependency-name: "gopkg.in/yaml.v2"
+      - ignore:	k8s.io/api
+      - ignore:	k8s.io/apiextensions-apiserver
+      - ignore:	k8s.io/apimachinery
+      - ignore:	k8s.io/cli-runtime
+      - ignore:	k8s.io/client-go
+      - ignore:	k8s.io/kubectl


### PR DESCRIPTION
<!-- Description -->



The idea of this PR is to increase the level of dependencies upgrade automation to try to be aligned to the last developments. We only control Kubernetes dependencies which are the ones from which we depends in its core and we may want to have under full control.

NOTE: of course, we should not blindly merge any upgrade but reviewing carefully, and never do that if there is even a single check failing.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(deps): ignore only k8s dependencies
```
