### PR TITLE
feat(core): Move jib plugins versions to camelcatalog

### DIFF
--- a/pkg/apis/camel/v1/camelcatalog_types_support.go
+++ b/pkg/apis/camel/v1/camelcatalog_types_support.go
@@ -202,6 +202,16 @@ func (c *CamelCatalogSpec) GetQuarkusToolingImage() string {
 	return c.Runtime.Metadata["quarkus.native-builder-image"]
 }
 
+// GetJibMavenPluginVersion returns the Jib plugin version required to publish an integration kit based on this catalog with jib strategy.
+func (c *CamelCatalogSpec) GetJibMavenPluginVersion() string {
+	return c.Runtime.Metadata["jib.maven-plugin.version"]
+}
+
+// GetJibLayerFilterExtensionMavenVersion returns the Jib layer filter plugin version required to publish an integration kit based on this catalog with jib strategy.
+func (c *CamelCatalogSpec) GetJibLayerFilterExtensionMavenVersion() string {
+	return c.Runtime.Metadata["jib.layer-filter-extension-maven.version"]
+}
+
 // HasCapability checks if the given capability is present in the catalog.
 func (c *CamelCatalogSpec) HasCapability(capability string) bool {
 	_, ok := c.Runtime.Capabilities[capability]

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -153,9 +153,9 @@ func operatorInfo(ctx context.Context, c client.Client, namespace string) (map[s
 		return nil, err
 	}
 	if catalog != nil {
-		infos["Camel Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel-quarkus.version"]
-		infos["Camel version"] = catalog.CamelCatalogSpec.Runtime.Metadata["camel.version"]
-		infos["Quarkus version"] = catalog.CamelCatalogSpec.Runtime.Metadata["quarkus.version"]
+		infos["Camel Quarkus version"] = catalog.CamelCatalogSpec.GetCamelQuarkusVersion()
+		infos["Camel version"] = catalog.CamelCatalogSpec.GetCamelVersion()
+		infos["Quarkus version"] = catalog.CamelCatalogSpec.GetQuarkusVersion()
 	}
 
 	return infos, nil

--- a/pkg/cmd/version_test.go
+++ b/pkg/cmd/version_test.go
@@ -101,9 +101,9 @@ func TestOperatorVersionVerbose(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, true, versionCmdOptions.Verbose)
 	assert.Contains(t, output, fmt.Sprintf("Camel K Operator %s\n", defaults.Version))
-	assert.Contains(t, output, fmt.Sprintf("Camel version: %s\n", catalog.Spec.Runtime.Metadata["camel.version"]))
-	assert.Contains(t, output, fmt.Sprintf("Camel Quarkus version: %s\n", catalog.Spec.Runtime.Metadata["camel-quarkus.version"]))
-	assert.Contains(t, output, fmt.Sprintf("Quarkus version: %s\n", catalog.Spec.Runtime.Metadata["quarkus.version"]))
+	assert.Contains(t, output, fmt.Sprintf("Camel version: %s\n", catalog.Spec.GetCamelVersion()))
+	assert.Contains(t, output, fmt.Sprintf("Camel Quarkus version: %s\n", catalog.Spec.GetCamelQuarkusVersion()))
+	assert.Contains(t, output, fmt.Sprintf("Quarkus version: %s\n", catalog.Spec.GetQuarkusVersion()))
 }
 
 func TestCompatibleVersions(t *testing.T) {

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -350,8 +350,12 @@ func (t *builderTrait) builderTask(e *Environment, taskConf *v1.BuildConfigurati
 	}
 
 	if e.Platform.Status.Build.PublishStrategy == v1.IntegrationPlatformBuildPublishStrategyJib {
-		if err := jib.CreateProfileConfigmap(e.Ctx, e.Client, e.IntegrationKit); err != nil {
-			return nil, fmt.Errorf("could not create default maven jib profile: %w. ", err)
+		profile, err := jib.JibMavenProfile(e.CamelCatalog.GetJibMavenPluginVersion(), e.CamelCatalog.GetJibLayerFilterExtensionMavenVersion())
+		if err != nil {
+			return nil, fmt.Errorf("error generating default maven jib profile: %w. ", err)
+		}
+		if err := jib.CreateProfileConfigmap(e.Ctx, e.Client, e.IntegrationKit, profile); err != nil {
+			return nil, fmt.Errorf("could not create default maven jib profile configmap: %w. ", err)
 		}
 		t.MavenProfiles = append(t.MavenProfiles, "configmap:"+e.IntegrationKit.Name+"-publish-jib-profile/profile.xml")
 	}

--- a/pkg/util/jib/configuration_test.go
+++ b/pkg/util/jib/configuration_test.go
@@ -32,11 +32,24 @@ import (
 )
 
 func TestJibMavenProfile(t *testing.T) {
-	profile, err := jibMavenProfile()
+	profile, err := JibMavenProfile("3.3.0", "0.2.0")
 
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(profile, "<profile>"))
 	assert.True(t, strings.HasSuffix(profile, "</profile>"))
+	assert.True(t, strings.Contains(profile, "<version>3.3.0</version>"))
+	assert.True(t, strings.Contains(profile, "<version>0.2.0</version>"))
+
+}
+
+func TestJibMavenProfileDefaultValues(t *testing.T) {
+	profile, err := JibMavenProfile("", "")
+
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(profile, "<profile>"))
+	assert.True(t, strings.HasSuffix(profile, "</profile>"))
+	assert.True(t, strings.Contains(profile, "<version>"+JibMavenPluginVersionDefault+"</version>"))
+	assert.True(t, strings.Contains(profile, "<version>"+JibLayerFilterExtensionMavenVersionDefault+"</version>"))
 
 }
 
@@ -58,7 +71,7 @@ func TestJibConfigMap(t *testing.T) {
 		},
 	}
 
-	err := CreateProfileConfigmap(ctx, c, kit)
+	err := CreateProfileConfigmap(ctx, c, kit, "<profile>awesomeprofile</profile>")
 	assert.NoError(t, err)
 
 	key := ctrl.ObjectKey{
@@ -71,5 +84,5 @@ func TestJibConfigMap(t *testing.T) {
 	assert.Equal(t, cm.OwnerReferences[0].Name, "test")
 	assert.Equal(t, cm.OwnerReferences[0].UID, types.UID("8dc44a2b-063c-490e-ae02-1fab285ac70a"))
 	assert.NotNil(t, cm.Data["profile.xml"])
-
+	assert.True(t, strings.Contains(cm.Data["profile.xml"], "awesome"))
 }


### PR DESCRIPTION
Ref #4703
    
## Description

Extracted jib plugin versions to camel-k-runtime:
* use camelcatalog CR .spec.runtime.metadata values
* set default values for catalog backward compatibility


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

NOTE:

Linked to: apache/camel-k-runtime#1096

**Release Note**
```release-note
feat(core): Move jib plugins versions to camelcatalog from camel-k-runtime
```
