### PR TITLE
fix(cicd): Add list camelcatalog permission in tekton SA

### DIFF
--- a/cicd/tekton/kamel-run/0.1/support/camel-k-tekton.yaml
+++ b/cicd/tekton/kamel-run/0.1/support/camel-k-tekton.yaml
@@ -37,6 +37,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - camelcatalogs
+  verbs:
+  - list
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Closes #4666

Add permission to list the `camelcatalogs` CR to the Role linked to camel-k-tekton SA.

**Release Note**
```release-note
feat(cicd): add permission to list the `camelcatalogs` CR for Tekton
```
