### PR TITLE
Increase log lines to 150 when dumping pod logs in e2e tests

### DIFF
--- a/e2e/support/util/dump.go
+++ b/e2e/support/util/dump.go
@@ -317,7 +317,7 @@ func dumpLogs(ctx context.Context, c client.Client, prefix string, ns string, na
 
 	if os.Getenv("CAMEL_K_TEST_LOG_LEVEL") != "debug" {
 		// If not in debug mode then curtail the dumping of log lines
-		lines := int64(50)
+		lines := int64(150)
 		logOptions.TailLines = &lines
 	}
 


### PR DESCRIPTION
To facilitate analysis, there are situations when the last 50 lines is not enough.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
