### PR TITLE
Refactor get_catalog.sh to allow local camel-catalog

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -344,7 +344,7 @@ else
 endif
 
 build-resources:
-	./script/get_catalog.sh $(RUNTIME_VERSION) $(STAGING_RUNTIME_REPO)
+	./script/get_catalog.sh -s "$(STAGING_RUNTIME_REPO)" -d "$(CAMEL_K_RUNTIME_DIR)" $(RUNTIME_VERSION)
 	go generate ./pkg/...
 
 bundle-kamelets:

--- a/script/get_catalog.sh
+++ b/script/get_catalog.sh
@@ -15,34 +15,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+script_dir=$(dirname $0)
+rootdir=$(realpath ${script_dir}/../)
 
-location=$(dirname $0)
-rootdir=$location/../
+while getopts "d:s:" opt; do
+  case "${opt}" in
+  d)
+    local_runtime_dir="${OPTARG}"
+    ;;
+  s)
+    staging_repo="${OPTARG}"
+    ;;
+  *) ;;
+  esac
+done
+shift $((OPTIND - 1))
 
 if [ "$#" -lt 1 ]; then
-  echo "usage: $0 <Camel K runtime version> [<staging repository>]"
+  echo "usage: $0 [-s <staging repository>] [-d <local Camel K runtime project directory>] <Camel K runtime version>"
   exit 1
 fi
-runtime_version="$1"
 
-if [ ! -z $2 ]; then
-  # Change the settings to include the staging repo if it's not already there
-  echo "INFO: updating the settings staging repository"
-  sed -i.bak "s;<url>https://repository\.apache\.org/content/repositories/orgapachecamel-.*</url>;<url>$2</url>;" $location/maven-settings.xml
-  rm $location/maven-settings.xml.bak
-fi
+runtime_version=$1
 
-# Refresh catalog sets. We can clean any leftover as well.
-rm -f ${rootdir}/resources/camel-catalog-*
+if [ -z "${local_runtime_dir}" ]; then
+  # Remote M2 distro
+  if [ ! -z $staging_repo ]; then
+    # Change the settings to include the staging repo if it's not already there
+    echo "INFO: updating the settings staging repository to $staging_repo"
+    sed -i "s;<url>https://repository\.apache\.org/content/repositories/orgapachecamel-.*</url>;<url>$staging_repo</url>;" $script_dir/maven-settings.xml
+  fi
 
-mvn -q dependency:copy -Dartifact="org.apache.camel.k:camel-k-catalog:$runtime_version:yaml:catalog" \
-  -Dmdep.useBaseVersion=true \
-  -DoutputDirectory=${rootdir}/resources/ \
-  -s $location/maven-settings.xml \
-  -Papache
+  echo "INFO: Retrieving camel-k-catalog:$runtime_version:yaml:catalog from the apache repository"
+  mvn -q dependency:copy -Dartifact="org.apache.camel.k:camel-k-catalog:$runtime_version:yaml:catalog" \
+    -Dmdep.useBaseVersion=true \
+    -DoutputDirectory=${rootdir}/resources/ \
+    -s $script_dir/maven-settings.xml \
+    -Papache
 
-if [ -f "${rootdir}/resources/camel-k-catalog-${runtime_version}-catalog.yaml" ]; then
+  if [ -f "${rootdir}/resources/camel-k-catalog-${runtime_version}-catalog.yaml" ]; then
     mv ${rootdir}/resources/camel-k-catalog-"${runtime_version}"-catalog.yaml ${rootdir}/resources/camel-catalog-"${runtime_version}".yaml
-fi
+  fi
 
+else
+
+  local_camel_catalog="support/camel-k-catalog/target/camel-k-catalog-${runtime_version}.yaml"
+
+  if [ -f "${local_runtime_dir}/$local_camel_catalog" ]; then
+    echo "INFO: Copy Existing ${local_runtime_dir}/$local_camel_catalog to resources/camel-catalog-${runtime_version}.yaml"
+    cp "${local_runtime_dir}/$local_camel_catalog" ${rootdir}/resources/camel-catalog-"${runtime_version}".yaml
+  else
+    echo "INFO: Build and copy camel-k-catalog from local ${local_runtime_dir} to resources/camel-catalog-${runtime_version}.yaml"
+    mvn -o -q -f "${local_runtime_dir}/support/camel-k-catalog/pom.xml" install
+    if [ -f "${local_runtime_dir}/$local_camel_catalog" ]; then
+      cp "${local_runtime_dir}/$local_camel_catalog" ${rootdir}/resources/camel-catalog-"${runtime_version}".yaml
+    fi
+  fi
+
+fi

--- a/script/package_maven_artifacts.sh
+++ b/script/package_maven_artifacts.sh
@@ -57,13 +57,7 @@ if [ -z "${local_runtime_dir}" ]; then
     sed -i "s;<url>https://repository\.apache\.org/content/repositories/orgapachecamel-.*</url>;<url>$staging_repo</url>;" $location/maven-settings.xml
   fi
 
-  #TODO: remove this check once Camel K 1.16.0 is released
-  if [[ $camel_k_runtime_version != *"SNAPSHOT"* ]]; then
-    echo "WARN: Package Camel K runtime artifacts temporary removed because of https://github.com/apache/camel-k-runtime/pull/928 issue"
-    echo "Please, remove this check when Camel K Runtime 1.16.0 is officially released"
-    exit 0
-  fi
-  echo "Downloading Camel K runtime $camel_k_runtime_version M2 (may take some minute ...)"
+  echo "INFO: Downloading Camel K runtime $camel_k_runtime_version M2 (may take some minute ...)"
   mvn -q dependency:copy -Dartifact="org.apache.camel.k:apache-camel-k-runtime:$camel_k_runtime_version:zip:m2" \
     -Dmdep.useBaseVersion=true \
     -DoutputDirectory=${rootdir}/build/m2 \
@@ -72,9 +66,7 @@ if [ -z "${local_runtime_dir}" ]; then
   unzip -q -o $PWD/build/m2/apache-camel-k-runtime-${camel_k_runtime_version}-m2.zip -d $camel_k_destination
 else
   # Local M2 distro
-  echo "Installing local Camel K runtime $camel_k_runtime_version M2 from $local_runtime_dir (may take some minute ...)"
+  echo "INFO: Installing local Camel K runtime $camel_k_runtime_version M2 from $local_runtime_dir (may take some minute ...)"
   mvn -q -f $local_runtime_dir/distribution clean install
   unzip -q -o $local_runtime_dir/distribution/target/apache-camel-k-runtime-${camel_k_runtime_version}-m2.zip -d $camel_k_destination
 fi
-
-


### PR DESCRIPTION
- Refactor get_catalog to allow camel-catalog from local camel-k-runtime
- Remove outdated TODO from package_maven_artifacts.sh

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
