### PR TITLE
fix(cli): skip k8s lookup when dry-run

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -747,8 +747,10 @@ func (o *runCmdOptions) parseAndConvertToTrait(cmd *cobra.Command,
 		if err != nil {
 			return err
 		}
-		if err := parseConfig(o.Context, cmd, c, config, integration); err != nil {
-			return err
+		if o.OutputFormat == "" {
+			if err := parseConfig(o.Context, cmd, c, config, integration); err != nil {
+				return err
+			}
 		}
 		o.Traits = append(o.Traits, convertToTrait(convert(config), traitParam))
 	}


### PR DESCRIPTION
Closes #4566
Closes #4543

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): skip k8s lookup when dry-run
```
