### PR TITLE
chore: use fixed default runtime version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -43,6 +43,8 @@ RUN ${MVNW_DIR}/mvnw --version | grep "Maven home:" | sed 's/Maven home: //' >> 
 ENV MAVEN_OPTS="${MAVEN_OPTS} -Dlogback.configurationFile=${MAVEN_HOME}/conf/logback.xml"
 
 ADD build/_maven_output ${MVN_REPO}
+# Fix https://github.com/moby/moby/issues/37965
+RUN true
 ADD build/_kamelets /kamelets
 
 RUN chgrp -R 0 ${MVN_REPO} \

--- a/pkg/util/defaults/defaults.go
+++ b/pkg/util/defaults/defaults.go
@@ -26,7 +26,7 @@ const (
 	Version = "2.0.0-SNAPSHOT"
 
 	// DefaultRuntimeVersion --
-	DefaultRuntimeVersion = "2.16.0-SNAPSHOT"
+	DefaultRuntimeVersion = "2.16.0"
 
 	// BuildahVersion --
 	BuildahVersion = "1.30.0"

--- a/resources/camel-catalog-2.16.0.yaml
+++ b/resources/camel-catalog-2.16.0.yaml
@@ -18,15 +18,15 @@
 apiVersion: camel.apache.org/v1
 kind: CamelCatalog
 metadata:
-  name: camel-catalog-2.16.0-snapshot
+  name: camel-catalog-2.16.0
   labels:
     app: camel-k
     camel.apache.org/catalog.loader.version: 3.20.1
     camel.apache.org/catalog.version: 3.20.1
-    camel.apache.org/runtime.version: 2.16.0-SNAPSHOT
+    camel.apache.org/runtime.version: 2.16.0
 spec:
   runtime:
-    version: 2.16.0-SNAPSHOT
+    version: 2.16.0
     provider: quarkus
     applicationClass: io.quarkus.bootstrap.runner.QuarkusEntryPoint
     metadata:

--- a/script/Makefile
+++ b/script/Makefile
@@ -23,7 +23,7 @@ VERSIONFILE := pkg/util/defaults/defaults.go
 VERSION ?= 2.0.0-SNAPSHOT
 LAST_RELEASED_IMAGE_NAME := camel-k-operator
 LAST_RELEASED_VERSION ?= 1.12.1
-RUNTIME_VERSION := 2.16.0-SNAPSHOT
+DEFAULT_RUNTIME_VERSION := 2.16.0
 BUILDAH_VERSION := 1.30.0
 KANIKO_VERSION := 1.9.1
 CONTROLLER_GEN_VERSION := v0.6.1
@@ -179,7 +179,7 @@ codegen:
 	@echo "  Version = \"$(CUSTOM_VERSION)\"" >> $(VERSIONFILE)
 	@echo "" >> $(VERSIONFILE)
 	@echo "  // DefaultRuntimeVersion -- " >> $(VERSIONFILE)
-	@echo "  DefaultRuntimeVersion = \"$(RUNTIME_VERSION)\"" >> $(VERSIONFILE)
+	@echo "  DefaultRuntimeVersion = \"$(DEFAULT_RUNTIME_VERSION)\"" >> $(VERSIONFILE)
 	@echo "" >> $(VERSIONFILE)
 	@echo "  // BuildahVersion -- " >> $(VERSIONFILE)
 	@echo "  BuildahVersion = \"$(BUILDAH_VERSION)\"" >> $(VERSIONFILE)
@@ -348,7 +348,7 @@ build-kamel:
 	ln -sf build/_output/bin/kamel-$(IMAGE_ARCH) ./kamel
 
 build-resources:
-	./script/get_catalog.sh $(RUNTIME_VERSION) $(STAGING_RUNTIME_REPO)
+	./script/get_catalog.sh $(DEFAULT_RUNTIME_VERSION) $(STAGING_RUNTIME_REPO)
 	go generate ./pkg/...
 
 bundle-kamelets:
@@ -419,7 +419,7 @@ check-licenses:
 maven-overlay:
 	@echo "####### Preparing maven dependencies bundle..."
 	mkdir -p build/_maven_overlay
-	./script/maven_overlay.sh -s "$(STAGING_RUNTIME_REPO)" -d "$(CAMEL_K_RUNTIME_DIR)" $(RUNTIME_VERSION) build/_maven_overlay
+	./script/maven_overlay.sh -s "$(STAGING_RUNTIME_REPO)" -d "$(CAMEL_K_RUNTIME_DIR)" $(DEFAULT_RUNTIME_VERSION) build/_maven_overlay
 
 kamel-overlay:
 	mkdir -p build/_output/bin
@@ -444,8 +444,8 @@ ifneq ($(IMAGE_ARCH), amd64)
 endif
 
 images: build kamel-overlay maven-overlay bundle-kamelets
-ifneq (,$(findstring SNAPSHOT,$(RUNTIME_VERSION)))
-	./script/package_maven_artifacts.sh -s "$(STAGING_RUNTIME_REPO)" -d "$(CAMEL_K_RUNTIME_DIR)" $(RUNTIME_VERSION)
+ifneq (,$(findstring SNAPSHOT,$(DEFAULT_RUNTIME_VERSION)))
+	./script/package_maven_artifacts.sh -s "$(STAGING_RUNTIME_REPO)" -d "$(CAMEL_K_RUNTIME_DIR)" $(DEFAULT_RUNTIME_VERSION)
 endif
 	@echo "####### Building Camel K operator arch $(IMAGE_ARCH) container image..."
 	mkdir -p build/_maven_output

--- a/script/update_docs.sh
+++ b/script/update_docs.sh
@@ -18,7 +18,7 @@
 location=$(dirname $0)
 
 echo "Scraping information from Makefile"
-RUNTIME_VERSION=$(grep '^RUNTIME_VERSION := ' Makefile | sed 's/^.* \?= //')
+RUNTIME_VERSION=$(grep '^DEFAULT_RUNTIME_VERSION := ' Makefile | sed 's/^.* \?= //')
 
 CATALOG="$location/../resources/camel-catalog-$RUNTIME_VERSION.yaml"
 # This script requires the catalog to be available (via make build-resources for instance)


### PR DESCRIPTION
As we now don't depend on the runtime directly, it makes sense to use a final release instead of a snapshot.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore: use fixed default runtime version
```
