### PR TITLE
Kamelet - Inject secret in Vaults - Hashicorp Vault

### DIFF
--- a/docs/modules/traits/pages/aws-secrets-manager.adoc
+++ b/docs/modules/traits/pages/aws-secrets-manager.adoc
@@ -50,8 +50,8 @@ Syntax: [configmap\|secret]:name[/key], where name represents the resource name,
 | aws-secrets-manager.secret-key
 | string
 | The AWS Secret Key to use. This could be a plain text or a configmap/secret
-	// The content of the aws secret key is expected to be a text containing a valid AWS secret key.
-	// Syntax: [configmap\|secret]:name[/key], where name represents the resource name, key optionally represents the resource key to be filtered (default key value = aws-secret-key).
+The content of the aws secret key is expected to be a text containing a valid AWS secret key.
+Syntax: [configmap\|secret]:name[/key], where name represents the resource name, key optionally represents the resource key to be filtered (default key value = aws-secret-key).
 
 | aws-secrets-manager.region
 | string

--- a/docs/modules/traits/pages/hashicorp-vault.adoc
+++ b/docs/modules/traits/pages/hashicorp-vault.adoc
@@ -51,7 +51,9 @@ The following configuration options are available:
 
 | hashicorp-vault.token
 | string
-| The token to access Hashicorp Vault
+| The token to access Hashicorp Vault. This could be a plain text or a configmap/secret
+The content of the hashicorp vault token is expected to be a text containing a valid Hashicorp Vault Token.
+Syntax: [configmap\|secret]:name[/key], where name represents the resource name, key optionally represents the resource key to be filtered (default key value = hashicorp-vault-token).
 
 | hashicorp-vault.scheme
 | string

--- a/resources/traits.yaml
+++ b/resources/traits.yaml
@@ -116,11 +116,11 @@ traits:
       (default key value = aws-access-key).'
   - name: secret-key
     type: string
-    description: "The AWS Secret Key to use. This could be a plain text or a configmap/secret
-      \t// The content of the aws secret key is expected to be a text containing a
-      valid AWS secret key. \t// Syntax: [configmap|secret]:name[/key], where name
-      represents the resource name, key optionally represents the resource key to
-      be filtered (default key value = aws-secret-key)."
+    description: 'The AWS Secret Key to use. This could be a plain text or a configmap/secret
+      The content of the aws secret key is expected to be a text containing a valid
+      AWS secret key. Syntax: [configmap|secret]:name[/key], where name represents
+      the resource name, key optionally represents the resource key to be filtered
+      (default key value = aws-secret-key).'
   - name: region
     type: string
     description: The AWS Region to use
@@ -641,7 +641,11 @@ traits:
     description: The Hashicorp engine to use
   - name: token
     type: string
-    description: The token to access Hashicorp Vault
+    description: 'The token to access Hashicorp Vault. This could be a plain text
+      or a configmap/secret The content of the hashicorp vault token is expected to
+      be a text containing a valid Hashicorp Vault Token. Syntax: [configmap|secret]:name[/key],
+      where name represents the resource name, key optionally represents the resource
+      key to be filtered (default key value = hashicorp-vault-token).'
   - name: scheme
     type: string
     description: The scheme to access Hashicorp Vault


### PR DESCRIPTION
Fixes #4743 

**Release Note**
```release-note
Implementing the requested feature in Hashicorp Vault addon
```

For GCP there is nothing to do since we are pointing a file containing the service account key.
