### PR TITLE
fix: use non deprecated components

### DIFF
--- a/docs/modules/ROOT/pages/configuration/dependencies.adoc
+++ b/docs/modules/ROOT/pages/configuration/dependencies.adoc
@@ -17,6 +17,28 @@ Automatic resolution is also a nice feature in xref:running/dev-mode.adoc[dev mo
 
 NOTE: Camel K won't be able to resolve automatically the dependencies when your routes specify dynamic URIs.
 
+[[dependencies-from-import]]
+== Import path dependencies
+
+While developing your route, you will start including references to Camel dependencies via Java (or any other DSL) import mechanism. Camel K is able to scan and detect such dependencies as well. Take the following example:
+
+```java
+import org.apache.camel.builder.RouteBuilder;
+...
+import org.apache.camel.component.kafka.KafkaComponent;
+
+public class Test extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("timer:java?period={{time:1000}}").
+            ...
+    }
+}
+
+```
+Camel K will be able to include `camel-kafka` dependency as it discover scanning the import paths. No need to specify it in such circumstances.
+
 [[dependencies-explicit]]
 == Add explicit dependencies
 

--- a/pkg/metadata/metadata_dependencies_test.go
+++ b/pkg/metadata/metadata_dependencies_test.go
@@ -32,7 +32,7 @@ func TestDependenciesJavaSource(t *testing.T) {
 		DataSpec: v1.DataSpec{
 			Name: "Request.java",
 			Content: `
-			    import org.apache.camel.component.activemq.ActiveMQComponent;
+			    import org.apache.camel.component.kafka.KafkaComponent;
 
 			    from("telegram:bots/cippa").to("log:stash");
 			    from("timer:tick").to("amqp:queue");
@@ -52,7 +52,7 @@ func TestDependenciesJavaSource(t *testing.T) {
 	assert.ElementsMatch(
 		t,
 		[]string{
-			"camel:activemq",
+			"camel:kafka",
 			"camel:amqp",
 			"camel:log",
 			"camel:telegram",
@@ -67,7 +67,7 @@ func TestDependenciesJavaScript(t *testing.T) {
 		DataSpec: v1.DataSpec{
 			Name: "source.js",
 			Content: `
-			    var component = Java.type("org.apache.camel.component.activemq.ActiveMQComponent");
+			    var component = Java.type("org.apache.camel.component.kafka.KafkaComponent");
 
 			    from('telegram:bots/cippa').to("log:stash");
 			    from('timer:tick').to("amqp:queue");
@@ -86,7 +86,7 @@ func TestDependenciesJavaScript(t *testing.T) {
 	assert.ElementsMatch(
 		t,
 		[]string{
-			"camel:activemq",
+			"camel:kafka",
 			"camel:amqp",
 			"camel:log",
 			"camel:telegram",
@@ -100,7 +100,7 @@ func TestDependenciesGroovy(t *testing.T) {
 		DataSpec: v1.DataSpec{
 			Name: "source.groovy",
 			Content: `
-			    import org.apache.camel.component.activemq.ActiveMQComponent;
+			    import org.apache.camel.component.kafka.KafkaComponent;
 
 			    from('telegram:bots/cippa').to("log:stash");
 			    from('timer:tick').to("amqp:queue");
@@ -121,7 +121,7 @@ func TestDependenciesGroovy(t *testing.T) {
 	assert.ElementsMatch(
 		t,
 		[]string{
-			"camel:activemq",
+			"camel:kafka",
 			"camel:amqp",
 			"camel:log",
 			"camel:telegram",

--- a/pkg/metadata/metadata_http_test.go
+++ b/pkg/metadata/metadata_http_test.go
@@ -101,7 +101,7 @@ func TestHttpOnlyJavaSourceRest2(t *testing.T) {
 		DataSpec: v1.DataSpec{
 			Name: "Request.java",
 			Content: `
-			from("vm:bots/cippa").to("log:stash");
+			from("seda:bots/cippa").to("log:stash");
 			rest( ).get("").to("log:stash");
 		`,
 		},

--- a/release.adoc
+++ b/release.adoc
@@ -265,6 +265,6 @@ git push upstream main
 ```
 Where <new-version> represents the new version you want to bump and <replace-version> the version that was previously released.
 
-Note: this action should also replace automatically the oldest nightly release Github Action with the newest one just created.
+NOTE: this action should also replace automatically the oldest nightly release Github Action with the newest one just created.
 
 You will also need to update the `docs/antora.yml` configuration in order to provide the proper versions for the upcoming release in `main` branch.


### PR DESCRIPTION
<!-- Description -->

Closes #4609 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix: use non deprecated components
```
