### PR TITLE
fix(core): Remove ownership from CamelCatalog on builder image IS

### DIFF
--- a/pkg/controller/catalog/initialize.go
+++ b/pkg/controller/catalog/initialize.go
@@ -282,7 +282,7 @@ func initializeS2i(ctx context.Context, c client.Client, ip *v1.IntegrationPlatf
 		return target, err
 	}
 
-	err = s2i.ImageStream(ctx, c, is, owner)
+	err = s2i.ImageStream(ctx, c, is, nil)
 	if err != nil {
 		target.Status.Phase = v1.CamelCatalogPhaseError
 		target.Status.SetErrorCondition(

--- a/pkg/util/s2i/build.go
+++ b/pkg/util/s2i/build.go
@@ -97,8 +97,10 @@ func ImageStream(ctx context.Context, c client.Client, is *imagev1.ImageStream, 
 		return fmt.Errorf("cannot delete image stream: %w", err)
 	}
 
-	if err := ctrlutil.SetOwnerReference(owner, is, c.GetScheme()); err != nil {
-		return fmt.Errorf("cannot set owner reference on ImageStream: %s: %w", is.Name, err)
+	if owner != nil {
+		if err := ctrlutil.SetOwnerReference(owner, is, c.GetScheme()); err != nil {
+			return fmt.Errorf("cannot set owner reference on ImageStream: %s: %w", is.Name, err)
+		}
 	}
 
 	if err := c.Create(ctx, is); err != nil {


### PR DESCRIPTION
Fix #4569 

This will remove the ownership from the CamelCatalog on the build image ImageStream resource. It will be kept when the camel-k operator is removed.

The side effects this modification is that any uninstall won't remove the ImageStream so it needs to be done manually.

**Release Note**
```release-note
fix(core): Remove ownership from CamelCatalog on builder image IS
```
