### PR TITLE
chore(e2e): Randomize integration names in e2e tests

### DIFF
--- a/e2e/common/cli/run_test.go
+++ b/e2e/common/cli/run_test.go
@@ -78,7 +78,7 @@ func TestKamelCLIRun(t *testing.T) {
 		os.Unsetenv("GITHUB_TOKEN")
 
 		t.Run("Gist (ID)", func(t *testing.T) {
-			name := "github-gist-id"
+			name := RandomizedSuffixName("github-gist-id")
 			Expect(KamelRunWithID(operatorID, ns, "--name", name,
 				"gist:e2c3f9a5fd0d9e79b21b04809786f17a").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
@@ -90,7 +90,7 @@ func TestKamelCLIRun(t *testing.T) {
 		})
 
 		t.Run("Gist (URL)", func(t *testing.T) {
-			name := "github-gist-url"
+			name := RandomizedSuffixName("github-gist-url")
 			Expect(KamelRunWithID(operatorID, ns, "--name", name,
 				"https://gist.github.com/lburgazzoli/e2c3f9a5fd0d9e79b21b04809786f17a").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
@@ -110,7 +110,7 @@ func TestKamelCLIRun(t *testing.T) {
 	})
 
 	t.Run("Run and update", func(t *testing.T) {
-		name := "run"
+		name := RandomizedSuffixName("run")
 		Expect(KamelRunWithID(operatorID, ns, "files/run.yaml", "--name", name).Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).

--- a/e2e/common/config/kamelet_config_test.go
+++ b/e2e/common/config/kamelet_config_test.go
@@ -40,7 +40,7 @@ func TestKameletImplicitConfigDefaultUserPropery(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "iconfig01-timer-source")()).To(Succeed())
 
-		name := "iconfig-test-timer-source-int01"
+		name := RandomizedSuffixName("iconfig-test-timer-source-int01")
 		Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationConfiguration01.java",
 			"-p", "camel.kamelet.iconfig01-timer-source.message='Default message 01'",
 			"--name", name).Execute()).To(Succeed())
@@ -62,7 +62,7 @@ func TestKameletImplicitConfigDefaultMountedSecret(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "iconfig03-timer-source")()).To(Succeed())
 
-		name := "iconfig-test-timer-source-int3"
+		name := RandomizedSuffixName("iconfig-test-timer-source-int3")
 		secretName := "my-iconfig-int3-secret"
 
 		var secData = make(map[string]string)
@@ -93,7 +93,7 @@ func TestKameletImplicitConfigDefaultMountedConfigmap(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "iconfig04-timer-source")()).To(Succeed())
 
-		name := "iconfig-test-timer-source-int4"
+		name := RandomizedSuffixName("iconfig-test-timer-source-int4")
 		cmName := "my-iconfig-int4-configmap"
 
 		var cmData = make(map[string]string)
@@ -121,7 +121,7 @@ func TestKameletImplicitConfigNamedUserPropery(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "iconfig05-timer-source")()).To(Succeed())
 
-		name := "iconfig-test-timer-source-int5"
+		name := RandomizedSuffixName("iconfig-test-timer-source-int5")
 		Expect(KamelRunWithID(operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration05.java",
 			"-p", "camel.kamelet.iconfig05-timer-source.message='Default message 05'",
 			"-p", "camel.kamelet.iconfig05-timer-source.mynamedconfig.message='My Named Config message'",
@@ -144,7 +144,7 @@ func TestKameletImplicitConfigNamedLabeledSecret(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "iconfig06-timer-source")()).To(Succeed())
 
-		name := "iconfig-test-timer-source-int6"
+		name := RandomizedSuffixName("iconfig-test-timer-source-int6")
 		secretName := "my-iconfig-int6-secret"
 
 		var secData = make(map[string]string)
@@ -178,7 +178,7 @@ func TestKameletImplicitConfigNamedMountedSecret(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "iconfig07-timer-source")()).To(Succeed())
 
-		name := "iconfig-test-timer-source-int7"
+		name := RandomizedSuffixName("iconfig-test-timer-source-int7")
 		secretName := "my-iconfig-int7-secret"
 
 		var secData = make(map[string]string)
@@ -210,7 +210,7 @@ func TestKameletImplicitConfigNamedMountedConfigmap(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "iconfig08-timer-source")()).To(Succeed())
 
-		name := "iconfig-test-timer-source-int8"
+		name := RandomizedSuffixName("iconfig-test-timer-source-int8")
 		cmName := "my-iconfig-int8-configmap"
 
 		var cmData = make(map[string]string)
@@ -240,7 +240,7 @@ func TestKameletImplicitConfigDefaultLabeledSecret(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "iconfig09-timer-source")()).To(Succeed())
 
-		name := "iconfig-test-timer-source-int9"
+		name := RandomizedSuffixName("iconfig-test-timer-source-int9")
 		secretName := "my-iconfig-int9-secret"
 
 		var secData = make(map[string]string)
@@ -274,7 +274,7 @@ func TestKameletConfigInlinedUserPropery(t *testing.T) {
 		Expect(CreateTimerKamelet(ns, "config01-timer-source")()).To(Succeed())
 		Expect(CreateLogKamelet(ns, "config01-log-sink")()).To(Succeed())
 
-		name := "config-test-timer-source-int1"
+		name := RandomizedSuffixName("config-test-timer-source-int1")
 
 		Expect(KamelRunWithID(operatorID, ns, "files/timer-kamelet-integration-inlined-configuration-01.yaml",
 			"--name", name).Execute()).To(Succeed())
@@ -298,7 +298,7 @@ func TestKameletConfigDefaultParamUserPropery(t *testing.T) {
 		Expect(CreateTimerKamelet(ns, "config02-timer-source")()).To(Succeed())
 		Expect(CreateLogKamelet(ns, "config02-log-sink")()).To(Succeed())
 
-		name := "config-test-timer-source-int2"
+		name := RandomizedSuffixName("config-test-timer-source-int2")
 
 		Expect(KamelRunWithID(operatorID, ns, "files/timer-kamelet-integration-parameters-configuration-02.yaml",
 			"-p", "my-message='My parameter message 02'",
@@ -324,7 +324,7 @@ func TestKameletConfigDefaultParamMountedSecret(t *testing.T) {
 		Expect(CreateTimerKamelet(ns, "config03-timer-source")()).To(Succeed())
 		Expect(CreateLogKamelet(ns, "config03-log-sink")()).To(Succeed())
 
-		name := "config-test-timer-source-int3"
+		name := RandomizedSuffixName("config-test-timer-source-int3")
 		secretName := "my-config-int3-secret"
 
 		var secData = make(map[string]string)
@@ -356,7 +356,7 @@ func TestKameletConfigDefaultParamMountedConfigmap(t *testing.T) {
 		Expect(CreateTimerKamelet(ns, "config04-timer-source")()).To(Succeed())
 		Expect(CreateLogKamelet(ns, "config04-log-sink")()).To(Succeed())
 
-		name := "config-test-timer-source-int4"
+		name := RandomizedSuffixName("config-test-timer-source-int4")
 		cmName := "my-config-int4-configmap"
 
 		var cmData = make(map[string]string)

--- a/e2e/common/config/pipe_config_test.go
+++ b/e2e/common/config/pipe_config_test.go
@@ -38,7 +38,7 @@ func TestPipeConfig(t *testing.T) {
 		Expect(CreateTimerKamelet(ns, "my-pipe-timer-source")()).To(Succeed())
 		Expect(CreateLogKamelet(ns, "my-pipe-log-sink")()).To(Succeed())
 		t.Run("run test default config using properties", func(t *testing.T) {
-			name := "my-pipe-with-properties"
+			name := RandomizedSuffixName("my-pipe-with-properties")
 
 			Expect(KamelBindWithID(operatorID, ns,
 				"my-pipe-timer-source",
@@ -55,7 +55,7 @@ func TestPipeConfig(t *testing.T) {
 		})
 
 		t.Run("run test implicit default config using labeled secret", func(t *testing.T) {
-			name := "my-pipe-with-default-implicit-secret"
+			name := RandomizedSuffixName("my-pipe-with-default-implicit-secret")
 			secretName := "my-pipe-default-implicit-secret"
 
 			var secData = make(map[string]string)
@@ -79,7 +79,7 @@ func TestPipeConfig(t *testing.T) {
 		})
 
 		t.Run("run test implicit default config using mounted secret", func(t *testing.T) {
-			name := "my-pipe-with-default-implicit-secret"
+			name := RandomizedSuffixName("my-pipe-with-default-implicit-secret")
 			secretName := "my-pipe-default-implicit-secret"
 
 			var secData = make(map[string]string)
@@ -102,7 +102,7 @@ func TestPipeConfig(t *testing.T) {
 		})
 
 		t.Run("run test implicit default config using mounted configmap", func(t *testing.T) {
-			name := "my-pipe-with-default-implicit-configmap"
+			name := RandomizedSuffixName("my-pipe-with-default-implicit-configmap")
 			cmName := "my-pipe-default-implicit-configmap"
 
 			var cmData = make(map[string]string)
@@ -125,7 +125,7 @@ func TestPipeConfig(t *testing.T) {
 		})
 
 		t.Run("run test implicit named config using mounted secret", func(t *testing.T) {
-			name := "my-pipe-with-named-implicit-secret"
+			name := RandomizedSuffixName("my-pipe-with-named-implicit-secret")
 			secretName := "my-pipe-named-implicit-secret"
 
 			var secData = make(map[string]string)
@@ -151,7 +151,7 @@ func TestPipeConfig(t *testing.T) {
 		})
 
 		t.Run("run test implicit named config using mounted configmap", func(t *testing.T) {
-			name := "my-pipe-with-named-implicit-configmap"
+			name := RandomizedSuffixName("my-pipe-with-named-implicit-configmap")
 			cmName := "my-pipe-named-implicit-configmap"
 
 			var cmData = make(map[string]string)
@@ -176,7 +176,7 @@ func TestPipeConfig(t *testing.T) {
 			Expect(DeleteConfigmap(ns, cmName)).To(Succeed())
 		})
 		t.Run("run test implicit specific config using mounted secret", func(t *testing.T) {
-			name := "my-pipe-with-specific-secret"
+			name := RandomizedSuffixName("my-pipe-with-specific-secret")
 			secretName := "my-pipe-specific-secret"
 
 			var secData = make(map[string]string)
@@ -201,7 +201,7 @@ func TestPipeConfig(t *testing.T) {
 			Expect(DeleteSecret(ns, secretName)).To(Succeed())
 		})
 		t.Run("run test implicit specific config using mounted configmap", func(t *testing.T) {
-			name := "my-pipe-with-specific-configmap"
+			name := RandomizedSuffixName("my-pipe-with-specific-configmap")
 			cmName := "my-pipe-specific-configmap"
 
 			var cmData = make(map[string]string)

--- a/e2e/common/misc/integration_fail_test.go
+++ b/e2e/common/misc/integration_fail_test.go
@@ -38,7 +38,7 @@ func TestBadRouteIntegration(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("run bad java route", func(t *testing.T) {
-		name := "bad-route"
+		name := RandomizedSuffixName("bad-route")
 		Expect(KamelRunWithID(operatorID, ns, "files/BadRoute.java", "--name", name).Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationPhase(ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
@@ -62,7 +62,7 @@ func TestBadRouteIntegration(t *testing.T) {
 	})
 
 	t.Run("run missing dependency java route", func(t *testing.T) {
-		name := "java-route"
+		name := RandomizedSuffixName("java-route")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
 			"-d", "mvn:com.example:nonexistent:1.0").Execute()).To(Succeed())
 		// Integration in error
@@ -96,7 +96,7 @@ func TestBadRouteIntegration(t *testing.T) {
 	})
 
 	t.Run("run invalid dependency java route", func(t *testing.T) {
-		name := "invalid-dependency"
+		name := RandomizedSuffixName("invalid-dependency")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
 			"-d", "camel:non-existent").Execute()).To(Succeed())
 		// Integration in error with Initialization Failed condition
@@ -126,7 +126,7 @@ func TestBadRouteIntegration(t *testing.T) {
 	})
 
 	t.Run("run unresolvable component java route", func(t *testing.T) {
-		name := "unresolvable-route"
+		name := RandomizedSuffixName("unresolvable-route")
 		Expect(KamelRunWithID(operatorID, ns, "files/Unresolvable.java", "--name", name).Execute()).To(Succeed())
 		// Integration in error with Initialization Failed condition
 		Eventually(IntegrationPhase(ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
@@ -155,7 +155,7 @@ func TestBadRouteIntegration(t *testing.T) {
 	})
 
 	t.Run("run invalid java route", func(t *testing.T) {
-		name := "invalid-java-route"
+		name := RandomizedSuffixName("invalid-java-route")
 		Expect(KamelRunWithID(operatorID, ns, "files/InvalidJava.java", "--name", name).Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationPhase(ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))

--- a/e2e/common/misc/maven_repository_test.go
+++ b/e2e/common/misc/maven_repository_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestRunExtraRepository(t *testing.T) {
 	RegisterTestingT(t)
-	name := "java"
+	name := RandomizedSuffixName("java")
 	Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 		"--maven-repository", "https://maven.repository.redhat.com/ga@id=redhat",
 		"--dependency", "mvn:org.jolokia:jolokia-core:1.7.1.redhat-00001",

--- a/e2e/common/misc/pipe_test.go
+++ b/e2e/common/misc/pipe_test.go
@@ -98,7 +98,7 @@ func TestPipe(t *testing.T) {
 
 	// Pipe with wrong spec
 	t.Run("test Pipe with wrong spec", func(t *testing.T) {
-		name := "bad-klb"
+		name := RandomizedSuffixName("bad-klb")
 		kb := v1.NewPipe(ns, name)
 		kb.Spec = v1.PipeSpec{}
 		_, err := kubernetes.ReplaceResource(TestContext, TestClient(), &kb)

--- a/e2e/common/misc/registry_maven_wagon_test.go
+++ b/e2e/common/misc/registry_maven_wagon_test.go
@@ -48,7 +48,7 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 
 	t.Run("image registry is a maven repository", func(t *testing.T) {
 		// Create integration that should decrypt an encrypted message to "foobar" and log it
-		name := "foobar-decryption"
+		name := RandomizedSuffixName("foobar-decryption")
 		jar, err := filepath.Abs("files/registry/sample-decryption-1.0.jar?skipPOM=true")
 		assert.Nil(t, err)
 		pom, err := filepath.Abs("files/registry/sample-decryption-1.0.pom")
@@ -66,7 +66,7 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 	})
 
 	t.Run("local files are mounted in the integration container at the default path", func(t *testing.T) {
-		name := "laughing-route-default-path"
+		name := RandomizedSuffixName("laughing-route-default-path")
 
 		Expect(KamelRunWithID(operatorID, ns, "files/registry/LaughingRoute.java",
 			"--name", name,
@@ -80,7 +80,7 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 	})
 
 	t.Run("local files are mounted in the integration container at a custom path", func(t *testing.T) {
-		name := "laughing-route-custom-path"
+		name := RandomizedSuffixName("laughing-route-custom-path")
 		customPath := "this/is/a/custom/path/"
 
 		Expect(KamelRunWithID(operatorID, ns, "files/registry/LaughingRoute.java",
@@ -95,7 +95,7 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 	})
 
 	t.Run("local directory is mounted in the integration container", func(t *testing.T) {
-		name := "laughing-route-directory"
+		name := RandomizedSuffixName("laughing-route-directory")
 
 		Expect(KamelRunWithID(operatorID, ns, "files/registry/LaughingRoute.java",
 			"--name", name,
@@ -111,7 +111,7 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 
 	t.Run("pom file is extracted from JAR", func(t *testing.T) {
 		// Create integration that should decrypt foobar and log it
-		name := "foobar-decryption-pom-extraction"
+		name := RandomizedSuffixName("foobar-decryption-pom-extraction")
 		jar, err := filepath.Abs("files/registry/sample-decryption-1.0.jar")
 		assert.Nil(t, err)
 
@@ -126,7 +126,7 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 	})
 	t.Run("dependency can be used at build time", func(t *testing.T) {
 		// Create integration that should run an Xslt transformation whose template needs to be present at build time
-		name := "xslt"
+		name := RandomizedSuffixName("xslt")
 		Expect(KamelRunWithID(operatorID, ns, "files/registry/classpath/Xslt.java", "--name", name,
 			"-d", "file://files/registry/classpath/cheese.xsl?targetPath=xslt/cheese.xsl&classpath=true",
 		).Execute()).To(Succeed())

--- a/e2e/common/misc/rest_test.go
+++ b/e2e/common/misc/rest_test.go
@@ -48,7 +48,7 @@ func TestRunRest(t *testing.T) {
 	Eventually(IntegrationPodPhase(ns, "rest-consumer"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
 	t.Run("Service works", func(t *testing.T) {
-		name := "John"
+		name := RandomizedSuffixName("John")
 		service := Service(ns, "rest-consumer")
 		Eventually(service, TestTimeoutShort).ShouldNot(BeNil())
 		Expect(KamelRunWithID(operatorID, ns, "files/rest-producer.yaml", "-p", "serviceName=rest-consumer", "-p", "name="+name).Execute()).To(Succeed())
@@ -59,7 +59,7 @@ func TestRunRest(t *testing.T) {
 
 	if ocp {
 		t.Run("Route works", func(t *testing.T) {
-			name := "Peter"
+			name := RandomizedSuffixName("Peter")
 			route := Route(ns, "rest-consumer")
 			Eventually(route, TestTimeoutShort).ShouldNot(BeNil())
 			Eventually(RouteStatus(ns, "rest-consumer"), TestTimeoutMedium).Should(Equal("True"))

--- a/e2e/common/misc/scale_binding_test.go
+++ b/e2e/common/misc/scale_binding_test.go
@@ -49,7 +49,7 @@ func TestPipeScale(t *testing.T) {
 		return
 	}
 
-	name := "timer2log"
+	name := RandomizedSuffixName("timer2log")
 	Expect(KamelBindWithID(operatorID, ns, "timer-source?message=HelloPipe", "log-sink", "--name", name).Execute()).To(Succeed())
 	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 	Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/common/misc/scale_integration_test.go
+++ b/e2e/common/misc/scale_integration_test.go
@@ -41,7 +41,7 @@ import (
 func TestIntegrationScale(t *testing.T) {
 	RegisterTestingT(t)
 
-	name := "java"
+	name := RandomizedSuffixName("java")
 	Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
 	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 	Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/common/misc/structured_logs_test.go
+++ b/e2e/common/misc/structured_logs_test.go
@@ -37,8 +37,9 @@ import (
 func TestStructuredLogs(t *testing.T) {
 	RegisterTestingT(t)
 
-	name := "java"
+	name := RandomizedSuffixName("java")
 	Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
+		"--name", name,
 		"-t", "logging.format=json").Execute()).To(Succeed())
 	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 	Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/common/traits/builder_test.go
+++ b/e2e/common/traits/builder_test.go
@@ -39,7 +39,7 @@ func TestBuilderTrait(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("Run build strategy routine", func(t *testing.T) {
-		name := "java"
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "builder.strategy=routine").Execute()).To(Succeed())
@@ -66,7 +66,7 @@ func TestBuilderTrait(t *testing.T) {
 	})
 
 	t.Run("Run build order strategy dependencies", func(t *testing.T) {
-		name := "java-fifo-strategy"
+		name := RandomizedSuffixName("java-fifo-strategy")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "builder.order-strategy=dependencies").Execute()).To(Succeed())
@@ -93,7 +93,7 @@ func TestBuilderTrait(t *testing.T) {
 	})
 
 	t.Run("Run build order strategy fifo", func(t *testing.T) {
-		name := "java-fifo-strategy"
+		name := RandomizedSuffixName("java-fifo-strategy")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "builder.order-strategy=fifo").Execute()).To(Succeed())
@@ -120,7 +120,7 @@ func TestBuilderTrait(t *testing.T) {
 	})
 
 	t.Run("Run build resources configuration", func(t *testing.T) {
-		name := "java-resource-config"
+		name := RandomizedSuffixName("java-resource-config")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "builder.tasks-request-cpu=builder:500m",
@@ -157,7 +157,7 @@ func TestBuilderTrait(t *testing.T) {
 	})
 
 	t.Run("Run custom pipeline task", func(t *testing.T) {
-		name := "java-pipeline"
+		name := RandomizedSuffixName("java-pipeline")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "builder.tasks=custom1;alpine;tree",
@@ -203,7 +203,7 @@ func TestBuilderTrait(t *testing.T) {
 	})
 
 	t.Run("Run custom pipeline task error", func(t *testing.T) {
-		name := "java-error"
+		name := RandomizedSuffixName("java-error")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "builder.tasks=custom1;alpine;cat missingfile.txt",
@@ -227,7 +227,7 @@ func TestBuilderTrait(t *testing.T) {
 	})
 
 	t.Run("Run maven profile", func(t *testing.T) {
-		name := "java-maven-profile"
+		name := RandomizedSuffixName("java-maven-profile")
 
 		mavenProfile1Cm := newMavenProfileConfigMap(ns, "maven-profile-owasp", "owasp-profile")
 		Expect(TestClient().Create(TestContext, mavenProfile1Cm)).To(Succeed())

--- a/e2e/common/traits/camel_test.go
+++ b/e2e/common/traits/camel_test.go
@@ -37,10 +37,15 @@ func TestCamelTrait(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("properties changes should not rebuild", func(t *testing.T) {
-		name := "javapropertiesnorebuild"
+
+		Expect(Kamel("reset", "-n", ns).Execute()).To(Succeed())
+
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 		).Execute()).To(Succeed())
+
+		// checking the integration status
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 		Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))

--- a/e2e/common/traits/container_test.go
+++ b/e2e/common/traits/container_test.go
@@ -37,7 +37,7 @@ func TestContainerTrait(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("Container image pull policy and resources configuration", func(t *testing.T) {
-		name := "java1"
+		name := RandomizedSuffixName("java1")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"-t", "container.image-pull-policy=Always",
 			"-t", "container.request-cpu=0.005",
@@ -76,7 +76,7 @@ func TestContainerTrait(t *testing.T) {
 	})
 
 	t.Run("Container name", func(t *testing.T) {
-		name := "java2"
+		name := RandomizedSuffixName("java2")
 		containerName := "my-container-name"
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"-t", "container.name="+containerName,

--- a/e2e/common/traits/error_handler_test.go
+++ b/e2e/common/traits/error_handler_test.go
@@ -37,7 +37,7 @@ func TestErrorHandlerTrait(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("Run errored integration with error handler", func(t *testing.T) {
-		name := "error-handler"
+		name := RandomizedSuffixName("error-handler")
 		Expect(KamelRunWithID(operatorID, ns, "files/ErroredRoute.java",
 			"--name", name,
 			"-t", "error-handler.enabled=true",

--- a/e2e/common/traits/errored_trait_test.go
+++ b/e2e/common/traits/errored_trait_test.go
@@ -37,7 +37,7 @@ func TestErroredTrait(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("Integration trait should fail", func(t *testing.T) {
-		name := "it-errored"
+		name := RandomizedSuffixName("it-errored")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "kamelets.list=missing",
@@ -51,7 +51,7 @@ func TestErroredTrait(t *testing.T) {
 	})
 
 	t.Run("Pipe trait should fail", func(t *testing.T) {
-		name := "kb-errored"
+		name := RandomizedSuffixName("kb-errored")
 		Expect(KamelBindWithID(operatorID, ns, "timer:foo", "log:bar",
 			"--name", name,
 			"-t", "kamelets.list=missing",

--- a/e2e/common/traits/health_test.go
+++ b/e2e/common/traits/health_test.go
@@ -43,13 +43,14 @@ func TestHealthTrait(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("Readiness condition with stopped route", func(t *testing.T) {
-		name := "java"
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"-t", "health.enabled=true",
 			// Enable Jolokia for the test to stop the Camel route
 			"-t", "jolokia.enabled=true",
 			"-t", "jolokia.use-ssl-client-authentication=false",
 			"-t", "jolokia.protocol=http",
+			"--name", name,
 		).Execute()).To(Succeed())
 
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
@@ -136,7 +137,7 @@ func TestHealthTrait(t *testing.T) {
 	})
 
 	t.Run("Readiness condition with stopped binding", func(t *testing.T) {
-		name := "stopped-binding"
+		name := RandomizedSuffixName("stopped-binding")
 
 		Expect(CreateTimerKamelet(ns, "my-health-timer-source")()).To(Succeed())
 		Expect(CreateLogKamelet(ns, "my-health-log-sink")()).To(Succeed())
@@ -257,9 +258,10 @@ func TestHealthTrait(t *testing.T) {
 	})
 
 	t.Run("Readiness condition with never ready route", func(t *testing.T) {
-		name := "never-ready"
+		name := RandomizedSuffixName("never-ready")
 
 		Expect(KamelRunWithID(operatorID, ns, "files/NeverReady.java",
+			"--name", name,
 			"-t", "health.enabled=true",
 		).Execute()).To(Succeed())
 
@@ -309,7 +311,7 @@ func TestHealthTrait(t *testing.T) {
 	})
 
 	t.Run("Startup condition with never ready route", func(t *testing.T) {
-		name := "startup-probe-never-ready-route"
+		name := RandomizedSuffixName("startup-probe-never-ready-route")
 
 		Expect(KamelRunWithID(operatorID, ns, "files/NeverReady.java",
 			"--name", name,
@@ -371,7 +373,7 @@ func TestHealthTrait(t *testing.T) {
 	})
 
 	t.Run("Startup condition with ready route", func(t *testing.T) {
-		name := "startup-probe-ready-route"
+		name := RandomizedSuffixName("startup-probe-ready-route")
 
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,

--- a/e2e/common/traits/istio_test.go
+++ b/e2e/common/traits/istio_test.go
@@ -37,13 +37,15 @@ func TestIstioTrait(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("Run Java with Istio", func(t *testing.T) {
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
+			"--name", name,
 			"-t", "istio.enabled=true").Execute()).To(Succeed())
-		Eventually(IntegrationPodPhase(ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		Eventually(IntegrationConditionStatus(ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		Eventually(IntegrationLogs(ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-		pod := IntegrationPod(ns, "java")()
+		pod := IntegrationPod(ns, name)()
 		Expect(pod.ObjectMeta.Annotations).NotTo(BeNil())
 		annotations := pod.ObjectMeta.Annotations
 		Expect(annotations["sidecar.istio.io/inject"]).To(Equal("true"))

--- a/e2e/common/traits/kamelet_test.go
+++ b/e2e/common/traits/kamelet_test.go
@@ -49,7 +49,7 @@ func TestKameletTrait(t *testing.T) {
 		}
 		Expect(CreateKamelet(ns, "capabilities-webhook-source", template, nil, nil)()).To(Succeed())
 
-		name := "webhook"
+		name := RandomizedSuffixName("webhook")
 		Expect(KamelRunWithID(operatorID, ns, "files/webhook.yaml", "--name", name).Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/common/traits/pdb_test.go
+++ b/e2e/common/traits/pdb_test.go
@@ -44,7 +44,7 @@ import (
 func TestPodDisruptionBudgetTrait(t *testing.T) {
 	RegisterTestingT(t)
 
-	name := "java"
+	name := RandomizedSuffixName("java")
 	Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 		"--name", name,
 		"-t", "pdb.enabled=true",
@@ -112,7 +112,7 @@ func TestPodDisruptionBudgetTrait(t *testing.T) {
 				Causes: []metav1.StatusCause{
 					{
 						Type:    "DisruptionBudget",
-						Message: "The disruption budget java needs 2 healthy pods and has 2 currently",
+						Message: "The disruption budget " + name + " needs 2 healthy pods and has 2 currently",
 					},
 				},
 			},

--- a/e2e/common/traits/pod_test.go
+++ b/e2e/common/traits/pod_test.go
@@ -77,7 +77,7 @@ func TestPodTrait(t *testing.T) {
 		},
 	}
 
-	name := "pod-template-test"
+	name := RandomizedSuffixName("pod-template-test")
 
 	for i := range tc {
 		test := tc[i]

--- a/e2e/common/traits/pull_secret_test.go
+++ b/e2e/common/traits/pull_secret_test.go
@@ -41,7 +41,7 @@ func TestPullSecretTrait(t *testing.T) {
 	Expect(err).To(BeNil())
 
 	t.Run("Image pull secret is set on pod", func(t *testing.T) {
-		name := "java1"
+		name := RandomizedSuffixName("java1")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
 			"-t", "pull-secret.enabled=true",
 			"-t", "pull-secret.secret-name=dummy-secret").Execute()).To(Succeed())
@@ -54,7 +54,7 @@ func TestPullSecretTrait(t *testing.T) {
 	})
 
 	t.Run("Explicitly disable image pull secret", func(t *testing.T) {
-		name := "java2"
+		name := RandomizedSuffixName("java2")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
 			"-t", "pull-secret.enabled=false").Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
@@ -73,7 +73,7 @@ func TestPullSecretTrait(t *testing.T) {
 	if ocp {
 		// OpenShift always has an internal registry so image pull secret is set by default
 		t.Run("Image pull secret is automatically set by default", func(t *testing.T) {
-			name := "java3"
+			name := RandomizedSuffixName("java3")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/common/traits/service_binding_test.go
+++ b/e2e/common/traits/service_binding_test.go
@@ -63,7 +63,7 @@ func TestServiceBindingTrait(t *testing.T) {
 		serviceRef := fmt.Sprintf("%s:%s/%s", service.TypeMeta.Kind, ns, service.ObjectMeta.Name)
 		Expect(TestClient().Create(TestContext, service)).To(Succeed())
 		// Create integration and bind it to our service
-		name := "service-binding"
+		name := RandomizedSuffixName("service-binding")
 		Expect(KamelRunWithID(operatorID, ns, "files/ServiceBinding.java",
 			"--name", name,
 			"--connect", serviceRef,

--- a/e2e/common/traits/toleration_test.go
+++ b/e2e/common/traits/toleration_test.go
@@ -39,7 +39,7 @@ func TestTolerationTrait(t *testing.T) {
 	RegisterTestingT(t)
 
 	t.Run("Run Java with node toleration operation exists", func(t *testing.T) {
-		name := "java1"
+		name := RandomizedSuffixName("java1")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "toleration.enabled=true",
@@ -61,7 +61,7 @@ func TestTolerationTrait(t *testing.T) {
 	})
 
 	t.Run("Run Java with node toleration operation equals", func(t *testing.T) {
-		name := "java2"
+		name := RandomizedSuffixName("java2")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "toleration.enabled=true",
@@ -87,7 +87,7 @@ func TestTolerationTrait(t *testing.T) {
 			t.Skip("Skip master node toleration test on single-node cluster")
 		}
 
-		name := "java3"
+		name := RandomizedSuffixName("java3")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			// Use the affinity trait to force the scheduling of the Integration pod onto a master node

--- a/e2e/commonwithcustominstall/build_order_strategy_test.go
+++ b/e2e/commonwithcustominstall/build_order_strategy_test.go
@@ -42,7 +42,7 @@ func TestRunBuildOrderStrategyMatchingDependencies(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "timer-source")()).To(Succeed())
 
-		integrationA := "java-a"
+		integrationA := RandomizedSuffixName("java-a")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", integrationA,
 		).Execute()).To(Succeed())
@@ -51,20 +51,20 @@ func TestRunBuildOrderStrategyMatchingDependencies(t *testing.T) {
 		integrationKitNameA := IntegrationKit(ns, integrationA)()
 		Eventually(Build(ns, integrationKitNameA), TestTimeoutMedium).ShouldNot(BeNil())
 
-		integrationB := "java-b"
+		integrationB := RandomizedSuffixName("java-b")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", integrationB,
 			"-d", "camel:joor",
 		).Execute()).To(Succeed())
 
-		integrationC := "java-c"
+		integrationC := RandomizedSuffixName("java-c")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", integrationC,
 			"-d", "camel:joor",
 			"-d", "camel:zipfile",
 		).Execute()).To(Succeed())
 
-		integrationZ := "groovy-z"
+		integrationZ := RandomizedSuffixName("groovy-z")
 		Expect(KamelRunWithID(operatorID, ns, "files/timer-source.groovy",
 			"--name", integrationZ,
 		).Execute()).To(Succeed())
@@ -124,19 +124,19 @@ func TestRunBuildOrderStrategyFIFO(t *testing.T) {
 
 		Expect(CreateTimerKamelet(ns, "timer-source")()).To(Succeed())
 
-		integrationA := "java-a"
+		integrationA := RandomizedSuffixName("java-a")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", integrationA,
 		).Execute()).To(Succeed())
 		Eventually(IntegrationPhase(ns, integrationA)).Should(Equal(v1.IntegrationPhaseBuildingKit))
 
-		integrationB := "java-b"
+		integrationB := RandomizedSuffixName("java-b")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", integrationB,
 			"-d", "camel:joor",
 		).Execute()).To(Succeed())
 
-		integrationZ := "groovy-z"
+		integrationZ := RandomizedSuffixName("groovy-z")
 		Expect(KamelRunWithID(operatorID, ns, "files/timer-source.groovy",
 			"--name", integrationZ,
 		).Execute()).To(Succeed())

--- a/e2e/commonwithcustominstall/builder_test.go
+++ b/e2e/commonwithcustominstall/builder_test.go
@@ -58,8 +58,10 @@ func TestBuilderTimeout(t *testing.T) {
 		))
 
 		t.Run("run yaml", func(t *testing.T) {
-			name := "yaml"
-			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml", "-t", "builder.strategy=pod").Execute()).To(Succeed())
+			name := RandomizedSuffixName("yaml")
+			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml",
+				"--name", name,
+				"-t", "builder.strategy=pod").Execute()).To(Succeed())
 			// As the build hits timeout, it keeps trying building
 			Eventually(IntegrationPhase(ns, name)).Should(Equal(v1.IntegrationPhaseBuildingKit))
 			integrationKitName := IntegrationKit(ns, name)()

--- a/e2e/commonwithcustominstall/catalog_builder_test.go
+++ b/e2e/commonwithcustominstall/catalog_builder_test.go
@@ -52,7 +52,7 @@ func TestCamelCatalogBuilder(t *testing.T) {
 		// The operator should create the catalog, but fail on reconciliation as it is not compatible
 		// and the integration should fail as well
 		t.Run("Run catalog not compatible", func(t *testing.T) {
-			name := "java-1-15"
+			name := RandomizedSuffixName("java-1-15")
 			nonCompatibleCatalogName := "camel-catalog-1.15.0"
 			Expect(
 				KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
@@ -77,7 +77,7 @@ func TestCamelCatalogBuilder(t *testing.T) {
 		// Run an integration with a compatible catalog
 		// The operator should create the catalog, reconcile it properly and run the Integration accordingly
 		t.Run("Run catalog compatible", func(t *testing.T) {
-			name := "java-1-17"
+			name := RandomizedSuffixName("java-1-17")
 			compatibleVersion := "1.17.0"
 			compatibleCatalogName := "camel-catalog-" + strings.ToLower(compatibleVersion)
 
@@ -103,7 +103,7 @@ func TestCamelCatalogBuilder(t *testing.T) {
 		})
 
 		t.Run("Run catalog container exists", func(t *testing.T) {
-			name := "java"
+			name := RandomizedSuffixName("java")
 			compatibleVersion := "1.17.0"
 			compatibleCatalogName := "camel-catalog-" + strings.ToLower(compatibleVersion)
 

--- a/e2e/commonwithcustominstall/environment_test.go
+++ b/e2e/commonwithcustominstall/environment_test.go
@@ -70,7 +70,7 @@ func TestEnvironmentTrait(t *testing.T) {
 		).Execute()).To(Succeed())
 
 		t.Run("Run integration with default environment", func(t *testing.T) {
-			name := "java-default"
+			name := RandomizedSuffixName("java-default")
 			Expect(KamelRunWithID(operatorID, ns, "--name", name, "files/Java.java").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
@@ -96,7 +96,7 @@ func TestEnvironmentTrait(t *testing.T) {
 		})
 
 		t.Run("Run integration with custom environment", func(t *testing.T) {
-			name := "java-custom-proxy"
+			name := RandomizedSuffixName("java-custom-proxy")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", name,
 				"-t", "environment.vars=HTTP_PROXY=http://custom.proxy",
@@ -125,7 +125,7 @@ func TestEnvironmentTrait(t *testing.T) {
 		})
 
 		t.Run("Run integration without default HTTP proxy environment", func(t *testing.T) {
-			name := "java-no-proxy"
+			name := RandomizedSuffixName("java-no-proxy")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", name,
 				"-t", "environment.http-proxy=false",

--- a/e2e/commonwithcustominstall/incremental_build_test.go
+++ b/e2e/commonwithcustominstall/incremental_build_test.go
@@ -40,7 +40,7 @@ func TestRunIncrementalBuildRoutine(t *testing.T) {
 		operatorID := "camel-k-incremental-build"
 		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
 
-		name := "java"
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 		).Execute()).To(Succeed())
@@ -66,7 +66,7 @@ func TestRunIncrementalBuildRoutine(t *testing.T) {
 		t.Run("Create incremental kit", func(t *testing.T) {
 			// Another integration that should be built on top of the previous IntegrationKit
 			// just add a new random dependency
-			nameIncremental := "java-incremental"
+			nameIncremental := RandomizedSuffixName("java-incremental")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", nameIncremental,
 				"-d", "camel:zipfile",
@@ -91,7 +91,7 @@ func TestRunIncrementalBuildPod(t *testing.T) {
 		operatorID := "camel-k-incremental-build"
 		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
 
-		name := "java"
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 			"-t", "builder.strategy=pod",
@@ -105,7 +105,7 @@ func TestRunIncrementalBuildPod(t *testing.T) {
 		Eventually(BuilderPodsCount(ns)).Should(Equal(1))
 
 		t.Run("Reuse previous kit", func(t *testing.T) {
-			nameClone := "java-clone"
+			nameClone := RandomizedSuffixName("java-clone")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", nameClone,
 				"-t", "builder.strategy=pod",
@@ -121,7 +121,7 @@ func TestRunIncrementalBuildPod(t *testing.T) {
 		t.Run("Create incremental kit", func(t *testing.T) {
 			// Another integration that should be built on top of the previous IntegrationKit
 			// just add a new random dependency
-			nameIncremental := "java-incremental"
+			nameIncremental := RandomizedSuffixName("java-incremental")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", nameIncremental,
 				"-d", "camel:zipfile",
@@ -148,7 +148,7 @@ func TestRunIncrementalBuildOff(t *testing.T) {
 		operatorID := "camel-k-standard-build"
 		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
 
-		name := "java"
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 		).Execute()).To(Succeed())
@@ -159,7 +159,7 @@ func TestRunIncrementalBuildOff(t *testing.T) {
 		Eventually(Kit(ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
 
 		t.Run("Don't reuse previous kit", func(t *testing.T) {
-			nameClone := "java-clone"
+			nameClone := RandomizedSuffixName("java-clone")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", nameClone,
 				"-t", "builder.incremental-image-build=false",
@@ -174,7 +174,7 @@ func TestRunIncrementalBuildOff(t *testing.T) {
 		t.Run("Don't create incremental kit", func(t *testing.T) {
 			// Another integration that should be built on top of the previous IntegrationKit
 			// just add a new random dependency
-			nameIncremental := "java-incremental"
+			nameIncremental := RandomizedSuffixName("java-incremental")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", nameIncremental,
 				"-d", "camel:zipfile",
@@ -196,7 +196,7 @@ func TestRunIncrementalBuildWithDifferentBaseImages(t *testing.T) {
 		operatorID := "camel-k-standard-build"
 		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
 
-		name := "java"
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 			"--name", name,
 		).Execute()).To(Succeed())
@@ -210,7 +210,7 @@ func TestRunIncrementalBuildWithDifferentBaseImages(t *testing.T) {
 		t.Run("Create incremental kit", func(t *testing.T) {
 			// Another integration that should be built on top of the previous IntegrationKit
 			// just add a new random dependency
-			nameIncremental := "java-incremental"
+			nameIncremental := RandomizedSuffixName("java-incremental")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", nameIncremental,
 				"-d", "camel:zipfile",
@@ -229,7 +229,7 @@ func TestRunIncrementalBuildWithDifferentBaseImages(t *testing.T) {
 		t.Run("Create new hierarchy kit", func(t *testing.T) {
 			// We should spin off a new hierarchy of builds
 			newBaseImage := "eclipse-temurin:17.0.8.1_1-jdk-ubi9-minimal"
-			name = "java-new"
+			name = RandomizedSuffixName("java-new")
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", name,
 				"-d", "camel:mongodb",

--- a/e2e/commonwithcustominstall/maven_http_proxy_test.go
+++ b/e2e/commonwithcustominstall/maven_http_proxy_test.go
@@ -191,7 +191,7 @@ func TestMavenProxy(t *testing.T) {
 		Eventually(PlatformPhase(ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		// Run the Integration
-		name := "java"
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
 
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))

--- a/e2e/commonwithcustominstall/operator_metrics_test.go
+++ b/e2e/commonwithcustominstall/operator_metrics_test.go
@@ -59,10 +59,11 @@ func TestMetrics(t *testing.T) {
 	RegisterTestingT(t)
 
 	WithNewTestNamespace(t, func(ns string) {
-		name := "java"
+		name := RandomizedSuffixName("java")
 		operatorID := "camel-k-metrics"
 		Expect(KamelInstallWithID(operatorID, ns, "--log-level", "debug").Execute()).To(Succeed())
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
+			"--name", name,
 			"-t", "prometheus.enabled=true",
 			"-t", "prometheus.pod-monitor=false",
 		).Execute()).To(Succeed())

--- a/e2e/commonwithcustominstall/platform_traits_test.go
+++ b/e2e/commonwithcustominstall/platform_traits_test.go
@@ -48,7 +48,7 @@ func TestTraitOnIntegrationPlatform(t *testing.T) {
 			t.Fatal("Can't create IntegrationPlatform", err)
 		}
 
-		name := "java"
+		name := RandomizedSuffixName("java")
 		t.Run("Run integration with platform traits", func(t *testing.T) {
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java",
 				"--name", name,

--- a/e2e/commonwithcustominstall/reset_test.go
+++ b/e2e/commonwithcustominstall/reset_test.go
@@ -37,7 +37,7 @@ func TestKamelReset(t *testing.T) {
 		Expect(KamelInstallWithID(operatorID, ns).Execute()).To(Succeed())
 
 		t.Run("Reset the whole platform", func(t *testing.T) {
-			name := "yaml1"
+			name := RandomizedSuffixName("yaml1")
 			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
@@ -52,7 +52,7 @@ func TestKamelReset(t *testing.T) {
 		})
 
 		t.Run("Reset skip-integrations", func(t *testing.T) {
-			name := "yaml2"
+			name := RandomizedSuffixName("yaml2")
 			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
@@ -67,7 +67,7 @@ func TestKamelReset(t *testing.T) {
 		})
 
 		t.Run("Reset skip-kits", func(t *testing.T) {
-			name := "yaml3"
+			name := RandomizedSuffixName("yaml3")
 			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))

--- a/e2e/install/cli/maven_ca_secret_test.go
+++ b/e2e/install/cli/maven_ca_secret_test.go
@@ -432,7 +432,7 @@ ProxyPreserveHost On
 		Eventually(PlatformPhase(ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		// Run the Integration
-		name := "java"
+		name := RandomizedSuffixName("java")
 		Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
 
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))

--- a/e2e/install/helm/setup_test.go
+++ b/e2e/install/helm/setup_test.go
@@ -73,7 +73,7 @@ func TestHelmInstallRunUninstall(t *testing.T) {
 
 		//Test a simple route
 		t.Run("simple route", func(t *testing.T) {
-			name := "yaml"
+			name := RandomizedSuffixName("yaml")
 			Expect(KamelRun(ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))

--- a/e2e/install/upgrade/cli_upgrade_test.go
+++ b/e2e/install/upgrade/cli_upgrade_test.go
@@ -72,8 +72,8 @@ func TestCLIOperatorUpgrade(t *testing.T) {
 		Eventually(PlatformVersion(ns), TestTimeoutMedium).Should(Equal(version))
 
 		// Run the Integration
-		name := "yaml"
-		Expect(Kamel("run", "-n", ns, "files/yaml.yaml").Execute()).To(Succeed())
+		name := RandomizedSuffixName("yaml")
+		Expect(Kamel("run", "-n", ns, "--name", name, "files/yaml.yaml").Execute()).To(Succeed())
 		Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 		Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
 

--- a/e2e/install/upgrade/olm_upgrade_test.go
+++ b/e2e/install/upgrade/olm_upgrade_test.go
@@ -24,15 +24,16 @@ package upgrade
 
 import (
 	"fmt"
+	"os"
+	"testing"
+	"time"
+
 	. "github.com/apache/camel-k/v2/e2e/support"
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
-	"time"
 
 	"github.com/operator-framework/api/pkg/lib/version"
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"

--- a/e2e/native/native_test.go
+++ b/e2e/native/native_test.go
@@ -43,7 +43,7 @@ func TestNativeIntegrations(t *testing.T) {
 		Eventually(PlatformPhase(ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("unsupported integration source language", func(t *testing.T) {
-			name := "unsupported-js"
+			name := RandomizedSuffixName("unsupported-js")
 			Expect(KamelRunWithID(operatorID, ns, "files/JavaScript.js", "--name", name,
 				"-t", "quarkus.build-mode=native",
 				"-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi",
@@ -58,7 +58,7 @@ func TestNativeIntegrations(t *testing.T) {
 		})
 
 		t.Run("xml native support", func(t *testing.T) {
-			name := "xml-native"
+			name := RandomizedSuffixName("xml-native")
 			Expect(KamelRunWithID(operatorID, ns, "files/Xml.xml", "--name", name,
 				"-t", "quarkus.build-mode=native",
 				"-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi",
@@ -79,7 +79,7 @@ func TestNativeIntegrations(t *testing.T) {
 		t.Run("automatic rollout deployment from jvm to native kit", func(t *testing.T) {
 			// Let's make sure we start from a clean state
 			Expect(DeleteKits(ns)).To(Succeed())
-			name := "yaml-native"
+			name := RandomizedSuffixName("yaml-native")
 			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml", "--name", name,
 				"-t", "quarkus.build-mode=jvm",
 				"-t", "quarkus.build-mode=native",
@@ -132,7 +132,7 @@ func TestNativeIntegrations(t *testing.T) {
 			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 			t.Run("yaml native should not rebuild", func(t *testing.T) {
-				name := "yaml-native-2"
+				name := RandomizedSuffixName("yaml-native-2")
 				Expect(KamelRunWithID(operatorID, ns, "files/yaml2.yaml", "--name", name,
 					"-t", "quarkus.build-mode=native",
 					"-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi",

--- a/e2e/native/native_with_sources_test.go
+++ b/e2e/native/native_with_sources_test.go
@@ -41,8 +41,12 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 		).Execute()).To(Succeed())
 		Eventually(PlatformPhase(ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
+		javaNativeName := RandomizedSuffixName("java-native")
+		javaNativeCloneName := RandomizedSuffixName("java-native-clone")
+		javaNative2Name := RandomizedSuffixName("java-native-2")
+
 		t.Run("java native support", func(t *testing.T) {
-			name := "java-native"
+			name := javaNativeName
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
 				"-t", "quarkus.build-mode=native",
 				"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
@@ -56,7 +60,7 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magicstring!"))
 
 			t.Run("java native same should not rebuild", func(t *testing.T) {
-				name := "java-native-clone"
+				name := javaNativeCloneName
 				Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
 					"-t", "quarkus.build-mode=native",
 					"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
@@ -69,11 +73,11 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 				Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
 				Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magicstring!"))
-				Eventually(IntegrationKit(ns, "java-native-clone")).Should(Equal(IntegrationKit(ns, "java-native")()))
+				Eventually(IntegrationKit(ns, javaNativeCloneName)).Should(Equal(IntegrationKit(ns, javaNativeName)()))
 			})
 
 			t.Run("java native should rebuild", func(t *testing.T) {
-				name := "java-native-2"
+				name := javaNative2Name
 				Expect(KamelRunWithID(operatorID, ns, "files/Java2.java", "--name", name,
 					"-t", "quarkus.build-mode=native",
 					"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
@@ -85,7 +89,7 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 				Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
 				Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magic2string!"))
-				Eventually(IntegrationKit(ns, "java-native-2")).ShouldNot(Equal(IntegrationKit(ns, "java-native")()))
+				Eventually(IntegrationKit(ns, javaNative2Name)).ShouldNot(Equal(IntegrationKit(ns, javaNativeName)()))
 			})
 
 			// Clean up
@@ -93,7 +97,7 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 		})
 
 		t.Run("groovy native support", func(t *testing.T) {
-			name := "groovy-native"
+			name := RandomizedSuffixName("groovy-native")
 			Expect(KamelRunWithID(operatorID, ns, "files/Groovy.groovy", "--name", name,
 				"-t", "quarkus.build-mode=native",
 				"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
@@ -112,7 +116,7 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 		})
 
 		t.Run("kotlin native support", func(t *testing.T) {
-			name := "kotlin-native"
+			name := RandomizedSuffixName("kotlin-native")
 			Expect(KamelRunWithID(operatorID, ns, "files/Kotlin.kts", "--name", name,
 				"-t", "quarkus.build-mode=native",
 				"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -82,6 +82,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/cmd"
 	"github.com/apache/camel-k/v2/pkg/install"
 	"github.com/apache/camel-k/v2/pkg/platform"
+	v2util "github.com/apache/camel-k/v2/pkg/util"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/log"
@@ -2885,4 +2886,8 @@ func GetOperatorNamespace(testNamespace string) string {
 	} else {
 		return testNamespace
 	}
+}
+
+func RandomizedSuffixName(name string) string {
+	return name + strings.ToLower(v2util.RandomString(5))
 }


### PR DESCRIPTION
Add lower case random suffix on integration names to avoid test collisions.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(e2e): Randomize integration names in e2e tests
```
