### PR TITLE
chore(ci): Use latest minor version of golang in ci workflows

### DIFF
--- a/.github/actions/automatic-updates/action.yml
+++ b/.github/actions/automatic-updates/action.yml
@@ -35,6 +35,7 @@ runs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ inputs.goVersion }}
+        check-latest: true
     - name: Generate changelog
       uses: ./.github/actions/changelog
       with:

--- a/.github/actions/automatic-updates/action.yml
+++ b/.github/actions/automatic-updates/action.yml
@@ -24,17 +24,17 @@ inputs:
     type: string
   secretGithubToken:
     required: true
-  goVersion:
+  goVersionFile:
     required: true
     type: string
 
 runs:
   using: "composite"
   steps:
-    - name: Install Go ${{ inputs.goVersion }}
+    - name: Install Go ${{ inputs.goVersionFile }}
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ inputs.goVersion }}
+        go-version-file: ${{ inputs.goVersionFile }}
         check-latest: true
     - name: Generate changelog
       uses: ./.github/actions/changelog

--- a/.github/actions/kamel-prepare-env/action.yml
+++ b/.github/actions/kamel-prepare-env/action.yml
@@ -75,6 +75,7 @@ runs:
       if: ${{ env.KAMEL_PREPARE_ENV != 'true' }}
       with:
         go-version: 1.20.x
+        check-latest: true
 
     - name: (Re-)install kustomize
       shell: bash

--- a/.github/actions/kamel-prepare-env/action.yml
+++ b/.github/actions/kamel-prepare-env/action.yml
@@ -74,7 +74,7 @@ runs:
       uses: actions/setup-go@v4
       if: ${{ env.KAMEL_PREPARE_ENV != 'true' }}
       with:
-        go-version: 1.20.x
+        go-version-file: 'go.mod'
         check-latest: true
 
     - name: (Re-)install kustomize

--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -19,7 +19,7 @@ name: release-nightly
 description: 'action used to release nightly'
 
 inputs:
-  goVersion:
+  goVersionFile:
     required: true
     type: string
   javaVersion:
@@ -46,10 +46,10 @@ runs:
       with:
         java-version: ${{ inputs.javaVersion }}
         distribution: "temurin"
-    - name: Install Go ${{ inputs.goVersion }}
+    - name: Install Go ${{ inputs.goVersionFile }}
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ inputs.goVersion }}
+        go-version-file: ${{ inputs.goVersionFile }}
         check-latest: true
     - name: Common smoke tests
       uses: ./.github/actions/e2e-common

--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -50,6 +50,7 @@ runs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ inputs.goVersion }}
+        check-latest: true
     - name: Common smoke tests
       uses: ./.github/actions/e2e-common
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
           check-latest: true
 
       - name: Prepare repo configuration

--- a/.github/workflows/nightly-automatic-updates.yml
+++ b/.github/workflows/nightly-automatic-updates.yml
@@ -48,4 +48,4 @@ jobs:
       with:
         branch-ref: ${{ matrix.ref-branch }}
         secretGithubToken: ${{ secrets.GITHUB_TOKEN }}
-        goVersion: "1.20.x"
+        goVersionFile: "go.mod"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Release nightly ${{ matrix.ref-branch }} branch
       uses: ./.github/actions/release-nightly
       with:
-        goVersion: "1.20.x"
+        goVersionFile: "go.mod"
         javaVersion: "17"
         secretE2ECluster: ${{ secrets.E2E_CLUSTER_CONFIG }}
         secretE2EKube: ${{ secrets.E2E_KUBE_CONFIG }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version-file: 'go.mod'
           check-latest: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version-file: 'go.mod'
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
+          check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         env:


### PR DESCRIPTION
Closes #4641

## Description

Ensure we use the latest minor version available of golang in every workflow.
Nothing more need to be done. I checked and all of the workflow (expect the "stale" workflow and it does not need golang) define golang version either directly either through the action `kamel-prepare-env` called in the workflow pipeline.


**Release Note**
```release-note
chore(ci): Use latest minor version of golang in ci workflows
```
