### PR TITLE
fix(cli): Use maven repository CLI flag for plugins

### DIFF
--- a/e2e/common/misc/maven_repository_test.go
+++ b/e2e/common/misc/maven_repository_test.go
@@ -45,6 +45,10 @@ func TestRunExtraRepository(t *testing.T) {
 	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 	Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 	Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+	Eventually(Integration(ns, name)).Should(WithTransform(IntegrationSpec, And(
+		HaveExistingField("Repositories"),
+		HaveField("Repositories", ContainElements("https://maven.repository.redhat.com/ga@id=redhat")),
+	)))
 
 	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 }

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -764,6 +764,10 @@ func Annotations(object metav1.Object) map[string]string {
 	return object.GetAnnotations()
 }
 
+func IntegrationSpec(it *v1.Integration) *v1.IntegrationSpec {
+	return &it.Spec
+}
+
 func Lease(ns string, name string) func() *coordination.Lease {
 	return func() *coordination.Lease {
 		lease := coordination.Lease{}

--- a/pkg/builder/quarkus.go
+++ b/pkg/builder/quarkus.go
@@ -136,6 +136,7 @@ func generateQuarkusProject(ctx *builderContext) error {
 
 	// Add Maven repositories
 	p.Repositories = append(p.Repositories, ctx.Build.Maven.Repositories...)
+	p.PluginRepositories = append(p.PluginRepositories, ctx.Build.Maven.Repositories...)
 
 	ctx.Maven.Project = p
 


### PR DESCRIPTION
Fixes #4608 

## Description 

Use maven repositories from `kamel run --maven-repository` command flag also as plugin repository in the generated maven project.



**Note:** This `--maven-repository` flag values from `run` command are not added in the generated settings.xml file but embedded in the pom.xml generated file.
This flag is translated in integration CR as:
```
spec:
  repositories:
  - https://repository.apache.org/content/groups/snapshots-group@id=apache@snapshots@noreleases
```

**Release Note**
```release-note
fix(cli): Use maven repository CLI flag for plugins
```
