### PR TITLE
fix: removed unnecessary defaul value in route trait

### DIFF
--- a/pkg/trait/route.go
+++ b/pkg/trait/route.go
@@ -45,7 +45,6 @@ func newRouteTrait() Trait {
 		BaseTrait: NewBaseTrait("route", 2200),
 		RouteTrait: traitv1.RouteTrait{
 			Annotations: map[string]string{},
-			Host:        "",
 		},
 	}
 }


### PR DESCRIPTION
<!-- Description -->

- removed unnecessary defaul value for Host in Route trait.



_As we are  currently not setting a specific default value for Host, this line is unnecessary and could cause problems if left in._

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
