### PR TITLE
Remove route() from examples

### DIFF
--- a/examples/rest/routes-rest.js
+++ b/examples/rest/routes-rest.js
@@ -23,5 +23,7 @@
 rest('/say/hello')
     .produces("text/plain")
     .get()
-        .route()
-        .transform().constant("Hello World");
+    .to('direct:sayHello')
+  
+from('direct:sayHello')
+    .transform().constant("Hello World");

--- a/examples/saga/Flight.java
+++ b/examples/saga/Flight.java
@@ -31,7 +31,9 @@ public class Flight extends RouteBuilder {
 
 		rest("/api").post("/flight/buy")
 			.param().type(RestParamType.header).name("id").required(true).endParam()
-			.route()
+			.to("direct:buy");
+			
+		from("direct:buy")
 			.saga()
 				.propagation(SagaPropagation.MANDATORY)
 				.option("id", header("id"))

--- a/examples/saga/Payment.java
+++ b/examples/saga/Payment.java
@@ -31,7 +31,9 @@ public class Payment extends RouteBuilder {
 		rest("/api/").post("/pay")
                     .param().type(RestParamType.query).name("type").required(true).endParam()
                     .param().type(RestParamType.header).name("id").required(true).endParam()
-                    .route()
+                    .to("direct:pay");
+        
+        from("direct:pay")
                     .saga()
                         .propagation(SagaPropagation.MANDATORY)
                         .option("id", header("id"))

--- a/examples/saga/Train.java
+++ b/examples/saga/Train.java
@@ -31,7 +31,9 @@ public class Train extends RouteBuilder {
 
 		rest("/api/").post("/train/buy/seat")
                     .param().type(RestParamType.header).name("id").required(true).endParam()
-                    .route()
+                    .to("direct:buySeat");
+                    
+        from("direct:buySeat")
                     .saga()
                         .propagation(SagaPropagation.SUPPORTS)
                         .option("id", header("id"))

--- a/examples/saga/lra-coordinator.yaml
+++ b/examples/saga/lra-coordinator.yaml
@@ -79,7 +79,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 180
         name: lra-coordinator
-        image: docker.io/jbosstm/lra-coordinator:5.9.8.Final
+        image: quay.io/jbosstm/lra-coordinator:latest
         ports:
         - containerPort: 8080
           protocol: TCP


### PR DESCRIPTION
Examples `saga` and `route` contain obsolete code - RestDefinition doesn't contain route() since Camel 3.16; updated via [Camel migration guide ](https://camel.apache.org/manual/camel-3x-upgrade-guide-3_16.html#_rest_dsl).
