### PR TITLE
chore(ci): Updates of otlp collector and some github actions

### DIFF
--- a/.github/actions/e2e-telemetry/action.yml
+++ b/.github/actions/e2e-telemetry/action.yml
@@ -103,7 +103,7 @@ runs:
     uses: ./.github/actions/kamel-install-otlp-collector
     with:
       otlp-collector-image-name: otel/opentelemetry-collector
-      otlp-collector-image-version: 0.75.0
+      otlp-collector-image-version: 0.82.0
 
   - id: report-problematic
     name: List Tests Marked As Problematic

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -99,7 +99,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
         submodules: recursive

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.20'
           check-latest: true

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
         submodules: recursive
@@ -122,7 +122,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         persist-credentials: false
         submodules: recursive


### PR DESCRIPTION
* Upgrade telemetry otlp collector version in telemetry workflow

* Fix not up to date actions in some ci workflows:
  * github action setup-go@v4
  * github action checkout@v3

**Release Note**
```release-note
NONE
```
