### PR TITLE
Chore: Added annotations support for route trait

### DIFF
--- a/pkg/apis/camel/v1/trait/route.go
+++ b/pkg/apis/camel/v1/trait/route.go
@@ -31,6 +31,10 @@ package trait
 // nolint: tagliatelle
 type RouteTrait struct {
 	Trait `property:",squash" json:",inline"`
+	// The annotations added to route.
+	// This can be used to set route specific annotations
+	// See https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#route-specific-annotations
+	Annotations map[string]string `property:"annotations" json:"annotations,omitempty"`
 	// To configure the host exposed by the route.
 	Host string `property:"host" json:"host,omitempty"`
 	// The TLS termination type, like `edge`, `passthrough` or `reencrypt`.

--- a/pkg/apis/camel/v1/trait/route.go
+++ b/pkg/apis/camel/v1/trait/route.go
@@ -33,7 +33,8 @@ type RouteTrait struct {
 	Trait `property:",squash" json:",inline"`
 	// The annotations added to route.
 	// This can be used to set route specific annotations
-	// See https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#route-specific-annotations
+	// For annotations options see https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#route-specific-annotations
+	// CLI usage example: -t "ingress.annotations.'nginx.ingress.kubernetes.io/use-regex'=true"
 	Annotations map[string]string `property:"annotations" json:"annotations,omitempty"`
 	// To configure the host exposed by the route.
 	Host string `property:"host" json:"host,omitempty"`

--- a/pkg/trait/route.go
+++ b/pkg/trait/route.go
@@ -43,6 +43,10 @@ type routeTrait struct {
 func newRouteTrait() Trait {
 	return &routeTrait{
 		BaseTrait: NewBaseTrait("route", 2200),
+		RouteTrait: traitv1.RouteTrait{
+			Annotations: map[string]string{},
+			Host:        "",
+		},
 	}
 }
 
@@ -109,6 +113,7 @@ func (t *routeTrait) Apply(e *Environment) error {
 			Labels: map[string]string{
 				v1.IntegrationLabel: e.Integration.Name,
 			},
+			Annotations: t.Annotations,
 		},
 		Spec: routev1.RouteSpec{
 			Port: &routev1.RoutePort{

--- a/pkg/trait/route_test.go
+++ b/pkg/trait/route_test.go
@@ -538,3 +538,14 @@ func TestRoute_WithCustomServicePort(t *testing.T) {
 		route.Spec.Port.TargetPort.StrVal,
 	)
 }
+
+func TestRouteAnnotation(t *testing.T) {
+	name := xid.New().String()
+	environment := createTestRouteEnvironment(t, name)
+	traitsCatalog := environment.Catalog
+
+	err := traitsCatalog.apply(environment)
+
+	assert.Nil(t, err)
+
+}


### PR DESCRIPTION
<!-- Description -->
### Issue CMLK-865
- Added route annotations implementation
- Added unit tests
- Added documentation



_CLI parameter usage example for clarity:_
```-t "haproxy.router.openshift.io/balance'=true"```


**Release Note**
```release-note
Chore: Added annotations support for route trait
```
