### PR TITLE
fix: Restrict Knative service trait to Http exposed and passive endpoints

### DIFF
--- a/pkg/trait/knative_service_test.go
+++ b/pkg/trait/knative_service_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -265,7 +266,7 @@ func TestKnativeServiceWithCustomContainerName(t *testing.T) {
 	)
 }
 
-func TestKnativeServiceWithResr(t *testing.T) {
+func TestKnativeServiceWithRest(t *testing.T) {
 	catalog, err := camel.DefaultCatalog()
 	require.NoError(t, err)
 
@@ -336,6 +337,77 @@ func TestKnativeServiceWithResr(t *testing.T) {
 
 	assert.NotNil(t, environment.Resources.GetKnativeService(func(service *serving.Service) bool {
 		return service.Name == KnativeServiceTestName
+	}))
+}
+
+func TestKnativeServiceNotApplicable(t *testing.T) {
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
+
+	client, _ := test.NewFakeClient()
+	traitCatalog := NewCatalog(nil)
+
+	environment := Environment{
+		CamelCatalog: catalog,
+		Catalog:      traitCatalog,
+		Client:       client,
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      KnativeServiceTestName,
+				Namespace: KnativeServiceTestNamespace,
+			},
+			Status: v1.IntegrationStatus{
+				Phase: v1.IntegrationPhaseDeploying,
+			},
+			Spec: v1.IntegrationSpec{
+				Profile: v1.TraitProfileKnative,
+				Sources: []v1.SourceSpec{
+					{
+						DataSpec: v1.DataSpec{
+							Name:    "routes.js",
+							Content: `from("timer:tick").log("hello")`,
+						},
+						Language: v1.LanguageJavaScript,
+					},
+				},
+			},
+		},
+		IntegrationKit: &v1.IntegrationKit{
+			Status: v1.IntegrationKitStatus{
+				Phase: v1.IntegrationKitPhaseReady,
+			},
+		},
+		Platform: &v1.IntegrationPlatform{
+			Spec: v1.IntegrationPlatformSpec{
+				Cluster: v1.IntegrationPlatformClusterOpenShift,
+				Build: v1.IntegrationPlatformBuildSpec{
+					PublishStrategy: v1.IntegrationPlatformBuildPublishStrategyS2I,
+					Registry:        v1.RegistrySpec{Address: "registry"},
+					RuntimeVersion:  catalog.Runtime.Version,
+				},
+			},
+			Status: v1.IntegrationPlatformStatus{
+				Phase: v1.IntegrationPlatformPhaseReady,
+			},
+		},
+		EnvVars:        make([]corev1.EnvVar, 0),
+		ExecutedTraits: make([]Trait, 0),
+		Resources:      kubernetes.NewCollection(),
+	}
+	environment.Platform.ResyncStatusFullConfig()
+
+	err = traitCatalog.apply(&environment)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, environment.ExecutedTraits)
+	assert.NotNil(t, environment.GetTrait("knative"))
+
+	assert.Nil(t, environment.Resources.GetKnativeService(func(service *serving.Service) bool {
+		return service.Name == KnativeServiceTestName
+	}))
+
+	assert.NotNil(t, environment.Resources.GetDeployment(func(deployment *appsv1.Deployment) bool {
+		return deployment.Name == KnativeServiceTestName
 	}))
 }
 


### PR DESCRIPTION
The Knative service trait is responsible for choosing a Knative service as deployment strategy for an integration. This PR restricts the trait to integrations that either use passive consumers (e.g. knative, seda) or expose at least one Http endpoint (e.g. rest, http-platform)

Before that users could forcibly enable the trait also on active consumers (e.g. timer) which lead to errors on the Knative serving controllers. The trait has been using a Knative service with `min-scale=1` for these integrations. Now we use a normal deployment instead.

- Only apply Knative service trait on integrations that either use passive consumers or expos at least one Http endpoint
- Integrations are considered unsuitable for Knative service trait when they exclusively use active consumers that are not Http based
- Do not use Knative service with `min-scale=1` for unsuitable integrations instead use normal deployment

**Release Note**
```release-note
fix: Restrict Knative service trait to Http exposed and passive endpoints
```
