### PR TITLE
fix(e2e): HotReload tests should not reload by default

### DIFF
--- a/e2e/common/config/config_reload_test.go
+++ b/e2e/common/config/config_reload_test.go
@@ -36,6 +36,8 @@ import (
 func TestConfigmapHotReload(t *testing.T) {
 	RegisterTestingT(t)
 
+	name := RandomizedSuffixName("config-configmap-route")
+
 	var cmData = make(map[string]string)
 	cmData["my-configmap-key"] = "my configmap content"
 	CreatePlainTextConfigmap(ns, "my-hot-cm", cmData)
@@ -46,20 +48,24 @@ func TestConfigmapHotReload(t *testing.T) {
 		"configmap:my-hot-cm",
 		"-t",
 		"mount.hot-reload=true",
+		"--name",
+		name,
 	).Execute()).To(Succeed())
-	Eventually(IntegrationPodPhase(ns, "config-configmap-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	Eventually(IntegrationConditionStatus(ns, "config-configmap-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	Eventually(IntegrationLogs(ns, "config-configmap-route"), TestTimeoutShort).Should(ContainSubstring("my configmap content"))
+	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("my configmap content"))
 
 	cmData["my-configmap-key"] = "my configmap content updated"
 	UpdatePlainTextConfigmap(ns, "my-hot-cm", cmData)
-	Eventually(IntegrationLogs(ns, "config-configmap-route"), TestTimeoutShort).Should(ContainSubstring("my configmap content updated"))
+	Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("my configmap content updated"))
 
 	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 }
 
 func TestConfigmapHotReloadDefault(t *testing.T) {
 	RegisterTestingT(t)
+
+	name := RandomizedSuffixName("config-configmap-route")
 
 	var cmData = make(map[string]string)
 	cmData["my-configmap-key"] = "my configmap content"
@@ -68,14 +74,16 @@ func TestConfigmapHotReloadDefault(t *testing.T) {
 	Expect(KamelRunWithID(operatorID, ns, "./files/config-configmap-route.groovy",
 		"--config",
 		"configmap:my-hot-cm-2",
+		"--name",
+		name,
 	).Execute()).To(Succeed())
-	Eventually(IntegrationPodPhase(ns, "config-configmap-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	Eventually(IntegrationConditionStatus(ns, "config-configmap-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	Eventually(IntegrationLogs(ns, "config-configmap-route"), TestTimeoutShort).Should(ContainSubstring("my configmap content"))
+	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("my configmap content"))
 
 	cmData["my-configmap-key"] = "my configmap content updated"
 	UpdatePlainTextConfigmap(ns, "my-hot-cm-2", cmData)
-	Eventually(IntegrationLogs(ns, "config-configmap-route"), TestTimeoutShort).Should(Not(ContainSubstring("my configmap content updated")))
+	Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(Not(ContainSubstring("my configmap content updated")))
 
 	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 }
@@ -83,18 +91,27 @@ func TestConfigmapHotReloadDefault(t *testing.T) {
 func TestSecretHotReload(t *testing.T) {
 	RegisterTestingT(t)
 
+	name := RandomizedSuffixName("config-secret-route")
+
 	var secData = make(map[string]string)
 	secData["my-secret-key"] = "very top secret"
 	CreatePlainTextSecret(ns, "my-hot-sec", secData)
 
-	Expect(KamelRunWithID(operatorID, ns, "./files/config-secret-route.groovy", "--config", "secret:my-hot-sec").Execute()).To(Succeed())
-	Eventually(IntegrationPodPhase(ns, "config-secret-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	Eventually(IntegrationConditionStatus(ns, "config-secret-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	Eventually(IntegrationLogs(ns, "config-secret-route"), TestTimeoutShort).Should(ContainSubstring("very top secret"))
+	Expect(KamelRunWithID(operatorID, ns, "./files/config-secret-route.groovy",
+		"--config",
+		"secret:my-hot-sec",
+		"-t",
+		"mount.hot-reload=true",
+		"--name",
+		name,
+	).Execute()).To(Succeed())
+	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	Eventually(IntegrationConditionStatus(ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("very top secret"))
 
 	secData["my-secret-key"] = "very top secret updated"
 	UpdatePlainTextSecret(ns, "my-hot-sec", secData)
-	Eventually(IntegrationLogs(ns, "config-secret-route"), TestTimeoutShort).Should(ContainSubstring("very top secret updated"))
+	Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("very top secret updated"))
 
 	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 }


### PR DESCRIPTION
Fix #4902 

## Description

* Fix the default hotreload for secrets
* Randomize the integration names

Note: For some unknown reason the test was passing before enforcing the default value to `false` in CRD.

**Release Note**
```release-note
NONE
```
