### PR TITLE
fix(core): Access configmap from another namespace for KEP-1755

### DIFF
--- a/.github/actions/kamel-config-cluster-kind/action.yml
+++ b/.github/actions/kamel-config-cluster-kind/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - id: install-cluster
       name: Install Cluster
-      uses: container-tools/kind-action@v2.0.1
+      uses: container-tools/kind-action@7075d1458484493c6a92d4604cb27b87de0f8107
       if: ${{ env.CLUSTER_KIND_CONFIGURED != 'true' }}
       with:
         version: v0.19.0

--- a/e2e/install/kustomize/operator_test.go
+++ b/e2e/install/kustomize/operator_test.go
@@ -69,6 +69,13 @@ func TestOperatorBasic(t *testing.T) {
 		Expect(operatorPod.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(Equal(kubernetes.DefaultOperatorSecurityContext().AllowPrivilegeEscalation))
 
 		Eventually(Platform(ns)).ShouldNot(BeNil())
+		registry := os.Getenv("KIND_REGISTRY")
+		if registry != "" {
+			platform := Platform(ns)()
+			Expect(platform.Status.Build.Registry).ShouldNot(BeNil())
+			Expect(platform.Status.Build.Registry.Address).To(Equal(registry))
+		}
+
 	})
 }
 

--- a/install/setup/kustomization.yaml
+++ b/install/setup/kustomization.yaml
@@ -19,3 +19,15 @@ kind: Kustomization
 
 resources:
 - ../config/rbac
+
+transformers:
+- |-
+  apiVersion: builtin
+  kind: PatchTransformer
+  metadata:
+    name: fix-local-registry-rbac-namespace
+  patch: '[{"op": "replace", "path": "/metadata/namespace", "value": "kube-public"}]'
+  target:
+    group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: camel-k-operator-local-registry

--- a/pkg/util/registry/kep_1755.go
+++ b/pkg/util/registry/kep_1755.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	"github.com/apache/camel-k/v2/pkg/client"
+	"github.com/apache/camel-k/v2/pkg/util/log"
 	"gopkg.in/yaml.v2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,11 @@ import (
 func GetRegistryAddress(ctx context.Context, c client.Client) (*string, error) {
 	config, err := c.CoreV1().ConfigMaps("kube-public").Get(ctx, "local-registry-hosting", metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if k8serrors.IsForbidden(err) {
+			log.Debug("Cannot access registry configuration local-registry-hosting ConfigMap", "error", err)
+			return nil, nil
+		} else if k8serrors.IsNotFound(err) {
+			log.Debug("Cannot find registry configuration local-registry-hosting ConfigMap", "error", err)
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/util/registry/kep_1755.go
+++ b/pkg/util/registry/kep_1755.go
@@ -22,18 +22,16 @@ import (
 
 	"github.com/apache/camel-k/v2/pkg/client"
 	"gopkg.in/yaml.v2"
-	corev1 "k8s.io/api/core/v1"
-	k8errors "k8s.io/apimachinery/pkg/api/errors"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetRegistryAddress KEP-1755
 // https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
 func GetRegistryAddress(ctx context.Context, c client.Client) (*string, error) {
-	config := corev1.ConfigMap{}
-	err := c.Get(ctx, ctrl.ObjectKey{Namespace: "kube-public", Name: "local-registry-hosting"}, &config)
+	config, err := c.CoreV1().ConfigMaps("kube-public").Get(ctx, "local-registry-hosting", metav1.GetOptions{})
 	if err != nil {
-		if k8errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
Change kubernetes CLI usage to actually get the configmap `local-registry-hosting` in namespace `kube-public` for kind action registry configuration from KEP-1755.


**Release Note**
```release-note
fix(core): Access configmap from another namespace for KEP-1755
```
