### PR TITLE
fix(ctrl): Change reconciliation of int in error

### DIFF
--- a/pkg/trait/health.go
+++ b/pkg/trait/health.go
@@ -18,6 +18,7 @@ limitations under the License.
 package trait
 
 import (
+	"fmt"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -81,6 +82,9 @@ func (t *healthTrait) Apply(e *Environment) error {
 	}
 
 	container := e.GetIntegrationContainer()
+	if container == nil {
+		return fmt.Errorf("unable to find integration container: %s", e.Integration.Name)
+	}
 	var port *intstr.IntOrString
 	// Use the default named HTTP container port if it exists.
 	// For Knative, the Serving webhook is responsible for setting the user-land port,

--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -124,7 +124,7 @@ func (t *jvmTrait) Apply(e *Environment) error {
 
 	container := e.GetIntegrationContainer()
 	if container == nil {
-		return fmt.Errorf("unable to find integration container")
+		return fmt.Errorf("unable to find integration container: %s", e.Integration.Name)
 	}
 
 	// Build the container command


### PR DESCRIPTION
## Description

When the integration is in Error with the Kit condition in error, then if the integration kit referenced is still in error then finish the reconciliation process without any change to the integration.

Fix the health trait to avoid panic errors.
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Change reconciliation of integration in error
```
