### PR TITLE
Fix operator check of the catalog

### DIFF
--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -153,18 +152,11 @@ func operatorInfo(ctx context.Context, c client.Client, namespace string) (map[s
 	if err != nil {
 		return nil, err
 	}
-	if catalog == nil {
-		msg := fmt.Sprintf("CamelCatalog version: %s", platform.Status.Build.RuntimeVersion)
-		if platform.Status.Build.RuntimeProvider != "" {
-			msg += fmt.Sprintf(", provider: %s", platform.Status.Build.RuntimeProvider)
-		}
-		msg += fmt.Sprintf(" can't be found in %s namespace", platform.Namespace)
-		return nil, errors.New(msg)
+	if catalog != nil {
+		infos["Camel Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel-quarkus.version"]
+		infos["Camel version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel.version"]
+		infos["Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["quarkus.version"]
 	}
-
-	infos["Camel Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel-quarkus.version"]
-	infos["Camel version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel.version"]
-	infos["Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["quarkus.version"]
 
 	return infos, nil
 }

--- a/pkg/controller/catalog/initialize.go
+++ b/pkg/controller/catalog/initialize.go
@@ -152,6 +152,7 @@ func initializeSpectrum(options spectrum.Options, ip *v1.IntegrationPlatform, ca
 	err := buildRuntimeBuilderWithTimeoutSpectrum(options, ip.Status.Build.GetBuildCatalogToolTimeout().Duration)
 
 	if err != nil {
+		Log.Error(err, "Error trying to build Camel K builder container")
 		target.Status.Phase = v1.CamelCatalogPhaseError
 		target.Status.SetErrorCondition(
 			v1.CamelCatalogConditionReady,


### PR DESCRIPTION
Fix https://github.com/apache/camel-k/issues/4715

* When there is a catalog build error, show in the operator log
* Only prints catalog information when it's available

In case there is an error when parsing the camelcatalog version, the camelcatalog controller will create a new one.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
