### PR TITLE
Fix some OLM tests recently broken

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,7 +35,7 @@ RUN tar -xC ${MVNW_DIR} -f ${MVNW_DIR}mvnw.tar \
 # Used by mvnw to download maven dist into it
 ENV MAVEN_USER_HOME="${MAVEN_HOME}"
 # Install a default mvnw distribution at build time and prepare the config for formatting log
-RUN ${MVNW_DIR}mvnw --version | grep "Maven home:" | sed 's/Maven home: //' >> ${MVNW_DIR}default \
+RUN ${MVNW_DIR}/mvnw --version | grep "Maven home:" | sed 's/Maven home: //' >> ${MVNW_DIR}default \
     && cp -r /usr/share/maven/lib/. $(cat ${MVNW_DIR}default)/lib \
     && rm $(cat ${MVNW_DIR}default)/lib/maven-slf4j-provider*
 ENV MAVEN_OPTS="${MAVEN_OPTS} -Dlogback.configurationFile=${MAVEN_HOME}/conf/logback.xml"
@@ -44,10 +44,8 @@ ADD build/_maven_output /tmp/local/m2
 ADD build/_kamelets /kamelets
 
 RUN mkdir -p /etc/maven/m2 \
-    && chgrp -R 1000 /etc/maven/m2 \
+    && chgrp -R 0 /etc/maven/m2 \
     && chmod -R g=u /etc/maven/m2 \
-    && chgrp -R 1000 /tmp/local/m2 \
-    && chmod -R g=u /tmp/local/m2 \
     && chgrp -R 0 /kamelets \
     && chmod -R g=u /kamelets \
     && chgrp -R 0 ${MAVEN_HOME} \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -46,6 +46,8 @@ ADD build/_kamelets /kamelets
 RUN mkdir -p /etc/maven/m2 \
     && chgrp -R 0 /etc/maven/m2 \
     && chmod -R g=u /etc/maven/m2 \
+    && chgrp -R 0 /tmp/local/m2 \
+    && chmod -R g=u /tmp/local/m2 \
     && chgrp -R 0 /kamelets \
     && chmod -R g=u /kamelets \
     && chgrp -R 0 ${MAVEN_HOME} \

--- a/pkg/controller/build/build_pod.go
+++ b/pkg/controller/build/build_pod.go
@@ -114,7 +114,6 @@ var (
 
 func newBuildPod(ctx context.Context, c ctrl.Reader, build *v1.Build) (*corev1.Pod, error) {
 	var ugfid int64 = 1000
-	var nonRoot = true
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -132,10 +131,9 @@ func newBuildPod(ctx context.Context, c ctrl.Reader, build *v1.Build) (*corev1.P
 			ServiceAccountName: platform.BuilderServiceAccount,
 			RestartPolicy:      corev1.RestartPolicyNever,
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsUser:    &ugfid,
-				RunAsGroup:   &ugfid,
-				FSGroup:      &ugfid,
-				RunAsNonRoot: &nonRoot,
+				RunAsUser:  &ugfid,
+				RunAsGroup: &ugfid,
+				FSGroup:    &ugfid,
 			},
 		},
 	}

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -205,6 +205,10 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 					fmt.Sprintf("--health-port=%d", cfg.Health.Port))
 				d.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(int(cfg.Health.Port))
 			}
+			var ugfid int64 = 0
+			d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				FSGroup: &ugfid,
+			}
 		}
 
 		if cfg.Global {

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -204,14 +204,6 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 				d.Spec.Template.Spec.Containers[0].Args = append(d.Spec.Template.Spec.Containers[0].Args,
 					fmt.Sprintf("--health-port=%d", cfg.Health.Port))
 				d.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(int(cfg.Health.Port))
-				var ugfid int64 = 1000
-				var nonRoot = true
-				d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-					FSGroup:      &ugfid,
-					RunAsGroup:   &ugfid,
-					RunAsUser:    &ugfid,
-					RunAsNonRoot: &nonRoot,
-				}
 			}
 		}
 

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -174,18 +174,6 @@ var assets = func() http.FileSystem {
 			name:    "manager",
 			modTime: time.Time{},
 		},
-		"/manager/bundle": &vfsgen۰DirInfo{
-			name:    "bundle",
-			modTime: time.Time{},
-		},
-		"/manager/bundle/manifests": &vfsgen۰DirInfo{
-			name:    "manifests",
-			modTime: time.Time{},
-		},
-		"/manager/bundle/metadata": &vfsgen۰DirInfo{
-			name:    "metadata",
-			modTime: time.Time{},
-		},
 		"/manager/operator-deployment.yaml": &vfsgen۰CompressedFileInfo{
 			name:             "operator-deployment.yaml",
 			modTime:          time.Time{},
@@ -698,7 +686,6 @@ var assets = func() http.FileSystem {
 		fs["/crd/bases/camel.apache.org_pipes.yaml"].(os.FileInfo),
 	}
 	fs["/manager"].(*vfsgen۰DirInfo).entries = []os.FileInfo{
-		fs["/manager/bundle"].(os.FileInfo),
 		fs["/manager/operator-deployment.yaml"].(os.FileInfo),
 		fs["/manager/operator-pvc.yaml"].(os.FileInfo),
 		fs["/manager/operator-service-account.yaml"].(os.FileInfo),
@@ -711,10 +698,6 @@ var assets = func() http.FileSystem {
 		fs["/manager/patch-resource-requirements.yaml"].(os.FileInfo),
 		fs["/manager/patch-toleration.yaml"].(os.FileInfo),
 		fs["/manager/patch-watch-namespace-global.yaml"].(os.FileInfo),
-	}
-	fs["/manager/bundle"].(*vfsgen۰DirInfo).entries = []os.FileInfo{
-		fs["/manager/bundle/manifests"].(os.FileInfo),
-		fs["/manager/bundle/metadata"].(os.FileInfo),
 	}
 	fs["/prometheus"].(*vfsgen۰DirInfo).entries = []os.FileInfo{
 		fs["/prometheus/operator-pod-monitor.yaml"].(os.FileInfo),


### PR DESCRIPTION
Revert "feat(core): Fix Operator and Builder Pod user as non root 1000"

This reverts commit 8272026321f79a8bedfdacf357c806210338888c.

The user 0 (root) is set on:
* Dockerfile's folders that the operatory copy 
* SecurityContext.FSGroup of the operator's pod

**Release Note**
```release-note
Revert usage of non-root user (1000) on operator and builder pods FS.
```

