### PR TITLE
chore(e2e): Test on kamelets configurations

### DIFF
--- a/e2e/common/config/files/TimerKameletIntegrationConfiguration.java
+++ b/e2e/common/config/files/TimerKameletIntegrationConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.Exception;
+import java.lang.Override;
+import org.apache.camel.builder.RouteBuilder;
+
+public class TimerKameletIntegrationConfiguration extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("kamelet:my-own-timer-source")
+            .to("log:info");
+    }
+}

--- a/e2e/common/config/files/TimerKameletIntegrationNamedConfiguration.java
+++ b/e2e/common/config/files/TimerKameletIntegrationNamedConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.Exception;
+import java.lang.Override;
+import org.apache.camel.builder.RouteBuilder;
+
+public class TimerKameletIntegrationNamedConfiguration extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("kamelet:my-own-timer-source/mynamedconfig")
+            .to("log:info");
+    }
+}

--- a/e2e/common/config/files/timer-kamelet-integration-inlined-configuration.yaml
+++ b/e2e/common/config/files/timer-kamelet-integration-inlined-configuration.yaml
@@ -1,0 +1,23 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "kamelet:my-own-timer-source?message=important%20message"
+      steps:
+        - to:
+            uri: "kamelet:my-own-log-sink?loggerName=integrationLogger"

--- a/e2e/common/config/files/timer-kamelet-integration-parameters-configuration.yaml
+++ b/e2e/common/config/files/timer-kamelet-integration-parameters-configuration.yaml
@@ -1,0 +1,27 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "kamelet:my-own-timer-source"
+      parameters:
+        message: "{{my-message}}"
+      steps:
+        - to:
+            uri: "kamelet:my-own-log-sink"
+            parameters:
+              loggerName: "{{my-logger}}"

--- a/e2e/common/config/kamelet_config_test.go
+++ b/e2e/common/config/kamelet_config_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/apache/camel-k/v2/e2e/support"
+)
+
+// Tests on integration with kamelets containing configuration from properties and secrets
+//  without having to change the integration code.
+func TestKameletImplicitConfig(t *testing.T) {
+	RegisterTestingT(t)
+	t.Run("test custom timer source", func(t *testing.T) {
+		Expect(CreateTimerKamelet(ns, "my-own-timer-source")()).To(Succeed())
+
+		t.Run("run test default config using properties", func(t *testing.T) {
+			name := "my-own-timer-source-config-properties"
+
+			Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationConfiguration.java",
+				"-p", "camel.kamelet.my-own-timer-source.message='My Default message'",
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My Default message"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("run test default config using labeled secret", func(t *testing.T) {
+			name := "my-own-timer-source-default-config-secrets"
+			secretName := "my-own-timer-source-default"
+
+			var secData = make(map[string]string)
+			secData["camel.kamelet.my-own-timer-source.message"] = "very top secret message"
+			var labels = make(map[string]string)
+			labels["camel.apache.org/kamelet"] = "my-own-timer-source"
+			Expect(CreatePlainTextSecretWithLabels(ns, secretName, secData, labels)).To(Succeed())
+
+			Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationConfiguration.java",
+				"-p", "camel.kamelet.my-own-timer-source.message='Default message'",
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("very top secret message"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+
+		t.Run("run test default config using mounted secret", func(t *testing.T) {
+			name := "my-own-timer-source-default-config-mounted-secrets"
+			secretName := "my-mounted-default-secret"
+
+			var secData = make(map[string]string)
+			secData["camel.kamelet.my-own-timer-source.message"] = "very top mounted secret message"
+			Expect(CreatePlainTextSecret(ns, secretName, secData)).To(Succeed())
+
+			Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationConfiguration.java",
+				"-p", "camel.kamelet.my-own-timer-source.message='Default message'",
+				"-t", "mount.configs=secret:"+secretName,
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("very top mounted secret message"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+
+		t.Run("run test named config using properties", func(t *testing.T) {
+			name := "my-own-timer-source-config-properties"
+			Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration.java",
+				"-p", "camel.kamelet.my-own-timer-source.message='Default message'",
+				"-p", "camel.kamelet.my-own-timer-source.mynamedconfig.message='My Named Config message'",
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My Named Config message"))
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("run test named config using labeled secrets", func(t *testing.T) {
+			name := "my-own-timer-source-implicit-config-secrets"
+			secretName := "my-own-timer-source-mynamedconfig"
+
+			var secData = make(map[string]string)
+			secData["camel.kamelet.my-own-timer-source.mynamedconfig.message"] = "very top named secret message"
+			var labels = make(map[string]string)
+			labels["camel.apache.org/kamelet"] = "my-own-timer-source"
+			labels["camel.apache.org/kamelet.configuration"] = "mynamedconfig"
+			Expect(CreatePlainTextSecretWithLabels(ns, secretName, secData, labels)).To(Succeed())
+
+			Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration.java",
+				"-p", "camel.kamelet.my-own-timer-source.message='Default message'",
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("very top named secret message"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+
+		t.Run("run test named config using mounted secrets", func(t *testing.T) {
+			name := "my-own-timer-source-named-config-mounted-secrets"
+			secretName := "my-mounted-named-secret"
+
+			var secData = make(map[string]string)
+			secData["camel.kamelet.my-own-timer-source.mynamedconfig.message"] = "very top named mounted secret message"
+			Expect(CreatePlainTextSecret(ns, secretName, secData)).To(Succeed())
+
+			Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration.java",
+				"-p", "camel.kamelet.my-own-timer-source.message='Default message'",
+				"-t", "mount.configs=secret:"+secretName,
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("very top named mounted secret message"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+
+	})
+
+	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+	Expect(DeleteKamelet(ns, "my-own-timer-source")).To(Succeed())
+}
+
+// Tests on integration with kamelets containing configuration from properties and secrets with parameters inside the integration.
+func TestKameletConfig(t *testing.T) {
+	RegisterTestingT(t)
+	t.Run("test custom timer source", func(t *testing.T) {
+		Expect(CreateTimerKamelet(ns, "my-own-timer-source")()).To(Succeed())
+		Expect(CreateLogKamelet(ns, "my-own-log-sink")()).To(Succeed())
+		t.Run("run test default config inlined properties", func(t *testing.T) {
+			name := "my-own-timer-source-inline-properties"
+
+			Expect(KamelRunWithID(operatorID, ns, "files/timer-kamelet-integration-inlined-configuration.yaml",
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("important message"))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("integrationLogger"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("run test default config parameters properties", func(t *testing.T) {
+			name := "my-own-timer-source-parameters-properties"
+
+			Expect(KamelRunWithID(operatorID, ns, "files/timer-kamelet-integration-parameters-configuration.yaml",
+				"-p", "my-message='My parameter message'",
+				"-p", "my-logger='myIntegrationLogger'",
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My parameter message"))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("myIntegrationLogger"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("run test default config secrer properties", func(t *testing.T) {
+			name := "my-own-timer-source-secret-properties"
+			secretName := "my-mounted-secret-properties"
+
+			var secData = make(map[string]string)
+			secData["my-message"] = "My secret message"
+			secData["my-logger"] = "mySecretIntegrationLogger"
+			Expect(CreatePlainTextSecret(ns, secretName, secData)).To(Succeed())
+
+			Expect(KamelRunWithID(operatorID, ns, "files/timer-kamelet-integration-parameters-configuration.yaml",
+				"-t", "mount.configs=secret:"+secretName,
+				"--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My secret message"))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("mySecretIntegrationLogger"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+
+	})
+
+	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+	Expect(DeleteKamelet(ns, "my-own-timer-source")).To(Succeed())
+	Expect(DeleteKamelet(ns, "my-own-log-sink")).To(Succeed())
+}

--- a/e2e/common/config/pipe_config_test.go
+++ b/e2e/common/config/pipe_config_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/apache/camel-k/v2/e2e/support"
+)
+
+// Tests on pipe with kamelets containing configuration from properties and secrets.
+func TestPipeConfig(t *testing.T) {
+	RegisterTestingT(t)
+	t.Run("test custom source/sink pipe", func(t *testing.T) {
+		Expect(CreateTimerKamelet(ns, "my-pipe-timer-source")()).To(Succeed())
+		Expect(CreateLogKamelet(ns, "my-pipe-log-sink")()).To(Succeed())
+		t.Run("run test default config using properties", func(t *testing.T) {
+			name := "my-pipe-with-properties"
+
+			Expect(KamelBindWithID(operatorID, ns,
+				"my-pipe-timer-source",
+				"my-pipe-log-sink",
+				"-p", "source.message=My pipe message",
+				"-p", "sink.loggerName=myPipeLogger",
+				"--name", name,
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My pipe message"))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("myPipeLogger"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("run test implicit default config using labeled secret", func(t *testing.T) {
+			name := "my-pipe-with-default-implicit-secret"
+			secretName := "my-pipe-default-implicit-secret"
+
+			var secData = make(map[string]string)
+			secData["camel.kamelet.my-pipe-timer-source.message"] = "My pipe secret message"
+			var labels = make(map[string]string)
+			labels["camel.apache.org/kamelet"] = "my-pipe-timer-source"
+			Expect(CreatePlainTextSecretWithLabels(ns, secretName, secData, labels)).To(Succeed())
+
+			Expect(KamelBindWithID(operatorID, ns,
+				"my-pipe-timer-source",
+				"my-pipe-log-sink",
+				"-p", "sink.loggerName=myDefaultLogger",
+				"--name", name,
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My pipe secret message"))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("myDefaultLogger"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+
+		t.Run("run test implicit default config using mounted secret", func(t *testing.T) {
+			name := "my-pipe-with-default-implicit-secret"
+			secretName := "my-pipe-default-implicit-secret"
+
+			var secData = make(map[string]string)
+			secData["camel.kamelet.my-pipe-timer-source.message"] = "My pipe secret message"
+			secData["camel.kamelet.my-pipe-log-sink.loggerName"] = "myPipeSecretLogger"
+			Expect(CreatePlainTextSecret(ns, secretName, secData)).To(Succeed())
+
+			Expect(KamelBindWithID(operatorID, ns,
+				"my-pipe-timer-source",
+				"my-pipe-log-sink",
+				"-t", "mount.configs=secret:"+secretName,
+				"--name", name,
+			).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My pipe secret message"))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("myPipeSecretLogger"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+
+		t.Run("run test implicit named config using mounted secret", func(t *testing.T) {
+			name := "my-pipe-with-named-implicit-secret"
+			secretName := "my-pipe-named-implicit-secret"
+
+			var secData = make(map[string]string)
+			secData["camel.kamelet.my-pipe-timer-source.mynamedconfig.message"] = "My pipe named secret message"
+			secData["camel.kamelet.my-pipe-log-sink.mynamedconfig.loggerName"] = "myPipeNamedSecretLogger"
+			Expect(CreatePlainTextSecret(ns, secretName, secData)).To(Succeed())
+
+			Expect(KamelBindWithID(operatorID, ns,
+				"my-pipe-timer-source",
+				"my-pipe-log-sink",
+				"-t", "mount.configs=secret:"+secretName,
+				"-p", "source.message={{mynamedconfig.message}}",
+				"-p", "sink.loggerName={{mynamedconfig.loggerName}}",
+				"--name", name,
+			).Execute()).To(Succeed())
+
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My pipe named secret message"))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("myPipeNamedSecretLogger"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+		t.Run("run test implicit specific config using mounted secret", func(t *testing.T) {
+			name := "my-pipe-with-specific-secret"
+			secretName := "my-pipe-specific-secret"
+
+			var secData = make(map[string]string)
+			secData["mynamedconfig.message"] = "My pipe specific secret message"
+			secData["mynamedconfig.loggerName"] = "myPipeSpecificSecretLogger"
+			Expect(CreatePlainTextSecret(ns, secretName, secData)).To(Succeed())
+
+			Expect(KamelBindWithID(operatorID, ns,
+				"my-pipe-timer-source",
+				"my-pipe-log-sink",
+				"-t", "mount.configs=secret:"+secretName,
+				"-p", "source.message={{mynamedconfig.message}}",
+				"-p", "sink.loggerName={{mynamedconfig.loggerName}}",
+				"--name", name,
+			).Execute()).To(Succeed())
+
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("My pipe specific secret message"))
+			Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("myPipeSpecificSecretLogger"))
+
+			Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+			Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		})
+	})
+
+	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+	Expect(DeleteKamelet(ns, "my-pipe-timer-source")).To(Succeed())
+	Expect(DeleteKamelet(ns, "my-pipe-log-sink")).To(Succeed())
+}

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1500,7 +1500,25 @@ func CreateBinaryConfigmap(ns string, name string, data map[string][]byte) error
 	return TestClient().Create(TestContext, &cm)
 }
 
+func DeleteConfigmap(ns string, name string) error {
+	cm := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+	return TestClient().Delete(TestContext, &cm)
+}
+
 func CreatePlainTextSecret(ns string, name string, data map[string]string) error {
+	return CreatePlainTextSecretWithLabels(ns, name, data, map[string]string{})
+}
+
+func CreatePlainTextSecretWithLabels(ns string, name string, data map[string]string, labels map[string]string) error {
 	sec := corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -1509,6 +1527,7 @@ func CreatePlainTextSecret(ns string, name string, data map[string]string) error
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
+			Labels:    labels,
 		},
 		StringData: data,
 	}
@@ -1537,6 +1556,20 @@ func SecretByName(ns string, prefix string) func() *corev1.Secret {
 
 		return nil
 	}
+}
+
+func DeleteSecret(ns string, name string) error {
+	sec := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+	return TestClient().Delete(TestContext, &sec)
 }
 
 func KnativeService(ns string, name string) func() *servingv1.Service {
@@ -2396,6 +2429,16 @@ func CreateTimerKamelet(ns string, name string) func() error {
 	}
 
 	return CreateKamelet(ns, name, flow, props, nil)
+}
+
+func DeleteKamelet(ns string, name string) error {
+	kamelet := v1.Kamelet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+	return TestClient().Delete(TestContext, &kamelet)
 }
 
 func asTemplate(source map[string]interface{}) *v1.Template {


### PR DESCRIPTION
## Motivation

Strengthen the tests on configuration via secret/configmap to define what type of configurations actually works.

## Description

* Test of Integrations using kamelets and properties/secrets
* Test of Pipes using kamelets and properties/secrets


**Release Note**
```release-note
chore(e2e): Test on kamelets configurations
```
