### PR TITLE
feat(core): Remove Openshift security warning message

### DIFF
--- a/config/manager/operator-deployment.yaml
+++ b/config/manager/operator-deployment.yaml
@@ -78,4 +78,12 @@ spec:
               port: 8081
             initialDelaySeconds: 20
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
 

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1341,6 +1341,16 @@ func OperatorImage(ns string) func() string {
 	}
 }
 
+func OperatorPodHas(ns string, predicate func(pod *corev1.Pod) bool) func() bool {
+	return func() bool {
+		pod := OperatorPod(ns)()
+		if pod == nil {
+			return false
+		}
+		return predicate(pod)
+	}
+}
+
 func OperatorPodPhase(ns string) func() corev1.PodPhase {
 	return func() corev1.PodPhase {
 		pod := OperatorPod(ns)()

--- a/helm/camel-k/templates/operator.yaml
+++ b/helm/camel-k/templates/operator.yaml
@@ -89,9 +89,20 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.operator.securityContext }}
           {{- with .Values.operator.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           {{- end }}
       serviceAccountName: camel-k-operator
       {{- with .Values.operator.tolerations }}

--- a/pkg/util/kubernetes/security.go
+++ b/pkg/util/kubernetes/security.go
@@ -1,0 +1,38 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// DefaultOperatorSecurityContext to ensure a container with low privilege and limited permissions.
+func DefaultOperatorSecurityContext() *corev1.SecurityContext {
+	runAsNonRoot := true
+	allowPrivilegeEscalation := false
+	sc := corev1.SecurityContext{
+		RunAsNonRoot: &runAsNonRoot,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+	}
+
+	return &sc
+}


### PR DESCRIPTION
Closes #4424

## Description

Add the valid openshift security contexts, as done with the builder pod,  to :
* operator pod
* integration pod





<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Add the valid openshift security context to integration and operator pods
```
