### PR TITLE
Added build-catalog-tool-timeout parameter to install command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,5 @@ pkg/resources/resources.go
 # MAC OS files
 .DS_Store
 
+# Audit logs file
+logs.txt

--- a/docs/modules/ROOT/pages/contributing/e2e.adoc
+++ b/docs/modules/ROOT/pages/contributing/e2e.adoc
@@ -31,15 +31,22 @@ This is the list of the groups we are using (please, notice that they can slight
     * builder (`make test-builder`)
     * common (`make test-common`)
     * commonwithcustominstall (`make test-common-with-custom-install`)
-    * install (`make test-install` and `make test-install-olm`)
+    * install (`make test-install`, `make test-install-olm` and `make test-install-upgrade`)
     * knative (`make test-knative`)
     * native (`make test-quarkus-native` and `make test-quarkus-native-high-memory`)
     * telemetry (`make test-telemetry`)
-    * yaks (run only in CI)
 
 Each group tests a specific feature of Camel K. Typically any new test should be falling under the `common` group, unless it belongs to any other category or it requires some particular customization. As an example, `telemetry` requires the configuration of an OTLP Collector, reason why it requires its own group. If the test still is a common one but needs to perform customization on the Camel K Operator, then, it should be developed under `commonwithcustominstall`: as an example, we have there tests which requires the configuration of a Maven proxy.
 
-It's important to know that `common` is used as smoke test in the nightly release process. We want to keep this group of test as fast as possible.
+It's important to know that a subset of `common` named `test-smoke` is used as smoke test in the nightly release process. We want to keep this group of test as fast as possible.
+
+=== Configure End To End tests runs with env vars
+Some e2e test runs parameters can be configured usually with env vars.
+Most of them are located at https://github.com/apache/camel-k/tree/main/e2e/support/test_support.go[e2e/support/test_support.go] in `init` and `kamelInstallWithContext` functions.
+A list of the most commonly used:
+
+    * `CAMEL_K_TEST_SKIP_PROBLEMATIC`: set it to `true` to skip tests that might fail.
+    * `CAMEL_K_BUILD_CATALOG_TOOL_TIMEOUT`: set timeout time (in seconds) for building the catalog tool image is the default 2 minutes are not enough for your setup.
 
 [[testing-operator]]
 == Testing Operator under development

--- a/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
@@ -28,6 +28,7 @@ We have several configuration used to influence the building of an integration:
 --build-strategy string                       Set the build strategy
 --build-order-strategy string                 Set the build order strategy
 --build-timeout string                        Set how long the build process can last
+--build-catalog-tool-timeout string          Set how long the catalogtool image build can last
 ```
 A very important set of configuration you can provide is related to Maven:
 ```

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -291,6 +291,12 @@ func kamelInstallWithContext(ctx context.Context, operatorID string, namespace s
 		installArgs = append(installArgs, "--operator-image-pull-policy", opImagePullPolicy)
 	}
 
+	opBuildCatalogToolTimeout := os.Getenv("CAMEL_K_BUILD_CATALOG_TOOL_TIMEOUT")
+	if opImagePullPolicy != "" {
+		fmt.Printf("Setting build catalog tool timeout to %s\n", opBuildCatalogToolTimeout)
+		installArgs = append(installArgs, "--build-catalog-tool-timeout", opBuildCatalogToolTimeout)
+	}
+
 	installArgs = append(installArgs, args...)
 	return KamelWithContext(ctx, installArgs...)
 }

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -111,6 +111,7 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *installCmdO
 	cmd.Flags().String("build-publish-strategy", "", "Set the build publish strategy")
 	cmd.Flags().StringArray("build-publish-strategy-option", nil, "Add a build publish strategy option, as <name=value>")
 	cmd.Flags().String("build-timeout", "", "Set how long the build process can last")
+	cmd.Flags().String("build-catalog-tool-timeout", "", "Set how long the catalogtool image build can last")
 	cmd.Flags().String("trait-profile", "", "The profile to use for traits")
 
 	// OLM
@@ -186,6 +187,7 @@ type installCmdOptions struct {
 	BuildPublishStrategy        string   `mapstructure:"build-publish-strategy"`
 	BuildPublishStrategyOptions []string `mapstructure:"build-publish-strategy-options"`
 	BuildTimeout                string   `mapstructure:"build-timeout"`
+	BuildCatalogToolTimeout     string   `mapstructure:"build-catalog-tool-timeout"`
 	MavenExtensions             []string `mapstructure:"maven-extensions"`
 	MavenLocalRepository        string   `mapstructure:"maven-local-repository"`
 	MavenProperties             []string `mapstructure:"maven-properties"`
@@ -539,6 +541,16 @@ func (o *installCmdOptions) setupIntegrationPlatform(c client.Client, namespace 
 		}
 
 		platform.Spec.Build.Timeout = &metav1.Duration{
+			Duration: d,
+		}
+	}
+	if o.BuildCatalogToolTimeout != "" {
+		d, err := time.ParseDuration(o.BuildCatalogToolTimeout)
+		if err != nil {
+			return nil, err
+		}
+
+		platform.Spec.Build.BuildCatalogToolTimeout = &metav1.Duration{
 			Duration: d,
 		}
 	}

--- a/pkg/cmd/install_test.go
+++ b/pkg/cmd/install_test.go
@@ -121,6 +121,13 @@ func TestInstallBuildTimeoutFlag(t *testing.T) {
 	assert.Equal(t, "10", installCmdOptions.BuildTimeout)
 }
 
+func TestInstallBuildCatalogToolTimeoutFlag(t *testing.T) {
+	installCmdOptions, rootCmd, _ := initializeInstallCmdOptions(t)
+	_, err := test.ExecuteCommand(rootCmd, cmdInstall, "--build-catalog-tool-timeout", "600")
+	assert.Nil(t, err)
+	assert.Equal(t, "600", installCmdOptions.BuildCatalogToolTimeout)
+}
+
 func TestInstallClusterSetupFlag(t *testing.T) {
 	installCmdOptions, rootCmd, _ := initializeInstallCmdOptions(t)
 	_, err := test.ExecuteCommand(rootCmd, cmdInstall, "--cluster-setup")


### PR DESCRIPTION
Added `build-catalog-tool-timeout` parameter to the `install` command.
Added `CAMEL_K_BUILD_CATALOG_TOOL_TIMEOUT` to e2e tests scripts to leverage the new install parameter. 
Updated doc.
Small addition to .gitignore

This is useful in environment where the default timeout of 2 minutes is not sufficient.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
