### PR TITLE
feat(ci): Add govulncheck as ci workflow

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,57 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: security
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+    paths:
+      - '**.go'
+      - '**.sum'
+      - '**.mod'
+  push:
+    branches:
+      - main
+      - "release-*"
+    paths:
+      - '**.go'
+      - '**.sum'
+      - '**.mod'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        shell: bash
+      - name: Run govulncheck
+        run: govulncheck ./...
+        shell: bash


### PR DESCRIPTION
Ref #3753 

## Motivation

Adding the [govulncheck](https://go.dev/blog/govulncheck) tool to the project CI will provides more visibility on vulnerabilities of the golang code.


## Description

The govulncheck looks into the dependencies but also [how they are used in the code](https://brandur.org/fragments/govulncheck-ci). As a result, it has been activated for any change on not only in go.mod/go.sum files but also on any golang file (*.go) changed.

It is active on PRs and main/release branches changes.

For now I decided not to use the [recently created github action](https://github.com/golang/govulncheck-action/tree/master) as I plan to see if other security tools  like [gosec](https://github.com/securego/gosec) could be added.

**Release Note**
```release-note
feat(ci): Add govulncheck as ci workflow
```
