### PR TITLE
Removed coverage badge 3rd party dependency

### DIFF
--- a/.github/actions/coverage-badge/action.yml
+++ b/.github/actions/coverage-badge/action.yml
@@ -1,0 +1,48 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: Go Coverage Badge
+description: Generate coverage badge for go projects
+inputs:
+  filename:
+    description: 'File containing the tests output'
+    required: true
+    default: coverage.out
+  target:
+    description: 'Target file (default "README.md")'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - run: |
+        EXTRA_ARGS=""
+
+        if [[ -n '${{ inputs.target }}'  ]]; then
+          EXTRA_ARGS+="-target=${{ inputs.target }}"
+        fi
+        
+        TEMP_DIR=$(mktemp -d)
+        curl -sf https://gobinaries.com/github.com/AlexBeauchemin/gobadge@v0.2.0 | PREFIX=$TEMP_DIR sh
+        $TEMP_DIR/gobadge -filename=${{ inputs.filename }} $EXTRA_ARGS
+        rm -rf $TEMP_DIR
+      id: coverage-badge-go
+      shell: bash
+
+branding:
+  icon: check-circle
+  color: white

--- a/.github/workflows/nightly-coverage.yml
+++ b/.github/workflows/nightly-coverage.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Go Coverage Badge
 
-        uses: tj-actions/coverage-badge-go@v2
+        uses: ./.github/actions/coverage-badge
         with:
           filename: coverage.out
           target: badge.out
@@ -65,13 +65,6 @@ jobs:
           replacement=$(grep -o 'https://[^)]*' badge.out)
           target="(?:https:\/\/img\.shields\.io\/badge\/Coverage).*?(?=\.svg)"
           perl -i -pe "s|${target}|${replacement}|g" README.adoc
-          
-          
-      - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v12
-        id: verify-changed-files
-        with:
-          files: README.adoc
 
       - name: Commit changes
         shell: bash

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ image:https://github.com/apache/camel-k/workflows/kubernetes/badge.svg["Kubernet
 image:https://github.com/apache/camel-k/workflows/knative/badge.svg["Knative", link="https://github.com/apache/camel-k/actions/workflows/knative.yml"]
 image:https://github.com/apache/camel-k/actions/workflows/nightly-release.yml/badge.svg["Nightly releases", link="https://github.com/apache/camel-k/actions/workflows/nightly-release.yml"]
 image:https://github.com/apache/camel-k/actions/workflows/nightly-native-test.yml/badge.svg["Quarkus native", link="https://github.com/apache/camel-k/actions/workflows/nightly-native-test.yml"]
-image:https://img.shields.io/badge/Coverage-38.7%25-yellow.svg["Go coverage", link="https://github.com/apache/camel-k/actions/workflows/nightly-coverage.yml"]
+image:https://img.shields.io/badge/Coverage-39.6%25-yellow.svg["Go coverage", link="https://github.com/apache/camel-k/actions/workflows/nightly-coverage.yml"]
 image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg["Chat on Zulip", link="https://camel.zulipchat.com"]
 
 Apache Camel K is a lightweight integration framework built from **Apache Camel** that runs natively on Kubernetes and is specifically designed for serverless and microservice architectures. Users of `Camel K` can instantly run integration code written in Camel DSL on their preferred **Cloud** provider.

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ image:https://github.com/apache/camel-k/workflows/kubernetes/badge.svg["Kubernet
 image:https://github.com/apache/camel-k/workflows/knative/badge.svg["Knative", link="https://github.com/apache/camel-k/actions/workflows/knative.yml"]
 image:https://github.com/apache/camel-k/actions/workflows/nightly-release.yml/badge.svg["Nightly releases", link="https://github.com/apache/camel-k/actions/workflows/nightly-release.yml"]
 image:https://github.com/apache/camel-k/actions/workflows/nightly-native-test.yml/badge.svg["Quarkus native", link="https://github.com/apache/camel-k/actions/workflows/nightly-native-test.yml"]
-image:https://img.shields.io/badge/Coverage-39.6%25-yellow.svg["Go coverage", link="https://github.com/apache/camel-k/actions/workflows/nightly-coverage.yml"]
+image:https://img.shields.io/badge/Coverage-38.7%25-yellow.svg["Go coverage", link="https://github.com/apache/camel-k/actions/workflows/nightly-coverage.yml"]
 image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg["Chat on Zulip", link="https://camel.zulipchat.com"]
 
 Apache Camel K is a lightweight integration framework built from **Apache Camel** that runs natively on Kubernetes and is specifically designed for serverless and microservice architectures. Users of `Camel K` can instantly run integration code written in Camel DSL on their preferred **Cloud** provider.


### PR DESCRIPTION
<!-- Description -->
Removed 3rd party dependencies from coverage badge workflow.
Added option to run the workflow manually.




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
