### PR TITLE
[Backport-1.12.x] chore: Improve Camel dependency validation

### DIFF
--- a/docs/modules/ROOT/pages/configuration/dependencies.adoc
+++ b/docs/modules/ROOT/pages/configuration/dependencies.adoc
@@ -39,6 +39,13 @@ kamel run -d camel:http Integration.java
 ```
 In this case, the dependency will be added with the correct version. Note that the standard notation for specifying a Camel dependency is `camel:xxx`, while `kamel` also accepts `camel-xxx` for usability.
 
+While resolving Camel dependencies (`camel:xxx` or `camel-xxx`) the Camel K operator tries to find the dependency in the xref:architecture/cr/camel-catalog.adoc[Camel catalog].
+In case the dependency is not listed in the catalog for some reason you will be provided with am error.
+Please make sure to use Camel dependencies listed in the catalog as these components are eligible to being used in Camel K (e.g. due to proper version resolving and runtime optimization).
+Using Camel dependencies not listed in the catalog may lead to unexpected behavior and is not supported.
+In case you do have a custom Camel component that you want to use as part of an Integration you can add this as an external Maven dependency using the respective Maven coordinates of your project.
+Please do not use one of the reserved the Camel groupIds (`org.apache.camel`) in that case.
+
 *External dependencies* can be added using the `-d` flag, the `mvn` prefix, and the maven coordinates:
 ```
 kamel run -d mvn:com.google.guava:guava:26.0-jre Integration.java

--- a/pkg/cmd/local/local.go
+++ b/pkg/cmd/local/local.go
@@ -57,7 +57,7 @@ func GetDependencies(ctx context.Context, cmd *cobra.Command, srcs, userDependen
 	}
 
 	// Validate user-provided dependencies against Camel catalog
-	camel.ValidateDependencies(catalog, userDependencies, cmd)
+	camel.ValidateDependencies(catalog, userDependencies, cmd.ErrOrStderr())
 
 	// Get top-level dependencies from sources
 	dependencies, err := getTopLevelDependencies(ctx, catalog, srcs)

--- a/pkg/cmd/run_support.go
+++ b/pkg/cmd/run_support.go
@@ -42,7 +42,7 @@ import (
 
 func addDependency(cmd *cobra.Command, it *v1.Integration, dependency string, catalog *camel.RuntimeCatalog) {
 	normalized := camel.NormalizeDependency(dependency)
-	camel.ValidateDependency(catalog, normalized, cmd)
+	camel.ValidateDependency(catalog, normalized, cmd.ErrOrStderr())
 	it.Spec.AddDependency(normalized)
 }
 

--- a/pkg/util/camel/camel_dependencies_test.go
+++ b/pkg/util/camel/camel_dependencies_test.go
@@ -18,8 +18,11 @@ limitations under the License.
 package camel
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/apache/camel-k/pkg/util/maven"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,4 +33,129 @@ func TestNormalizeDependency(t *testing.T) {
 	assert.Equal(t, "camel:file", NormalizeDependency("camel-quarkus:file"))
 	assert.Equal(t, "camel-k:knative", NormalizeDependency("camel-k-knative"))
 	assert.Equal(t, "camel-k:knative", NormalizeDependency("camel-k:knative"))
+	assert.Equal(t, "mvn:org.apache.camel:camel-file", NormalizeDependency("mvn:org.apache.camel:camel-file"))
+	assert.Equal(t, "mvn:org.apache.camel.quarkus:camel-quarkus-file", NormalizeDependency("mvn:org.apache.camel.quarkus:camel-quarkus-file"))
+	assert.Equal(t, "mvn:org.apache.camel:camel-k-knative", NormalizeDependency("mvn:org.apache.camel:camel-k-knative"))
+}
+
+func TestValidateDependency(t *testing.T) {
+	catalog, err := DefaultCatalog()
+	assert.Nil(t, err)
+
+	output := strings.Builder{}
+	ValidateDependency(catalog, "", &output)
+	assert.Equal(t, "", output.String())
+
+	output.Reset()
+	ValidateDependency(catalog, "camel:file", &output)
+	assert.Equal(t, "", output.String())
+
+	output.Reset()
+	ValidateDependency(catalog, "camel-quarkus-file", &output)
+	assert.Equal(t, "", output.String())
+
+	output.Reset()
+	ValidateDependency(catalog, "camel-quarkus:file", &output)
+	assert.Equal(t, "", output.String())
+
+	output.Reset()
+	ValidateDependency(catalog, "camel:unknown", &output)
+	assert.Equal(t, "Warning: dependency camel:unknown not found in Camel catalog\n", output.String())
+
+	output.Reset()
+	ValidateDependency(catalog, "mvn:org.apache.camel:camel-foo", &output)
+	assert.Equal(t, "Warning: do not use mvn:org.apache.camel:camel-foo. Use camel:foo instead\n", output.String())
+
+	output.Reset()
+	ValidateDependency(catalog, "mvn:org.apache.camel.quarkus:camel-quarkus-foo", &output)
+	assert.Equal(t, "Warning: do not use mvn:org.apache.camel.quarkus:camel-quarkus-foo. Use camel:foo instead\n", output.String())
+}
+
+func TestManageIntegrationDependencies(t *testing.T) {
+	catalog, err := DefaultCatalog()
+	assert.Nil(t, err)
+
+	tests := []struct {
+		name         string
+		dependencies []string
+		coordinates  string
+	}{
+		{
+			name: "basic_camel",
+			dependencies: []string{
+				"camel:direct",
+				"camel:log",
+				"camel:core",
+			},
+			coordinates: "org.apache.camel.quarkus:camel-quarkus-direct," +
+				"org.apache.camel.quarkus:camel-quarkus-log," +
+				"org.apache.camel.quarkus:camel-quarkus-core",
+		},
+		{
+			name: "camel_quarkus",
+			dependencies: []string{
+				"camel:direct",
+				"camel-quarkus:log",
+				"camel:camel-quarkus-core",
+			},
+			coordinates: "org.apache.camel.quarkus:camel-quarkus-direct," +
+				"org.apache.camel.quarkus:camel-quarkus-log," +
+				"org.apache.camel.quarkus:camel-quarkus-core",
+		},
+		{
+			name: "camel_k",
+			dependencies: []string{
+				"camel:direct",
+				"camel-k:webhook",
+			},
+			coordinates: "org.apache.camel.quarkus:camel-quarkus-direct," +
+				"org.apache.camel.k:camel-k-webhook",
+		},
+		{
+			name: "not_in_catalog",
+			dependencies: []string{
+				"camel:direct",
+				"camel:resiliance4j",
+			},
+			coordinates: "org.apache.camel.quarkus:camel-quarkus-direct," +
+				"org.apache.camel.quarkus:camel-quarkus-resiliance4j",
+		},
+		{
+			name: "mvn",
+			dependencies: []string{
+				"mvn:org.foo:bar",
+				"mvn:org.apache.camel:camel-resiliance4j",
+			},
+			coordinates: "org.foo:bar," +
+				"org.apache.camel:camel-resiliance4j",
+		},
+		{
+			name: "jitpack",
+			dependencies: []string{
+				"github:apache/camel-sample/1.0",
+			},
+			coordinates: "com.github.apache:camel-sample",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			project := maven.Project{}
+
+			err = ManageIntegrationDependencies(&project, test.dependencies, catalog)
+			assert.Nil(t, err)
+
+			coordinates := strings.Builder{}
+			for i, d := range project.Dependencies {
+				if i == 0 {
+					_, err = fmt.Fprintf(&coordinates, "%s:%s", d.GroupID, d.ArtifactID)
+					assert.Nil(t, err)
+				} else {
+					_, err = fmt.Fprintf(&coordinates, ",%s:%s", d.GroupID, d.ArtifactID)
+					assert.Nil(t, err)
+				}
+			}
+			assert.Equal(t, test.coordinates, coordinates.String(), coordinates)
+		})
+	}
 }


### PR DESCRIPTION
- Reuse logic in validate function just logging a warning and those validate function raising errors
- Remove unused function ValidateDependencies
- Add some unit tests
- Add some documentation on Camel dependency resolution via catalog

Manual backport of #4411 