### PR TITLE
chore: Change order of how resources get dumped

### DIFF
--- a/e2e/support/util/dump.go
+++ b/e2e/support/util/dump.go
@@ -52,48 +52,19 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 		return err
 	}
 
-	// IntegrationPlatforms
-	pls, err := camelClient.CamelV1().IntegrationPlatforms(ns).List(ctx, metav1.ListOptions{})
+	// Integrations
+	its, err := camelClient.CamelV1().Integrations(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-	t.Logf("Found %d platforms:\n", len(pls.Items))
-	for _, p := range pls.Items {
-		ref := p
+	t.Logf("Found %d integrations:\n", len(its.Items))
+	for _, integration := range its.Items {
+		ref := integration
 		pdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
 		if err != nil {
 			return err
 		}
 		t.Logf("---\n%s\n---\n", string(pdata))
-	}
-
-	// CamelCatalogs
-	cats, err := camelClient.CamelV1().CamelCatalogs(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	t.Logf("Found %d catalogs:\n", len(cats.Items))
-	for _, c := range cats.Items {
-		ref := c
-		cdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
-		if err != nil {
-			return err
-		}
-		t.Logf("---\n%s\n---\n", string(cdata))
-	}
-
-	// Builds
-	builds, err := camelClient.CamelV1().Builds(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	t.Logf("Found %d builds:\n", len(builds.Items))
-	for _, build := range builds.Items {
-		data, err := kubernetes.ToYAMLNoManagedFields(&build)
-		if err != nil {
-			return err
-		}
-		t.Logf("---\n%s\n---\n", string(data))
 	}
 
 	// IntegrationKits
@@ -111,19 +82,18 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 		t.Logf("---\n%s\n---\n", string(pdata))
 	}
 
-	// Integrations
-	its, err := camelClient.CamelV1().Integrations(ns).List(ctx, metav1.ListOptions{})
+	// Builds
+	builds, err := camelClient.CamelV1().Builds(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-	t.Logf("Found %d integrations:\n", len(its.Items))
-	for _, integration := range its.Items {
-		ref := integration
-		pdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
+	t.Logf("Found %d builds:\n", len(builds.Items))
+	for _, build := range builds.Items {
+		data, err := kubernetes.ToYAMLNoManagedFields(&build)
 		if err != nil {
 			return err
 		}
-		t.Logf("---\n%s\n---\n", string(pdata))
+		t.Logf("---\n%s\n---\n", string(data))
 	}
 
 	// Configmaps
@@ -201,6 +171,36 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 				t.Logf("%sERROR while reading the logs: %v\n", pad, err)
 			}
 		}
+	}
+
+	// IntegrationPlatforms
+	pls, err := camelClient.CamelV1().IntegrationPlatforms(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	t.Logf("Found %d platforms:\n", len(pls.Items))
+	for _, p := range pls.Items {
+		ref := p
+		pdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
+		if err != nil {
+			return err
+		}
+		t.Logf("---\n%s\n---\n", string(pdata))
+	}
+
+	// CamelCatalogs
+	cats, err := camelClient.CamelV1().CamelCatalogs(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	t.Logf("Found %d catalogs:\n", len(cats.Items))
+	for _, c := range cats.Items {
+		ref := c
+		cdata, err := kubernetes.ToYAMLNoManagedFields(&ref)
+		if err != nil {
+			return err
+		}
+		t.Logf("---\n%s\n---\n", string(cdata))
 	}
 
 	// Services

--- a/pkg/cmd/dump.go
+++ b/pkg/cmd/dump.go
@@ -90,6 +90,7 @@ func dumpNamespace(ctx context.Context, c client.Client, ns string, out io.Write
 		return err
 	}
 
+	// Integrations
 	its, err := camelClient.CamelV1().Integrations(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -104,34 +105,7 @@ func dumpNamespace(ctx context.Context, c client.Client, ns string, out io.Write
 		fmt.Fprintf(out, "---\n%s\n---\n", string(pdata))
 	}
 
-	pls, err := camelClient.CamelV1().IntegrationPlatforms(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(out, "Found %d platforms:\n", len(pls.Items))
-	for _, p := range pls.Items {
-		ref := p
-		pdata, err := kubernetes.ToYAML(&ref)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(out, "---\n%s\n---\n", string(pdata))
-	}
-
-	cat, err := camelClient.CamelV1().CamelCatalogs(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(out, "Found %d catalogs:\n", len(pls.Items))
-	for _, c := range cat.Items {
-		ref := c
-		cdata, err := kubernetes.ToYAML(&ref)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(out, "---\n%s\n---\n", string(cdata))
-	}
-
+	// IntegrationKits
 	iks, err := camelClient.CamelV1().IntegrationKits(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -146,6 +120,7 @@ func dumpNamespace(ctx context.Context, c client.Client, ns string, out io.Write
 		fmt.Fprintf(out, "---\n%s\n---\n", string(pdata))
 	}
 
+	// ConfigMaps
 	cms, err := c.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -160,6 +135,7 @@ func dumpNamespace(ctx context.Context, c client.Client, ns string, out io.Write
 		fmt.Fprintf(out, "---\n%s\n---\n", string(pdata))
 	}
 
+	// Deployments
 	deployments, err := c.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -174,6 +150,37 @@ func dumpNamespace(ctx context.Context, c client.Client, ns string, out io.Write
 		fmt.Fprintf(out, "---\n%s\n---\n", string(data))
 	}
 
+	// IntegrationPlatforms
+	pls, err := camelClient.CamelV1().IntegrationPlatforms(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Found %d platforms:\n", len(pls.Items))
+	for _, p := range pls.Items {
+		ref := p
+		pdata, err := kubernetes.ToYAML(&ref)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "---\n%s\n---\n", string(pdata))
+	}
+
+	// CamelCatalogs
+	cat, err := camelClient.CamelV1().CamelCatalogs(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Found %d catalogs:\n", len(pls.Items))
+	for _, c := range cat.Items {
+		ref := c
+		cdata, err := kubernetes.ToYAML(&ref)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "---\n%s\n---\n", string(cdata))
+	}
+
+	// Pods and Logs
 	lst, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
Dump CamelCatalog at the end to avoid heavy log scrolling during failure analysis