### PR TITLE
fix(cli): dev mode init controller-runtime log.SetLogger()

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -55,8 +55,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/kubernetes/scheme"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/client"
@@ -332,6 +334,7 @@ func (o *runCmdOptions) run(cmd *cobra.Command, args []string) error {
 		signal.Notify(cs, os.Interrupt, syscall.SIGTERM)
 		go func() {
 			<-cs
+			logf.SetLogger(zap.New(zap.UseDevMode(true)))
 			if o.Context.Err() != nil {
 				// Context canceled
 				return


### PR DESCRIPTION
Closes #4770 

## Description 

Init the setLogger() for CLI's --dev mode.


Note: same issue as #4754 

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): dev mode init controller-runtime log.SetLogger()
```
