### PR TITLE
feat(crd): Add default value trait in CRDs when declared in doc

### DIFF
--- a/addons/master/master.go
+++ b/addons/master/master.go
@@ -50,13 +50,16 @@ type Trait struct {
 	// When this flag is active, the operator analyzes the source code to add dependencies required by delegate endpoints.
 	// E.g. when using `master:lockname:timer`, then `camel:timer` is automatically added to the set of dependencies.
 	// It's enabled by default.
+	// +kubebuilder:default=true
 	IncludeDelegateDependencies *bool `property:"include-delegate-dependencies" json:"includeDelegateDependencies,omitempty"`
 	// Name of the configmap that will be used to store the lock. Defaults to "<integration-name>-lock".
 	// Name of the configmap/lease resource that will be used to store the lock. Defaults to "<integration-name>-lock".
 	ResourceName *string `property:"resource-name" json:"resourceName,omitempty"`
 	// Type of Kubernetes resource to use for locking ("ConfigMap" or "Lease"). Defaults to "Lease".
+	// +kubebuilder:default="Lease"
 	ResourceType *string `property:"resource-type" json:"resourceType,omitempty"`
 	// Label that will be used to identify all pods contending the lock. Defaults to "camel.apache.org/integration".
+	// +kubebuilder:default="camel.apache.org/integration"
 	LabelKey *string `property:"label-key" json:"labelKey,omitempty"`
 	// Label value that will be used to identify all pods contending the lock. Defaults to the integration name.
 	LabelValue *string `property:"label-value" json:"labelValue,omitempty"`

--- a/addons/telemetry/telemetry.go
+++ b/addons/telemetry/telemetry.go
@@ -41,16 +41,19 @@ import (
 type Trait struct {
 	traitv1.Trait `property:",squash" json:",inline"`
 	// Enables automatic configuration of the trait, including automatic discovery of the telemetry endpoint.
+	// +kubebuilder:default=true
 	Auto *bool `property:"auto" json:"auto,omitempty"`
 	// The name of the service that publishes telemetry data (defaults to the integration name)
 	ServiceName string `property:"service-name" json:"serviceName,omitempty"`
 	// The target endpoint of the Telemetry service (automatically discovered by default)
 	Endpoint string `property:"endpoint" json:"endpoint,omitempty"`
 	// The sampler of the telemetry used for tracing (default "on")
+	// +kubebuilder:default="on"
 	Sampler string `property:"sampler" json:"sampler,omitempty"`
 	// The sampler ratio of the telemetry used for tracing
 	SamplerRatio string `property:"sampler-ratio" json:"sampler-ratio,omitempty"`
 	// The sampler of the telemetry used for tracing is parent based (default "true")
+	// +kubebuilder:default=true
 	SamplerParentBased *bool `property:"sampler-parent-based" json:"sampler-parent-based,omitempty"`
 }
 

--- a/addons/threescale/3scale.go
+++ b/addons/threescale/3scale.go
@@ -39,12 +39,16 @@ type Trait struct {
 	// Enables automatic configuration of the trait.
 	Auto *bool `property:"auto" json:"auto,omitempty"`
 	// The scheme to use to contact the service (default `http`)
+	// +kubebuilder:default="http"
 	Scheme string `property:"scheme" json:"scheme,omitempty"`
 	// The path where the API is published (default `/`)
+	// +kubebuilder:default="/"
 	Path string `property:"path" json:"path,omitempty"`
 	// The port where the service is exposed (default `80`)
+	// +kubebuilder:default=80
 	Port int `property:"port" json:"port,omitempty"`
 	// The path where the Open-API specification is published (default `/openapi.json`)
+	// +kubebuilder:default="/openapi.json"
 	DescriptionPath *string `property:"description-path" json:"descriptionPath,omitempty"`
 }
 

--- a/addons/tracing/tracing.go
+++ b/addons/tracing/tracing.go
@@ -41,14 +41,17 @@ import (
 type Trait struct {
 	traitv1.Trait `property:",squash" json:",inline"`
 	// Enables automatic configuration of the trait, including automatic discovery of the tracing endpoint.
+	// +kubebuilder:default=true
 	Auto *bool `property:"auto" json:"auto,omitempty"`
 	// The name of the service that publishes tracing data (defaults to the integration name)
 	ServiceName string `property:"service-name" json:"serviceName,omitempty"`
 	// The target endpoint of the OpenTracing service (automatically discovered by default)
 	Endpoint string `property:"endpoint" json:"endpoint,omitempty"`
 	// The sampler type (default "const")
+	// +kubebuilder:default="const"
 	SamplerType *string `property:"sampler-type" json:"samplerType,omitempty"`
 	// The sampler specific param (default "1")
+	// +kubebuilder:default="1"
 	SamplerParam *string `property:"sampler-param" json:"samplerParam,omitempty"`
 }
 

--- a/config/crd/bases/camel.apache.org_integrationkits.yaml
+++ b/config/crd/bases/camel.apache.org_integrationkits.yaml
@@ -213,6 +213,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       incrementalImageBuild:
+                        default: true
                         description: Use the incremental image build option, to reuse
                           existing containers (default `true`)
                         type: boolean
@@ -239,8 +240,13 @@ spec:
                           type: string
                         type: array
                       orderStrategy:
+                        default: sequential
                         description: The build order strategy to use, either `dependencies`,
-                          `fifo` or `sequential` (default sequential)
+                          `fifo` or `sequential` (default `sequential`)
+                        enum:
+                        - dependencies
+                        - fifo
+                        - sequential
                         type: string
                       properties:
                         description: A list of properties to be provided to the build
@@ -259,8 +265,12 @@ spec:
                           instead with task name `builder`.'
                         type: string
                       strategy:
+                        default: routine
                         description: The strategy to use, either `pod` or `routine`
-                          (default routine)
+                          (default `routine`)
+                        enum:
+                        - pod
+                        - routine
                         type: string
                       tasks:
                         description: A list of tasks to be executed (available only
@@ -327,6 +337,8 @@ spec:
                       build must have enough memory available.'
                     properties:
                       buildMode:
+                        default:
+                        - jvm
                         description: 'The Quarkus mode to run: either `jvm` or `native`
                           (default `jvm`). In case both `jvm` and `native` are specified,
                           two `IntegrationKit` resources are created, with the `native`
@@ -347,6 +359,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       nativeBaseImage:
+                        default: quay.io/quarkus/quarkus-micro-image:2.0
                         description: The base image to use when running a native build
                           (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                         type: string

--- a/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -472,8 +472,9 @@ spec:
                           type: string
                         type: array
                       podAffinity:
+                        default: false
                         description: Always co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -483,8 +484,9 @@ spec:
                           type: string
                         type: array
                       podAntiAffinity:
+                        default: false
                         description: Never co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAntiAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -509,6 +511,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       incrementalImageBuild:
+                        default: true
                         description: Use the incremental image build option, to reuse
                           existing containers (default `true`)
                         type: boolean
@@ -535,8 +538,13 @@ spec:
                           type: string
                         type: array
                       orderStrategy:
+                        default: sequential
                         description: The build order strategy to use, either `dependencies`,
-                          `fifo` or `sequential` (default sequential)
+                          `fifo` or `sequential` (default `sequential`)
+                        enum:
+                        - dependencies
+                        - fifo
+                        - sequential
                         type: string
                       properties:
                         description: A list of properties to be provided to the build
@@ -555,8 +563,12 @@ spec:
                           instead with task name `builder`.'
                         type: string
                       strategy:
+                        default: routine
                         description: The strategy to use, either `pod` or `routine`
-                          (default routine)
+                          (default `routine`)
+                        enum:
+                        - pod
+                        - routine
                         type: string
                       tasks:
                         description: A list of tasks to be executed (available only
@@ -651,10 +663,12 @@ spec:
                         description: The maximum amount of memory required.
                         type: string
                       name:
+                        default: integration
                         description: The main container name. It's named `integration`
                           by default.
                         type: string
                       port:
+                        default: 8080
                         description: To configure a different port exposed by the
                           container (default `8080`).
                         type: integer
@@ -670,10 +684,12 @@ spec:
                         description: The minimum amount of memory required.
                         type: string
                       servicePort:
+                        default: 80
                         description: To configure under which service port the container
                           port is to be exposed (default `80`).
                         type: integer
                       servicePortName:
+                        default: http
                         description: To configure under which service port name the
                           container port is to be exposed (default `http`).
                         type: string
@@ -682,6 +698,7 @@ spec:
                     description: The configuration of Cron trait
                     properties:
                       activeDeadlineSeconds:
+                        default: 60
                         description: Specifies the duration in seconds, relative to
                           the start time, that the job may be continuously active
                           before it is considered to be failed. It defaults to 60s.
@@ -697,6 +714,7 @@ spec:
                           be expressed as `0/1 * * * *`, while `35m` or `50s` cannot)."
                         type: boolean
                       backoffLimit:
+                        default: 2
                         description: Specifies the number of retries before marking
                           the job failed. It defaults to 2.
                         format: int32
@@ -782,6 +800,7 @@ spec:
                         - knative-service
                         type: string
                       useSSA:
+                        default: true
                         description: Use server-side apply to update the owned resources
                           (default `true`). Note that it automatically falls back
                           to client-side patching, if SSA is not available, e.g.,
@@ -800,25 +819,28 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       progressDeadlineSeconds:
+                        default: 60
                         description: The maximum time in seconds for the deployment
                           to make progress before it is considered to be failed. It
-                          defaults to 60s.
+                          defaults to `60s`.
                         format: int32
                         type: integer
                       rollingUpdateMaxSurge:
+                        default: 25
                         description: 'The maximum number of pods that can be scheduled
                           above the desired number of pods. Value can be an absolute
                           number (ex: 5) or a percentage of desired pods (ex: 10%).
                           This can not be 0 if MaxUnavailable is 0. Absolute number
                           is calculated from percentage by rounding up. Defaults to
-                          25%.'
+                          `25%`.'
                         type: integer
                       rollingUpdateMaxUnavailable:
+                        default: 25
                         description: 'The maximum number of pods that can be unavailable
                           during the update. Value can be an absolute number (ex:
                           5) or a percentage of desired pods (ex: 10%). Absolute number
                           is calculated from percentage by rounding down. This can
-                          not be 0 if MaxSurge is 0. Defaults to 25%.'
+                          not be 0 if MaxSurge is 0. Defaults to `25%`.'
                         type: integer
                       strategy:
                         description: The deployment strategy to use to replace existing
@@ -837,6 +859,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       containerMeta:
+                        default: true
                         description: Enables injection of `NAMESPACE` and `POD_NAME`
                           environment variables (default `true`)
                         type: boolean
@@ -844,6 +867,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       httpProxy:
+                        default: true
                         description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY` and
                           `NO_PROXY` environment variables (default `true`)
                         type: boolean
@@ -881,6 +905,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryCache:
+                        default: memory
                         description: 'Discovery client cache to be used, either `disabled`,
                           `disk` or `memory` (default `memory`). Deprecated: to be
                           removed from trait configuration.'
@@ -921,10 +946,12 @@ spec:
                         format: int32
                         type: integer
                       livenessProbeEnabled:
+                        default: false
                         description: Configures the liveness probe for the integration
                           container (default `false`).
                         type: boolean
                       livenessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the liveness
                           probe (default `HTTP`).
                         type: string
@@ -953,10 +980,12 @@ spec:
                         format: int32
                         type: integer
                       readinessProbeEnabled:
+                        default: true
                         description: Configures the readiness probe for the integration
                           container (default `true`).
                         type: boolean
                       readinessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the readiness
                           probe (default `HTTP`).
                         type: string
@@ -985,10 +1014,12 @@ spec:
                         format: int32
                         type: integer
                       startupProbeEnabled:
+                        default: false
                         description: Configures the startup probe for the integration
                           container (default `false`).
                         type: boolean
                       startupScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the startup
                           probe (default `HTTP`).
                         type: string
@@ -1030,10 +1061,12 @@ spec:
                         description: To configure the host exposed by the ingress.
                         type: string
                       path:
+                        default: /
                         description: To configure the path exposed by the ingress
                           (default `/`).
                         type: string
                       pathType:
+                        default: Prefix
                         description: To configure the path type exposed by the ingress.
                           One of `Exact`, `Prefix`, `ImplementationSpecific` (default
                           to `Prefix`).
@@ -1047,6 +1080,7 @@ spec:
                     description: The configuration of Istio trait
                     properties:
                       allow:
+                        default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                         description: Configures a (comma-separated) list of CIDR subnets
                           that should not be intercepted by the Istio proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`
                           by default).
@@ -1092,6 +1126,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryEnabled:
+                        default: false
                         description: Listen for multicast requests (default `false`)
                         type: boolean
                       enabled:
@@ -1105,6 +1140,7 @@ spec:
                           is `true` (default `true` for OpenShift).
                         type: boolean
                       host:
+                        default: '*'
                         description: The Host address to which the Jolokia agent should
                           bind to. If `"\*"` or `"0.0.0.0"` is given, the servers
                           binds to every network interface (default `"*"`).
@@ -1121,6 +1157,7 @@ spec:
                           when the `user` option is set.
                         type: string
                       port:
+                        default: 8778
                         description: The Jolokia endpoint port (default `8778`).
                         type: integer
                       protocol:
@@ -1152,6 +1189,7 @@ spec:
                           can be attached to the JVM, e.g., using port-forwarding
                         type: boolean
                       debugAddress:
+                        default: '*:5005'
                         description: Transport address at which to listen for the
                           newly launched JVM (default `*:5005`)
                         type: string
@@ -1169,6 +1207,7 @@ spec:
                           type: string
                         type: array
                       printCommand:
+                        default: true
                         description: Prints the command used the start the JVM in
                           the container logs (default `true`)
                         type: boolean
@@ -1177,6 +1216,7 @@ spec:
                     description: The configuration of Kamelets trait
                     properties:
                       auto:
+                        default: true
                         description: Automatically inject all referenced Kamelets
                           and their default configuration (enabled by default)
                         type: boolean
@@ -1194,6 +1234,7 @@ spec:
                           into the current integration
                         type: string
                       mountPoint:
+                        default: /etc/camel/kamelets
                         description: The directory where the application mounts and
                           reads Kamelet spec (default `/etc/camel/kamelets`)
                         type: string
@@ -1272,6 +1313,7 @@ spec:
                           in newer versions of Knative, filtering is disabled by default.
                         type: boolean
                       namespaceLabel:
+                        default: true
                         description: 'Enables the camel-k-operator to set the "bindings.knative.dev/include=true"
                           label to the namespace As Knative requires this label to
                           perform injection of K_SINK URL into the service. If this
@@ -1384,7 +1426,8 @@ spec:
                         description: Enable "pretty printing" of the JSON logs
                         type: boolean
                       level:
-                        description: Adjust the logging level (defaults to INFO)
+                        default: INFO
+                        description: Adjust the logging level (defaults to `INFO`)
                         enum:
                         - FATAL
                         - WARN
@@ -1427,8 +1470,9 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       hotReload:
+                        default: false
                         description: Enable "hot reload" when a secret/configmap mounted
-                          is edited (default false)
+                          is edited (default `false`)
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -1536,6 +1580,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       global:
+                        default: true
                         description: Indicates if the platform should be created globally
                           in the case of global operator (default true).
                         type: boolean
@@ -1566,6 +1611,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       podMonitor:
+                        default: true
                         description: Whether a `PodMonitor` resource is created (default
                           `true`).
                         type: boolean
@@ -1608,6 +1654,8 @@ spec:
                     description: The configuration of Quarkus trait
                     properties:
                       buildMode:
+                        default:
+                        - jvm
                         description: 'The Quarkus mode to run: either `jvm` or `native`
                           (default `jvm`). In case both `jvm` and `native` are specified,
                           two `IntegrationKit` resources are created, with the `native`
@@ -1628,6 +1676,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       nativeBaseImage:
+                        default: quay.io/quarkus/quarkus-micro-image:2.0
                         description: The base image to use when running a native build
                           (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                         type: string
@@ -1783,6 +1832,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       nodePort:
+                        default: false
                         description: 'Enable Service to be exposed as NodePort (default
                           `false`). Deprecated: Use service type instead.'
                         type: boolean
@@ -2293,8 +2343,9 @@ spec:
                           type: string
                         type: array
                       podAffinity:
+                        default: false
                         description: Always co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -2304,8 +2355,9 @@ spec:
                           type: string
                         type: array
                       podAntiAffinity:
+                        default: false
                         description: Never co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAntiAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -2330,6 +2382,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       incrementalImageBuild:
+                        default: true
                         description: Use the incremental image build option, to reuse
                           existing containers (default `true`)
                         type: boolean
@@ -2356,8 +2409,13 @@ spec:
                           type: string
                         type: array
                       orderStrategy:
+                        default: sequential
                         description: The build order strategy to use, either `dependencies`,
-                          `fifo` or `sequential` (default sequential)
+                          `fifo` or `sequential` (default `sequential`)
+                        enum:
+                        - dependencies
+                        - fifo
+                        - sequential
                         type: string
                       properties:
                         description: A list of properties to be provided to the build
@@ -2376,8 +2434,12 @@ spec:
                           instead with task name `builder`.'
                         type: string
                       strategy:
+                        default: routine
                         description: The strategy to use, either `pod` or `routine`
-                          (default routine)
+                          (default `routine`)
+                        enum:
+                        - pod
+                        - routine
                         type: string
                       tasks:
                         description: A list of tasks to be executed (available only
@@ -2472,10 +2534,12 @@ spec:
                         description: The maximum amount of memory required.
                         type: string
                       name:
+                        default: integration
                         description: The main container name. It's named `integration`
                           by default.
                         type: string
                       port:
+                        default: 8080
                         description: To configure a different port exposed by the
                           container (default `8080`).
                         type: integer
@@ -2491,10 +2555,12 @@ spec:
                         description: The minimum amount of memory required.
                         type: string
                       servicePort:
+                        default: 80
                         description: To configure under which service port the container
                           port is to be exposed (default `80`).
                         type: integer
                       servicePortName:
+                        default: http
                         description: To configure under which service port name the
                           container port is to be exposed (default `http`).
                         type: string
@@ -2503,6 +2569,7 @@ spec:
                     description: The configuration of Cron trait
                     properties:
                       activeDeadlineSeconds:
+                        default: 60
                         description: Specifies the duration in seconds, relative to
                           the start time, that the job may be continuously active
                           before it is considered to be failed. It defaults to 60s.
@@ -2518,6 +2585,7 @@ spec:
                           be expressed as `0/1 * * * *`, while `35m` or `50s` cannot)."
                         type: boolean
                       backoffLimit:
+                        default: 2
                         description: Specifies the number of retries before marking
                           the job failed. It defaults to 2.
                         format: int32
@@ -2603,6 +2671,7 @@ spec:
                         - knative-service
                         type: string
                       useSSA:
+                        default: true
                         description: Use server-side apply to update the owned resources
                           (default `true`). Note that it automatically falls back
                           to client-side patching, if SSA is not available, e.g.,
@@ -2621,25 +2690,28 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       progressDeadlineSeconds:
+                        default: 60
                         description: The maximum time in seconds for the deployment
                           to make progress before it is considered to be failed. It
-                          defaults to 60s.
+                          defaults to `60s`.
                         format: int32
                         type: integer
                       rollingUpdateMaxSurge:
+                        default: 25
                         description: 'The maximum number of pods that can be scheduled
                           above the desired number of pods. Value can be an absolute
                           number (ex: 5) or a percentage of desired pods (ex: 10%).
                           This can not be 0 if MaxUnavailable is 0. Absolute number
                           is calculated from percentage by rounding up. Defaults to
-                          25%.'
+                          `25%`.'
                         type: integer
                       rollingUpdateMaxUnavailable:
+                        default: 25
                         description: 'The maximum number of pods that can be unavailable
                           during the update. Value can be an absolute number (ex:
                           5) or a percentage of desired pods (ex: 10%). Absolute number
                           is calculated from percentage by rounding down. This can
-                          not be 0 if MaxSurge is 0. Defaults to 25%.'
+                          not be 0 if MaxSurge is 0. Defaults to `25%`.'
                         type: integer
                       strategy:
                         description: The deployment strategy to use to replace existing
@@ -2658,6 +2730,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       containerMeta:
+                        default: true
                         description: Enables injection of `NAMESPACE` and `POD_NAME`
                           environment variables (default `true`)
                         type: boolean
@@ -2665,6 +2738,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       httpProxy:
+                        default: true
                         description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY` and
                           `NO_PROXY` environment variables (default `true`)
                         type: boolean
@@ -2702,6 +2776,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryCache:
+                        default: memory
                         description: 'Discovery client cache to be used, either `disabled`,
                           `disk` or `memory` (default `memory`). Deprecated: to be
                           removed from trait configuration.'
@@ -2742,10 +2817,12 @@ spec:
                         format: int32
                         type: integer
                       livenessProbeEnabled:
+                        default: false
                         description: Configures the liveness probe for the integration
                           container (default `false`).
                         type: boolean
                       livenessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the liveness
                           probe (default `HTTP`).
                         type: string
@@ -2774,10 +2851,12 @@ spec:
                         format: int32
                         type: integer
                       readinessProbeEnabled:
+                        default: true
                         description: Configures the readiness probe for the integration
                           container (default `true`).
                         type: boolean
                       readinessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the readiness
                           probe (default `HTTP`).
                         type: string
@@ -2806,10 +2885,12 @@ spec:
                         format: int32
                         type: integer
                       startupProbeEnabled:
+                        default: false
                         description: Configures the startup probe for the integration
                           container (default `false`).
                         type: boolean
                       startupScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the startup
                           probe (default `HTTP`).
                         type: string
@@ -2851,10 +2932,12 @@ spec:
                         description: To configure the host exposed by the ingress.
                         type: string
                       path:
+                        default: /
                         description: To configure the path exposed by the ingress
                           (default `/`).
                         type: string
                       pathType:
+                        default: Prefix
                         description: To configure the path type exposed by the ingress.
                           One of `Exact`, `Prefix`, `ImplementationSpecific` (default
                           to `Prefix`).
@@ -2868,6 +2951,7 @@ spec:
                     description: The configuration of Istio trait
                     properties:
                       allow:
+                        default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                         description: Configures a (comma-separated) list of CIDR subnets
                           that should not be intercepted by the Istio proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`
                           by default).
@@ -2913,6 +2997,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryEnabled:
+                        default: false
                         description: Listen for multicast requests (default `false`)
                         type: boolean
                       enabled:
@@ -2926,6 +3011,7 @@ spec:
                           is `true` (default `true` for OpenShift).
                         type: boolean
                       host:
+                        default: '*'
                         description: The Host address to which the Jolokia agent should
                           bind to. If `"\*"` or `"0.0.0.0"` is given, the servers
                           binds to every network interface (default `"*"`).
@@ -2942,6 +3028,7 @@ spec:
                           when the `user` option is set.
                         type: string
                       port:
+                        default: 8778
                         description: The Jolokia endpoint port (default `8778`).
                         type: integer
                       protocol:
@@ -2973,6 +3060,7 @@ spec:
                           can be attached to the JVM, e.g., using port-forwarding
                         type: boolean
                       debugAddress:
+                        default: '*:5005'
                         description: Transport address at which to listen for the
                           newly launched JVM (default `*:5005`)
                         type: string
@@ -2990,6 +3078,7 @@ spec:
                           type: string
                         type: array
                       printCommand:
+                        default: true
                         description: Prints the command used the start the JVM in
                           the container logs (default `true`)
                         type: boolean
@@ -2998,6 +3087,7 @@ spec:
                     description: The configuration of Kamelets trait
                     properties:
                       auto:
+                        default: true
                         description: Automatically inject all referenced Kamelets
                           and their default configuration (enabled by default)
                         type: boolean
@@ -3015,6 +3105,7 @@ spec:
                           into the current integration
                         type: string
                       mountPoint:
+                        default: /etc/camel/kamelets
                         description: The directory where the application mounts and
                           reads Kamelet spec (default `/etc/camel/kamelets`)
                         type: string
@@ -3093,6 +3184,7 @@ spec:
                           in newer versions of Knative, filtering is disabled by default.
                         type: boolean
                       namespaceLabel:
+                        default: true
                         description: 'Enables the camel-k-operator to set the "bindings.knative.dev/include=true"
                           label to the namespace As Knative requires this label to
                           perform injection of K_SINK URL into the service. If this
@@ -3205,7 +3297,8 @@ spec:
                         description: Enable "pretty printing" of the JSON logs
                         type: boolean
                       level:
-                        description: Adjust the logging level (defaults to INFO)
+                        default: INFO
+                        description: Adjust the logging level (defaults to `INFO`)
                         enum:
                         - FATAL
                         - WARN
@@ -3248,8 +3341,9 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       hotReload:
+                        default: false
                         description: Enable "hot reload" when a secret/configmap mounted
-                          is edited (default false)
+                          is edited (default `false`)
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -3357,6 +3451,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       global:
+                        default: true
                         description: Indicates if the platform should be created globally
                           in the case of global operator (default true).
                         type: boolean
@@ -3387,6 +3482,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       podMonitor:
+                        default: true
                         description: Whether a `PodMonitor` resource is created (default
                           `true`).
                         type: boolean
@@ -3429,6 +3525,8 @@ spec:
                     description: The configuration of Quarkus trait
                     properties:
                       buildMode:
+                        default:
+                        - jvm
                         description: 'The Quarkus mode to run: either `jvm` or `native`
                           (default `jvm`). In case both `jvm` and `native` are specified,
                           two `IntegrationKit` resources are created, with the `native`
@@ -3449,6 +3547,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       nativeBaseImage:
+                        default: quay.io/quarkus/quarkus-micro-image:2.0
                         description: The base image to use when running a native build
                           (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                         type: string
@@ -3604,6 +3703,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       nodePort:
+                        default: false
                         description: 'Enable Service to be exposed as NodePort (default
                           `false`). Deprecated: Use service type instead.'
                         type: boolean

--- a/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/config/crd/bases/camel.apache.org_integrations.yaml
@@ -6392,8 +6392,9 @@ spec:
                           type: string
                         type: array
                       podAffinity:
+                        default: false
                         description: Always co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -6403,8 +6404,9 @@ spec:
                           type: string
                         type: array
                       podAntiAffinity:
+                        default: false
                         description: Never co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAntiAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -6429,6 +6431,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       incrementalImageBuild:
+                        default: true
                         description: Use the incremental image build option, to reuse
                           existing containers (default `true`)
                         type: boolean
@@ -6455,8 +6458,13 @@ spec:
                           type: string
                         type: array
                       orderStrategy:
+                        default: sequential
                         description: The build order strategy to use, either `dependencies`,
-                          `fifo` or `sequential` (default sequential)
+                          `fifo` or `sequential` (default `sequential`)
+                        enum:
+                        - dependencies
+                        - fifo
+                        - sequential
                         type: string
                       properties:
                         description: A list of properties to be provided to the build
@@ -6475,8 +6483,12 @@ spec:
                           instead with task name `builder`.'
                         type: string
                       strategy:
+                        default: routine
                         description: The strategy to use, either `pod` or `routine`
-                          (default routine)
+                          (default `routine`)
+                        enum:
+                        - pod
+                        - routine
                         type: string
                       tasks:
                         description: A list of tasks to be executed (available only
@@ -6571,10 +6583,12 @@ spec:
                         description: The maximum amount of memory required.
                         type: string
                       name:
+                        default: integration
                         description: The main container name. It's named `integration`
                           by default.
                         type: string
                       port:
+                        default: 8080
                         description: To configure a different port exposed by the
                           container (default `8080`).
                         type: integer
@@ -6590,10 +6604,12 @@ spec:
                         description: The minimum amount of memory required.
                         type: string
                       servicePort:
+                        default: 80
                         description: To configure under which service port the container
                           port is to be exposed (default `80`).
                         type: integer
                       servicePortName:
+                        default: http
                         description: To configure under which service port name the
                           container port is to be exposed (default `http`).
                         type: string
@@ -6602,6 +6618,7 @@ spec:
                     description: The configuration of Cron trait
                     properties:
                       activeDeadlineSeconds:
+                        default: 60
                         description: Specifies the duration in seconds, relative to
                           the start time, that the job may be continuously active
                           before it is considered to be failed. It defaults to 60s.
@@ -6617,6 +6634,7 @@ spec:
                           be expressed as `0/1 * * * *`, while `35m` or `50s` cannot)."
                         type: boolean
                       backoffLimit:
+                        default: 2
                         description: Specifies the number of retries before marking
                           the job failed. It defaults to 2.
                         format: int32
@@ -6702,6 +6720,7 @@ spec:
                         - knative-service
                         type: string
                       useSSA:
+                        default: true
                         description: Use server-side apply to update the owned resources
                           (default `true`). Note that it automatically falls back
                           to client-side patching, if SSA is not available, e.g.,
@@ -6720,25 +6739,28 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       progressDeadlineSeconds:
+                        default: 60
                         description: The maximum time in seconds for the deployment
                           to make progress before it is considered to be failed. It
-                          defaults to 60s.
+                          defaults to `60s`.
                         format: int32
                         type: integer
                       rollingUpdateMaxSurge:
+                        default: 25
                         description: 'The maximum number of pods that can be scheduled
                           above the desired number of pods. Value can be an absolute
                           number (ex: 5) or a percentage of desired pods (ex: 10%).
                           This can not be 0 if MaxUnavailable is 0. Absolute number
                           is calculated from percentage by rounding up. Defaults to
-                          25%.'
+                          `25%`.'
                         type: integer
                       rollingUpdateMaxUnavailable:
+                        default: 25
                         description: 'The maximum number of pods that can be unavailable
                           during the update. Value can be an absolute number (ex:
                           5) or a percentage of desired pods (ex: 10%). Absolute number
                           is calculated from percentage by rounding down. This can
-                          not be 0 if MaxSurge is 0. Defaults to 25%.'
+                          not be 0 if MaxSurge is 0. Defaults to `25%`.'
                         type: integer
                       strategy:
                         description: The deployment strategy to use to replace existing
@@ -6757,6 +6779,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       containerMeta:
+                        default: true
                         description: Enables injection of `NAMESPACE` and `POD_NAME`
                           environment variables (default `true`)
                         type: boolean
@@ -6764,6 +6787,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       httpProxy:
+                        default: true
                         description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY` and
                           `NO_PROXY` environment variables (default `true`)
                         type: boolean
@@ -6801,6 +6825,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryCache:
+                        default: memory
                         description: 'Discovery client cache to be used, either `disabled`,
                           `disk` or `memory` (default `memory`). Deprecated: to be
                           removed from trait configuration.'
@@ -6841,10 +6866,12 @@ spec:
                         format: int32
                         type: integer
                       livenessProbeEnabled:
+                        default: false
                         description: Configures the liveness probe for the integration
                           container (default `false`).
                         type: boolean
                       livenessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the liveness
                           probe (default `HTTP`).
                         type: string
@@ -6873,10 +6900,12 @@ spec:
                         format: int32
                         type: integer
                       readinessProbeEnabled:
+                        default: true
                         description: Configures the readiness probe for the integration
                           container (default `true`).
                         type: boolean
                       readinessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the readiness
                           probe (default `HTTP`).
                         type: string
@@ -6905,10 +6934,12 @@ spec:
                         format: int32
                         type: integer
                       startupProbeEnabled:
+                        default: false
                         description: Configures the startup probe for the integration
                           container (default `false`).
                         type: boolean
                       startupScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the startup
                           probe (default `HTTP`).
                         type: string
@@ -6950,10 +6981,12 @@ spec:
                         description: To configure the host exposed by the ingress.
                         type: string
                       path:
+                        default: /
                         description: To configure the path exposed by the ingress
                           (default `/`).
                         type: string
                       pathType:
+                        default: Prefix
                         description: To configure the path type exposed by the ingress.
                           One of `Exact`, `Prefix`, `ImplementationSpecific` (default
                           to `Prefix`).
@@ -6967,6 +7000,7 @@ spec:
                     description: The configuration of Istio trait
                     properties:
                       allow:
+                        default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                         description: Configures a (comma-separated) list of CIDR subnets
                           that should not be intercepted by the Istio proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`
                           by default).
@@ -7012,6 +7046,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryEnabled:
+                        default: false
                         description: Listen for multicast requests (default `false`)
                         type: boolean
                       enabled:
@@ -7025,6 +7060,7 @@ spec:
                           is `true` (default `true` for OpenShift).
                         type: boolean
                       host:
+                        default: '*'
                         description: The Host address to which the Jolokia agent should
                           bind to. If `"\*"` or `"0.0.0.0"` is given, the servers
                           binds to every network interface (default `"*"`).
@@ -7041,6 +7077,7 @@ spec:
                           when the `user` option is set.
                         type: string
                       port:
+                        default: 8778
                         description: The Jolokia endpoint port (default `8778`).
                         type: integer
                       protocol:
@@ -7072,6 +7109,7 @@ spec:
                           can be attached to the JVM, e.g., using port-forwarding
                         type: boolean
                       debugAddress:
+                        default: '*:5005'
                         description: Transport address at which to listen for the
                           newly launched JVM (default `*:5005`)
                         type: string
@@ -7089,6 +7127,7 @@ spec:
                           type: string
                         type: array
                       printCommand:
+                        default: true
                         description: Prints the command used the start the JVM in
                           the container logs (default `true`)
                         type: boolean
@@ -7097,6 +7136,7 @@ spec:
                     description: The configuration of Kamelets trait
                     properties:
                       auto:
+                        default: true
                         description: Automatically inject all referenced Kamelets
                           and their default configuration (enabled by default)
                         type: boolean
@@ -7114,6 +7154,7 @@ spec:
                           into the current integration
                         type: string
                       mountPoint:
+                        default: /etc/camel/kamelets
                         description: The directory where the application mounts and
                           reads Kamelet spec (default `/etc/camel/kamelets`)
                         type: string
@@ -7192,6 +7233,7 @@ spec:
                           in newer versions of Knative, filtering is disabled by default.
                         type: boolean
                       namespaceLabel:
+                        default: true
                         description: 'Enables the camel-k-operator to set the "bindings.knative.dev/include=true"
                           label to the namespace As Knative requires this label to
                           perform injection of K_SINK URL into the service. If this
@@ -7304,7 +7346,8 @@ spec:
                         description: Enable "pretty printing" of the JSON logs
                         type: boolean
                       level:
-                        description: Adjust the logging level (defaults to INFO)
+                        default: INFO
+                        description: Adjust the logging level (defaults to `INFO`)
                         enum:
                         - FATAL
                         - WARN
@@ -7347,8 +7390,9 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       hotReload:
+                        default: false
                         description: Enable "hot reload" when a secret/configmap mounted
-                          is edited (default false)
+                          is edited (default `false`)
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -7456,6 +7500,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       global:
+                        default: true
                         description: Indicates if the platform should be created globally
                           in the case of global operator (default true).
                         type: boolean
@@ -7486,6 +7531,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       podMonitor:
+                        default: true
                         description: Whether a `PodMonitor` resource is created (default
                           `true`).
                         type: boolean
@@ -7528,6 +7574,8 @@ spec:
                     description: The configuration of Quarkus trait
                     properties:
                       buildMode:
+                        default:
+                        - jvm
                         description: 'The Quarkus mode to run: either `jvm` or `native`
                           (default `jvm`). In case both `jvm` and `native` are specified,
                           two `IntegrationKit` resources are created, with the `native`
@@ -7548,6 +7596,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       nativeBaseImage:
+                        default: quay.io/quarkus/quarkus-micro-image:2.0
                         description: The base image to use when running a native build
                           (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                         type: string
@@ -7703,6 +7752,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       nodePort:
+                        default: false
                         description: 'Enable Service to be exposed as NodePort (default
                           `false`). Deprecated: Use service type instead.'
                         type: boolean

--- a/config/crd/bases/camel.apache.org_kameletbindings.yaml
+++ b/config/crd/bases/camel.apache.org_kameletbindings.yaml
@@ -6673,8 +6673,9 @@ spec:
                               type: string
                             type: array
                           podAffinity:
+                            default: false
                             description: Always co-locates multiple replicas of the
-                              integration in the same node (default *false*).
+                              integration in the same node (default `false`).
                             type: boolean
                           podAffinityLabels:
                             description: Defines a set of pods (namely those matching
@@ -6684,8 +6685,9 @@ spec:
                               type: string
                             type: array
                           podAntiAffinity:
+                            default: false
                             description: Never co-locates multiple replicas of the
-                              integration in the same node (default *false*).
+                              integration in the same node (default `false`).
                             type: boolean
                           podAntiAffinityLabels:
                             description: Defines a set of pods (namely those matching
@@ -6711,6 +6713,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           incrementalImageBuild:
+                            default: true
                             description: Use the incremental image build option, to
                               reuse existing containers (default `true`)
                             type: boolean
@@ -6738,8 +6741,13 @@ spec:
                               type: string
                             type: array
                           orderStrategy:
+                            default: sequential
                             description: The build order strategy to use, either `dependencies`,
-                              `fifo` or `sequential` (default sequential)
+                              `fifo` or `sequential` (default `sequential`)
+                            enum:
+                            - dependencies
+                            - fifo
+                            - sequential
                             type: string
                           properties:
                             description: A list of properties to be provided to the
@@ -6758,8 +6766,12 @@ spec:
                               TasksRequestCPU instead with task name `builder`.'
                             type: string
                           strategy:
+                            default: routine
                             description: The strategy to use, either `pod` or `routine`
-                              (default routine)
+                              (default `routine`)
+                            enum:
+                            - pod
+                            - routine
                             type: string
                           tasks:
                             description: A list of tasks to be executed (available
@@ -6854,10 +6866,12 @@ spec:
                             description: The maximum amount of memory required.
                             type: string
                           name:
+                            default: integration
                             description: The main container name. It's named `integration`
                               by default.
                             type: string
                           port:
+                            default: 8080
                             description: To configure a different port exposed by
                               the container (default `8080`).
                             type: integer
@@ -6873,10 +6887,12 @@ spec:
                             description: The minimum amount of memory required.
                             type: string
                           servicePort:
+                            default: 80
                             description: To configure under which service port the
                               container port is to be exposed (default `80`).
                             type: integer
                           servicePortName:
+                            default: http
                             description: To configure under which service port name
                               the container port is to be exposed (default `http`).
                             type: string
@@ -6885,6 +6901,7 @@ spec:
                         description: The configuration of Cron trait
                         properties:
                           activeDeadlineSeconds:
+                            default: 60
                             description: Specifies the duration in seconds, relative
                               to the start time, that the job may be continuously
                               active before it is considered to be failed. It defaults
@@ -6902,6 +6919,7 @@ spec:
                               `35m` or `50s` cannot)."
                             type: boolean
                           backoffLimit:
+                            default: 2
                             description: Specifies the number of retries before marking
                               the job failed. It defaults to 2.
                             format: int32
@@ -6987,6 +7005,7 @@ spec:
                             - knative-service
                             type: string
                           useSSA:
+                            default: true
                             description: Use server-side apply to update the owned
                               resources (default `true`). Note that it automatically
                               falls back to client-side patching, if SSA is not available,
@@ -7005,25 +7024,28 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           progressDeadlineSeconds:
+                            default: 60
                             description: The maximum time in seconds for the deployment
                               to make progress before it is considered to be failed.
-                              It defaults to 60s.
+                              It defaults to `60s`.
                             format: int32
                             type: integer
                           rollingUpdateMaxSurge:
+                            default: 25
                             description: 'The maximum number of pods that can be scheduled
                               above the desired number of pods. Value can be an absolute
                               number (ex: 5) or a percentage of desired pods (ex:
                               10%). This can not be 0 if MaxUnavailable is 0. Absolute
                               number is calculated from percentage by rounding up.
-                              Defaults to 25%.'
+                              Defaults to `25%`.'
                             type: integer
                           rollingUpdateMaxUnavailable:
+                            default: 25
                             description: 'The maximum number of pods that can be unavailable
                               during the update. Value can be an absolute number (ex:
                               5) or a percentage of desired pods (ex: 10%). Absolute
                               number is calculated from percentage by rounding down.
-                              This can not be 0 if MaxSurge is 0. Defaults to 25%.'
+                              This can not be 0 if MaxSurge is 0. Defaults to `25%`.'
                             type: integer
                           strategy:
                             description: The deployment strategy to use to replace
@@ -7042,6 +7064,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           containerMeta:
+                            default: true
                             description: Enables injection of `NAMESPACE` and `POD_NAME`
                               environment variables (default `true`)
                             type: boolean
@@ -7049,6 +7072,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           httpProxy:
+                            default: true
                             description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY`
                               and `NO_PROXY` environment variables (default `true`)
                             type: boolean
@@ -7086,6 +7110,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           discoveryCache:
+                            default: memory
                             description: 'Discovery client cache to be used, either
                               `disabled`, `disk` or `memory` (default `memory`). Deprecated:
                               to be removed from trait configuration.'
@@ -7126,10 +7151,12 @@ spec:
                             format: int32
                             type: integer
                           livenessProbeEnabled:
+                            default: false
                             description: Configures the liveness probe for the integration
                               container (default `false`).
                             type: boolean
                           livenessScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the liveness
                               probe (default `HTTP`).
                             type: string
@@ -7158,10 +7185,12 @@ spec:
                             format: int32
                             type: integer
                           readinessProbeEnabled:
+                            default: true
                             description: Configures the readiness probe for the integration
                               container (default `true`).
                             type: boolean
                           readinessScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the readiness
                               probe (default `HTTP`).
                             type: string
@@ -7190,10 +7219,12 @@ spec:
                             format: int32
                             type: integer
                           startupProbeEnabled:
+                            default: false
                             description: Configures the startup probe for the integration
                               container (default `false`).
                             type: boolean
                           startupScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the startup
                               probe (default `HTTP`).
                             type: string
@@ -7235,10 +7266,12 @@ spec:
                             description: To configure the host exposed by the ingress.
                             type: string
                           path:
+                            default: /
                             description: To configure the path exposed by the ingress
                               (default `/`).
                             type: string
                           pathType:
+                            default: Prefix
                             description: To configure the path type exposed by the
                               ingress. One of `Exact`, `Prefix`, `ImplementationSpecific`
                               (default to `Prefix`).
@@ -7252,6 +7285,7 @@ spec:
                         description: The configuration of Istio trait
                         properties:
                           allow:
+                            default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                             description: Configures a (comma-separated) list of CIDR
                               subnets that should not be intercepted by the Istio
                               proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` by
@@ -7298,6 +7332,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           discoveryEnabled:
+                            default: false
                             description: Listen for multicast requests (default `false`)
                             type: boolean
                           enabled:
@@ -7311,6 +7346,7 @@ spec:
                               is `true` (default `true` for OpenShift).
                             type: boolean
                           host:
+                            default: '*'
                             description: The Host address to which the Jolokia agent
                               should bind to. If `"\*"` or `"0.0.0.0"` is given, the
                               servers binds to every network interface (default `"*"`).
@@ -7327,6 +7363,7 @@ spec:
                               when the `user` option is set.
                             type: string
                           port:
+                            default: 8778
                             description: The Jolokia endpoint port (default `8778`).
                             type: integer
                           protocol:
@@ -7358,6 +7395,7 @@ spec:
                               can be attached to the JVM, e.g., using port-forwarding
                             type: boolean
                           debugAddress:
+                            default: '*:5005'
                             description: Transport address at which to listen for
                               the newly launched JVM (default `*:5005`)
                             type: string
@@ -7375,6 +7413,7 @@ spec:
                               type: string
                             type: array
                           printCommand:
+                            default: true
                             description: Prints the command used the start the JVM
                               in the container logs (default `true`)
                             type: boolean
@@ -7383,6 +7422,7 @@ spec:
                         description: The configuration of Kamelets trait
                         properties:
                           auto:
+                            default: true
                             description: Automatically inject all referenced Kamelets
                               and their default configuration (enabled by default)
                             type: boolean
@@ -7400,6 +7440,7 @@ spec:
                               load into the current integration
                             type: string
                           mountPoint:
+                            default: /etc/camel/kamelets
                             description: The directory where the application mounts
                               and reads Kamelet spec (default `/etc/camel/kamelets`)
                             type: string
@@ -7482,6 +7523,7 @@ spec:
                               by default.
                             type: boolean
                           namespaceLabel:
+                            default: true
                             description: 'Enables the camel-k-operator to set the
                               "bindings.knative.dev/include=true" label to the namespace
                               As Knative requires this label to perform injection
@@ -7599,7 +7641,8 @@ spec:
                             description: Enable "pretty printing" of the JSON logs
                             type: boolean
                           level:
-                            description: Adjust the logging level (defaults to INFO)
+                            default: INFO
+                            description: Adjust the logging level (defaults to `INFO`)
                             enum:
                             - FATAL
                             - WARN
@@ -7642,8 +7685,9 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           hotReload:
+                            default: false
                             description: Enable "hot reload" when a secret/configmap
-                              mounted is edited (default false)
+                              mounted is edited (default `false`)
                             type: boolean
                           resources:
                             description: 'A list of resources (text or binary content)
@@ -7751,6 +7795,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           global:
+                            default: true
                             description: Indicates if the platform should be created
                               globally in the case of global operator (default true).
                             type: boolean
@@ -7781,6 +7826,7 @@ spec:
                               All traits share this common property.
                             type: boolean
                           podMonitor:
+                            default: true
                             description: Whether a `PodMonitor` resource is created
                               (default `true`).
                             type: boolean
@@ -7823,6 +7869,8 @@ spec:
                         description: The configuration of Quarkus trait
                         properties:
                           buildMode:
+                            default:
+                            - jvm
                             description: 'The Quarkus mode to run: either `jvm` or
                               `native` (default `jvm`). In case both `jvm` and `native`
                               are specified, two `IntegrationKit` resources are created,
@@ -7845,6 +7893,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           nativeBaseImage:
+                            default: quay.io/quarkus/quarkus-micro-image:2.0
                             description: The base image to use when running a native
                               build (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                             type: string
@@ -8009,6 +8058,7 @@ spec:
                               All traits share this common property.
                             type: boolean
                           nodePort:
+                            default: false
                             description: 'Enable Service to be exposed as NodePort
                               (default `false`). Deprecated: Use service type instead.'
                             type: boolean

--- a/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/config/crd/bases/camel.apache.org_pipes.yaml
@@ -6671,8 +6671,9 @@ spec:
                               type: string
                             type: array
                           podAffinity:
+                            default: false
                             description: Always co-locates multiple replicas of the
-                              integration in the same node (default *false*).
+                              integration in the same node (default `false`).
                             type: boolean
                           podAffinityLabels:
                             description: Defines a set of pods (namely those matching
@@ -6682,8 +6683,9 @@ spec:
                               type: string
                             type: array
                           podAntiAffinity:
+                            default: false
                             description: Never co-locates multiple replicas of the
-                              integration in the same node (default *false*).
+                              integration in the same node (default `false`).
                             type: boolean
                           podAntiAffinityLabels:
                             description: Defines a set of pods (namely those matching
@@ -6709,6 +6711,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           incrementalImageBuild:
+                            default: true
                             description: Use the incremental image build option, to
                               reuse existing containers (default `true`)
                             type: boolean
@@ -6736,8 +6739,13 @@ spec:
                               type: string
                             type: array
                           orderStrategy:
+                            default: sequential
                             description: The build order strategy to use, either `dependencies`,
-                              `fifo` or `sequential` (default sequential)
+                              `fifo` or `sequential` (default `sequential`)
+                            enum:
+                            - dependencies
+                            - fifo
+                            - sequential
                             type: string
                           properties:
                             description: A list of properties to be provided to the
@@ -6756,8 +6764,12 @@ spec:
                               TasksRequestCPU instead with task name `builder`.'
                             type: string
                           strategy:
+                            default: routine
                             description: The strategy to use, either `pod` or `routine`
-                              (default routine)
+                              (default `routine`)
+                            enum:
+                            - pod
+                            - routine
                             type: string
                           tasks:
                             description: A list of tasks to be executed (available
@@ -6852,10 +6864,12 @@ spec:
                             description: The maximum amount of memory required.
                             type: string
                           name:
+                            default: integration
                             description: The main container name. It's named `integration`
                               by default.
                             type: string
                           port:
+                            default: 8080
                             description: To configure a different port exposed by
                               the container (default `8080`).
                             type: integer
@@ -6871,10 +6885,12 @@ spec:
                             description: The minimum amount of memory required.
                             type: string
                           servicePort:
+                            default: 80
                             description: To configure under which service port the
                               container port is to be exposed (default `80`).
                             type: integer
                           servicePortName:
+                            default: http
                             description: To configure under which service port name
                               the container port is to be exposed (default `http`).
                             type: string
@@ -6883,6 +6899,7 @@ spec:
                         description: The configuration of Cron trait
                         properties:
                           activeDeadlineSeconds:
+                            default: 60
                             description: Specifies the duration in seconds, relative
                               to the start time, that the job may be continuously
                               active before it is considered to be failed. It defaults
@@ -6900,6 +6917,7 @@ spec:
                               `35m` or `50s` cannot)."
                             type: boolean
                           backoffLimit:
+                            default: 2
                             description: Specifies the number of retries before marking
                               the job failed. It defaults to 2.
                             format: int32
@@ -6985,6 +7003,7 @@ spec:
                             - knative-service
                             type: string
                           useSSA:
+                            default: true
                             description: Use server-side apply to update the owned
                               resources (default `true`). Note that it automatically
                               falls back to client-side patching, if SSA is not available,
@@ -7003,25 +7022,28 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           progressDeadlineSeconds:
+                            default: 60
                             description: The maximum time in seconds for the deployment
                               to make progress before it is considered to be failed.
-                              It defaults to 60s.
+                              It defaults to `60s`.
                             format: int32
                             type: integer
                           rollingUpdateMaxSurge:
+                            default: 25
                             description: 'The maximum number of pods that can be scheduled
                               above the desired number of pods. Value can be an absolute
                               number (ex: 5) or a percentage of desired pods (ex:
                               10%). This can not be 0 if MaxUnavailable is 0. Absolute
                               number is calculated from percentage by rounding up.
-                              Defaults to 25%.'
+                              Defaults to `25%`.'
                             type: integer
                           rollingUpdateMaxUnavailable:
+                            default: 25
                             description: 'The maximum number of pods that can be unavailable
                               during the update. Value can be an absolute number (ex:
                               5) or a percentage of desired pods (ex: 10%). Absolute
                               number is calculated from percentage by rounding down.
-                              This can not be 0 if MaxSurge is 0. Defaults to 25%.'
+                              This can not be 0 if MaxSurge is 0. Defaults to `25%`.'
                             type: integer
                           strategy:
                             description: The deployment strategy to use to replace
@@ -7040,6 +7062,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           containerMeta:
+                            default: true
                             description: Enables injection of `NAMESPACE` and `POD_NAME`
                               environment variables (default `true`)
                             type: boolean
@@ -7047,6 +7070,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           httpProxy:
+                            default: true
                             description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY`
                               and `NO_PROXY` environment variables (default `true`)
                             type: boolean
@@ -7084,6 +7108,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           discoveryCache:
+                            default: memory
                             description: 'Discovery client cache to be used, either
                               `disabled`, `disk` or `memory` (default `memory`). Deprecated:
                               to be removed from trait configuration.'
@@ -7124,10 +7149,12 @@ spec:
                             format: int32
                             type: integer
                           livenessProbeEnabled:
+                            default: false
                             description: Configures the liveness probe for the integration
                               container (default `false`).
                             type: boolean
                           livenessScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the liveness
                               probe (default `HTTP`).
                             type: string
@@ -7156,10 +7183,12 @@ spec:
                             format: int32
                             type: integer
                           readinessProbeEnabled:
+                            default: true
                             description: Configures the readiness probe for the integration
                               container (default `true`).
                             type: boolean
                           readinessScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the readiness
                               probe (default `HTTP`).
                             type: string
@@ -7188,10 +7217,12 @@ spec:
                             format: int32
                             type: integer
                           startupProbeEnabled:
+                            default: false
                             description: Configures the startup probe for the integration
                               container (default `false`).
                             type: boolean
                           startupScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the startup
                               probe (default `HTTP`).
                             type: string
@@ -7233,10 +7264,12 @@ spec:
                             description: To configure the host exposed by the ingress.
                             type: string
                           path:
+                            default: /
                             description: To configure the path exposed by the ingress
                               (default `/`).
                             type: string
                           pathType:
+                            default: Prefix
                             description: To configure the path type exposed by the
                               ingress. One of `Exact`, `Prefix`, `ImplementationSpecific`
                               (default to `Prefix`).
@@ -7250,6 +7283,7 @@ spec:
                         description: The configuration of Istio trait
                         properties:
                           allow:
+                            default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                             description: Configures a (comma-separated) list of CIDR
                               subnets that should not be intercepted by the Istio
                               proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` by
@@ -7296,6 +7330,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           discoveryEnabled:
+                            default: false
                             description: Listen for multicast requests (default `false`)
                             type: boolean
                           enabled:
@@ -7309,6 +7344,7 @@ spec:
                               is `true` (default `true` for OpenShift).
                             type: boolean
                           host:
+                            default: '*'
                             description: The Host address to which the Jolokia agent
                               should bind to. If `"\*"` or `"0.0.0.0"` is given, the
                               servers binds to every network interface (default `"*"`).
@@ -7325,6 +7361,7 @@ spec:
                               when the `user` option is set.
                             type: string
                           port:
+                            default: 8778
                             description: The Jolokia endpoint port (default `8778`).
                             type: integer
                           protocol:
@@ -7356,6 +7393,7 @@ spec:
                               can be attached to the JVM, e.g., using port-forwarding
                             type: boolean
                           debugAddress:
+                            default: '*:5005'
                             description: Transport address at which to listen for
                               the newly launched JVM (default `*:5005`)
                             type: string
@@ -7373,6 +7411,7 @@ spec:
                               type: string
                             type: array
                           printCommand:
+                            default: true
                             description: Prints the command used the start the JVM
                               in the container logs (default `true`)
                             type: boolean
@@ -7381,6 +7420,7 @@ spec:
                         description: The configuration of Kamelets trait
                         properties:
                           auto:
+                            default: true
                             description: Automatically inject all referenced Kamelets
                               and their default configuration (enabled by default)
                             type: boolean
@@ -7398,6 +7438,7 @@ spec:
                               load into the current integration
                             type: string
                           mountPoint:
+                            default: /etc/camel/kamelets
                             description: The directory where the application mounts
                               and reads Kamelet spec (default `/etc/camel/kamelets`)
                             type: string
@@ -7480,6 +7521,7 @@ spec:
                               by default.
                             type: boolean
                           namespaceLabel:
+                            default: true
                             description: 'Enables the camel-k-operator to set the
                               "bindings.knative.dev/include=true" label to the namespace
                               As Knative requires this label to perform injection
@@ -7597,7 +7639,8 @@ spec:
                             description: Enable "pretty printing" of the JSON logs
                             type: boolean
                           level:
-                            description: Adjust the logging level (defaults to INFO)
+                            default: INFO
+                            description: Adjust the logging level (defaults to `INFO`)
                             enum:
                             - FATAL
                             - WARN
@@ -7640,8 +7683,9 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           hotReload:
+                            default: false
                             description: Enable "hot reload" when a secret/configmap
-                              mounted is edited (default false)
+                              mounted is edited (default `false`)
                             type: boolean
                           resources:
                             description: 'A list of resources (text or binary content)
@@ -7749,6 +7793,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           global:
+                            default: true
                             description: Indicates if the platform should be created
                               globally in the case of global operator (default true).
                             type: boolean
@@ -7779,6 +7824,7 @@ spec:
                               All traits share this common property.
                             type: boolean
                           podMonitor:
+                            default: true
                             description: Whether a `PodMonitor` resource is created
                               (default `true`).
                             type: boolean
@@ -7821,6 +7867,8 @@ spec:
                         description: The configuration of Quarkus trait
                         properties:
                           buildMode:
+                            default:
+                            - jvm
                             description: 'The Quarkus mode to run: either `jvm` or
                               `native` (default `jvm`). In case both `jvm` and `native`
                               are specified, two `IntegrationKit` resources are created,
@@ -7843,6 +7891,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           nativeBaseImage:
+                            default: quay.io/quarkus/quarkus-micro-image:2.0
                             description: The base image to use when running a native
                               build (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                             type: string
@@ -8007,6 +8056,7 @@ spec:
                               All traits share this common property.
                             type: boolean
                           nodePort:
+                            default: false
                             description: 'Enable Service to be exposed as NodePort
                               (default `false`). Deprecated: Use service type instead.'
                             type: boolean

--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -5731,14 +5731,14 @@ bool
 |
 
 
-Always co-locates multiple replicas of the integration in the same node (default *false*).
+Always co-locates multiple replicas of the integration in the same node (default `false`).
 
 |`podAntiAffinity` +
 bool
 |
 
 
-Never co-locates multiple replicas of the integration in the same node (default *false*).
+Never co-locates multiple replicas of the integration in the same node (default `false`).
 
 |`nodeAffinityLabels` +
 []string
@@ -5809,7 +5809,7 @@ string
 |
 
 
-The strategy to use, either `pod` or `routine` (default routine)
+The strategy to use, either `pod` or `routine` (default `routine`)
 
 |`baseImage` +
 string
@@ -5830,7 +5830,7 @@ string
 |
 
 
-The build order strategy to use, either `dependencies`, `fifo` or `sequential` (default sequential)
+The build order strategy to use, either `dependencies`, `fifo` or `sequential` (default `sequential`)
 
 |`requestCPU` +
 string
@@ -6306,7 +6306,7 @@ int32
 
 
 The maximum time in seconds for the deployment to make progress before it
-is considered to be failed. It defaults to 60s.
+is considered to be failed. It defaults to `60s`.
 
 |`strategy` +
 *https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#deploymentstrategytype-v1-apps[Kubernetes apps/v1.DeploymentStrategyType]*
@@ -6324,7 +6324,7 @@ The maximum number of pods that can be unavailable during the update.
 Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 Absolute number is calculated from percentage by rounding down.
 This can not be 0 if MaxSurge is 0.
-Defaults to 25%.
+Defaults to `25%`.
 
 |`rollingUpdateMaxSurge` +
 int
@@ -6336,7 +6336,7 @@ pods.
 Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 This can not be 0 if MaxUnavailable is 0.
 Absolute number is calculated from percentage by rounding up.
-Defaults to 25%.
+Defaults to `25%`.
 
 
 |===
@@ -7250,7 +7250,7 @@ string
 |
 
 
-Adjust the logging level (defaults to INFO)
+Adjust the logging level (defaults to `INFO`)
 
 |`json` +
 bool
@@ -7324,7 +7324,7 @@ bool
 |
 
 
-Enable "hot reload" when a secret/configmap mounted is edited (default false)
+Enable "hot reload" when a secret/configmap mounted is edited (default `false`)
 
 
 |===

--- a/docs/modules/traits/pages/affinity.adoc
+++ b/docs/modules/traits/pages/affinity.adoc
@@ -30,11 +30,11 @@ The following configuration options are available:
 
 | affinity.pod-affinity
 | bool
-| Always co-locates multiple replicas of the integration in the same node (default *false*).
+| Always co-locates multiple replicas of the integration in the same node (default `false`).
 
 | affinity.pod-anti-affinity
 | bool
-| Never co-locates multiple replicas of the integration in the same node (default *false*).
+| Never co-locates multiple replicas of the integration in the same node (default `false`).
 
 | affinity.node-affinity-labels
 | []string

--- a/docs/modules/traits/pages/builder.adoc
+++ b/docs/modules/traits/pages/builder.adoc
@@ -38,7 +38,7 @@ The following configuration options are available:
 
 | builder.strategy
 | string
-| The strategy to use, either `pod` or `routine` (default routine)
+| The strategy to use, either `pod` or `routine` (default `routine`)
 
 | builder.base-image
 | string
@@ -50,7 +50,7 @@ The following configuration options are available:
 
 | builder.order-strategy
 | string
-| The build order strategy to use, either `dependencies`, `fifo` or `sequential` (default sequential)
+| The build order strategy to use, either `dependencies`, `fifo` or `sequential` (default `sequential`)
 
 | builder.request-cpu
 | string

--- a/docs/modules/traits/pages/deployment.adoc
+++ b/docs/modules/traits/pages/deployment.adoc
@@ -31,7 +31,7 @@ The following configuration options are available:
 | deployment.progress-deadline-seconds
 | int32
 | The maximum time in seconds for the deployment to make progress before it
-is considered to be failed. It defaults to 60s.
+is considered to be failed. It defaults to `60s`.
 
 | deployment.strategy
 | DeploymentStrategyType
@@ -43,7 +43,7 @@ is considered to be failed. It defaults to 60s.
 Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 Absolute number is calculated from percentage by rounding down.
 This can not be 0 if MaxSurge is 0.
-Defaults to 25%.
+Defaults to `25%`.
 
 | deployment.rolling-update-max-surge
 | int
@@ -52,7 +52,7 @@ pods.
 Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 This can not be 0 if MaxUnavailable is 0.
 Absolute number is calculated from percentage by rounding up.
-Defaults to 25%.
+Defaults to `25%`.
 
 |===
 

--- a/docs/modules/traits/pages/logging.adoc
+++ b/docs/modules/traits/pages/logging.adoc
@@ -36,7 +36,7 @@ The following configuration options are available:
 
 | logging.level
 | string
-| Adjust the logging level (defaults to INFO)
+| Adjust the logging level (defaults to `INFO`)
 
 | logging.json
 | bool

--- a/docs/modules/traits/pages/mount.adoc
+++ b/docs/modules/traits/pages/mount.adoc
@@ -47,7 +47,7 @@ Syntax: [configmap\|secret]:name[/key][@path], where name represents the resourc
 
 | mount.hot-reload
 | bool
-| Enable "hot reload" when a secret/configmap mounted is edited (default false)
+| Enable "hot reload" when a secret/configmap mounted is edited (default `false`)
 
 |===
 

--- a/helm/camel-k/crds/crd-integration-kit.yaml
+++ b/helm/camel-k/crds/crd-integration-kit.yaml
@@ -213,6 +213,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       incrementalImageBuild:
+                        default: true
                         description: Use the incremental image build option, to reuse
                           existing containers (default `true`)
                         type: boolean
@@ -239,8 +240,13 @@ spec:
                           type: string
                         type: array
                       orderStrategy:
+                        default: sequential
                         description: The build order strategy to use, either `dependencies`,
-                          `fifo` or `sequential` (default sequential)
+                          `fifo` or `sequential` (default `sequential`)
+                        enum:
+                        - dependencies
+                        - fifo
+                        - sequential
                         type: string
                       properties:
                         description: A list of properties to be provided to the build
@@ -259,8 +265,12 @@ spec:
                           instead with task name `builder`.'
                         type: string
                       strategy:
+                        default: routine
                         description: The strategy to use, either `pod` or `routine`
-                          (default routine)
+                          (default `routine`)
+                        enum:
+                        - pod
+                        - routine
                         type: string
                       tasks:
                         description: A list of tasks to be executed (available only
@@ -327,6 +337,8 @@ spec:
                       build must have enough memory available.'
                     properties:
                       buildMode:
+                        default:
+                        - jvm
                         description: 'The Quarkus mode to run: either `jvm` or `native`
                           (default `jvm`). In case both `jvm` and `native` are specified,
                           two `IntegrationKit` resources are created, with the `native`
@@ -347,6 +359,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       nativeBaseImage:
+                        default: quay.io/quarkus/quarkus-micro-image:2.0
                         description: The base image to use when running a native build
                           (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                         type: string

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -472,8 +472,9 @@ spec:
                           type: string
                         type: array
                       podAffinity:
+                        default: false
                         description: Always co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -483,8 +484,9 @@ spec:
                           type: string
                         type: array
                       podAntiAffinity:
+                        default: false
                         description: Never co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAntiAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -509,6 +511,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       incrementalImageBuild:
+                        default: true
                         description: Use the incremental image build option, to reuse
                           existing containers (default `true`)
                         type: boolean
@@ -535,8 +538,13 @@ spec:
                           type: string
                         type: array
                       orderStrategy:
+                        default: sequential
                         description: The build order strategy to use, either `dependencies`,
-                          `fifo` or `sequential` (default sequential)
+                          `fifo` or `sequential` (default `sequential`)
+                        enum:
+                        - dependencies
+                        - fifo
+                        - sequential
                         type: string
                       properties:
                         description: A list of properties to be provided to the build
@@ -555,8 +563,12 @@ spec:
                           instead with task name `builder`.'
                         type: string
                       strategy:
+                        default: routine
                         description: The strategy to use, either `pod` or `routine`
-                          (default routine)
+                          (default `routine`)
+                        enum:
+                        - pod
+                        - routine
                         type: string
                       tasks:
                         description: A list of tasks to be executed (available only
@@ -651,10 +663,12 @@ spec:
                         description: The maximum amount of memory required.
                         type: string
                       name:
+                        default: integration
                         description: The main container name. It's named `integration`
                           by default.
                         type: string
                       port:
+                        default: 8080
                         description: To configure a different port exposed by the
                           container (default `8080`).
                         type: integer
@@ -670,10 +684,12 @@ spec:
                         description: The minimum amount of memory required.
                         type: string
                       servicePort:
+                        default: 80
                         description: To configure under which service port the container
                           port is to be exposed (default `80`).
                         type: integer
                       servicePortName:
+                        default: http
                         description: To configure under which service port name the
                           container port is to be exposed (default `http`).
                         type: string
@@ -682,6 +698,7 @@ spec:
                     description: The configuration of Cron trait
                     properties:
                       activeDeadlineSeconds:
+                        default: 60
                         description: Specifies the duration in seconds, relative to
                           the start time, that the job may be continuously active
                           before it is considered to be failed. It defaults to 60s.
@@ -697,6 +714,7 @@ spec:
                           be expressed as `0/1 * * * *`, while `35m` or `50s` cannot)."
                         type: boolean
                       backoffLimit:
+                        default: 2
                         description: Specifies the number of retries before marking
                           the job failed. It defaults to 2.
                         format: int32
@@ -782,6 +800,7 @@ spec:
                         - knative-service
                         type: string
                       useSSA:
+                        default: true
                         description: Use server-side apply to update the owned resources
                           (default `true`). Note that it automatically falls back
                           to client-side patching, if SSA is not available, e.g.,
@@ -800,25 +819,28 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       progressDeadlineSeconds:
+                        default: 60
                         description: The maximum time in seconds for the deployment
                           to make progress before it is considered to be failed. It
-                          defaults to 60s.
+                          defaults to `60s`.
                         format: int32
                         type: integer
                       rollingUpdateMaxSurge:
+                        default: 25
                         description: 'The maximum number of pods that can be scheduled
                           above the desired number of pods. Value can be an absolute
                           number (ex: 5) or a percentage of desired pods (ex: 10%).
                           This can not be 0 if MaxUnavailable is 0. Absolute number
                           is calculated from percentage by rounding up. Defaults to
-                          25%.'
+                          `25%`.'
                         type: integer
                       rollingUpdateMaxUnavailable:
+                        default: 25
                         description: 'The maximum number of pods that can be unavailable
                           during the update. Value can be an absolute number (ex:
                           5) or a percentage of desired pods (ex: 10%). Absolute number
                           is calculated from percentage by rounding down. This can
-                          not be 0 if MaxSurge is 0. Defaults to 25%.'
+                          not be 0 if MaxSurge is 0. Defaults to `25%`.'
                         type: integer
                       strategy:
                         description: The deployment strategy to use to replace existing
@@ -837,6 +859,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       containerMeta:
+                        default: true
                         description: Enables injection of `NAMESPACE` and `POD_NAME`
                           environment variables (default `true`)
                         type: boolean
@@ -844,6 +867,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       httpProxy:
+                        default: true
                         description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY` and
                           `NO_PROXY` environment variables (default `true`)
                         type: boolean
@@ -881,6 +905,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryCache:
+                        default: memory
                         description: 'Discovery client cache to be used, either `disabled`,
                           `disk` or `memory` (default `memory`). Deprecated: to be
                           removed from trait configuration.'
@@ -921,10 +946,12 @@ spec:
                         format: int32
                         type: integer
                       livenessProbeEnabled:
+                        default: false
                         description: Configures the liveness probe for the integration
                           container (default `false`).
                         type: boolean
                       livenessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the liveness
                           probe (default `HTTP`).
                         type: string
@@ -953,10 +980,12 @@ spec:
                         format: int32
                         type: integer
                       readinessProbeEnabled:
+                        default: true
                         description: Configures the readiness probe for the integration
                           container (default `true`).
                         type: boolean
                       readinessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the readiness
                           probe (default `HTTP`).
                         type: string
@@ -985,10 +1014,12 @@ spec:
                         format: int32
                         type: integer
                       startupProbeEnabled:
+                        default: false
                         description: Configures the startup probe for the integration
                           container (default `false`).
                         type: boolean
                       startupScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the startup
                           probe (default `HTTP`).
                         type: string
@@ -1030,10 +1061,12 @@ spec:
                         description: To configure the host exposed by the ingress.
                         type: string
                       path:
+                        default: /
                         description: To configure the path exposed by the ingress
                           (default `/`).
                         type: string
                       pathType:
+                        default: Prefix
                         description: To configure the path type exposed by the ingress.
                           One of `Exact`, `Prefix`, `ImplementationSpecific` (default
                           to `Prefix`).
@@ -1047,6 +1080,7 @@ spec:
                     description: The configuration of Istio trait
                     properties:
                       allow:
+                        default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                         description: Configures a (comma-separated) list of CIDR subnets
                           that should not be intercepted by the Istio proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`
                           by default).
@@ -1092,6 +1126,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryEnabled:
+                        default: false
                         description: Listen for multicast requests (default `false`)
                         type: boolean
                       enabled:
@@ -1105,6 +1140,7 @@ spec:
                           is `true` (default `true` for OpenShift).
                         type: boolean
                       host:
+                        default: '*'
                         description: The Host address to which the Jolokia agent should
                           bind to. If `"\*"` or `"0.0.0.0"` is given, the servers
                           binds to every network interface (default `"*"`).
@@ -1121,6 +1157,7 @@ spec:
                           when the `user` option is set.
                         type: string
                       port:
+                        default: 8778
                         description: The Jolokia endpoint port (default `8778`).
                         type: integer
                       protocol:
@@ -1152,6 +1189,7 @@ spec:
                           can be attached to the JVM, e.g., using port-forwarding
                         type: boolean
                       debugAddress:
+                        default: '*:5005'
                         description: Transport address at which to listen for the
                           newly launched JVM (default `*:5005`)
                         type: string
@@ -1169,6 +1207,7 @@ spec:
                           type: string
                         type: array
                       printCommand:
+                        default: true
                         description: Prints the command used the start the JVM in
                           the container logs (default `true`)
                         type: boolean
@@ -1177,6 +1216,7 @@ spec:
                     description: The configuration of Kamelets trait
                     properties:
                       auto:
+                        default: true
                         description: Automatically inject all referenced Kamelets
                           and their default configuration (enabled by default)
                         type: boolean
@@ -1194,6 +1234,7 @@ spec:
                           into the current integration
                         type: string
                       mountPoint:
+                        default: /etc/camel/kamelets
                         description: The directory where the application mounts and
                           reads Kamelet spec (default `/etc/camel/kamelets`)
                         type: string
@@ -1272,6 +1313,7 @@ spec:
                           in newer versions of Knative, filtering is disabled by default.
                         type: boolean
                       namespaceLabel:
+                        default: true
                         description: 'Enables the camel-k-operator to set the "bindings.knative.dev/include=true"
                           label to the namespace As Knative requires this label to
                           perform injection of K_SINK URL into the service. If this
@@ -1384,7 +1426,8 @@ spec:
                         description: Enable "pretty printing" of the JSON logs
                         type: boolean
                       level:
-                        description: Adjust the logging level (defaults to INFO)
+                        default: INFO
+                        description: Adjust the logging level (defaults to `INFO`)
                         enum:
                         - FATAL
                         - WARN
@@ -1427,8 +1470,9 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       hotReload:
+                        default: false
                         description: Enable "hot reload" when a secret/configmap mounted
-                          is edited (default false)
+                          is edited (default `false`)
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -1536,6 +1580,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       global:
+                        default: true
                         description: Indicates if the platform should be created globally
                           in the case of global operator (default true).
                         type: boolean
@@ -1566,6 +1611,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       podMonitor:
+                        default: true
                         description: Whether a `PodMonitor` resource is created (default
                           `true`).
                         type: boolean
@@ -1608,6 +1654,8 @@ spec:
                     description: The configuration of Quarkus trait
                     properties:
                       buildMode:
+                        default:
+                        - jvm
                         description: 'The Quarkus mode to run: either `jvm` or `native`
                           (default `jvm`). In case both `jvm` and `native` are specified,
                           two `IntegrationKit` resources are created, with the `native`
@@ -1628,6 +1676,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       nativeBaseImage:
+                        default: quay.io/quarkus/quarkus-micro-image:2.0
                         description: The base image to use when running a native build
                           (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                         type: string
@@ -1783,6 +1832,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       nodePort:
+                        default: false
                         description: 'Enable Service to be exposed as NodePort (default
                           `false`). Deprecated: Use service type instead.'
                         type: boolean
@@ -2293,8 +2343,9 @@ spec:
                           type: string
                         type: array
                       podAffinity:
+                        default: false
                         description: Always co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -2304,8 +2355,9 @@ spec:
                           type: string
                         type: array
                       podAntiAffinity:
+                        default: false
                         description: Never co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAntiAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -2330,6 +2382,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       incrementalImageBuild:
+                        default: true
                         description: Use the incremental image build option, to reuse
                           existing containers (default `true`)
                         type: boolean
@@ -2356,8 +2409,13 @@ spec:
                           type: string
                         type: array
                       orderStrategy:
+                        default: sequential
                         description: The build order strategy to use, either `dependencies`,
-                          `fifo` or `sequential` (default sequential)
+                          `fifo` or `sequential` (default `sequential`)
+                        enum:
+                        - dependencies
+                        - fifo
+                        - sequential
                         type: string
                       properties:
                         description: A list of properties to be provided to the build
@@ -2376,8 +2434,12 @@ spec:
                           instead with task name `builder`.'
                         type: string
                       strategy:
+                        default: routine
                         description: The strategy to use, either `pod` or `routine`
-                          (default routine)
+                          (default `routine`)
+                        enum:
+                        - pod
+                        - routine
                         type: string
                       tasks:
                         description: A list of tasks to be executed (available only
@@ -2472,10 +2534,12 @@ spec:
                         description: The maximum amount of memory required.
                         type: string
                       name:
+                        default: integration
                         description: The main container name. It's named `integration`
                           by default.
                         type: string
                       port:
+                        default: 8080
                         description: To configure a different port exposed by the
                           container (default `8080`).
                         type: integer
@@ -2491,10 +2555,12 @@ spec:
                         description: The minimum amount of memory required.
                         type: string
                       servicePort:
+                        default: 80
                         description: To configure under which service port the container
                           port is to be exposed (default `80`).
                         type: integer
                       servicePortName:
+                        default: http
                         description: To configure under which service port name the
                           container port is to be exposed (default `http`).
                         type: string
@@ -2503,6 +2569,7 @@ spec:
                     description: The configuration of Cron trait
                     properties:
                       activeDeadlineSeconds:
+                        default: 60
                         description: Specifies the duration in seconds, relative to
                           the start time, that the job may be continuously active
                           before it is considered to be failed. It defaults to 60s.
@@ -2518,6 +2585,7 @@ spec:
                           be expressed as `0/1 * * * *`, while `35m` or `50s` cannot)."
                         type: boolean
                       backoffLimit:
+                        default: 2
                         description: Specifies the number of retries before marking
                           the job failed. It defaults to 2.
                         format: int32
@@ -2603,6 +2671,7 @@ spec:
                         - knative-service
                         type: string
                       useSSA:
+                        default: true
                         description: Use server-side apply to update the owned resources
                           (default `true`). Note that it automatically falls back
                           to client-side patching, if SSA is not available, e.g.,
@@ -2621,25 +2690,28 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       progressDeadlineSeconds:
+                        default: 60
                         description: The maximum time in seconds for the deployment
                           to make progress before it is considered to be failed. It
-                          defaults to 60s.
+                          defaults to `60s`.
                         format: int32
                         type: integer
                       rollingUpdateMaxSurge:
+                        default: 25
                         description: 'The maximum number of pods that can be scheduled
                           above the desired number of pods. Value can be an absolute
                           number (ex: 5) or a percentage of desired pods (ex: 10%).
                           This can not be 0 if MaxUnavailable is 0. Absolute number
                           is calculated from percentage by rounding up. Defaults to
-                          25%.'
+                          `25%`.'
                         type: integer
                       rollingUpdateMaxUnavailable:
+                        default: 25
                         description: 'The maximum number of pods that can be unavailable
                           during the update. Value can be an absolute number (ex:
                           5) or a percentage of desired pods (ex: 10%). Absolute number
                           is calculated from percentage by rounding down. This can
-                          not be 0 if MaxSurge is 0. Defaults to 25%.'
+                          not be 0 if MaxSurge is 0. Defaults to `25%`.'
                         type: integer
                       strategy:
                         description: The deployment strategy to use to replace existing
@@ -2658,6 +2730,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       containerMeta:
+                        default: true
                         description: Enables injection of `NAMESPACE` and `POD_NAME`
                           environment variables (default `true`)
                         type: boolean
@@ -2665,6 +2738,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       httpProxy:
+                        default: true
                         description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY` and
                           `NO_PROXY` environment variables (default `true`)
                         type: boolean
@@ -2702,6 +2776,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryCache:
+                        default: memory
                         description: 'Discovery client cache to be used, either `disabled`,
                           `disk` or `memory` (default `memory`). Deprecated: to be
                           removed from trait configuration.'
@@ -2742,10 +2817,12 @@ spec:
                         format: int32
                         type: integer
                       livenessProbeEnabled:
+                        default: false
                         description: Configures the liveness probe for the integration
                           container (default `false`).
                         type: boolean
                       livenessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the liveness
                           probe (default `HTTP`).
                         type: string
@@ -2774,10 +2851,12 @@ spec:
                         format: int32
                         type: integer
                       readinessProbeEnabled:
+                        default: true
                         description: Configures the readiness probe for the integration
                           container (default `true`).
                         type: boolean
                       readinessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the readiness
                           probe (default `HTTP`).
                         type: string
@@ -2806,10 +2885,12 @@ spec:
                         format: int32
                         type: integer
                       startupProbeEnabled:
+                        default: false
                         description: Configures the startup probe for the integration
                           container (default `false`).
                         type: boolean
                       startupScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the startup
                           probe (default `HTTP`).
                         type: string
@@ -2851,10 +2932,12 @@ spec:
                         description: To configure the host exposed by the ingress.
                         type: string
                       path:
+                        default: /
                         description: To configure the path exposed by the ingress
                           (default `/`).
                         type: string
                       pathType:
+                        default: Prefix
                         description: To configure the path type exposed by the ingress.
                           One of `Exact`, `Prefix`, `ImplementationSpecific` (default
                           to `Prefix`).
@@ -2868,6 +2951,7 @@ spec:
                     description: The configuration of Istio trait
                     properties:
                       allow:
+                        default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                         description: Configures a (comma-separated) list of CIDR subnets
                           that should not be intercepted by the Istio proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`
                           by default).
@@ -2913,6 +2997,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryEnabled:
+                        default: false
                         description: Listen for multicast requests (default `false`)
                         type: boolean
                       enabled:
@@ -2926,6 +3011,7 @@ spec:
                           is `true` (default `true` for OpenShift).
                         type: boolean
                       host:
+                        default: '*'
                         description: The Host address to which the Jolokia agent should
                           bind to. If `"\*"` or `"0.0.0.0"` is given, the servers
                           binds to every network interface (default `"*"`).
@@ -2942,6 +3028,7 @@ spec:
                           when the `user` option is set.
                         type: string
                       port:
+                        default: 8778
                         description: The Jolokia endpoint port (default `8778`).
                         type: integer
                       protocol:
@@ -2973,6 +3060,7 @@ spec:
                           can be attached to the JVM, e.g., using port-forwarding
                         type: boolean
                       debugAddress:
+                        default: '*:5005'
                         description: Transport address at which to listen for the
                           newly launched JVM (default `*:5005`)
                         type: string
@@ -2990,6 +3078,7 @@ spec:
                           type: string
                         type: array
                       printCommand:
+                        default: true
                         description: Prints the command used the start the JVM in
                           the container logs (default `true`)
                         type: boolean
@@ -2998,6 +3087,7 @@ spec:
                     description: The configuration of Kamelets trait
                     properties:
                       auto:
+                        default: true
                         description: Automatically inject all referenced Kamelets
                           and their default configuration (enabled by default)
                         type: boolean
@@ -3015,6 +3105,7 @@ spec:
                           into the current integration
                         type: string
                       mountPoint:
+                        default: /etc/camel/kamelets
                         description: The directory where the application mounts and
                           reads Kamelet spec (default `/etc/camel/kamelets`)
                         type: string
@@ -3093,6 +3184,7 @@ spec:
                           in newer versions of Knative, filtering is disabled by default.
                         type: boolean
                       namespaceLabel:
+                        default: true
                         description: 'Enables the camel-k-operator to set the "bindings.knative.dev/include=true"
                           label to the namespace As Knative requires this label to
                           perform injection of K_SINK URL into the service. If this
@@ -3205,7 +3297,8 @@ spec:
                         description: Enable "pretty printing" of the JSON logs
                         type: boolean
                       level:
-                        description: Adjust the logging level (defaults to INFO)
+                        default: INFO
+                        description: Adjust the logging level (defaults to `INFO`)
                         enum:
                         - FATAL
                         - WARN
@@ -3248,8 +3341,9 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       hotReload:
+                        default: false
                         description: Enable "hot reload" when a secret/configmap mounted
-                          is edited (default false)
+                          is edited (default `false`)
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -3357,6 +3451,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       global:
+                        default: true
                         description: Indicates if the platform should be created globally
                           in the case of global operator (default true).
                         type: boolean
@@ -3387,6 +3482,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       podMonitor:
+                        default: true
                         description: Whether a `PodMonitor` resource is created (default
                           `true`).
                         type: boolean
@@ -3429,6 +3525,8 @@ spec:
                     description: The configuration of Quarkus trait
                     properties:
                       buildMode:
+                        default:
+                        - jvm
                         description: 'The Quarkus mode to run: either `jvm` or `native`
                           (default `jvm`). In case both `jvm` and `native` are specified,
                           two `IntegrationKit` resources are created, with the `native`
@@ -3449,6 +3547,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       nativeBaseImage:
+                        default: quay.io/quarkus/quarkus-micro-image:2.0
                         description: The base image to use when running a native build
                           (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                         type: string
@@ -3604,6 +3703,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       nodePort:
+                        default: false
                         description: 'Enable Service to be exposed as NodePort (default
                           `false`). Deprecated: Use service type instead.'
                         type: boolean

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -6392,8 +6392,9 @@ spec:
                           type: string
                         type: array
                       podAffinity:
+                        default: false
                         description: Always co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -6403,8 +6404,9 @@ spec:
                           type: string
                         type: array
                       podAntiAffinity:
+                        default: false
                         description: Never co-locates multiple replicas of the integration
-                          in the same node (default *false*).
+                          in the same node (default `false`).
                         type: boolean
                       podAntiAffinityLabels:
                         description: Defines a set of pods (namely those matching
@@ -6429,6 +6431,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       incrementalImageBuild:
+                        default: true
                         description: Use the incremental image build option, to reuse
                           existing containers (default `true`)
                         type: boolean
@@ -6455,8 +6458,13 @@ spec:
                           type: string
                         type: array
                       orderStrategy:
+                        default: sequential
                         description: The build order strategy to use, either `dependencies`,
-                          `fifo` or `sequential` (default sequential)
+                          `fifo` or `sequential` (default `sequential`)
+                        enum:
+                        - dependencies
+                        - fifo
+                        - sequential
                         type: string
                       properties:
                         description: A list of properties to be provided to the build
@@ -6475,8 +6483,12 @@ spec:
                           instead with task name `builder`.'
                         type: string
                       strategy:
+                        default: routine
                         description: The strategy to use, either `pod` or `routine`
-                          (default routine)
+                          (default `routine`)
+                        enum:
+                        - pod
+                        - routine
                         type: string
                       tasks:
                         description: A list of tasks to be executed (available only
@@ -6571,10 +6583,12 @@ spec:
                         description: The maximum amount of memory required.
                         type: string
                       name:
+                        default: integration
                         description: The main container name. It's named `integration`
                           by default.
                         type: string
                       port:
+                        default: 8080
                         description: To configure a different port exposed by the
                           container (default `8080`).
                         type: integer
@@ -6590,10 +6604,12 @@ spec:
                         description: The minimum amount of memory required.
                         type: string
                       servicePort:
+                        default: 80
                         description: To configure under which service port the container
                           port is to be exposed (default `80`).
                         type: integer
                       servicePortName:
+                        default: http
                         description: To configure under which service port name the
                           container port is to be exposed (default `http`).
                         type: string
@@ -6602,6 +6618,7 @@ spec:
                     description: The configuration of Cron trait
                     properties:
                       activeDeadlineSeconds:
+                        default: 60
                         description: Specifies the duration in seconds, relative to
                           the start time, that the job may be continuously active
                           before it is considered to be failed. It defaults to 60s.
@@ -6617,6 +6634,7 @@ spec:
                           be expressed as `0/1 * * * *`, while `35m` or `50s` cannot)."
                         type: boolean
                       backoffLimit:
+                        default: 2
                         description: Specifies the number of retries before marking
                           the job failed. It defaults to 2.
                         format: int32
@@ -6702,6 +6720,7 @@ spec:
                         - knative-service
                         type: string
                       useSSA:
+                        default: true
                         description: Use server-side apply to update the owned resources
                           (default `true`). Note that it automatically falls back
                           to client-side patching, if SSA is not available, e.g.,
@@ -6720,25 +6739,28 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       progressDeadlineSeconds:
+                        default: 60
                         description: The maximum time in seconds for the deployment
                           to make progress before it is considered to be failed. It
-                          defaults to 60s.
+                          defaults to `60s`.
                         format: int32
                         type: integer
                       rollingUpdateMaxSurge:
+                        default: 25
                         description: 'The maximum number of pods that can be scheduled
                           above the desired number of pods. Value can be an absolute
                           number (ex: 5) or a percentage of desired pods (ex: 10%).
                           This can not be 0 if MaxUnavailable is 0. Absolute number
                           is calculated from percentage by rounding up. Defaults to
-                          25%.'
+                          `25%`.'
                         type: integer
                       rollingUpdateMaxUnavailable:
+                        default: 25
                         description: 'The maximum number of pods that can be unavailable
                           during the update. Value can be an absolute number (ex:
                           5) or a percentage of desired pods (ex: 10%). Absolute number
                           is calculated from percentage by rounding down. This can
-                          not be 0 if MaxSurge is 0. Defaults to 25%.'
+                          not be 0 if MaxSurge is 0. Defaults to `25%`.'
                         type: integer
                       strategy:
                         description: The deployment strategy to use to replace existing
@@ -6757,6 +6779,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       containerMeta:
+                        default: true
                         description: Enables injection of `NAMESPACE` and `POD_NAME`
                           environment variables (default `true`)
                         type: boolean
@@ -6764,6 +6787,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       httpProxy:
+                        default: true
                         description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY` and
                           `NO_PROXY` environment variables (default `true`)
                         type: boolean
@@ -6801,6 +6825,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryCache:
+                        default: memory
                         description: 'Discovery client cache to be used, either `disabled`,
                           `disk` or `memory` (default `memory`). Deprecated: to be
                           removed from trait configuration.'
@@ -6841,10 +6866,12 @@ spec:
                         format: int32
                         type: integer
                       livenessProbeEnabled:
+                        default: false
                         description: Configures the liveness probe for the integration
                           container (default `false`).
                         type: boolean
                       livenessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the liveness
                           probe (default `HTTP`).
                         type: string
@@ -6873,10 +6900,12 @@ spec:
                         format: int32
                         type: integer
                       readinessProbeEnabled:
+                        default: true
                         description: Configures the readiness probe for the integration
                           container (default `true`).
                         type: boolean
                       readinessScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the readiness
                           probe (default `HTTP`).
                         type: string
@@ -6905,10 +6934,12 @@ spec:
                         format: int32
                         type: integer
                       startupProbeEnabled:
+                        default: false
                         description: Configures the startup probe for the integration
                           container (default `false`).
                         type: boolean
                       startupScheme:
+                        default: HTTP
                         description: Scheme to use when connecting to the startup
                           probe (default `HTTP`).
                         type: string
@@ -6950,10 +6981,12 @@ spec:
                         description: To configure the host exposed by the ingress.
                         type: string
                       path:
+                        default: /
                         description: To configure the path exposed by the ingress
                           (default `/`).
                         type: string
                       pathType:
+                        default: Prefix
                         description: To configure the path type exposed by the ingress.
                           One of `Exact`, `Prefix`, `ImplementationSpecific` (default
                           to `Prefix`).
@@ -6967,6 +7000,7 @@ spec:
                     description: The configuration of Istio trait
                     properties:
                       allow:
+                        default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                         description: Configures a (comma-separated) list of CIDR subnets
                           that should not be intercepted by the Istio proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`
                           by default).
@@ -7012,6 +7046,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       discoveryEnabled:
+                        default: false
                         description: Listen for multicast requests (default `false`)
                         type: boolean
                       enabled:
@@ -7025,6 +7060,7 @@ spec:
                           is `true` (default `true` for OpenShift).
                         type: boolean
                       host:
+                        default: '*'
                         description: The Host address to which the Jolokia agent should
                           bind to. If `"\*"` or `"0.0.0.0"` is given, the servers
                           binds to every network interface (default `"*"`).
@@ -7041,6 +7077,7 @@ spec:
                           when the `user` option is set.
                         type: string
                       port:
+                        default: 8778
                         description: The Jolokia endpoint port (default `8778`).
                         type: integer
                       protocol:
@@ -7072,6 +7109,7 @@ spec:
                           can be attached to the JVM, e.g., using port-forwarding
                         type: boolean
                       debugAddress:
+                        default: '*:5005'
                         description: Transport address at which to listen for the
                           newly launched JVM (default `*:5005`)
                         type: string
@@ -7089,6 +7127,7 @@ spec:
                           type: string
                         type: array
                       printCommand:
+                        default: true
                         description: Prints the command used the start the JVM in
                           the container logs (default `true`)
                         type: boolean
@@ -7097,6 +7136,7 @@ spec:
                     description: The configuration of Kamelets trait
                     properties:
                       auto:
+                        default: true
                         description: Automatically inject all referenced Kamelets
                           and their default configuration (enabled by default)
                         type: boolean
@@ -7114,6 +7154,7 @@ spec:
                           into the current integration
                         type: string
                       mountPoint:
+                        default: /etc/camel/kamelets
                         description: The directory where the application mounts and
                           reads Kamelet spec (default `/etc/camel/kamelets`)
                         type: string
@@ -7192,6 +7233,7 @@ spec:
                           in newer versions of Knative, filtering is disabled by default.
                         type: boolean
                       namespaceLabel:
+                        default: true
                         description: 'Enables the camel-k-operator to set the "bindings.knative.dev/include=true"
                           label to the namespace As Knative requires this label to
                           perform injection of K_SINK URL into the service. If this
@@ -7304,7 +7346,8 @@ spec:
                         description: Enable "pretty printing" of the JSON logs
                         type: boolean
                       level:
-                        description: Adjust the logging level (defaults to INFO)
+                        default: INFO
+                        description: Adjust the logging level (defaults to `INFO`)
                         enum:
                         - FATAL
                         - WARN
@@ -7347,8 +7390,9 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       hotReload:
+                        default: false
                         description: Enable "hot reload" when a secret/configmap mounted
-                          is edited (default false)
+                          is edited (default `false`)
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -7456,6 +7500,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       global:
+                        default: true
                         description: Indicates if the platform should be created globally
                           in the case of global operator (default true).
                         type: boolean
@@ -7486,6 +7531,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       podMonitor:
+                        default: true
                         description: Whether a `PodMonitor` resource is created (default
                           `true`).
                         type: boolean
@@ -7528,6 +7574,8 @@ spec:
                     description: The configuration of Quarkus trait
                     properties:
                       buildMode:
+                        default:
+                        - jvm
                         description: 'The Quarkus mode to run: either `jvm` or `native`
                           (default `jvm`). In case both `jvm` and `native` are specified,
                           two `IntegrationKit` resources are created, with the `native`
@@ -7548,6 +7596,7 @@ spec:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
                       nativeBaseImage:
+                        default: quay.io/quarkus/quarkus-micro-image:2.0
                         description: The base image to use when running a native build
                           (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                         type: string
@@ -7703,6 +7752,7 @@ spec:
                           traits share this common property.
                         type: boolean
                       nodePort:
+                        default: false
                         description: 'Enable Service to be exposed as NodePort (default
                           `false`). Deprecated: Use service type instead.'
                         type: boolean

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -6673,8 +6673,9 @@ spec:
                               type: string
                             type: array
                           podAffinity:
+                            default: false
                             description: Always co-locates multiple replicas of the
-                              integration in the same node (default *false*).
+                              integration in the same node (default `false`).
                             type: boolean
                           podAffinityLabels:
                             description: Defines a set of pods (namely those matching
@@ -6684,8 +6685,9 @@ spec:
                               type: string
                             type: array
                           podAntiAffinity:
+                            default: false
                             description: Never co-locates multiple replicas of the
-                              integration in the same node (default *false*).
+                              integration in the same node (default `false`).
                             type: boolean
                           podAntiAffinityLabels:
                             description: Defines a set of pods (namely those matching
@@ -6711,6 +6713,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           incrementalImageBuild:
+                            default: true
                             description: Use the incremental image build option, to
                               reuse existing containers (default `true`)
                             type: boolean
@@ -6738,8 +6741,13 @@ spec:
                               type: string
                             type: array
                           orderStrategy:
+                            default: sequential
                             description: The build order strategy to use, either `dependencies`,
-                              `fifo` or `sequential` (default sequential)
+                              `fifo` or `sequential` (default `sequential`)
+                            enum:
+                            - dependencies
+                            - fifo
+                            - sequential
                             type: string
                           properties:
                             description: A list of properties to be provided to the
@@ -6758,8 +6766,12 @@ spec:
                               TasksRequestCPU instead with task name `builder`.'
                             type: string
                           strategy:
+                            default: routine
                             description: The strategy to use, either `pod` or `routine`
-                              (default routine)
+                              (default `routine`)
+                            enum:
+                            - pod
+                            - routine
                             type: string
                           tasks:
                             description: A list of tasks to be executed (available
@@ -6854,10 +6866,12 @@ spec:
                             description: The maximum amount of memory required.
                             type: string
                           name:
+                            default: integration
                             description: The main container name. It's named `integration`
                               by default.
                             type: string
                           port:
+                            default: 8080
                             description: To configure a different port exposed by
                               the container (default `8080`).
                             type: integer
@@ -6873,10 +6887,12 @@ spec:
                             description: The minimum amount of memory required.
                             type: string
                           servicePort:
+                            default: 80
                             description: To configure under which service port the
                               container port is to be exposed (default `80`).
                             type: integer
                           servicePortName:
+                            default: http
                             description: To configure under which service port name
                               the container port is to be exposed (default `http`).
                             type: string
@@ -6885,6 +6901,7 @@ spec:
                         description: The configuration of Cron trait
                         properties:
                           activeDeadlineSeconds:
+                            default: 60
                             description: Specifies the duration in seconds, relative
                               to the start time, that the job may be continuously
                               active before it is considered to be failed. It defaults
@@ -6902,6 +6919,7 @@ spec:
                               `35m` or `50s` cannot)."
                             type: boolean
                           backoffLimit:
+                            default: 2
                             description: Specifies the number of retries before marking
                               the job failed. It defaults to 2.
                             format: int32
@@ -6987,6 +7005,7 @@ spec:
                             - knative-service
                             type: string
                           useSSA:
+                            default: true
                             description: Use server-side apply to update the owned
                               resources (default `true`). Note that it automatically
                               falls back to client-side patching, if SSA is not available,
@@ -7005,25 +7024,28 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           progressDeadlineSeconds:
+                            default: 60
                             description: The maximum time in seconds for the deployment
                               to make progress before it is considered to be failed.
-                              It defaults to 60s.
+                              It defaults to `60s`.
                             format: int32
                             type: integer
                           rollingUpdateMaxSurge:
+                            default: 25
                             description: 'The maximum number of pods that can be scheduled
                               above the desired number of pods. Value can be an absolute
                               number (ex: 5) or a percentage of desired pods (ex:
                               10%). This can not be 0 if MaxUnavailable is 0. Absolute
                               number is calculated from percentage by rounding up.
-                              Defaults to 25%.'
+                              Defaults to `25%`.'
                             type: integer
                           rollingUpdateMaxUnavailable:
+                            default: 25
                             description: 'The maximum number of pods that can be unavailable
                               during the update. Value can be an absolute number (ex:
                               5) or a percentage of desired pods (ex: 10%). Absolute
                               number is calculated from percentage by rounding down.
-                              This can not be 0 if MaxSurge is 0. Defaults to 25%.'
+                              This can not be 0 if MaxSurge is 0. Defaults to `25%`.'
                             type: integer
                           strategy:
                             description: The deployment strategy to use to replace
@@ -7042,6 +7064,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           containerMeta:
+                            default: true
                             description: Enables injection of `NAMESPACE` and `POD_NAME`
                               environment variables (default `true`)
                             type: boolean
@@ -7049,6 +7072,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           httpProxy:
+                            default: true
                             description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY`
                               and `NO_PROXY` environment variables (default `true`)
                             type: boolean
@@ -7086,6 +7110,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           discoveryCache:
+                            default: memory
                             description: 'Discovery client cache to be used, either
                               `disabled`, `disk` or `memory` (default `memory`). Deprecated:
                               to be removed from trait configuration.'
@@ -7126,10 +7151,12 @@ spec:
                             format: int32
                             type: integer
                           livenessProbeEnabled:
+                            default: false
                             description: Configures the liveness probe for the integration
                               container (default `false`).
                             type: boolean
                           livenessScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the liveness
                               probe (default `HTTP`).
                             type: string
@@ -7158,10 +7185,12 @@ spec:
                             format: int32
                             type: integer
                           readinessProbeEnabled:
+                            default: true
                             description: Configures the readiness probe for the integration
                               container (default `true`).
                             type: boolean
                           readinessScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the readiness
                               probe (default `HTTP`).
                             type: string
@@ -7190,10 +7219,12 @@ spec:
                             format: int32
                             type: integer
                           startupProbeEnabled:
+                            default: false
                             description: Configures the startup probe for the integration
                               container (default `false`).
                             type: boolean
                           startupScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the startup
                               probe (default `HTTP`).
                             type: string
@@ -7235,10 +7266,12 @@ spec:
                             description: To configure the host exposed by the ingress.
                             type: string
                           path:
+                            default: /
                             description: To configure the path exposed by the ingress
                               (default `/`).
                             type: string
                           pathType:
+                            default: Prefix
                             description: To configure the path type exposed by the
                               ingress. One of `Exact`, `Prefix`, `ImplementationSpecific`
                               (default to `Prefix`).
@@ -7252,6 +7285,7 @@ spec:
                         description: The configuration of Istio trait
                         properties:
                           allow:
+                            default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                             description: Configures a (comma-separated) list of CIDR
                               subnets that should not be intercepted by the Istio
                               proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` by
@@ -7298,6 +7332,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           discoveryEnabled:
+                            default: false
                             description: Listen for multicast requests (default `false`)
                             type: boolean
                           enabled:
@@ -7311,6 +7346,7 @@ spec:
                               is `true` (default `true` for OpenShift).
                             type: boolean
                           host:
+                            default: '*'
                             description: The Host address to which the Jolokia agent
                               should bind to. If `"\*"` or `"0.0.0.0"` is given, the
                               servers binds to every network interface (default `"*"`).
@@ -7327,6 +7363,7 @@ spec:
                               when the `user` option is set.
                             type: string
                           port:
+                            default: 8778
                             description: The Jolokia endpoint port (default `8778`).
                             type: integer
                           protocol:
@@ -7358,6 +7395,7 @@ spec:
                               can be attached to the JVM, e.g., using port-forwarding
                             type: boolean
                           debugAddress:
+                            default: '*:5005'
                             description: Transport address at which to listen for
                               the newly launched JVM (default `*:5005`)
                             type: string
@@ -7375,6 +7413,7 @@ spec:
                               type: string
                             type: array
                           printCommand:
+                            default: true
                             description: Prints the command used the start the JVM
                               in the container logs (default `true`)
                             type: boolean
@@ -7383,6 +7422,7 @@ spec:
                         description: The configuration of Kamelets trait
                         properties:
                           auto:
+                            default: true
                             description: Automatically inject all referenced Kamelets
                               and their default configuration (enabled by default)
                             type: boolean
@@ -7400,6 +7440,7 @@ spec:
                               load into the current integration
                             type: string
                           mountPoint:
+                            default: /etc/camel/kamelets
                             description: The directory where the application mounts
                               and reads Kamelet spec (default `/etc/camel/kamelets`)
                             type: string
@@ -7482,6 +7523,7 @@ spec:
                               by default.
                             type: boolean
                           namespaceLabel:
+                            default: true
                             description: 'Enables the camel-k-operator to set the
                               "bindings.knative.dev/include=true" label to the namespace
                               As Knative requires this label to perform injection
@@ -7599,7 +7641,8 @@ spec:
                             description: Enable "pretty printing" of the JSON logs
                             type: boolean
                           level:
-                            description: Adjust the logging level (defaults to INFO)
+                            default: INFO
+                            description: Adjust the logging level (defaults to `INFO`)
                             enum:
                             - FATAL
                             - WARN
@@ -7642,8 +7685,9 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           hotReload:
+                            default: false
                             description: Enable "hot reload" when a secret/configmap
-                              mounted is edited (default false)
+                              mounted is edited (default `false`)
                             type: boolean
                           resources:
                             description: 'A list of resources (text or binary content)
@@ -7751,6 +7795,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           global:
+                            default: true
                             description: Indicates if the platform should be created
                               globally in the case of global operator (default true).
                             type: boolean
@@ -7781,6 +7826,7 @@ spec:
                               All traits share this common property.
                             type: boolean
                           podMonitor:
+                            default: true
                             description: Whether a `PodMonitor` resource is created
                               (default `true`).
                             type: boolean
@@ -7823,6 +7869,8 @@ spec:
                         description: The configuration of Quarkus trait
                         properties:
                           buildMode:
+                            default:
+                            - jvm
                             description: 'The Quarkus mode to run: either `jvm` or
                               `native` (default `jvm`). In case both `jvm` and `native`
                               are specified, two `IntegrationKit` resources are created,
@@ -7845,6 +7893,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           nativeBaseImage:
+                            default: quay.io/quarkus/quarkus-micro-image:2.0
                             description: The base image to use when running a native
                               build (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                             type: string
@@ -8009,6 +8058,7 @@ spec:
                               All traits share this common property.
                             type: boolean
                           nodePort:
+                            default: false
                             description: 'Enable Service to be exposed as NodePort
                               (default `false`). Deprecated: Use service type instead.'
                             type: boolean

--- a/helm/camel-k/crds/crd-pipe.yaml
+++ b/helm/camel-k/crds/crd-pipe.yaml
@@ -6671,8 +6671,9 @@ spec:
                               type: string
                             type: array
                           podAffinity:
+                            default: false
                             description: Always co-locates multiple replicas of the
-                              integration in the same node (default *false*).
+                              integration in the same node (default `false`).
                             type: boolean
                           podAffinityLabels:
                             description: Defines a set of pods (namely those matching
@@ -6682,8 +6683,9 @@ spec:
                               type: string
                             type: array
                           podAntiAffinity:
+                            default: false
                             description: Never co-locates multiple replicas of the
-                              integration in the same node (default *false*).
+                              integration in the same node (default `false`).
                             type: boolean
                           podAntiAffinityLabels:
                             description: Defines a set of pods (namely those matching
@@ -6709,6 +6711,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           incrementalImageBuild:
+                            default: true
                             description: Use the incremental image build option, to
                               reuse existing containers (default `true`)
                             type: boolean
@@ -6736,8 +6739,13 @@ spec:
                               type: string
                             type: array
                           orderStrategy:
+                            default: sequential
                             description: The build order strategy to use, either `dependencies`,
-                              `fifo` or `sequential` (default sequential)
+                              `fifo` or `sequential` (default `sequential`)
+                            enum:
+                            - dependencies
+                            - fifo
+                            - sequential
                             type: string
                           properties:
                             description: A list of properties to be provided to the
@@ -6756,8 +6764,12 @@ spec:
                               TasksRequestCPU instead with task name `builder`.'
                             type: string
                           strategy:
+                            default: routine
                             description: The strategy to use, either `pod` or `routine`
-                              (default routine)
+                              (default `routine`)
+                            enum:
+                            - pod
+                            - routine
                             type: string
                           tasks:
                             description: A list of tasks to be executed (available
@@ -6852,10 +6864,12 @@ spec:
                             description: The maximum amount of memory required.
                             type: string
                           name:
+                            default: integration
                             description: The main container name. It's named `integration`
                               by default.
                             type: string
                           port:
+                            default: 8080
                             description: To configure a different port exposed by
                               the container (default `8080`).
                             type: integer
@@ -6871,10 +6885,12 @@ spec:
                             description: The minimum amount of memory required.
                             type: string
                           servicePort:
+                            default: 80
                             description: To configure under which service port the
                               container port is to be exposed (default `80`).
                             type: integer
                           servicePortName:
+                            default: http
                             description: To configure under which service port name
                               the container port is to be exposed (default `http`).
                             type: string
@@ -6883,6 +6899,7 @@ spec:
                         description: The configuration of Cron trait
                         properties:
                           activeDeadlineSeconds:
+                            default: 60
                             description: Specifies the duration in seconds, relative
                               to the start time, that the job may be continuously
                               active before it is considered to be failed. It defaults
@@ -6900,6 +6917,7 @@ spec:
                               `35m` or `50s` cannot)."
                             type: boolean
                           backoffLimit:
+                            default: 2
                             description: Specifies the number of retries before marking
                               the job failed. It defaults to 2.
                             format: int32
@@ -6985,6 +7003,7 @@ spec:
                             - knative-service
                             type: string
                           useSSA:
+                            default: true
                             description: Use server-side apply to update the owned
                               resources (default `true`). Note that it automatically
                               falls back to client-side patching, if SSA is not available,
@@ -7003,25 +7022,28 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           progressDeadlineSeconds:
+                            default: 60
                             description: The maximum time in seconds for the deployment
                               to make progress before it is considered to be failed.
-                              It defaults to 60s.
+                              It defaults to `60s`.
                             format: int32
                             type: integer
                           rollingUpdateMaxSurge:
+                            default: 25
                             description: 'The maximum number of pods that can be scheduled
                               above the desired number of pods. Value can be an absolute
                               number (ex: 5) or a percentage of desired pods (ex:
                               10%). This can not be 0 if MaxUnavailable is 0. Absolute
                               number is calculated from percentage by rounding up.
-                              Defaults to 25%.'
+                              Defaults to `25%`.'
                             type: integer
                           rollingUpdateMaxUnavailable:
+                            default: 25
                             description: 'The maximum number of pods that can be unavailable
                               during the update. Value can be an absolute number (ex:
                               5) or a percentage of desired pods (ex: 10%). Absolute
                               number is calculated from percentage by rounding down.
-                              This can not be 0 if MaxSurge is 0. Defaults to 25%.'
+                              This can not be 0 if MaxSurge is 0. Defaults to `25%`.'
                             type: integer
                           strategy:
                             description: The deployment strategy to use to replace
@@ -7040,6 +7062,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           containerMeta:
+                            default: true
                             description: Enables injection of `NAMESPACE` and `POD_NAME`
                               environment variables (default `true`)
                             type: boolean
@@ -7047,6 +7070,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           httpProxy:
+                            default: true
                             description: Propagates the `HTTP_PROXY`, `HTTPS_PROXY`
                               and `NO_PROXY` environment variables (default `true`)
                             type: boolean
@@ -7084,6 +7108,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           discoveryCache:
+                            default: memory
                             description: 'Discovery client cache to be used, either
                               `disabled`, `disk` or `memory` (default `memory`). Deprecated:
                               to be removed from trait configuration.'
@@ -7124,10 +7149,12 @@ spec:
                             format: int32
                             type: integer
                           livenessProbeEnabled:
+                            default: false
                             description: Configures the liveness probe for the integration
                               container (default `false`).
                             type: boolean
                           livenessScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the liveness
                               probe (default `HTTP`).
                             type: string
@@ -7156,10 +7183,12 @@ spec:
                             format: int32
                             type: integer
                           readinessProbeEnabled:
+                            default: true
                             description: Configures the readiness probe for the integration
                               container (default `true`).
                             type: boolean
                           readinessScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the readiness
                               probe (default `HTTP`).
                             type: string
@@ -7188,10 +7217,12 @@ spec:
                             format: int32
                             type: integer
                           startupProbeEnabled:
+                            default: false
                             description: Configures the startup probe for the integration
                               container (default `false`).
                             type: boolean
                           startupScheme:
+                            default: HTTP
                             description: Scheme to use when connecting to the startup
                               probe (default `HTTP`).
                             type: string
@@ -7233,10 +7264,12 @@ spec:
                             description: To configure the host exposed by the ingress.
                             type: string
                           path:
+                            default: /
                             description: To configure the path exposed by the ingress
                               (default `/`).
                             type: string
                           pathType:
+                            default: Prefix
                             description: To configure the path type exposed by the
                               ingress. One of `Exact`, `Prefix`, `ImplementationSpecific`
                               (default to `Prefix`).
@@ -7250,6 +7283,7 @@ spec:
                         description: The configuration of Istio trait
                         properties:
                           allow:
+                            default: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
                             description: Configures a (comma-separated) list of CIDR
                               subnets that should not be intercepted by the Istio
                               proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` by
@@ -7296,6 +7330,7 @@ spec:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                           discoveryEnabled:
+                            default: false
                             description: Listen for multicast requests (default `false`)
                             type: boolean
                           enabled:
@@ -7309,6 +7344,7 @@ spec:
                               is `true` (default `true` for OpenShift).
                             type: boolean
                           host:
+                            default: '*'
                             description: The Host address to which the Jolokia agent
                               should bind to. If `"\*"` or `"0.0.0.0"` is given, the
                               servers binds to every network interface (default `"*"`).
@@ -7325,6 +7361,7 @@ spec:
                               when the `user` option is set.
                             type: string
                           port:
+                            default: 8778
                             description: The Jolokia endpoint port (default `8778`).
                             type: integer
                           protocol:
@@ -7356,6 +7393,7 @@ spec:
                               can be attached to the JVM, e.g., using port-forwarding
                             type: boolean
                           debugAddress:
+                            default: '*:5005'
                             description: Transport address at which to listen for
                               the newly launched JVM (default `*:5005`)
                             type: string
@@ -7373,6 +7411,7 @@ spec:
                               type: string
                             type: array
                           printCommand:
+                            default: true
                             description: Prints the command used the start the JVM
                               in the container logs (default `true`)
                             type: boolean
@@ -7381,6 +7420,7 @@ spec:
                         description: The configuration of Kamelets trait
                         properties:
                           auto:
+                            default: true
                             description: Automatically inject all referenced Kamelets
                               and their default configuration (enabled by default)
                             type: boolean
@@ -7398,6 +7438,7 @@ spec:
                               load into the current integration
                             type: string
                           mountPoint:
+                            default: /etc/camel/kamelets
                             description: The directory where the application mounts
                               and reads Kamelet spec (default `/etc/camel/kamelets`)
                             type: string
@@ -7480,6 +7521,7 @@ spec:
                               by default.
                             type: boolean
                           namespaceLabel:
+                            default: true
                             description: 'Enables the camel-k-operator to set the
                               "bindings.knative.dev/include=true" label to the namespace
                               As Knative requires this label to perform injection
@@ -7597,7 +7639,8 @@ spec:
                             description: Enable "pretty printing" of the JSON logs
                             type: boolean
                           level:
-                            description: Adjust the logging level (defaults to INFO)
+                            default: INFO
+                            description: Adjust the logging level (defaults to `INFO`)
                             enum:
                             - FATAL
                             - WARN
@@ -7640,8 +7683,9 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           hotReload:
+                            default: false
                             description: Enable "hot reload" when a secret/configmap
-                              mounted is edited (default false)
+                              mounted is edited (default `false`)
                             type: boolean
                           resources:
                             description: 'A list of resources (text or binary content)
@@ -7749,6 +7793,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           global:
+                            default: true
                             description: Indicates if the platform should be created
                               globally in the case of global operator (default true).
                             type: boolean
@@ -7779,6 +7824,7 @@ spec:
                               All traits share this common property.
                             type: boolean
                           podMonitor:
+                            default: true
                             description: Whether a `PodMonitor` resource is created
                               (default `true`).
                             type: boolean
@@ -7821,6 +7867,8 @@ spec:
                         description: The configuration of Quarkus trait
                         properties:
                           buildMode:
+                            default:
+                            - jvm
                             description: 'The Quarkus mode to run: either `jvm` or
                               `native` (default `jvm`). In case both `jvm` and `native`
                               are specified, two `IntegrationKit` resources are created,
@@ -7843,6 +7891,7 @@ spec:
                             description: 'Deprecated: no longer in use.'
                             type: boolean
                           nativeBaseImage:
+                            default: quay.io/quarkus/quarkus-micro-image:2.0
                             description: The base image to use when running a native
                               build (default `quay.io/quarkus/quarkus-micro-image:2.0`)
                             type: string
@@ -8007,6 +8056,7 @@ spec:
                               All traits share this common property.
                             type: boolean
                           nodePort:
+                            default: false
                             description: 'Enable Service to be exposed as NodePort
                               (default `false`). Deprecated: Use service type instead.'
                             type: boolean

--- a/pkg/apis/camel/v1/trait/affinity.go
+++ b/pkg/apis/camel/v1/trait/affinity.go
@@ -25,9 +25,11 @@ package trait
 // +camel-k:trait=affinity.
 type AffinityTrait struct {
 	Trait `property:",squash" json:",inline"`
-	// Always co-locates multiple replicas of the integration in the same node (default *false*).
+	// +kubebuilder:default=false
+	// Always co-locates multiple replicas of the integration in the same node (default `false`).
 	PodAffinity *bool `property:"pod-affinity" json:"podAffinity,omitempty"`
-	// Never co-locates multiple replicas of the integration in the same node (default *false*).
+	// +kubebuilder:default=false
+	// Never co-locates multiple replicas of the integration in the same node (default `false`).
 	PodAntiAffinity *bool `property:"pod-anti-affinity" json:"podAntiAffinity,omitempty"`
 	// Defines a set of nodes the integration pod(s) are eligible to be scheduled on, based on labels on the node.
 	NodeAffinityLabels []string `property:"node-affinity-labels" json:"nodeAffinityLabels,omitempty"`

--- a/pkg/apis/camel/v1/trait/builder.go
+++ b/pkg/apis/camel/v1/trait/builder.go
@@ -27,13 +27,18 @@ type BuilderTrait struct {
 	Verbose *bool `property:"verbose" json:"verbose,omitempty"`
 	// A list of properties to be provided to the build task
 	Properties []string `property:"properties" json:"properties,omitempty"`
-	// The strategy to use, either `pod` or `routine` (default routine)
+	// The strategy to use, either `pod` or `routine` (default `routine`)
+	// +kubebuilder:validation:Enum=pod;routine
+	// +kubebuilder:default="routine"
 	Strategy string `property:"strategy" json:"strategy,omitempty"`
 	// Specify a base image
 	BaseImage string `property:"base-image" json:"baseImage,omitempty"`
 	// Use the incremental image build option, to reuse existing containers (default `true`)
+	// +kubebuilder:default=true
 	IncrementalImageBuild *bool `property:"incremental-image-build" json:"incrementalImageBuild,omitempty"`
-	// The build order strategy to use, either `dependencies`, `fifo` or `sequential` (default sequential)
+	// The build order strategy to use, either `dependencies`, `fifo` or `sequential` (default `sequential`)
+	// +kubebuilder:validation:Enum=dependencies;fifo;sequential
+	// +kubebuilder:default="sequential"
 	OrderStrategy string `property:"order-strategy" json:"orderStrategy,omitempty"`
 	// When using `pod` strategy, the minimum amount of CPU required by the pod builder.
 	// Deprecated: use TasksRequestCPU instead with task name `builder`.

--- a/pkg/apis/camel/v1/trait/container.go
+++ b/pkg/apis/camel/v1/trait/container.go
@@ -40,14 +40,18 @@ type ContainerTrait struct {
 	// Can be used to enable/disable exposure via kubernetes Service.
 	Expose *bool `property:"expose" json:"expose,omitempty"`
 	// To configure a different port exposed by the container (default `8080`).
+	// +kubebuilder:default=8080
 	Port int `property:"port" json:"port,omitempty"`
 	// To configure a different port name for the port exposed by the container. It defaults to `http` only when the `expose` parameter is true.
 	PortName string `property:"port-name" json:"portName,omitempty"`
 	// To configure under which service port the container port is to be exposed (default `80`).
+	// +kubebuilder:default=80
 	ServicePort int `property:"service-port" json:"servicePort,omitempty"`
 	// To configure under which service port name the container port is to be exposed (default `http`).
+	// +kubebuilder:default="http"
 	ServicePortName string `property:"service-port-name" json:"servicePortName,omitempty"`
 	// The main container name. It's named `integration` by default.
+	// +kubebuilder:default="integration"
 	Name string `property:"name" json:"name,omitempty"`
 	// The main container image
 	Image string `property:"image" json:"image,omitempty"`

--- a/pkg/apis/camel/v1/trait/cron.go
+++ b/pkg/apis/camel/v1/trait/cron.go
@@ -68,8 +68,10 @@ type CronTrait struct {
 	// Specifies the duration in seconds, relative to the start time, that the job
 	// may be continuously active before it is considered to be failed.
 	// It defaults to 60s.
+	// +kubebuilder:default=60
 	ActiveDeadlineSeconds *int64 `property:"active-deadline-seconds" json:"activeDeadlineSeconds,omitempty"`
 	// Specifies the number of retries before marking the job failed.
 	// It defaults to 2.
+	// +kubebuilder:default=2
 	BackoffLimit *int32 `property:"backoff-limit" json:"backoffLimit,omitempty"`
 }

--- a/pkg/apis/camel/v1/trait/deployer.go
+++ b/pkg/apis/camel/v1/trait/deployer.go
@@ -28,5 +28,6 @@ type DeployerTrait struct {
 	Kind string `property:"kind" json:"kind,omitempty"`
 	// Use server-side apply to update the owned resources (default `true`).
 	// Note that it automatically falls back to client-side patching, if SSA is not available, e.g., on old Kubernetes clusters.
+	// +kubebuilder:default=true
 	UseSSA *bool `property:"use-ssa" json:"useSSA,omitempty"`
 }

--- a/pkg/apis/camel/v1/trait/deployment.go
+++ b/pkg/apis/camel/v1/trait/deployment.go
@@ -28,7 +28,8 @@ import (
 type DeploymentTrait struct {
 	PlatformBaseTrait `property:",squash" json:",inline"`
 	// The maximum time in seconds for the deployment to make progress before it
-	// is considered to be failed. It defaults to 60s.
+	// is considered to be failed. It defaults to `60s`.
+	// +kubebuilder:default=60
 	ProgressDeadlineSeconds *int32 `property:"progress-deadline-seconds" json:"progressDeadlineSeconds,omitempty"`
 	// The deployment strategy to use to replace existing pods with new ones.
 	// +kubebuilder:validation:Enum=Recreate;RollingUpdate
@@ -37,13 +38,15 @@ type DeploymentTrait struct {
 	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 	// Absolute number is calculated from percentage by rounding down.
 	// This can not be 0 if MaxSurge is 0.
-	// Defaults to 25%.
+	// Defaults to `25%`.
+	// +kubebuilder:default=25
 	RollingUpdateMaxUnavailable *int `property:"rolling-update-max-unavailable" json:"rollingUpdateMaxUnavailable,omitempty"`
 	// The maximum number of pods that can be scheduled above the desired number of
 	// pods.
 	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 	// This can not be 0 if MaxUnavailable is 0.
 	// Absolute number is calculated from percentage by rounding up.
-	// Defaults to 25%.
+	// Defaults to `25%`.
+	// +kubebuilder:default=25
 	RollingUpdateMaxSurge *int `property:"rolling-update-max-surge" json:"rollingUpdateMaxSurge,omitempty"`
 }

--- a/pkg/apis/camel/v1/trait/environment.go
+++ b/pkg/apis/camel/v1/trait/environment.go
@@ -24,8 +24,10 @@ package trait
 type EnvironmentTrait struct {
 	PlatformBaseTrait `property:",squash" json:",inline"`
 	// Enables injection of `NAMESPACE` and `POD_NAME` environment variables (default `true`)
+	// +kubebuilder:default=true
 	ContainerMeta *bool `property:"container-meta" json:"containerMeta,omitempty"`
 	// Propagates the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables (default `true`)
+	// +kubebuilder:default=true
 	HTTPProxy *bool `property:"http-proxy" json:"httpProxy,omitempty"`
 	// A list of environment variables to be added to the integration container.
 	// The syntax is KEY=VALUE, e.g., `MY_VAR="my value"`.

--- a/pkg/apis/camel/v1/trait/gc.go
+++ b/pkg/apis/camel/v1/trait/gc.go
@@ -24,6 +24,7 @@ type GCTrait struct {
 	Trait `property:",squash" json:",inline"`
 	// Discovery client cache to be used, either `disabled`, `disk` or `memory` (default `memory`).
 	// Deprecated: to be removed from trait configuration.
+	// +kubebuilder:default="memory"
 	DiscoveryCache *DiscoveryCacheType `property:"discovery-cache" json:"discoveryCache,omitempty"`
 }
 

--- a/pkg/apis/camel/v1/trait/health.go
+++ b/pkg/apis/camel/v1/trait/health.go
@@ -26,8 +26,10 @@ type HealthTrait struct {
 	Trait `property:",squash" json:",inline"`
 
 	// Configures the liveness probe for the integration container (default `false`).
+	// +kubebuilder:default=false
 	LivenessProbeEnabled *bool `property:"liveness-probe-enabled" json:"livenessProbeEnabled,omitempty"`
 	// Scheme to use when connecting to the liveness probe (default `HTTP`).
+	// +kubebuilder:default="HTTP"
 	LivenessScheme string `property:"liveness-scheme" json:"livenessScheme,omitempty"`
 	// Number of seconds after the container has started before the liveness probe is initiated.
 	LivenessInitialDelay int32 `property:"liveness-initial-delay" json:"livenessInitialDelay,omitempty"`
@@ -41,8 +43,10 @@ type HealthTrait struct {
 	LivenessFailureThreshold int32 `property:"liveness-failure-threshold" json:"livenessFailureThreshold,omitempty"`
 
 	// Configures the readiness probe for the integration container (default `true`).
+	// +kubebuilder:default=true
 	ReadinessProbeEnabled *bool `property:"readiness-probe-enabled" json:"readinessProbeEnabled,omitempty"`
 	// Scheme to use when connecting to the readiness probe (default `HTTP`).
+	// +kubebuilder:default="HTTP"
 	ReadinessScheme string `property:"readiness-scheme" json:"readinessScheme,omitempty"`
 	// Number of seconds after the container has started before the readiness probe is initiated.
 	ReadinessInitialDelay int32 `property:"readiness-initial-delay" json:"readinessInitialDelay,omitempty"`
@@ -56,8 +60,10 @@ type HealthTrait struct {
 	ReadinessFailureThreshold int32 `property:"readiness-failure-threshold" json:"readinessFailureThreshold,omitempty"`
 
 	// Configures the startup probe for the integration container (default `false`).
+	// +kubebuilder:default=false
 	StartupProbeEnabled *bool `property:"startup-probe-enabled" json:"startupProbeEnabled,omitempty"`
 	// Scheme to use when connecting to the startup probe (default `HTTP`).
+	// +kubebuilder:default="HTTP"
 	StartupScheme string `property:"startup-scheme" json:"startupScheme,omitempty"`
 	// Number of seconds after the container has started before the startup probe is initiated.
 	StartupInitialDelay int32 `property:"startup-initial-delay" json:"startupInitialDelay,omitempty"`

--- a/pkg/apis/camel/v1/trait/ingress.go
+++ b/pkg/apis/camel/v1/trait/ingress.go
@@ -34,10 +34,12 @@ type IngressTrait struct {
 	// To configure the host exposed by the ingress.
 	Host string `property:"host" json:"host,omitempty"`
 	// To configure the path exposed by the ingress (default `/`).
+	// +kubebuilder:default="/"
 	Path string `property:"path" json:"path,omitempty"`
 	// To configure the path type exposed by the ingress.
 	// One of `Exact`, `Prefix`, `ImplementationSpecific` (default to `Prefix`).
 	// +kubebuilder:validation:Enum=Exact;Prefix;ImplementationSpecific
+	// +kubebuilder:default="Prefix"
 	PathType *networkingv1.PathType `property:"path-type" json:"pathType,omitempty"`
 	// To automatically add an ingress whenever the integration uses an HTTP endpoint consumer.
 	Auto *bool `property:"auto" json:"auto,omitempty"`

--- a/pkg/apis/camel/v1/trait/istio.go
+++ b/pkg/apis/camel/v1/trait/istio.go
@@ -24,6 +24,7 @@ package trait
 type IstioTrait struct {
 	Trait `property:",squash" json:",inline"`
 	// Configures a (comma-separated) list of CIDR subnets that should not be intercepted by the Istio proxy (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` by default).
+	// +kubebuilder:default="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 	Allow string `property:"allow" json:"allow,omitempty"`
 	// Forces the value for labels `sidecar.istio.io/inject`. By default the label is set to `true` on deployment and not set on Knative Service.
 	Inject *bool `property:"inject" json:"inject,omitempty"`

--- a/pkg/apis/camel/v1/trait/jolokia.go
+++ b/pkg/apis/camel/v1/trait/jolokia.go
@@ -34,6 +34,7 @@ type JolokiaTrait struct {
 	// (default `clientPrincipal=cn=system:master-proxy`, `cn=hawtio-online.hawtio.svc` and `cn=fuse-console.fuse.svc` for OpenShift).
 	ClientPrincipal []string `property:"client-principal" json:"clientPrincipal,omitempty"`
 	// Listen for multicast requests (default `false`)
+	// +kubebuilder:default=false
 	DiscoveryEnabled *bool `property:"discovery-enabled" json:"discoveryEnabled,omitempty"`
 	// Mandate the client certificate contains a client flag in the extended key usage section,
 	// applicable when `protocol` is `https` and `use-ssl-client-authentication` is `true`
@@ -41,10 +42,12 @@ type JolokiaTrait struct {
 	ExtendedClientCheck *bool `property:"extended-client-check" json:"extendedClientCheck,omitempty"`
 	// The Host address to which the Jolokia agent should bind to. If `"\*"` or `"0.0.0.0"` is given,
 	// the servers binds to every network interface (default `"*"`).
+	// +kubebuilder:default="*"
 	Host *string `property:"host" json:"host,omitempty"`
 	// The password used for authentication, applicable when the `user` option is set.
 	Password *string `property:"password" json:"password,omitempty"`
 	// The Jolokia endpoint port (default `8778`).
+	// +kubebuilder:default=8778
 	Port int `property:"port" json:"port,omitempty"`
 	// The protocol to use, either `http` or `https` (default `https` for OpenShift)
 	Protocol *string `property:"protocol" json:"protocol,omitempty"`

--- a/pkg/apis/camel/v1/trait/jvm.go
+++ b/pkg/apis/camel/v1/trait/jvm.go
@@ -31,8 +31,10 @@ type JVMTrait struct {
 	// Suspends the target JVM immediately before the main class is loaded
 	DebugSuspend *bool `property:"debug-suspend" json:"debugSuspend,omitempty"`
 	// Prints the command used the start the JVM in the container logs (default `true`)
+	// +kubebuilder:default=true
 	PrintCommand *bool `property:"print-command" json:"printCommand,omitempty"`
 	// Transport address at which to listen for the newly launched JVM (default `*:5005`)
+	// +kubebuilder:default="*:5005"
 	DebugAddress string `property:"debug-address" json:"debugAddress,omitempty"`
 	// A list of JVM options
 	Options []string `property:"options" json:"options,omitempty"`

--- a/pkg/apis/camel/v1/trait/kamelets.go
+++ b/pkg/apis/camel/v1/trait/kamelets.go
@@ -23,9 +23,11 @@ package trait
 type KameletsTrait struct {
 	Trait `property:",squash" json:",inline"`
 	// Automatically inject all referenced Kamelets and their default configuration (enabled by default)
+	// +kubebuilder:default=true
 	Auto *bool `property:"auto" json:"auto,omitempty"`
 	// Comma separated list of Kamelet names to load into the current integration
 	List string `property:"list" json:"list,omitempty"`
 	// The directory where the application mounts and reads Kamelet spec (default `/etc/camel/kamelets`)
+	// +kubebuilder:default="/etc/camel/kamelets"
 	MountPoint string `property:"mount-point" json:"mountPoint,omitempty"`
 }

--- a/pkg/apis/camel/v1/trait/knative.go
+++ b/pkg/apis/camel/v1/trait/knative.go
@@ -60,5 +60,6 @@ type KnativeTrait struct {
 	// Enables the camel-k-operator to set the "bindings.knative.dev/include=true" label to the namespace
 	// As Knative requires this label to perform injection of K_SINK URL into the service.
 	// If this is false, the integration pod may start and fail, read the SinkBinding Knative documentation. (default: true)
+	// +kubebuilder:default=true
 	NamespaceLabel *bool `property:"namespace-label" json:"namespaceLabel,omitempty"`
 }

--- a/pkg/apis/camel/v1/trait/logging.go
+++ b/pkg/apis/camel/v1/trait/logging.go
@@ -27,8 +27,9 @@ type LoggingTrait struct {
 	Color *bool `property:"color" json:"color,omitempty"`
 	// Logs message format
 	Format string `property:"format" json:"format,omitempty"`
-	// Adjust the logging level (defaults to INFO)
+	// Adjust the logging level (defaults to `INFO`)
 	// +kubebuilder:validation:Enum=FATAL;WARN;INFO;DEBUG;TRACE
+	// +kubebuilder:default="INFO"
 	Level string `property:"level" json:"level,omitempty"`
 	// Output the logs in JSON
 	JSON *bool `property:"json" json:"json,omitempty"`

--- a/pkg/apis/camel/v1/trait/mount.go
+++ b/pkg/apis/camel/v1/trait/mount.go
@@ -35,6 +35,7 @@ type MountTrait struct {
 	Resources []string `property:"resources" json:"resources,omitempty"`
 	// A list of Persistent Volume Claims to be mounted. Syntax: [pvcname:/container/path]
 	Volumes []string `property:"volumes" json:"volumes,omitempty"`
-	// Enable "hot reload" when a secret/configmap mounted is edited (default false)
+	// Enable "hot reload" when a secret/configmap mounted is edited (default `false`)
+	// +kubebuilder:default=false
 	HotReload *bool `property:"hot-reload" json:"hotReload,omitempty"`
 }

--- a/pkg/apis/camel/v1/trait/platform.go
+++ b/pkg/apis/camel/v1/trait/platform.go
@@ -29,6 +29,7 @@ type PlatformTrait struct {
 	// To create a default (empty) platform when the platform is missing.
 	CreateDefault *bool `property:"create-default" json:"createDefault,omitempty"`
 	// Indicates if the platform should be created globally in the case of global operator (default true).
+	// +kubebuilder:default=true
 	Global *bool `property:"global" json:"global,omitempty"`
 	// To automatically detect from the environment if a default platform can be created (it will be created on OpenShift only).
 	Auto *bool `property:"auto" json:"auto,omitempty"`

--- a/pkg/apis/camel/v1/trait/prometheus.go
+++ b/pkg/apis/camel/v1/trait/prometheus.go
@@ -34,6 +34,7 @@ package trait
 type PrometheusTrait struct {
 	Trait `property:",squash" json:",inline"`
 	// Whether a `PodMonitor` resource is created (default `true`).
+	// +kubebuilder:default=true
 	PodMonitor *bool `property:"pod-monitor" json:"podMonitor,omitempty"`
 	// The `PodMonitor` resource labels, applicable when `pod-monitor` is `true`.
 	PodMonitorLabels []string `property:"pod-monitor-labels" json:"podMonitorLabels,omitempty"`

--- a/pkg/apis/camel/v1/trait/quarkus.go
+++ b/pkg/apis/camel/v1/trait/quarkus.go
@@ -39,8 +39,10 @@ type QuarkusTrait struct {
 	// The Quarkus mode to run: either `jvm` or `native` (default `jvm`).
 	// In case both `jvm` and `native` are specified, two `IntegrationKit` resources are created,
 	// with the `native` kit having precedence over the `jvm` one once ready.
+	// +kubebuilder:default={"jvm"}
 	Modes []QuarkusMode `property:"build-mode" json:"buildMode,omitempty"`
 	// The base image to use when running a native build (default `quay.io/quarkus/quarkus-micro-image:2.0`)
+	// +kubebuilder:default="quay.io/quarkus/quarkus-micro-image:2.0"
 	NativeBaseImage string `property:"native-base-image" json:"nativeBaseImage,omitempty"`
 	// The image containing the tooling required for a native build (by default it will use the one provided in the runtime catalog)
 	NativeBuilderImage string `property:"native-builder-image" json:"nativeBuilderImage,omitempty"`

--- a/pkg/apis/camel/v1/trait/service.go
+++ b/pkg/apis/camel/v1/trait/service.go
@@ -29,6 +29,7 @@ type ServiceTrait struct {
 	Auto *bool `property:"auto" json:"auto,omitempty"`
 	// Enable Service to be exposed as NodePort (default `false`).
 	// Deprecated: Use service type instead.
+	// +kubebuilder:default=false
 	NodePort *bool `property:"node-port" json:"nodePort,omitempty"`
 	// The type of service to be used, either 'ClusterIP', 'NodePort' or 'LoadBalancer'.
 	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer

--- a/resources/traits.yaml
+++ b/resources/traits.yaml
@@ -62,11 +62,11 @@ traits:
   - name: pod-affinity
     type: bool
     description: Always co-locates multiple replicas of the integration in the same
-      node (default *false*).
+      node (default `false`).
   - name: pod-anti-affinity
     type: bool
     description: Never co-locates multiple replicas of the integration in the same
-      node (default *false*).
+      node (default `false`).
   - name: node-affinity-labels
     type: '[]string'
     description: Defines a set of nodes the integration pod(s) are eligible to be
@@ -243,7 +243,7 @@ traits:
     description: A list of properties to be provided to the build task
   - name: strategy
     type: string
-    description: The strategy to use, either `pod` or `routine` (default routine)
+    description: The strategy to use, either `pod` or `routine` (default `routine`)
   - name: base-image
     type: string
     description: Specify a base image
@@ -254,7 +254,7 @@ traits:
   - name: order-strategy
     type: string
     description: The build order strategy to use, either `dependencies`, `fifo` or
-      `sequential` (default sequential)
+      `sequential` (default `sequential`)
   - name: request-cpu
     type: string
     description: 'When using `pod` strategy, the minimum amount of CPU required by
@@ -489,7 +489,7 @@ traits:
   - name: progress-deadline-seconds
     type: int32
     description: The maximum time in seconds for the deployment to make progress before
-      it is considered to be failed. It defaults to 60s.
+      it is considered to be failed. It defaults to `60s`.
   - name: strategy
     type: DeploymentStrategyType
     description: The deployment strategy to use to replace existing pods with new
@@ -499,13 +499,13 @@ traits:
     description: 'The maximum number of pods that can be unavailable during the update.
       Value can be an absolute number (ex: 5) or a percentage of desired pods (ex:
       10%). Absolute number is calculated from percentage by rounding down. This can
-      not be 0 if MaxSurge is 0. Defaults to 25%.'
+      not be 0 if MaxSurge is 0. Defaults to `25%`.'
   - name: rolling-update-max-surge
     type: int
     description: 'The maximum number of pods that can be scheduled above the desired
       number of pods. Value can be an absolute number (ex: 5) or a percentage of desired
       pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is
-      calculated from percentage by rounding up. Defaults to 25%.'
+      calculated from percentage by rounding up. Defaults to `25%`.'
 - name: environment
   platform: true
   profiles:
@@ -1115,7 +1115,7 @@ traits:
     description: Logs message format
   - name: level
     type: string
-    description: Adjust the logging level (defaults to INFO)
+    description: Adjust the logging level (defaults to `INFO`)
   - name: json
     type: bool
     description: Output the logs in JSON
@@ -1200,7 +1200,7 @@ traits:
   - name: hot-reload
     type: bool
     description: Enable "hot reload" when a secret/configmap mounted is edited (default
-      false)
+      `false`)
 - name: openapi
   platform: true
   profiles:


### PR DESCRIPTION
Ref #4726 

Improve CRDdetails:
* Add default value in CRDs for traits when declared in documentation and not conditional 
* Add some validation for predictive values
* Some fixes in the traits documentation

**Release Note**
```release-note
feat(crd): Add default value trait in CRDs
```
