### PR TITLE
fix(ci): run coverage only on golang code changes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,8 @@ name: Coverage report
 
 on:
   pull_request_target:
+    paths:
+      - 'pkg/**'
 
 jobs:
   report:


### PR DESCRIPTION
Closes #4571

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ci): run coverage only on golang code changes
```
