### PR TITLE
Fix semantic version check of camel-k-runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apache/camel-k/v2
 go 1.20
 
 require (
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/container-tools/spectrum v0.6.35
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fsnotify/fsnotify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -27,7 +26,7 @@ import (
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/Masterminds/semver"
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 
 	"github.com/apache/camel-k/v2/pkg/client"
@@ -153,18 +152,11 @@ func operatorInfo(ctx context.Context, c client.Client, namespace string) (map[s
 	if err != nil {
 		return nil, err
 	}
-	if catalog == nil {
-		msg := fmt.Sprintf("CamelCatalog version: %s", platform.Status.Build.RuntimeVersion)
-		if platform.Status.Build.RuntimeProvider != "" {
-			msg += fmt.Sprintf(", provider: %s", platform.Status.Build.RuntimeProvider)
-		}
-		msg += fmt.Sprintf(" can't be found in %s namespace", platform.Namespace)
-		return nil, errors.New(msg)
+	if catalog != nil {
+		infos["Camel Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel-quarkus.version"]
+		infos["Camel version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel.version"]
+		infos["Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["quarkus.version"]
 	}
-
-	infos["Camel Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel-quarkus.version"]
-	infos["Camel version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel.version"]
-	infos["Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["quarkus.version"]
 
 	return infos, nil
 }

--- a/pkg/controller/catalog/initialize.go
+++ b/pkg/controller/catalog/initialize.go
@@ -467,7 +467,7 @@ func buildRuntimeBuilderImageSpectrum(options spectrum.Options) error {
 	if options.Base == "" {
 		return fmt.Errorf("missing base image, likely catalog is not compatible with this Camel K version")
 	}
-	Log.Infof("Making up Camel K builder container %s", options.Target)
+	Log.Infof("Making up Camel K builder container %s - base image: %s", options.Target, options.Base)
 
 	if jobs := runtime.GOMAXPROCS(0); jobs > 1 {
 		options.Jobs = jobs
@@ -483,6 +483,7 @@ func buildRuntimeBuilderImageSpectrum(options spectrum.Options) error {
 
 	_, err := spectrum.Build(options, directories...)
 	if err != nil {
+		Log.Error(err, "Error trying to build Camel K builder container")
 		return err
 	}
 

--- a/pkg/install/openshift.go
+++ b/pkg/install/openshift.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/Masterminds/semver"
+	semver "github.com/Masterminds/semver/v3"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/util/camel/camel_runtime.go
+++ b/pkg/util/camel/camel_runtime.go
@@ -38,7 +38,7 @@ func LoadCatalog(ctx context.Context, client client.Client, namespace string, ru
 		return nil, err
 	}
 
-	catalog, err := findBestMatch(list.Items, runtime)
+	catalog, err := findCatalog(list.Items, runtime)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/camel/camel_types.go
+++ b/pkg/util/camel/camel_types.go
@@ -18,13 +18,12 @@ limitations under the License.
 package camel
 
 import (
-	"github.com/Masterminds/semver"
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 )
 
 // CatalogVersion --.
 type CatalogVersion struct {
-	RuntimeVersion *semver.Version
+	RuntimeVersion string
 	Catalog        *v1.CamelCatalog
 }
 
@@ -40,7 +39,7 @@ func (c CatalogVersionCollection) Len() int {
 // Less is needed for the sort interface to compare two CatalogVersion objects on the
 // slice. If checks if one is less than the other.
 func (c CatalogVersionCollection) Less(i, j int) bool {
-	return c[i].RuntimeVersion.LessThan(c[j].RuntimeVersion)
+	return c[i].RuntimeVersion < c[j].RuntimeVersion
 }
 
 // Swap is needed for the sort interface to replace the CatalogVersion objects

--- a/pkg/util/camel/catalog.go
+++ b/pkg/util/camel/catalog.go
@@ -65,7 +65,7 @@ func catalogForRuntimeProvider(provider v1.RuntimeProvider) (*RuntimeCatalog, er
 		catalogs = append(catalogs, c)
 	}
 
-	return findBestMatch(catalogs, v1.RuntimeSpec{
+	return findCatalog(catalogs, v1.RuntimeSpec{
 		Version:  defaults.DefaultRuntimeVersion,
 		Provider: provider,
 		Metadata: make(map[string]string),


### PR DESCRIPTION
Fix https://github.com/apache/camel-k/issues/4715

<!-- Description -->

* Upgrade semver api to v3
* `kamel version -a` relies on loading the catalog using the runtime provider, which is not set in the IntegrationPlatform object, so rendering null and not loading the CamelCatalog object.
* It may occur the CamelCatalog object is not in the same namespace of the camel-k-operator pod, so we should not print an error message in case the CamelCatalog is not found.
* In the catalog initialization, print any error related to building the container image in the camel-k-operator log as the error was set only in the CamelCatalog status object.
* Change the `RuntimeVersion` type of CamelCatalog object to string, as there may be cases of the runtime version not following the semantic version.
* The `findBestMatch` was renamed to `findCatalog`, since it was not actually trying to match a version rule, but plainly using a full version to check it.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Update semver golang api to v3
```
