### PR TITLE
feat: knative service trait annotation support

### DIFF
--- a/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -1258,6 +1258,13 @@ spec:
                   knative-service:
                     description: The configuration of Knative Service trait
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'The annotations added to route. This can be
+                          used to set knative service specific annotations CLI usage
+                          example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                        type: object
                       auto:
                         description: "Automatically deploy the integration as Knative
                           service when all conditions hold: \n * Integration is using
@@ -3023,6 +3030,13 @@ spec:
                   knative-service:
                     description: The configuration of Knative Service trait
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'The annotations added to route. This can be
+                          used to set knative service specific annotations CLI usage
+                          example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                        type: object
                       auto:
                         description: "Automatically deploy the integration as Knative
                           service when all conditions hold: \n * Integration is using

--- a/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/config/crd/bases/camel.apache.org_integrations.yaml
@@ -7175,6 +7175,13 @@ spec:
                   knative-service:
                     description: The configuration of Knative Service trait
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'The annotations added to route. This can be
+                          used to set knative service specific annotations CLI usage
+                          example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                        type: object
                       auto:
                         description: "Automatically deploy the integration as Knative
                           service when all conditions hold: \n * Integration is using

--- a/config/crd/bases/camel.apache.org_kameletbindings.yaml
+++ b/config/crd/bases/camel.apache.org_kameletbindings.yaml
@@ -7466,6 +7466,13 @@ spec:
                       knative-service:
                         description: The configuration of Knative Service trait
                         properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'The annotations added to route. This can
+                              be used to set knative service specific annotations
+                              CLI usage example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                            type: object
                           auto:
                             description: "Automatically deploy the integration as
                               Knative service when all conditions hold: \n * Integration

--- a/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/config/crd/bases/camel.apache.org_pipes.yaml
@@ -7463,6 +7463,13 @@ spec:
                       knative-service:
                         description: The configuration of Knative Service trait
                         properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'The annotations added to route. This can
+                              be used to set knative service specific annotations
+                              CLI usage example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                            type: object
                           auto:
                             description: "Automatically deploy the integration as
                               Knative service when all conditions hold: \n * Integration

--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -6900,6 +6900,15 @@ are only relevant when the Camel route(s) use(s) an HTTP endpoint consumer.
 
 
 
+|`annotations` +
+map[string]string
+|
+
+
+The annotations added to route.
+This can be used to set knative service specific annotations
+CLI usage example: -t "knative-service.annotations.'haproxy.router.openshift.io/balance'=true"
+
 |`class` +
 string
 |

--- a/docs/modules/traits/pages/knative-service.adoc
+++ b/docs/modules/traits/pages/knative-service.adoc
@@ -29,6 +29,12 @@ The following configuration options are available:
 | bool
 | Can be used to enable or disable a trait. All traits share this common property.
 
+| knative-service.annotations
+| map[string]string
+| The annotations added to route.
+This can be used to set knative service specific annotations
+CLI usage example: -t "knative-service.annotations.'haproxy.router.openshift.io/balance'=true"
+
 | knative-service.autoscaling-class
 | string
 | Configures the Knative autoscaling class property (e.g. to set `hpa.autoscaling.knative.dev` or `kpa.autoscaling.knative.dev` autoscaling).

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -1258,6 +1258,13 @@ spec:
                   knative-service:
                     description: The configuration of Knative Service trait
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'The annotations added to route. This can be
+                          used to set knative service specific annotations CLI usage
+                          example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                        type: object
                       auto:
                         description: "Automatically deploy the integration as Knative
                           service when all conditions hold: \n * Integration is using
@@ -3023,6 +3030,13 @@ spec:
                   knative-service:
                     description: The configuration of Knative Service trait
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'The annotations added to route. This can be
+                          used to set knative service specific annotations CLI usage
+                          example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                        type: object
                       auto:
                         description: "Automatically deploy the integration as Knative
                           service when all conditions hold: \n * Integration is using

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -7175,6 +7175,13 @@ spec:
                   knative-service:
                     description: The configuration of Knative Service trait
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'The annotations added to route. This can be
+                          used to set knative service specific annotations CLI usage
+                          example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                        type: object
                       auto:
                         description: "Automatically deploy the integration as Knative
                           service when all conditions hold: \n * Integration is using

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -7466,6 +7466,13 @@ spec:
                       knative-service:
                         description: The configuration of Knative Service trait
                         properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'The annotations added to route. This can
+                              be used to set knative service specific annotations
+                              CLI usage example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                            type: object
                           auto:
                             description: "Automatically deploy the integration as
                               Knative service when all conditions hold: \n * Integration

--- a/helm/camel-k/crds/crd-pipe.yaml
+++ b/helm/camel-k/crds/crd-pipe.yaml
@@ -7463,6 +7463,13 @@ spec:
                       knative-service:
                         description: The configuration of Knative Service trait
                         properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'The annotations added to route. This can
+                              be used to set knative service specific annotations
+                              CLI usage example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
+                            type: object
                           auto:
                             description: "Automatically deploy the integration as
                               Knative service when all conditions hold: \n * Integration

--- a/pkg/apis/camel/v1/trait/knative_service.go
+++ b/pkg/apis/camel/v1/trait/knative_service.go
@@ -25,7 +25,8 @@ package trait
 //
 // +camel-k:trait=knative-service.
 type KnativeServiceTrait struct {
-	Trait `property:",squash" json:",inline"`
+	Annotations map[string]string `property:"annotations" json:"annotations,omitempty"`
+	Trait       `property:",squash" json:",inline"`
 	// Configures the Knative autoscaling class property (e.g. to set `hpa.autoscaling.knative.dev` or `kpa.autoscaling.knative.dev` autoscaling).
 	//
 	// Refer to the Knative documentation for more information.

--- a/pkg/apis/camel/v1/trait/knative_service.go
+++ b/pkg/apis/camel/v1/trait/knative_service.go
@@ -25,8 +25,11 @@ package trait
 //
 // +camel-k:trait=knative-service.
 type KnativeServiceTrait struct {
+	Trait `property:",squash" json:",inline"`
+	// The annotations added to route.
+	// This can be used to set knative service specific annotations
+	// CLI usage example: -t "route.annotations.'haproxy.router.openshift.io/balance'=true"
 	Annotations map[string]string `property:"annotations" json:"annotations,omitempty"`
-	Trait       `property:",squash" json:",inline"`
 	// Configures the Knative autoscaling class property (e.g. to set `hpa.autoscaling.knative.dev` or `kpa.autoscaling.knative.dev` autoscaling).
 	//
 	// Refer to the Knative documentation for more information.

--- a/pkg/apis/camel/v1/trait/knative_service.go
+++ b/pkg/apis/camel/v1/trait/knative_service.go
@@ -28,7 +28,7 @@ type KnativeServiceTrait struct {
 	Trait `property:",squash" json:",inline"`
 	// The annotations added to route.
 	// This can be used to set knative service specific annotations
-	// CLI usage example: -t "route.annotations.'haproxy.router.openshift.io/balance'=true"
+	// CLI usage example: -t "knative-service.annotations.'haproxy.router.openshift.io/balance'=true"
 	Annotations map[string]string `property:"annotations" json:"annotations,omitempty"`
 	// Configures the Knative autoscaling class property (e.g. to set `hpa.autoscaling.knative.dev` or `kpa.autoscaling.knative.dev` autoscaling).
 	//

--- a/pkg/apis/camel/v1/trait/zz_generated.deepcopy.go
+++ b/pkg/apis/camel/v1/trait/zz_generated.deepcopy.go
@@ -542,6 +542,13 @@ func (in *KameletsTrait) DeepCopy() *KameletsTrait {
 func (in *KnativeServiceTrait) DeepCopyInto(out *KnativeServiceTrait) {
 	*out = *in
 	in.Trait.DeepCopyInto(&out.Trait)
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Target != nil {
 		in, out := &in.Target, &out.Target
 		*out = new(int)

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -58,6 +58,9 @@ var _ ControllerStrategySelector = &knativeServiceTrait{}
 func newKnativeServiceTrait() Trait {
 	return &knativeServiceTrait{
 		BaseTrait: NewBaseTrait(knativeServiceTraitID, 1400),
+		KnativeServiceTrait: traitv1.KnativeServiceTrait{
+			Annotations: map[string]string{},
+		},
 	}
 }
 
@@ -175,6 +178,8 @@ func (t *knativeServiceTrait) getServiceFor(e *Environment) (*serving.Service, e
 		for k, v := range e.Integration.Annotations {
 			serviceAnnotations[k] = v
 		}
+	} else {
+		serviceAnnotations = t.Annotations
 	}
 	// Set Knative rollout
 	if t.RolloutDuration != "" {

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -178,12 +178,15 @@ func (t *knativeServiceTrait) getServiceFor(e *Environment) (*serving.Service, e
 		for k, v := range e.Integration.Annotations {
 			serviceAnnotations[k] = v
 		}
-	} else {
-		serviceAnnotations = t.Annotations
 	}
 	// Set Knative rollout
 	if t.RolloutDuration != "" {
 		serviceAnnotations[knativeServingRolloutDurationAnnotation] = t.RolloutDuration
+	}
+	if t.Annotations != nil {
+		for k, v := range t.Annotations {
+			serviceAnnotations[k] = v
+		}
 	}
 
 	revisionAnnotations := make(map[string]string)

--- a/pkg/trait/knative_service_test.go
+++ b/pkg/trait/knative_service_test.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"testing"
 
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -517,23 +516,20 @@ func createKnativeServiceTestEnvironment(t *testing.T, trait *traitv1.KnativeSer
 func TestServiceAnnotation(t *testing.T) {
 	annotationsTest := map[string]string{"haproxy.router.openshift.io/balance": "true"}
 
-	environment := createTestRouteEnvironment(t, KnativeServiceTestName)
-	environment.Integration.Spec.Traits = v1.Traits{
-		Route: &traitv1.RouteTrait{
-			Annotations: map[string]string{"haproxy.router.openshift.io/balance": "true"},
-		},
-	}
+	environment := createKnativeServiceTestEnvironment(t, &traitv1.KnativeServiceTrait{
+		Annotations: map[string]string{"haproxy.router.openshift.io/balance": "true"},
+	})
 
 	traitsCatalog := environment.Catalog
 	err := traitsCatalog.apply(environment)
 
 	assert.Nil(t, err)
 
-	route := environment.Resources.GetRoute(func(r *routev1.Route) bool {
-		return r.ObjectMeta.Name == KnativeServiceTestName
+	service := environment.Resources.GetKnativeService(func(s *serving.Service) bool {
+		return s.Name == KnativeServiceTestName
 	})
 
-	assert.NotNil(t, route)
-	assert.True(t, reflect.DeepEqual(route.GetAnnotations(), annotationsTest))
+	assert.NotNil(t, service)
+	assert.True(t, reflect.DeepEqual(service.GetAnnotations(), annotationsTest))
 
 }

--- a/resources/traits.yaml
+++ b/resources/traits.yaml
@@ -985,6 +985,10 @@ traits:
     type: bool
     description: Can be used to enable or disable a trait. All traits share this common
       property.
+  - name: annotations
+    type: map[string]string
+    description: 'The annotations added to route. This can be used to set knative
+      service specific annotations CLI usage example: -t "knative-service.annotations.''haproxy.router.openshift.io/balance''=true"'
   - name: autoscaling-class
     type: string
     description: Configures the Knative autoscaling class property (e.g. to set `hpa.autoscaling.knative.dev`


### PR DESCRIPTION
<!-- Description -->

    - Added route annotations implementation
    - Added unit tests
    - Added documentation

_CLI parameter usage example for clarity:_
`-t "knaive-service.annotations.'haproxy.router.openshift.io/balance'=true"`
_This can be repeated to add multiple annotations_




<!--
-->

**Release Note**
```release-note
feat: added annotations support for knative service trait
```
