### PR TITLE
Fix cron trait doc, timer usage is missing information

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -5669,8 +5669,11 @@ in order to save resources when the integration does not need to be executed.
 Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 
 The rules for using a Kubernetes CronJob are the following:
-  - `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
+
+  - `timer`: when period is set in milliseconds with no remaining seconds, for example 120000. If there is any second left as in 121000 (120s and 1s) or the presence of any of these parameters (delay, repeatCount, time) then a CronJob  won't be created, but a standard deployment.
+
   - `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
+
     `cron:tab?schedule=0/2$\{plus}*\{plus}*\{plus}*\{plus}?` or `quartz:trigger?cron=0\{plus}0/2\{plus}*\{plus}*\{plus}*\{plus}?`.
 
 

--- a/docs/modules/traits/pages/cron.adoc
+++ b/docs/modules/traits/pages/cron.adoc
@@ -11,8 +11,11 @@ in order to save resources when the integration does not need to be executed.
 Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 
 The rules for using a Kubernetes CronJob are the following:
-  - `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
+
+  - `timer`: when period is set in milliseconds with no remaining seconds, for example 120000. If there is any second left as in 121000 (120s and 1s) or the presence of any of these parameters (delay, repeatCount, time) then a CronJob  won't be created, but a standard deployment.
+
   - `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
+
     `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?` or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.
 
 

--- a/pkg/apis/camel/v1/trait/cron.go
+++ b/pkg/apis/camel/v1/trait/cron.go
@@ -27,8 +27,11 @@ package trait
 // Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 //
 // The rules for using a Kubernetes CronJob are the following:
-//   - `timer`: when periods can be written as cron expressions. E.g. `timer:tick?period=60000`.
+//
+//   - `timer`: when period is set in milliseconds with no remaining seconds, for example 120000. If there is any second left as in 121000 (120s and 1s) or the presence of any of these parameters (delay, repeatCount, time) then a CronJob  won't be created, but a standard deployment.
+//
 //   - `cron`, `quartz`: when the cron expression does not contain seconds (or the "seconds" part is set to 0). E.g.
+//
 //     `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?` or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.
 //
 // +camel-k:trait=cron.

--- a/resources/traits.yaml
+++ b/resources/traits.yaml
@@ -351,10 +351,13 @@ traits:
     CronJob instead of a standard deployment, in order to save resources when the
     integration does not need to be executed. Integrations that start from the following
     components are evaluated by the cron trait: `timer`, `cron`, `quartz`. The rules
-    for using a Kubernetes CronJob are the following: - `timer`: when periods can
-    be written as cron expressions. E.g. `timer:tick?period=60000`. - `cron`, `quartz`:
-    when the cron expression does not contain seconds (or the "seconds" part is set
-    to 0). E.g. `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?` or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.'
+    for using a Kubernetes CronJob are the following: - `timer`: when period is set
+    in milliseconds with no remaining seconds, for example 120000. If there is any
+    second left as in 121000 (120s and 1s) or the presence of any of these parameters
+    (delay, repeatCount, time) then a CronJob  won''t be created, but a standard deployment.
+    - `cron`, `quartz`: when the cron expression does not contain seconds (or the
+    "seconds" part is set to 0). E.g. `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?`
+    or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.'
   properties:
   - name: enabled
     type: bool


### PR DESCRIPTION
Fix doc related to when the timer is materialized as a CronJOb

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
