### PR TITLE
fix(#4361): Avoid errors when components not available in Camel catalog

### DIFF
--- a/docs/modules/ROOT/pages/configuration/dependencies.adoc
+++ b/docs/modules/ROOT/pages/configuration/dependencies.adoc
@@ -39,6 +39,11 @@ kamel run -d camel:http Integration.java
 ```
 In this case, the dependency will be added with the correct version. Note that the standard notation for specifying a Camel dependency is `camel:xxx`, while `kamel` also accepts `camel-xxx` for usability.
 
+While resolving Camel dependencies (`camel:xxx` or `camel-xxx`) the Camel K operator tries to find the dependency in the xref:architecture/cr/camel-catalog.adoc[Camel catalog].
+In case the dependency is not listed in the catalog for some reason you will be provided with a warning message.
+Please make sure to use Camel dependencies listed in the catalog as these components are eligible to being used in Camel K (e.g. with proper version resolving).
+Using Camel dependencies not listed in the catalog may lead to unexpected behavior.
+
 *External dependencies* can be added using the `-d` flag, the `mvn` prefix, and the maven coordinates:
 ```
 kamel run -d mvn:com.google.guava:guava:26.0-jre Integration.java

--- a/e2e/common/misc/integration_fail_test.go
+++ b/e2e/common/misc/integration_fail_test.go
@@ -71,29 +71,6 @@ func TestBadRouteIntegration(t *testing.T) {
 		Eventually(build.Status.Failure.Recovery.Attempt, TestTimeoutShort).Should(Equal(5))
 	})
 
-	t.Run("run invalid dependency java route", func(t *testing.T) {
-		name := "invalid-dependency"
-		Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
-			"-d", "camel:non-existent").Execute()).To(Succeed())
-		// Integration in error with Initialization Failed condition
-		Eventually(IntegrationPhase(ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseError))
-		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
-			Should(Equal(corev1.ConditionFalse))
-		Eventually(IntegrationCondition(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(And(
-			WithTransform(IntegrationConditionReason, Equal(v1.IntegrationConditionInitializationFailedReason)),
-			WithTransform(IntegrationConditionMessage, HavePrefix("error during trait customization")),
-		))
-		// Kit shouldn't be created
-		Consistently(IntegrationKit(ns, name), 10*time.Second).Should(BeEmpty())
-
-		// Fixing the route should reconcile the Integration in Initialization Failed condition to Running
-		Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
-		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
-			Should(Equal(corev1.ConditionTrue))
-		Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-	})
-
 	t.Run("run unresolvable component java route", func(t *testing.T) {
 		name := "unresolvable-route"
 		Expect(KamelRunWithID(operatorID, ns, "files/Unresolvable.java", "--name", name).Execute()).To(Succeed())

--- a/pkg/cmd/run_support.go
+++ b/pkg/cmd/run_support.go
@@ -43,7 +43,7 @@ import (
 
 func addDependency(cmd *cobra.Command, it *v1.Integration, dependency string, catalog *camel.RuntimeCatalog) {
 	normalized := camel.NormalizeDependency(dependency)
-	camel.ValidateDependency(catalog, normalized, cmd)
+	camel.ValidateDependency(catalog, normalized, cmd.ErrOrStderr())
 	it.Spec.AddDependency(normalized)
 }
 

--- a/pkg/trait/dependencies.go
+++ b/pkg/trait/dependencies.go
@@ -19,7 +19,6 @@ package trait
 
 import (
 	"github.com/scylladb/go-set/strset"
-
 	"k8s.io/utils/pointer"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -57,9 +56,7 @@ func (t *dependenciesTrait) Apply(e *Environment) error {
 	dependencies := strset.New()
 
 	if e.Integration.Spec.Dependencies != nil {
-		if err := camel.ValidateDependenciesE(e.CamelCatalog, e.Integration.Spec.Dependencies); err != nil {
-			return err
-		}
+		camel.ValidateDependencies(e.CamelCatalog, e.Integration.Spec.Dependencies, t.L)
 		dependencies.Add(e.Integration.Spec.Dependencies...)
 	}
 

--- a/pkg/util/camel/camel_dependencies.go
+++ b/pkg/util/camel/camel_dependencies.go
@@ -158,7 +158,7 @@ func addBOM(project *maven.Project, dependency string) error {
 
 func addCamelComponent(project *maven.Project, catalog *RuntimeCatalog, dependency string) {
 	artifactID := strings.TrimPrefix(dependency, "camel:")
-	if catalog != nil && catalog.Runtime.Provider == v1.RuntimeProviderQuarkus {
+	if catalog != nil && catalog.Runtime.Provider == v1.RuntimeProviderQuarkus && catalog.IsValidArtifact(artifactID) {
 		if !strings.HasPrefix(artifactID, "camel-") {
 			artifactID = "camel-quarkus-" + artifactID
 		}


### PR DESCRIPTION
- Allow integrations that uses components that are not listed in the Camel catalog
- Components may not be listed in the catalog for many reasons (e.g. custom components)
- Just log a warning message in case the component is missing in the catalog