### PR TITLE
fix(build): use maven context arguments

### DIFF
--- a/pkg/builder/runtime_support.go
+++ b/pkg/builder/runtime_support.go
@@ -63,7 +63,8 @@ type NativeAdapter struct {
 
 // BuildCommands -- .
 func (n *NativeAdapter) BuildCommands() string {
-	return "cd " + n.Directory() + " && ./mvnw package -Dquarkus.package.type=native --global-settings settings.xml"
+	// We must override the local repo as it's not shared from the builder container
+	return "cd " + n.Directory() + " && ./mvnw $(cat MAVEN_CONTEXT) package -Dquarkus.package.type=native -Dmaven.repo.local=./repo"
 }
 
 // Directory -- .


### PR DESCRIPTION
Closes #4892

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(build): use maven context arguments
```
