### PR TITLE
[1.12.x] Fix max running builds setting

### DIFF
--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -142,8 +142,14 @@ func (r *reconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 
 	var actions []Action
 
+	// build monitor with strictly sequential builds, only one single build running at a time
 	buildMonitor := Monitor{
-		maxRunningBuilds: instance.Spec.MaxRunningBuilds,
+		maxRunningBuilds: 1,
+	}
+
+	if instance.Spec.MaxRunningBuilds > 0 {
+		// set max running builds according to build spec to allow parallel builds for this operator
+		buildMonitor.maxRunningBuilds = instance.Spec.MaxRunningBuilds
 	}
 
 	switch instance.Spec.Strategy {


### PR DESCRIPTION
fix: Avoid build monitor to block builds with maxRunningBuilds=0

- MaxRunningBuilds=0 does not make sense
- Existing/pending builds may have MaxRunningBuilds=0 in its spec as it is a new setting in the BuildSpec
- Make sure to always use at least MaxRunningBuilds=1 which results in strictly sequential builds, only one single build running at a time