### PR TITLE
fix(#4916): Improve component resolver

### DIFF
--- a/pkg/util/camel/camel_runtime_catalog.go
+++ b/pkg/util/camel/camel_runtime_catalog.go
@@ -203,7 +203,12 @@ func (c *RuntimeCatalog) IsResolvable(uri string) bool {
 		return false
 	}
 
-	if scheme := uriSplit[0]; strings.HasPrefix(scheme, "{{") && strings.HasSuffix(scheme, "}}") {
+	scheme := uriSplit[0]
+	if strings.Contains(scheme, "?") {
+		scheme = strings.SplitN(scheme, "?", 2)[0]
+	}
+
+	if strings.HasPrefix(scheme, "{{") && strings.HasSuffix(scheme, "}}") {
 		// scheme is a property placeholder (e.g. {{url}}) which is not resolvable
 		return false
 	}

--- a/pkg/util/camel/camel_runtime_catalog_test.go
+++ b/pkg/util/camel/camel_runtime_catalog_test.go
@@ -46,3 +46,28 @@ func TestHasLoaderByArtifact(t *testing.T) {
 	assert.True(t, catalog.HasLoaderByArtifact("yaml-dsl"))
 	assert.False(t, catalog.HasLoaderByArtifact("python-dsl"))
 }
+
+func TestIsResolvable(t *testing.T) {
+	catalog, err := DefaultCatalog()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc     string
+		uri      string
+		expected bool
+	}{
+		{desc: "Basic", uri: "{{url}}", expected: false},
+		{desc: "With query param placeholder", uri: "{{url}}?authMethod={{authMethod}}", expected: false},
+		{desc: "With query param", uri: "{{url}}?authMethod=Basic", expected: false},
+		{desc: "With masked AND url-encoded query params", uri: "{{url}}?authMethod=%7B%7BauthMethod%7D%7D", expected: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			if got := catalog.IsResolvable(testCase.uri); got != testCase.expected {
+				t.Errorf("IsResolvable(%v) = %v, want %v", testCase.uri, got, testCase.expected)
+
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Support URL query parameters when resolving components by given scheme
- Do not resolve URLs that use parameter placeholder as a scheme
- Properly extract scheme from URL that has query parameters

Fixes #4916 

**Release Note**
```release-note
fix: Improve component resolver
```
