### PR TITLE
fix(core): Permissions on operator and builder pods (S2I compatibility)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -45,14 +45,16 @@ ENV MAVEN_OPTS="${MAVEN_OPTS} -Dlogback.configurationFile=${MAVEN_HOME}/conf/log
 ADD build/_maven_output ${MVN_REPO}
 ADD build/_kamelets /kamelets
 
-RUN chgrp -R 1001 ${MVN_REPO} \
-    && chown -R 1001 ${MVN_REPO} \
+RUN chgrp -R 0 ${MVN_REPO} \
+    && chown -R 1001:0 ${MVN_REPO} \
+    && chmod -R 775 ${MVN_REPO} \
     && chgrp -R 0 /kamelets \
     && chmod -R g=u /kamelets \
-    && chgrp -R 1001 ${MAVEN_HOME} \
-    && chown -R 1001 ${MAVEN_HOME}
+    && chgrp -R 0 ${MAVEN_HOME} \
+    && chown -R 1001:0 ${MAVEN_HOME} \
+    && chmod -R 775 ${MAVEN_HOME}
 
-USER 1001
+USER 1001:0
 
 ADD build/_output/bin/kamel /usr/local/bin/kamel
 

--- a/config/rbac/operator-role.yaml
+++ b/config/rbac/operator-role.yaml
@@ -179,3 +179,9 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get

--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -72,7 +72,7 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 		switch build.Status.Phase {
 
 		case v1.BuildPhasePending:
-			if pod, err = newBuildPod(ctx, action.reader, build); err != nil {
+			if pod, err = newBuildPod(ctx, action.reader, action.client, build); err != nil {
 				return nil, err
 			}
 

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -174,10 +174,6 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 					fmt.Sprintf("--health-port=%d", cfg.Health.Port))
 				d.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(int(cfg.Health.Port))
 			}
-			var ugfid int64 = 0
-			d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-				FSGroup: &ugfid,
-			}
 		}
 		if cfg.Debugging.Enabled {
 			if d, ok := o.(*appsv1.Deployment); ok {

--- a/pkg/util/openshift/openshift.go
+++ b/pkg/util/openshift/openshift.go
@@ -18,7 +18,15 @@ limitations under the License.
 package openshift
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -32,4 +40,95 @@ func IsOpenShift(client kubernetes.Interface) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// GetOpenshiftPodSecurityContextRestricted return the PodSecurityContext (https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html):
+// FsGroup set to the minimum value in the "openshift.io/sa.scc.supplemental-groups" annotation if exists, else falls back to minimum value "openshift.io/sa.scc.uid-range" annotation.
+func GetOpenshiftPodSecurityContextRestricted(ctx context.Context, client kubernetes.Interface, namespace string) (*corev1.PodSecurityContext, error) {
+
+	ns, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace %q: %w", namespace, err)
+	}
+
+	uidRange, ok := ns.ObjectMeta.Annotations["openshift.io/sa.scc.uid-range"]
+	if !ok {
+		return nil, errors.New("annotation 'openshift.io/sa.scc.uid-range' not found")
+	}
+
+	supplementalGroups, ok := ns.ObjectMeta.Annotations["openshift.io/sa.scc.supplemental-groups"]
+	if !ok {
+		supplementalGroups = uidRange
+	}
+
+	supplementalGroups = strings.Split(supplementalGroups, ",")[0]
+	fsGroupStr := strings.Split(supplementalGroups, "/")[0]
+	fsGroup, err := strconv.ParseInt(fsGroupStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert fsgroup to integer %q: %w", fsGroupStr, err)
+	}
+
+	psc := corev1.PodSecurityContext{
+		FSGroup: &fsGroup,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
+	return &psc, nil
+
+}
+
+// GetOpenshiftSecurityContextRestricted return the PodSecurityContext (https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html):
+// User set to the minimum value in the "openshift.io/sa.scc.uid-range" annotation.
+func GetOpenshiftSecurityContextRestricted(ctx context.Context, client kubernetes.Interface, namespace string) (*corev1.SecurityContext, error) {
+
+	ns, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace %q: %w", namespace, err)
+	}
+
+	uidRange, ok := ns.ObjectMeta.Annotations["openshift.io/sa.scc.uid-range"]
+	if !ok {
+		return nil, errors.New("annotation 'openshift.io/sa.scc.uid-range' not found")
+	}
+
+	uidStr := strings.Split(uidRange, "/")[0]
+	uid, err := strconv.ParseInt(uidStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert uid to integer %q: %w", uidStr, err)
+	}
+
+	runAsNonRoot := true
+	allowPrivilegeEscalation := false
+	sc := corev1.SecurityContext{
+		RunAsUser:    &uid,
+		RunAsNonRoot: &runAsNonRoot,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+	}
+
+	return &sc, nil
+
+}
+
+// GetOpenshiftUser return the UserId (https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html):
+// User set to the minimum value in the "openshift.io/sa.scc.uid-range" annotation.
+func GetOpenshiftUser(ctx context.Context, client kubernetes.Interface, namespace string) (string, error) {
+
+	ns, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get namespace %q: %w", namespace, err)
+	}
+
+	uidRange, ok := ns.ObjectMeta.Annotations["openshift.io/sa.scc.uid-range"]
+	if !ok {
+		return "", errors.New("annotation 'openshift.io/sa.scc.uid-range' not found")
+	}
+
+	uidStr := strings.Split(uidRange, "/")[0]
+	return uidStr, nil
 }

--- a/pkg/util/openshift/openshift_test.go
+++ b/pkg/util/openshift/openshift_test.go
@@ -1,0 +1,121 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+var noSccAnnotationNamespace *corev1.Namespace = &corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "no-scc-annotations-namespace",
+	},
+}
+
+var constrainedNamespace *corev1.Namespace = &corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "myuser",
+		Annotations: map[string]string{
+			"openshift.io/sa.scc.mcs":                 "s0:c26,c5",
+			"openshift.io/sa.scc.supplemental-groups": "1000860000/10000",
+			"openshift.io/sa.scc.uid-range":           "1000860000/10000",
+		},
+		Labels: map[string]string{
+			"kubernetes.io/metadata.name":              "myuser",
+			"pod-security.kubernetes.io/audit":         "restricted",
+			"pod-security.kubernetes.io/audit-version": "v1.24",
+			"pod-security.kubernetes.io/warn":          "restricted",
+			"pod-security.kubernetes.io/warn-version":  "v1.24",
+		},
+	},
+}
+
+func TestGetUserIdNamespaceWithoutLabels(t *testing.T) {
+	kclient := initClientWithNamespace(t, noSccAnnotationNamespace)
+
+	_, errUID := GetOpenshiftUser(context.Background(), kclient, "no-scc-annotations-namespace")
+
+	assert.NotNil(t, errUID)
+	assert.Contains(t, errUID.Error(), "annotation 'openshift.io/sa.scc.uid-range' not found")
+}
+
+func TestGetUserIdNamespaceConstrained(t *testing.T) {
+	kclient := initClientWithNamespace(t, constrainedNamespace)
+
+	uid, errUID := GetOpenshiftUser(context.Background(), kclient, "myuser")
+
+	assert.Nil(t, errUID)
+	assert.Equal(t, "1000860000", uid)
+}
+
+func TestGetPodSecurityContextNamespaceWithoutLabels(t *testing.T) {
+	kclient := initClientWithNamespace(t, noSccAnnotationNamespace)
+
+	_, errPsc := GetOpenshiftPodSecurityContextRestricted(context.Background(), kclient, "no-scc-annotations-namespace")
+
+	assert.NotNil(t, errPsc)
+	assert.Contains(t, errPsc.Error(), "annotation 'openshift.io/sa.scc.uid-range' not found")
+}
+
+func TestGetPodSecurityContextNamespaceConstrained(t *testing.T) {
+	kclient := initClientWithNamespace(t, constrainedNamespace)
+
+	psc, errPsc := GetOpenshiftPodSecurityContextRestricted(context.Background(), kclient, "myuser")
+
+	expectedFsGroup := int64(1000860000)
+	assert.Nil(t, errPsc)
+	assert.NotNil(t, psc)
+	assert.Equal(t, expectedFsGroup, *psc.FSGroup)
+}
+
+func TestGetSecurityContextNamespaceWithoutLabels(t *testing.T) {
+	kclient := initClientWithNamespace(t, noSccAnnotationNamespace)
+
+	_, errSc := GetOpenshiftSecurityContextRestricted(context.Background(), kclient, "no-scc-annotations-namespace")
+
+	assert.NotNil(t, errSc)
+	assert.Contains(t, errSc.Error(), "annotation 'openshift.io/sa.scc.uid-range' not found")
+}
+
+func TestGetSecurityContextNamespaceConstrained(t *testing.T) {
+	kclient := initClientWithNamespace(t, constrainedNamespace)
+
+	sc, errSc := GetOpenshiftSecurityContextRestricted(context.Background(), kclient, "myuser")
+
+	expectedUserID := int64(1000860000)
+	assert.Nil(t, errSc)
+	assert.NotNil(t, sc)
+	assert.Equal(t, expectedUserID, *sc.RunAsUser)
+}
+
+func initClientWithNamespace(t *testing.T, ns *corev1.Namespace) *fakeclientset.Clientset {
+	t.Helper()
+	kclient := fakeclientset.NewSimpleClientset()
+	_, err := kclient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	return kclient
+}


### PR DESCRIPTION
Ref #4476

For compatibility with S2I publish  strategy:
* Change default Dockerfile user from 1001 to 1001:0 with 775 permissions to be able the write with group 0
* Add builder pod security context compatible with OCP SecurityContextConstraint restricted-v2 (https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html)
* Change Dockerfile S2I to user compatible with SecurityContextConstraint
* Add permission to get a namespace to operator to ensure SecurityContextConstraint labels in namespace are accessible
* Remove root FsGroup on operator as it is no longer needed

This has been tested on:
* OCP (CRC) with default project on routine/pod strategy
* OCP (CRC) with user created project on routine/pod strategy
* spectrum on routine/pod strategy

Note: there is a different user on builder pod dockerfile (`--chown`) because the BuildConfig binary strategy replaces 775 permissions with 755, so we need to fall back to owner user.

**Release Note**
```release-note
fix(core): Permissions on operator and builder pods (S2I compatibility)
```
