### PR TITLE
chore(ci): no coverage message when coverage unchanged

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -126,13 +126,6 @@ jobs:
               repo: context.repo.repo,
               body: ':camel: **Thank you for contributing!**\n\nCode Coverage Report :warning: - Coverage changed: ${{env.OLD_COV}}% --> ${{env.NEW_COV}}% (Coverage difference: **${{env.COV_DIFF}}%**)'
               })
-            }else{
-              github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: ':camel: **Thank you for contributing!**\n\nCode Coverage Report :heavy_check_mark: - Coverage unchanged.'
-              })
             }
 
       - name: Comment Merge Conflicts


### PR DESCRIPTION
Let's avoid adding many messages when no useful info.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(ci): no coverage message when coverage unchanged
```
