### PR TITLE
fix(e2e): remove workaround pre 1.12.1

### DIFF
--- a/e2e/install/upgrade/cli_upgrade_test.go
+++ b/e2e/install/upgrade/cli_upgrade_test.go
@@ -60,9 +60,6 @@ func TestCLIOperatorUpgrade(t *testing.T) {
 			"--force",
 			"--base-image",
 			defaults.BaseImage(),
-			// TODO: remove GOMAXPROCS when https://github.com/apache/camel-k/issues/4312 is closed
-			"--operator-env-vars",
-			"GOMAXPROCS=1",
 		).Execute()).To(Succeed())
 
 		// Check the operator pod is running

--- a/e2e/install/upgrade/olm_upgrade_test.go
+++ b/e2e/install/upgrade/olm_upgrade_test.go
@@ -91,9 +91,6 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 			"--olm-source", catalogSourceName,
 			"--olm-source-namespace", ns,
 			"--base-image", defaults.BaseImage(),
-			// TODO: remove GOMAXPROCS when https://github.com/apache/camel-k/issues/4312 is closed
-			"--operator-env-vars",
-			"GOMAXPROCS=1",
 		}
 
 		if prevUpdateChannel != "" {


### PR DESCRIPTION
Closes #4478

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): remove workaround pre 1.12.1
```
