### PR TITLE
feat(core): Change Operator and Builder Pod user as non root 1000

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,7 +35,7 @@ RUN tar -xC ${MVNW_DIR} -f ${MVNW_DIR}mvnw.tar \
 # Used by mvnw to download maven dist into it
 ENV MAVEN_USER_HOME="${MAVEN_HOME}"
 # Install a default mvnw distribution at build time and prepare the config for formatting log
-RUN ${MVNW_DIR}/mvnw --version | grep "Maven home:" | sed 's/Maven home: //' >> ${MVNW_DIR}default \
+RUN ${MVNW_DIR}mvnw --version | grep "Maven home:" | sed 's/Maven home: //' >> ${MVNW_DIR}default \
     && cp -r /usr/share/maven/lib/. $(cat ${MVNW_DIR}default)/lib \
     && rm $(cat ${MVNW_DIR}default)/lib/maven-slf4j-provider*
 ENV MAVEN_OPTS="${MAVEN_OPTS} -Dlogback.configurationFile=${MAVEN_HOME}/conf/logback.xml"
@@ -44,8 +44,10 @@ ADD build/_maven_output /tmp/local/m2
 ADD build/_kamelets /kamelets
 
 RUN mkdir -p /etc/maven/m2 \
-    && chgrp -R 0 /etc/maven/m2 \
+    && chgrp -R 1000 /etc/maven/m2 \
     && chmod -R g=u /etc/maven/m2 \
+    && chgrp -R 1000 /tmp/local/m2 \
+    && chmod -R g=u /tmp/local/m2 \
     && chgrp -R 0 /kamelets \
     && chmod -R g=u /kamelets \
     && chgrp -R 0 ${MAVEN_HOME} \

--- a/pkg/controller/build/build_pod.go
+++ b/pkg/controller/build/build_pod.go
@@ -114,6 +114,7 @@ var (
 
 func newBuildPod(ctx context.Context, c ctrl.Reader, build *v1.Build) (*corev1.Pod, error) {
 	var ugfid int64 = 1000
+	var nonRoot bool = true
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -131,9 +132,10 @@ func newBuildPod(ctx context.Context, c ctrl.Reader, build *v1.Build) (*corev1.P
 			ServiceAccountName: platform.BuilderServiceAccount,
 			RestartPolicy:      corev1.RestartPolicyNever,
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsUser:  &ugfid,
-				RunAsGroup: &ugfid,
-				FSGroup:    &ugfid,
+				RunAsUser:    &ugfid,
+				RunAsGroup:   &ugfid,
+				FSGroup:      &ugfid,
+				RunAsNonRoot: &nonRoot,
 			},
 		},
 	}

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -204,6 +204,14 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 				d.Spec.Template.Spec.Containers[0].Args = append(d.Spec.Template.Spec.Containers[0].Args,
 					fmt.Sprintf("--health-port=%d", cfg.Health.Port))
 				d.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(int(cfg.Health.Port))
+				var ugfid int64 = 1000
+				var nonRoot bool = true
+				d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+					FSGroup:      &ugfid,
+					RunAsGroup:   &ugfid,
+					RunAsUser:    &ugfid,
+					RunAsNonRoot: &nonRoot,
+				}
 			}
 		}
 


### PR DESCRIPTION
## Motivation

Since the new builder pod is configured to run with non root user and a persistent volume has been created there have been some permission/copy issues I fixed while working on #4297. The permissions issues can be fixed two different way on kubernetes security : extend root user or extend non-root user. 

Since it make more sense to try to avoid root (as a general rule) and some Dockerfile already use user with ID 1000 (same for group ID), I made some first modifications to try to have more non-root user for operator and builder pods.

There are also some warnings on integration containers security validations, but they will be dealt with #4297.

## Description

* Dockerfile : sets the group for folders used for dependencies is 1000
* Force 1000 as User ID/ Group ID/FS Group ID to be coherent with the one declared in Dockerfile
* Use 1000 on volume to ensure dependencies from camel-k-runtime can be added

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Extend usage of non-root user (1000) on operator and builder pods
```
