### PR TITLE
chore(e2e): Regression test on referenced secret(/cm) properties

### DIFF
--- a/e2e/common/config/files/property-secret-route.groovy
+++ b/e2e/common/config/files/property-secret-route.groovy
@@ -1,0 +1,21 @@
+// camel-k: language=groovy
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+from('timer:property')
+    .routeId('property')
+    .log('property content is: {{secret:my-sec-inlined/my-message}}')


### PR DESCRIPTION
Ref #4841 

Add e2e test and some additional cleaning.

Note: should be updated when https://issues.apache.org/jira/browse/CAMEL-20054 is available via Camel-K-Runtime.

**Release Note**
```release-note
NONE
```
