### PR TITLE
Fix Unable to retrieve CamelCatalog with global installation

### DIFF
--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -148,7 +148,7 @@ func operatorInfo(ctx context.Context, c client.Client, namespace string) (map[s
 	infos["Registry address"] = platform.Status.Build.Registry.Address
 	infos["Git commit"] = platform.Status.Info["gitCommit"]
 
-	catalog, err := camel.LoadCatalog(ctx, c, namespace, v1.RuntimeSpec{Version: platform.Status.Build.RuntimeVersion, Provider: platform.Status.Build.RuntimeProvider})
+	catalog, err := camel.LoadCatalog(ctx, c, platform.Namespace, v1.RuntimeSpec{Version: platform.Status.Build.RuntimeVersion, Provider: platform.Status.Build.RuntimeProvider})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix 
```
➜  /tmp ./kamel version -av
Unable to retrieve the operator version: CamelCatalog can't be found in openshift-operators namespace
Camel K Client 2.0.0-nightly
Git Commit: 612d1cd286616c58a75d6820e05c984c73dd6f7d

Unable to retrieve operator version: CamelCatalog can't be found in openshift-operators namespace
```
with global operator installation
