### PR TITLE
fix(e2e): Kamelets Default config as a labeled secret

### DIFF
--- a/e2e/common/config/files/TimerKameletIntegrationConfiguration09.java
+++ b/e2e/common/config/files/TimerKameletIntegrationConfiguration09.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.Exception;
+import java.lang.Override;
+import org.apache.camel.builder.RouteBuilder;
+
+public class TimerKameletIntegrationConfiguration09 extends RouteBuilder {
+    @Override
+    public void configure() throws Exception {
+        from("kamelet:iconfig09-timer-source")
+            .to("log:info");
+    }
+}

--- a/e2e/common/config/kamelet_config_test.go
+++ b/e2e/common/config/kamelet_config_test.go
@@ -233,41 +233,37 @@ func TestKameletImplicitConfigNamedMountedConfigmap(t *testing.T) {
 	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 }
 
-// Comenting test as it is failing on a non documented behavior.
-// See https://github.com/apache/camel-k/issues/4750
-/*
-func TestKameletImplicitConfig(t *testing.T) {
+func TestKameletImplicitConfigDefaultLabeledSecret(t *testing.T) {
 	RegisterTestingT(t)
-	t.Run("test custom timer source", func(t *testing.T) {
-		Expect(CreateTimerKamelet(ns, "iconfig-test-timer-source")()).To(Succeed())
 
-			t.Run("run test default config using labeled secret", func(t *testing.T) {
-				name := "iconfig-test-timer-source-int2"
-				secretName := "my-labeled-iconfig-test-timer-source-default-secret"
+	t.Run("run test default config using labeled secret", func(t *testing.T) {
 
-				var secData = make(map[string]string)
-				secData["camel.kamelet.iconfig-test-timer-source.message"] = "very top secret message"
-				var labels = make(map[string]string)
-				labels["camel.apache.org/kamelet"] = "iconfig-test-timer-source"
-				Expect(CreatePlainTextSecretWithLabels(ns, secretName, secData, labels)).To(Succeed())
-				Eventually(SecretByName(ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
+		Expect(CreateTimerKamelet(ns, "iconfig09-timer-source")()).To(Succeed())
 
-				Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationConfiguration.java",
-					"-p", "camel.kamelet.iconfig-test-timer-source.message='Default message 02'",
-					"--name", name).Execute()).To(Succeed())
-				Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("very top secret message"))
+		name := "iconfig-test-timer-source-int9"
+		secretName := "my-iconfig-int9-secret"
 
-				Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
-				Expect(DeleteSecret(ns, secretName)).To(Succeed())
-			})
+		var secData = make(map[string]string)
+		secData["camel.kamelet.iconfig09-timer-source.message"] = "very top labeled secret message"
+		var labels = make(map[string]string)
+		labels["camel.apache.org/kamelet"] = "iconfig09-timer-source"
+		Expect(CreatePlainTextSecretWithLabels(ns, secretName, secData, labels)).To(Succeed())
+		Eventually(SecretByName(ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
 
+		Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationConfiguration09.java",
+			"--name", name).Execute()).To(Succeed())
+		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		Eventually(IntegrationLogs(ns, name)).Should(ContainSubstring("very top labeled secret message"))
+
+		Expect(Kamel("delete", name, "-n", ns).Execute()).To(Succeed())
+		Eventually(Integration(ns, name), TestTimeoutLong).Should(BeNil())
+		Expect(DeleteSecret(ns, secretName)).To(Succeed())
+		Eventually(SecretByName(ns, secretName), TestTimeoutLong).Should(BeNil())
+		Expect(DeleteKamelet(ns, "iconfig09-timer-source")).To(Succeed())
 	})
 
 	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
-	Expect(DeleteKamelet(ns, "iconfig-test-timer-source")).To(Succeed())
 }
-*/
 
 // Tests on integration with kamelets containing configuration from properties and secrets with parameters inside the integration.
 


### PR DESCRIPTION
Ref #4750

## Description

Refactor config e2e test for kamelets with a labeled secret.

Note : follow-up on https://github.com/apache/camel-k/pull/4753
<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): Kamelets Default config as a labeled secret
```
