### PR TITLE
Increase memory for builder spectrum knative test

### DIFF
--- a/e2e/global/builder/build_test.go
+++ b/e2e/global/builder/build_test.go
@@ -150,7 +150,7 @@ func TestKitTimerToLogFullBuild(t *testing.T) {
 }
 
 func TestKitKnativeFullBuild(t *testing.T) {
-	doKitFullBuild(t, "knative", "500Mi", "8m0s", TestTimeoutLong, kitOptions{
+	doKitFullBuild(t, "knative", "800Mi", "8m0s", TestTimeoutLong, kitOptions{
 		dependencies: []string{
 			"camel-k-knative",
 		},

--- a/e2e/support/util/dump.go
+++ b/e2e/support/util/dump.go
@@ -252,7 +252,7 @@ func dumpConditions(prefix string, conditions []corev1.PodCondition, t *testing.
 }
 
 func dumpLogs(ctx context.Context, c client.Client, prefix string, ns string, name string, container string, t *testing.T) error {
-	lines := int64(50)
+	lines := int64(250)
 	stream, err := c.CoreV1().Pods(ns).GetLogs(name, &corev1.PodLogOptions{
 		Container: container,
 		TailLines: &lines,


### PR DESCRIPTION
It was failing with: `Build step io.quarkus.deployment.index.ApplicationArchiveBuildStep#build threw an exception: java.lang.OutOfMemoryError: Java heap space",`

Also increase the available lines when dumping operator log to retrive more information for investigation

This should fix the recent CI e2e tests of builder spectrum tests.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
