### PR TITLE
feat(trait): prepare to remove runtime dependencies

### DIFF
--- a/addons/vault/aws/aws_secrets_manager.go
+++ b/addons/vault/aws/aws_secrets_manager.go
@@ -100,7 +100,7 @@ func (t *awsSecretsManagerTrait) Configure(environment *trait.Environment) (bool
 func (t *awsSecretsManagerTrait) Apply(environment *trait.Environment) error {
 	if environment.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
 		util.StringSliceUniqueAdd(&environment.Integration.Status.Capabilities, v1.CapabilityAwsSecretsManager)
-		// Add the Camel Quarkus AWS Secrets Manager
+		// TODO remove dependencies after runtime > 2.16.0
 		util.StringSliceUniqueAdd(&environment.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus:camel-quarkus-aws-secrets-manager")
 	}
 

--- a/addons/vault/azure/azure_key_vault.go
+++ b/addons/vault/azure/azure_key_vault.go
@@ -106,7 +106,7 @@ func (t *azureKeyVaultTrait) Configure(environment *trait.Environment) (bool, er
 func (t *azureKeyVaultTrait) Apply(environment *trait.Environment) error {
 	if environment.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
 		util.StringSliceUniqueAdd(&environment.Integration.Status.Capabilities, v1.CapabilityAzureKeyVault)
-		// Add the Camel Quarkus Azure Key Vault dependency
+		// TODO remove dependencies after runtime > 2.16.0
 		util.StringSliceUniqueAdd(&environment.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus:camel-quarkus-azure-key-vault")
 	}
 

--- a/addons/vault/gcp/gcp_secret_manager.go
+++ b/addons/vault/gcp/gcp_secret_manager.go
@@ -102,7 +102,7 @@ func (t *gcpSecretManagerTrait) Configure(environment *trait.Environment) (bool,
 func (t *gcpSecretManagerTrait) Apply(environment *trait.Environment) error {
 	if environment.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
 		util.StringSliceUniqueAdd(&environment.Integration.Status.Capabilities, v1.CapabilityGcpSecretManager)
-		// Add the Camel Quarkus Google Secrets Manager dependency
+		// TODO remove dependencies after runtime > 2.16.0
 		util.StringSliceUniqueAdd(&environment.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus:camel-quarkus-google-secret-manager")
 	}
 

--- a/addons/vault/hashicorp/hashicorp_vault.go
+++ b/addons/vault/hashicorp/hashicorp_vault.go
@@ -78,7 +78,7 @@ func (t *hashicorpVaultTrait) Configure(environment *trait.Environment) (bool, e
 func (t *hashicorpVaultTrait) Apply(environment *trait.Environment) error {
 	if environment.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
 		util.StringSliceUniqueAdd(&environment.Integration.Status.Capabilities, v1.CapabilityHashicorpVault)
-		// Add the Camel Quarkus AWS Secrets Manager
+		// TODO remove dependencies after runtime > 2.16.0
 		util.StringSliceUniqueAdd(&environment.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus:camel-quarkus-hashicorp-vault")
 	}
 

--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -319,6 +319,7 @@ type RuntimeSpec struct {
 }
 
 // Capability is a particular feature which requires a well known set of dependencies
+// which are specified in the runtime catalog
 type Capability struct {
 	Dependencies []MavenArtifact `json:"dependencies" yaml:"dependencies"`
 }
@@ -327,32 +328,38 @@ const (
 	// ServiceTypeUser service user type label marker
 	ServiceTypeUser = "user"
 
-	// CapabilityRest defines the REST API service exposure capability
-	CapabilityRest = "rest"
-	// CapabilityHealth defines the health monitoring capability
-	CapabilityHealth = "health"
-	// CapabilityCron defines the cron execution capability
-	CapabilityCron = "cron"
-	// CapabilityPlatformHTTP defines the http service exposure capability
-	CapabilityPlatformHTTP = "platform-http"
-	// CapabilityCircuitBreaker defines the circuit breaker capability
-	CapabilityCircuitBreaker = "circuit-breaker"
-	// CapabilityTracing defines the tracing (opentracing) capability
-	CapabilityTracing = "tracing"
-	// CapabilityTelemetry defines the telemetry (opentelemetry) capability
-	CapabilityTelemetry = "telemetry"
-	// CapabilityMaster defines the master capability
-	CapabilityMaster = "master"
-	// CapabilityResumeKafka defines the resume capability
-	CapabilityResumeKafka = "resume-kafka"
-	// CapabilityAwsSecretsManager defines the aws secrets manager capability
-	CapabilityAwsSecretsManager = "aws-secrets-manager"
-	// CapabilityGcpSecretManager defines the gcp secret manager capability
-	CapabilityGcpSecretManager = "gcp-secret-manager"
 	// CapabilityAzureKeyVault defines the azure key vault capability
 	CapabilityAzureKeyVault = "azure-key-vault"
+	// CapabilityAwsSecretsManager defines the aws secrets manager capability
+	CapabilityAwsSecretsManager = "aws-secrets-manager"
+	// CapabilityCircuitBreaker defines the circuit breaker capability
+	CapabilityCircuitBreaker = "circuit-breaker"
+	// CapabilityCron defines the cron execution capability
+	CapabilityCron = "cron"
+	// CapabilityGcpSecretManager defines the gcp secret manager capability
+	CapabilityGcpSecretManager = "gcp-secret-manager"
 	// CapabilityHashicorpVault defines the Hashicorp Vault capability
 	CapabilityHashicorpVault = "hashicorp-vault"
+	// CapabilityHealth defines the health monitoring capability
+	CapabilityHealth = "health"
+	// CapabilityJolokia --
+	CapabilityJolokia = "jolokia"
+	// CapabilityKnative --
+	CapabilityKnative = "knative"
+	// CapabilityMaster defines the master capability
+	CapabilityMaster = "master"
+	// CapabilityPrometheus --
+	CapabilityPrometheus = "prometheus"
+	// CapabilityRest defines the REST API service exposure capability
+	CapabilityRest = "rest"
+	// CapabilityResumeKafka defines the resume capability
+	CapabilityResumeKafka = "resume-kafka"
+	// CapabilityPlatformHTTP defines the http service exposure capability
+	CapabilityPlatformHTTP = "platform-http"
+	// CapabilityTelemetry defines the telemetry (opentelemetry) capability
+	CapabilityTelemetry = "telemetry"
+	// CapabilityTracing defines the tracing (opentracing) capability
+	CapabilityTracing = "tracing"
 )
 
 // +kubebuilder:object:generate=false

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -174,6 +174,18 @@ var assets = func() http.FileSystem {
 			name:    "manager",
 			modTime: time.Time{},
 		},
+		"/manager/bundle": &vfsgen۰DirInfo{
+			name:    "bundle",
+			modTime: time.Time{},
+		},
+		"/manager/bundle/manifests": &vfsgen۰DirInfo{
+			name:    "manifests",
+			modTime: time.Time{},
+		},
+		"/manager/bundle/metadata": &vfsgen۰DirInfo{
+			name:    "metadata",
+			modTime: time.Time{},
+		},
 		"/manager/operator-deployment.yaml": &vfsgen۰CompressedFileInfo{
 			name:             "operator-deployment.yaml",
 			modTime:          time.Time{},
@@ -672,6 +684,7 @@ var assets = func() http.FileSystem {
 		fs["/crd/bases/camel.apache.org_pipes.yaml"].(os.FileInfo),
 	}
 	fs["/manager"].(*vfsgen۰DirInfo).entries = []os.FileInfo{
+		fs["/manager/bundle"].(os.FileInfo),
 		fs["/manager/operator-deployment.yaml"].(os.FileInfo),
 		fs["/manager/operator-service-account.yaml"].(os.FileInfo),
 		fs["/manager/patch-image-pull-policy-always.yaml"].(os.FileInfo),
@@ -682,6 +695,10 @@ var assets = func() http.FileSystem {
 		fs["/manager/patch-resource-requirements.yaml"].(os.FileInfo),
 		fs["/manager/patch-toleration.yaml"].(os.FileInfo),
 		fs["/manager/patch-watch-namespace-global.yaml"].(os.FileInfo),
+	}
+	fs["/manager/bundle"].(*vfsgen۰DirInfo).entries = []os.FileInfo{
+		fs["/manager/bundle/manifests"].(os.FileInfo),
+		fs["/manager/bundle/metadata"].(os.FileInfo),
 	}
 	fs["/prometheus"].(*vfsgen۰DirInfo).entries = []os.FileInfo{
 		fs["/prometheus/operator-pod-monitor.yaml"].(os.FileInfo),

--- a/pkg/trait/jolokia.go
+++ b/pkg/trait/jolokia.go
@@ -54,15 +54,15 @@ func (t *jolokiaTrait) Configure(e *Environment) (bool, error) {
 
 func (t *jolokiaTrait) Apply(e *Environment) error {
 	if e.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
-		// Add the Camel management and Jolokia agent dependencies
-		// Also add the Camel JAXB dependency, that's required by Hawtio
+		util.StringSliceUniqueAdd(&e.Integration.Status.Capabilities, v1.CapabilityJolokia)
 
+		// TODO remove dependencies after runtime > 2.16.0
 		if e.CamelCatalog.Runtime.Provider == v1.RuntimeProviderQuarkus {
 			util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "camel-quarkus:management")
 			util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "camel:jaxb")
 		}
-
 		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.jolokia:jolokia-jvm")
+		//
 
 		return nil
 	}

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -180,6 +180,10 @@ func (t *knativeTrait) Configure(e *Environment) (bool, error) {
 }
 
 func (t *knativeTrait) Apply(e *Environment) error {
+	if e.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
+		util.StringSliceUniqueAdd(&e.Integration.Status.Capabilities, v1.CapabilityKnative)
+	}
+	// TODO remove dependencies after runtime > 2.16.0
 	if pointer.BoolDeref(t.SinkBinding, false) {
 		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "camel:knative")
 		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel.k:camel-k-knative-impl")

--- a/pkg/trait/prometheus.go
+++ b/pkg/trait/prometheus.go
@@ -55,7 +55,8 @@ func (t *prometheusTrait) Configure(e *Environment) (bool, error) {
 
 func (t *prometheusTrait) Apply(e *Environment) error {
 	if e.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
-		// Add the Camel Quarkus Micrometer extension and micrometer registry for prometheus
+		util.StringSliceUniqueAdd(&e.Integration.Status.Capabilities, v1.CapabilityPrometheus)
+		// TODO remove dependencies after runtime > 2.16.0
 		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus:camel-quarkus-micrometer")
 		util.StringSliceUniqueAdd(&e.Integration.Status.Dependencies, "mvn:io.micrometer:micrometer-registry-prometheus")
 		return nil


### PR DESCRIPTION
This PR will address the design available at [next runtime release](https://github.com/apache/camel-k-runtime/pull/1040).

This PR is different from original #4456 because we don't need to explicitly check for the usage of the capability. There is already a mechanism in the trait that will take care to include all the dependencies.

Once the runtime is available we can remove the dependencies which are now provided in the same trait.

Ref #4166

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(trait): prepare to remove runtime dependencies
```
