### PR TITLE
fix(trait): retrieve non cached version of generated Camel Catalog

### DIFF
--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -27,12 +27,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
+	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/maven"
 	"github.com/apache/camel-k/v2/pkg/util/property"
 )
@@ -162,6 +164,21 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 						catalogName, err)
 
 				}
+			}
+
+			// verify that the catalog was generated
+			ct, err := kubernetes.GetUnstructured(
+				e.Ctx,
+				e.Client,
+				schema.GroupVersionKind{Group: "camel.apache.org", Version: "v1", Kind: "CamelCatalog"},
+				catalogName,
+				e.Integration.Namespace,
+			)
+			if ct == nil || err != nil {
+				return fmt.Errorf("unable to create catalog runtime=%s, provider=%s, name=%s: %w",
+					runtime.Version,
+					runtime.Provider,
+					catalogName, err)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #4504

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): retrieve non cached version of generated Camel Catalog
```
