### PR TITLE
Add e2e test for knative service trait with annotation - backport to 1.10.x

### DIFF
--- a/e2e/global/knative/knative_test.go
+++ b/e2e/global/knative/knative_test.go
@@ -122,6 +122,17 @@ func TestKnative(t *testing.T) {
 			Eventually(KnativeService(ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
+
+		t.Run("Knative-service annotation", func(t *testing.T) {
+			Expect(KamelRunWithID(operatorID, ns, "files/knative2.groovy",
+				"-t", "knative-service.annotations.'haproxy.router.openshift.io/balance'=roundrobin").Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			ks := KnativeService(ns, "knative2")()
+			annotations := ks.ObjectMeta.Annotations
+			Expect(annotations["haproxy.router.openshift.io/balance"]).To(Equal("roundrobin"))
+			Eventually(KnativeService(ns, "knative2"), TestTimeoutShort).ShouldNot(BeNil())
+			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
 	})
 }
 


### PR DESCRIPTION
Add e2e test for knative service trait with annotation - backport to 1.10.x

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

