### PR TITLE
fix(e2e): Add installation with helm,kustomize,olm securityContext re…

### DIFF
--- a/e2e/install/helm/setup_test.go
+++ b/e2e/install/helm/setup_test.go
@@ -32,6 +32,7 @@ import (
 
 	. "github.com/apache/camel-k/v2/e2e/support"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
+	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	. "github.com/onsi/gomega"
 )
 
@@ -62,6 +63,13 @@ func TestHelmInstallRunUninstall(t *testing.T) {
 		)
 
 		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
+
+		// Check if restricted security context has been applyed
+		operatorPod := OperatorPod(ns)()
+		Expect(operatorPod.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(Equal(kubernetes.DefaultOperatorSecurityContext().RunAsNonRoot))
+		Expect(operatorPod.Spec.Containers[0].SecurityContext.Capabilities).To(Equal(kubernetes.DefaultOperatorSecurityContext().Capabilities))
+		Expect(operatorPod.Spec.Containers[0].SecurityContext.SeccompProfile).To(Equal(kubernetes.DefaultOperatorSecurityContext().SeccompProfile))
+		Expect(operatorPod.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(Equal(kubernetes.DefaultOperatorSecurityContext().AllowPrivilegeEscalation))
 
 		//Test a simple route
 		t.Run("simple route", func(t *testing.T) {

--- a/e2e/install/kustomize/operator_test.go
+++ b/e2e/install/kustomize/operator_test.go
@@ -31,6 +31,7 @@ import (
 
 	. "github.com/apache/camel-k/v2/e2e/support"
 	testutil "github.com/apache/camel-k/v2/e2e/support/util"
+	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 
 	. "github.com/onsi/gomega"
 )
@@ -59,6 +60,14 @@ func TestOperatorBasic(t *testing.T) {
 
 		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
 		Eventually(OperatorPodPhase(ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+
+		// Check if restricted security context has been applyed
+		operatorPod := OperatorPod(ns)()
+		Expect(operatorPod.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(Equal(kubernetes.DefaultOperatorSecurityContext().RunAsNonRoot))
+		Expect(operatorPod.Spec.Containers[0].SecurityContext.Capabilities).To(Equal(kubernetes.DefaultOperatorSecurityContext().Capabilities))
+		Expect(operatorPod.Spec.Containers[0].SecurityContext.SeccompProfile).To(Equal(kubernetes.DefaultOperatorSecurityContext().SeccompProfile))
+		Expect(operatorPod.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(Equal(kubernetes.DefaultOperatorSecurityContext().AllowPrivilegeEscalation))
+
 		Eventually(Platform(ns)).ShouldNot(BeNil())
 	})
 }

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1344,6 +1344,16 @@ func OperatorImage(ns string) func() string {
 	}
 }
 
+func OperatorPodSecurityContext(ns string) func() *corev1.SecurityContext {
+	return func() *corev1.SecurityContext {
+		pod := OperatorPod(ns)()
+		if pod == nil || pod.Spec.Containers == nil || len(pod.Spec.Containers) == 0 {
+			return nil
+		}
+		return pod.Spec.Containers[0].SecurityContext
+	}
+}
+
 func OperatorPodHas(ns string, predicate func(pod *corev1.Pod) bool) func() bool {
 	return func() bool {
 		pod := OperatorPod(ns)()


### PR DESCRIPTION
Fix #4786 

## Description

Add e2e tests installation with helm,kustomize,olm securityContext restricted validation

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): Add installation with helm,kustomize,olm securityContext restricted
```
