### PR TITLE
feat(trait): Add maven profile to Integration in builder trait

### DIFF
--- a/config/crd/bases/camel.apache.org_builds.yaml
+++ b/config/crd/bases/camel.apache.org_builds.yaml
@@ -310,6 +310,50 @@ spec:
                             localRepository:
                               description: The path of the local Maven repository.
                               type: string
+                            profile:
+                              description: A reference to the ConfigMap or Secret
+                                key that contains the Maven profile.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
                             properties:
                               additionalProperties:
                                 type: string

--- a/config/crd/bases/camel.apache.org_integrationkits.yaml
+++ b/config/crd/bases/camel.apache.org_integrationkits.yaml
@@ -211,6 +211,16 @@ spec:
                         description: When using `pod` strategy, the maximum amount
                           of memory required by the pod builder.
                         type: string
+                      mavenProfile:
+                        description: 'A reference pointing to a configmap/secret that
+                          contains a maven profile. The content of the maven profile
+                          is expected to be a text containing a valid maven profile
+                          starting with `<profile>` and ending with `</profile>` that
+                          will be integrated as an inline profile in the POM. Syntax:
+                          [configmap|secret]:name[/key], where name represents the
+                          resource name, key optionally represents the resource key
+                          to be filtered (default key value = profile.xml).'
+                        type: string
                       orderStrategy:
                         description: The build order strategy to use, either `dependencies`,
                           `fifo` or `sequential` (default sequential)

--- a/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -202,6 +202,48 @@ spec:
                       localRepository:
                         description: The path of the local Maven repository.
                         type: string
+                      profile:
+                        description: A reference to the ConfigMap or Secret key that
+                          contains the Maven profile.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
                       properties:
                         additionalProperties:
                           type: string
@@ -468,6 +510,16 @@ spec:
                       limitMemory:
                         description: When using `pod` strategy, the maximum amount
                           of memory required by the pod builder.
+                        type: string
+                      mavenProfile:
+                        description: 'A reference pointing to a configmap/secret that
+                          contains a maven profile. The content of the maven profile
+                          is expected to be a text containing a valid maven profile
+                          starting with `<profile>` and ending with `</profile>` that
+                          will be integrated as an inline profile in the POM. Syntax:
+                          [configmap|secret]:name[/key], where name represents the
+                          resource name, key optionally represents the resource key
+                          to be filtered (default key value = profile.xml).'
                         type: string
                       orderStrategy:
                         description: The build order strategy to use, either `dependencies`,
@@ -1850,6 +1902,48 @@ spec:
                       localRepository:
                         description: The path of the local Maven repository.
                         type: string
+                      profile:
+                        description: A reference to the ConfigMap or Secret key that
+                          contains the Maven profile.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
                       properties:
                         additionalProperties:
                           type: string
@@ -2164,6 +2258,16 @@ spec:
                       limitMemory:
                         description: When using `pod` strategy, the maximum amount
                           of memory required by the pod builder.
+                        type: string
+                      mavenProfile:
+                        description: 'A reference pointing to a configmap/secret that
+                          contains a maven profile. The content of the maven profile
+                          is expected to be a text containing a valid maven profile
+                          starting with `<profile>` and ending with `</profile>` that
+                          will be integrated as an inline profile in the POM. Syntax:
+                          [configmap|secret]:name[/key], where name represents the
+                          resource name, key optionally represents the resource key
+                          to be filtered (default key value = profile.xml).'
                         type: string
                       orderStrategy:
                         description: The build order strategy to use, either `dependencies`,

--- a/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/config/crd/bases/camel.apache.org_integrations.yaml
@@ -6194,6 +6194,16 @@ spec:
                         description: When using `pod` strategy, the maximum amount
                           of memory required by the pod builder.
                         type: string
+                      mavenProfile:
+                        description: 'A reference pointing to a configmap/secret that
+                          contains a maven profile. The content of the maven profile
+                          is expected to be a text containing a valid maven profile
+                          starting with `<profile>` and ending with `</profile>` that
+                          will be integrated as an inline profile in the POM. Syntax:
+                          [configmap|secret]:name[/key], where name represents the
+                          resource name, key optionally represents the resource key
+                          to be filtered (default key value = profile.xml).'
+                        type: string
                       orderStrategy:
                         description: The build order strategy to use, either `dependencies`,
                           `fifo` or `sequential` (default sequential)

--- a/config/crd/bases/camel.apache.org_kameletbindings.yaml
+++ b/config/crd/bases/camel.apache.org_kameletbindings.yaml
@@ -6469,6 +6469,17 @@ spec:
                             description: When using `pod` strategy, the maximum amount
                               of memory required by the pod builder.
                             type: string
+                          mavenProfile:
+                            description: 'A reference pointing to a configmap/secret
+                              that contains a maven profile. The content of the maven
+                              profile is expected to be a text containing a valid
+                              maven profile starting with `<profile>` and ending with
+                              `</profile>` that will be integrated as an inline profile
+                              in the POM. Syntax: [configmap|secret]:name[/key], where
+                              name represents the resource name, key optionally represents
+                              the resource key to be filtered (default key value =
+                              profile.xml).'
+                            type: string
                           orderStrategy:
                             description: The build order strategy to use, either `dependencies`,
                               `fifo` or `sequential` (default sequential)

--- a/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/config/crd/bases/camel.apache.org_pipes.yaml
@@ -6466,6 +6466,17 @@ spec:
                             description: When using `pod` strategy, the maximum amount
                               of memory required by the pod builder.
                             type: string
+                          mavenProfile:
+                            description: 'A reference pointing to a configmap/secret
+                              that contains a maven profile. The content of the maven
+                              profile is expected to be a text containing a valid
+                              maven profile starting with `<profile>` and ending with
+                              `</profile>` that will be integrated as an inline profile
+                              in the POM. Syntax: [configmap|secret]:name[/key], where
+                              name represents the resource name, key optionally represents
+                              the resource key to be filtered (default key value =
+                              profile.xml).'
+                            type: string
                           orderStrategy:
                             description: The build order strategy to use, either `dependencies`,
                               `fifo` or `sequential` (default sequential)

--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -3836,6 +3836,14 @@ map[string]string
 
 The Maven properties.
 
+|`profile` +
+*xref:#_camel_apache_org_v1_ValueSource[ValueSource]*
+|
+
+
+A reference to the ConfigMap or Secret key that contains
+the Maven profile.
+
 |`settings` +
 *xref:#_camel_apache_org_v1_ValueSource[ValueSource]*
 |
@@ -5441,6 +5449,15 @@ string
 
 
 When using `pod` strategy, the maximum amount of memory required by the pod builder.
+
+|`mavenProfile` +
+string
+|
+
+
+A reference pointing to a configmap/secret that contains a maven profile.
+The content of the maven profile is expected to be a text containing a valid maven profile starting with `<profile>` and ending with `</profile>` that will be integrated as an inline profile in the POM.
+Syntax: [configmap{vbar}secret]:name[/key], where name represents the resource name, key optionally represents the resource key to be filtered (default key value = profile.xml).
 
 |`tasks` +
 []string

--- a/docs/modules/traits/pages/builder.adoc
+++ b/docs/modules/traits/pages/builder.adoc
@@ -60,6 +60,12 @@ The following configuration options are available:
 | string
 | When using `pod` strategy, the maximum amount of memory required by the pod builder.
 
+| builder.maven-profile
+| string
+| A reference pointing to a configmap/secret that contains a maven profile.
+The content of the maven profile is expected to be a text containing a valid maven profile starting with `<profile>` and ending with `</profile>` that will be integrated as an inline profile in the POM.
+Syntax: [configmap\|secret]:name[/key], where name represents the resource name, key optionally represents the resource key to be filtered (default key value = profile.xml).
+
 | builder.tasks
 | []string
 | A list of tasks to be executed (available only when using `pod` strategy) with format <name>;<container-image>;<container-command>

--- a/helm/camel-k/crds/crd-build.yaml
+++ b/helm/camel-k/crds/crd-build.yaml
@@ -310,6 +310,50 @@ spec:
                             localRepository:
                               description: The path of the local Maven repository.
                               type: string
+                            profile:
+                              description: A reference to the ConfigMap or Secret
+                                key that contains the Maven profile.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
                             properties:
                               additionalProperties:
                                 type: string

--- a/helm/camel-k/crds/crd-integration-kit.yaml
+++ b/helm/camel-k/crds/crd-integration-kit.yaml
@@ -211,6 +211,16 @@ spec:
                         description: When using `pod` strategy, the maximum amount
                           of memory required by the pod builder.
                         type: string
+                      mavenProfile:
+                        description: 'A reference pointing to a configmap/secret that
+                          contains a maven profile. The content of the maven profile
+                          is expected to be a text containing a valid maven profile
+                          starting with `<profile>` and ending with `</profile>` that
+                          will be integrated as an inline profile in the POM. Syntax:
+                          [configmap|secret]:name[/key], where name represents the
+                          resource name, key optionally represents the resource key
+                          to be filtered (default key value = profile.xml).'
+                        type: string
                       orderStrategy:
                         description: The build order strategy to use, either `dependencies`,
                           `fifo` or `sequential` (default sequential)

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -202,6 +202,48 @@ spec:
                       localRepository:
                         description: The path of the local Maven repository.
                         type: string
+                      profile:
+                        description: A reference to the ConfigMap or Secret key that
+                          contains the Maven profile.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
                       properties:
                         additionalProperties:
                           type: string
@@ -468,6 +510,16 @@ spec:
                       limitMemory:
                         description: When using `pod` strategy, the maximum amount
                           of memory required by the pod builder.
+                        type: string
+                      mavenProfile:
+                        description: 'A reference pointing to a configmap/secret that
+                          contains a maven profile. The content of the maven profile
+                          is expected to be a text containing a valid maven profile
+                          starting with `<profile>` and ending with `</profile>` that
+                          will be integrated as an inline profile in the POM. Syntax:
+                          [configmap|secret]:name[/key], where name represents the
+                          resource name, key optionally represents the resource key
+                          to be filtered (default key value = profile.xml).'
                         type: string
                       orderStrategy:
                         description: The build order strategy to use, either `dependencies`,
@@ -1850,6 +1902,48 @@ spec:
                       localRepository:
                         description: The path of the local Maven repository.
                         type: string
+                      profile:
+                        description: A reference to the ConfigMap or Secret key that
+                          contains the Maven profile.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
                       properties:
                         additionalProperties:
                           type: string
@@ -2164,6 +2258,16 @@ spec:
                       limitMemory:
                         description: When using `pod` strategy, the maximum amount
                           of memory required by the pod builder.
+                        type: string
+                      mavenProfile:
+                        description: 'A reference pointing to a configmap/secret that
+                          contains a maven profile. The content of the maven profile
+                          is expected to be a text containing a valid maven profile
+                          starting with `<profile>` and ending with `</profile>` that
+                          will be integrated as an inline profile in the POM. Syntax:
+                          [configmap|secret]:name[/key], where name represents the
+                          resource name, key optionally represents the resource key
+                          to be filtered (default key value = profile.xml).'
                         type: string
                       orderStrategy:
                         description: The build order strategy to use, either `dependencies`,

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -6194,6 +6194,16 @@ spec:
                         description: When using `pod` strategy, the maximum amount
                           of memory required by the pod builder.
                         type: string
+                      mavenProfile:
+                        description: 'A reference pointing to a configmap/secret that
+                          contains a maven profile. The content of the maven profile
+                          is expected to be a text containing a valid maven profile
+                          starting with `<profile>` and ending with `</profile>` that
+                          will be integrated as an inline profile in the POM. Syntax:
+                          [configmap|secret]:name[/key], where name represents the
+                          resource name, key optionally represents the resource key
+                          to be filtered (default key value = profile.xml).'
+                        type: string
                       orderStrategy:
                         description: The build order strategy to use, either `dependencies`,
                           `fifo` or `sequential` (default sequential)

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -6469,6 +6469,17 @@ spec:
                             description: When using `pod` strategy, the maximum amount
                               of memory required by the pod builder.
                             type: string
+                          mavenProfile:
+                            description: 'A reference pointing to a configmap/secret
+                              that contains a maven profile. The content of the maven
+                              profile is expected to be a text containing a valid
+                              maven profile starting with `<profile>` and ending with
+                              `</profile>` that will be integrated as an inline profile
+                              in the POM. Syntax: [configmap|secret]:name[/key], where
+                              name represents the resource name, key optionally represents
+                              the resource key to be filtered (default key value =
+                              profile.xml).'
+                            type: string
                           orderStrategy:
                             description: The build order strategy to use, either `dependencies`,
                               `fifo` or `sequential` (default sequential)

--- a/helm/camel-k/crds/crd-pipe.yaml
+++ b/helm/camel-k/crds/crd-pipe.yaml
@@ -6466,6 +6466,17 @@ spec:
                             description: When using `pod` strategy, the maximum amount
                               of memory required by the pod builder.
                             type: string
+                          mavenProfile:
+                            description: 'A reference pointing to a configmap/secret
+                              that contains a maven profile. The content of the maven
+                              profile is expected to be a text containing a valid
+                              maven profile starting with `<profile>` and ending with
+                              `</profile>` that will be integrated as an inline profile
+                              in the POM. Syntax: [configmap|secret]:name[/key], where
+                              name represents the resource name, key optionally represents
+                              the resource key to be filtered (default key value =
+                              profile.xml).'
+                            type: string
                           orderStrategy:
                             description: The build order strategy to use, either `dependencies`,
                               `fifo` or `sequential` (default sequential)

--- a/pkg/apis/camel/v1/maven_types.go
+++ b/pkg/apis/camel/v1/maven_types.go
@@ -30,6 +30,9 @@ type MavenSpec struct {
 	// The Maven properties.
 	Properties map[string]string `json:"properties,omitempty"`
 	// A reference to the ConfigMap or Secret key that contains
+	// the Maven profile.
+	Profile ValueSource `json:"profile,omitempty"`
+	// A reference to the ConfigMap or Secret key that contains
 	// the Maven settings.
 	Settings ValueSource `json:"settings,omitempty"`
 	// A reference to the ConfigMap or Secret key that contains

--- a/pkg/apis/camel/v1/trait/builder.go
+++ b/pkg/apis/camel/v1/trait/builder.go
@@ -39,6 +39,10 @@ type BuilderTrait struct {
 	LimitCPU string `property:"limit-cpu" json:"limitCPU,omitempty"`
 	// When using `pod` strategy, the maximum amount of memory required by the pod builder.
 	LimitMemory string `property:"limit-memory" json:"limitMemory,omitempty"`
+	// A reference pointing to a configmap/secret that contains a maven profile.
+	// The content of the maven profile is expected to be a text containing a valid maven profile starting with `<profile>` and ending with `</profile>` that will be integrated as an inline profile in the POM.
+	// Syntax: [configmap|secret]:name[/key], where name represents the resource name, key optionally represents the resource key to be filtered (default key value = profile.xml).
+	MavenProfile string `property:"maven-profile" json:"mavenProfile,omitempty"`
 	// A list of tasks to be executed (available only when using `pod` strategy) with format <name>;<container-image>;<container-command>
 	Tasks []string `property:"tasks" json:"tasks,omitempty"`
 }

--- a/pkg/apis/camel/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/camel/v1/zz_generated.deepcopy.go
@@ -2000,6 +2000,7 @@ func (in *MavenSpec) DeepCopyInto(out *MavenSpec) {
 			(*out)[key] = val
 		}
 	}
+	in.Profile.DeepCopyInto(&out.Profile)
 	in.Settings.DeepCopyInto(&out.Settings)
 	in.SettingsSecurity.DeepCopyInto(&out.SettingsSecurity)
 	if in.CASecrets != nil {

--- a/pkg/client/camel/applyconfiguration/camel/v1/mavenbuildspec.go
+++ b/pkg/client/camel/applyconfiguration/camel/v1/mavenbuildspec.go
@@ -59,6 +59,14 @@ func (b *MavenBuildSpecApplyConfiguration) WithProperties(entries map[string]str
 	return b
 }
 
+// WithProfile sets the Profile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Profile field is set to the value of the last call.
+func (b *MavenBuildSpecApplyConfiguration) WithProfile(value *ValueSourceApplyConfiguration) *MavenBuildSpecApplyConfiguration {
+	b.Profile = value
+	return b
+}
+
 // WithSettings sets the Settings field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Settings field is set to the value of the last call.

--- a/pkg/client/camel/applyconfiguration/camel/v1/mavenspec.go
+++ b/pkg/client/camel/applyconfiguration/camel/v1/mavenspec.go
@@ -28,6 +28,7 @@ import (
 type MavenSpecApplyConfiguration struct {
 	LocalRepository  *string                           `json:"localRepository,omitempty"`
 	Properties       map[string]string                 `json:"properties,omitempty"`
+	Profile          *ValueSourceApplyConfiguration    `json:"profile,omitempty"`
 	Settings         *ValueSourceApplyConfiguration    `json:"settings,omitempty"`
 	SettingsSecurity *ValueSourceApplyConfiguration    `json:"settingsSecurity,omitempty"`
 	CASecrets        []corev1.SecretKeySelector        `json:"caSecrets,omitempty"`
@@ -60,6 +61,14 @@ func (b *MavenSpecApplyConfiguration) WithProperties(entries map[string]string) 
 	for k, v := range entries {
 		b.Properties[k] = v
 	}
+	return b
+}
+
+// WithProfile sets the Profile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Profile field is set to the value of the last call.
+func (b *MavenSpecApplyConfiguration) WithProfile(value *ValueSourceApplyConfiguration) *MavenSpecApplyConfiguration {
+	b.Profile = value
 	return b
 }
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -568,7 +568,8 @@ func (o *installCmdOptions) setupIntegrationPlatform(c client.Client, namespace 
 	}
 
 	if o.MavenSettings != "" {
-		mavenSettings, err := decodeMavenSettings(o.MavenSettings)
+		mavenSettings, err := v1.DecodeValueSource(o.MavenSettings, "settings.xml",
+			"illegal maven setting definition, syntax: configmap|secret:resource-name[/settings path]")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -261,6 +261,16 @@ func (t *builderTrait) builderTask(e *Environment) (*v1.BuilderTask, error) {
 		}
 	}
 
+	// User provides a maven profile
+	if t.MavenProfile != "" {
+		mavenProfile, err := v1.DecodeValueSource(t.MavenProfile, "profile.xml",
+			"illegal profile definition, syntax: configmap|secret:resource-name[/profile path]")
+		if err != nil {
+			return nil, fmt.Errorf("invalid maven profile: %s: %w. ", t.MavenProfile, err)
+		}
+		task.Maven.Profile = mavenProfile
+	}
+
 	steps := make([]builder.Step, 0)
 	steps = append(steps, builder.Project.CommonSteps...)
 

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -202,3 +202,22 @@ func findCustomTaskByName(tasks []v1.Task, name string) v1.Task {
 	}
 	return v1.Task{}
 }
+
+func TestMavenProfileBuilderTrait(t *testing.T) {
+	env := createBuilderTestEnv(v1.IntegrationPlatformClusterKubernetes, v1.IntegrationPlatformBuildPublishStrategyKaniko)
+	builderTrait := createNominalBuilderTraitTest()
+	builderTrait.MavenProfile = "configmap:maven-profile/owasp-profile.xml"
+
+	err := builderTrait.Apply(env)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, v1.ValueSource{
+		ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: "maven-profile",
+			},
+			Key: "owasp-profile.xml",
+		},
+	}, env.Pipeline[0].Builder.Maven.MavenSpec.Profile)
+}

--- a/pkg/util/maven/maven_project.go
+++ b/pkg/util/maven/maven_project.go
@@ -152,6 +152,10 @@ func (p *Project) AddEncodedDependencyExclusion(gav string, exclusion Exclusion)
 	}
 }
 
+func (p *Project) AddProfile(profile string) {
+	p.Profiles = ProfilesContent{InnerXML: profile}
+}
+
 // NewDependency creates an new dependency from the given GAV.
 func NewDependency(groupID string, artifactID string, version string) Dependency {
 	return Dependency{

--- a/pkg/util/maven/maven_project_test.go
+++ b/pkg/util/maven/maven_project_test.go
@@ -80,6 +80,7 @@ const expectedPom = `<?xml version="1.0" encoding="UTF-8"?>
       </releases>
     </pluginRepository>
   </pluginRepositories>
+  <profiles><profile><id>custom</id></profile></profiles>
 </project>`
 
 func TestPomGeneration(t *testing.T) {
@@ -128,6 +129,8 @@ func TestPomGeneration(t *testing.T) {
 			},
 		},
 	}
+
+	project.Profiles = ProfilesContent{InnerXML: `<profile><id>custom</id></profile>`}
 
 	pom, err := util.EncodeXML(project)
 

--- a/pkg/util/maven/maven_types.go
+++ b/pkg/util/maven/maven_types.go
@@ -80,6 +80,7 @@ type Project struct {
 	Repositories         []v1.Repository       `xml:"repositories>repository,omitempty"`
 	PluginRepositories   []v1.Repository       `xml:"pluginRepositories>pluginRepository,omitempty"`
 	Build                *Build                `xml:"build,omitempty"`
+	Profiles             ProfilesContent       `xml:"profiles,omitempty"`
 }
 
 // Exclusion models a dependency exclusion.
@@ -131,4 +132,8 @@ type Proxy struct {
 	Username      string `xml:"username,omitempty"`
 	Password      string `xml:"password,omitempty"`
 	NonProxyHosts string `xml:"nonProxyHosts,omitempty"`
+}
+
+type ProfilesContent struct {
+	InnerXML string `xml:",innerxml"`
 }

--- a/resources/traits.yaml
+++ b/resources/traits.yaml
@@ -232,6 +232,14 @@ traits:
     type: string
     description: When using `pod` strategy, the maximum amount of memory required
       by the pod builder.
+  - name: maven-profile
+    type: string
+    description: 'A reference pointing to a configmap/secret that contains a maven
+      profile. The content of the maven profile is expected to be a text containing
+      a valid maven profile starting with `<profile>` and ending with `</profile>`
+      that will be integrated as an inline profile in the POM. Syntax: [configmap|secret]:name[/key],
+      where name represents the resource name, key optionally represents the resource
+      key to be filtered (default key value = profile.xml).'
   - name: tasks
     type: '[]string'
     description: A list of tasks to be executed (available only when using `pod` strategy)


### PR DESCRIPTION
Ref #4560

## Description

* Add builder.maven-profile property referencing a secret or a configmap : `[configmap|secret]:name[/key]`
* Inject the given profile into the pom.xml generated in the project
* Some refactoring on configmap/secret decoding from cli

Example: 
* Creates a secret or a configmap: `kubectl create secret generic maven-profile-owasp --from-file=owasp-profile.xml`
* Use it in the builder trait: `-t builder.maven-profile=secret:maven-profile-owasp/owasp-profile.xml`

**Release Note**
```release-note
Add maven profile to Integration in builder trait as the maven-profile property referencing a secret or a configmap
```
