### PR TITLE
fix(e2e): Upgrade helm procedure test

### DIFF
--- a/e2e/install/kustomize/setup_test.go
+++ b/e2e/install/kustomize/setup_test.go
@@ -32,27 +32,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const (
-
-	// camel-k-operator,             camel-k-operator-events,
-	// camel-k-operator-knative,     camel-k-operator-leases,
-	// camel-k-operator-podmonitors, camel-k-operator-strimzi,
-	// camel-k-operator-keda
-	ExpectedKubePromoteRoles = 7
-
-	// camel-k-edit
-	// camel-k-operator-custom-resource-definitions
-	// camel-k-operator-bind-addressable-resolver
-	// camel-k-operator-local-registry
-	ExpectedKubeClusterRoles = 4
-
-	// camel-k-operator-openshift
-	ExpectedOSPromoteRoles = 1
-
-	// camel-k-operator-console-openshift
-	ExpectedOSClusterRoles = 1
-)
-
 func TestSetupKustomizeBasic(t *testing.T) {
 	RegisterTestingT(t)
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")

--- a/e2e/install/kustomize/setup_test.go
+++ b/e2e/install/kustomize/setup_test.go
@@ -33,11 +33,6 @@ import (
 )
 
 const (
-	// v1.Build,          v1.Integration
-	// v1.IntegrationKit, v1.IntegrationPlatform
-	// v1.Kamelet,  v1.Pipe,
-	// v1alpha1.Kamelet, v1alpha1.KameletBinding
-	ExpectedCRDs = 8
 
 	// camel-k-operator,             camel-k-operator-events,
 	// camel-k-operator-knative,     camel-k-operator-leases,

--- a/e2e/install/upgrade/helm_upgrade_test.go
+++ b/e2e/install/upgrade/helm_upgrade_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	. "github.com/apache/camel-k/v2/e2e/support"
+	"github.com/apache/camel-k/v2/pkg/util/defaults"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// WARNING: this test is not OLM specific but needs certain setting we provide in OLM installation scenario
+func TestHelmOperatorUpgrade(t *testing.T) {
+	RegisterTestingT(t)
+
+	KAMEL_INSTALL_REGISTRY := os.Getenv("KAMEL_INSTALL_REGISTRY")
+	// need to add last release version
+	releaseVersion := os.Getenv("KAMEL_K_TEST_RELEASE_VERSION")
+	customImage := fmt.Sprintf("%s/apache/camel-k", KAMEL_INSTALL_REGISTRY)
+
+	os.Setenv("CAMEL_K_TEST_MAKE_DIR", "../../../")
+
+	// Ensure no CRDs are already installed
+	UninstallAll()
+	Eventually(CRDs()).Should(HaveLen(0))
+
+	WithNewTestNamespace(t, func(ns string) {
+
+		// Install operator in last released version
+		ExpectExecSucceed(t,
+			exec.Command(
+				"helm",
+				"install",
+				"camel-k",
+				fmt.Sprintf("../../../docs/charts/camel-k-%s.tgz", releaseVersion),
+				"--set",
+				fmt.Sprintf("platform.build.registry.address=%s", KAMEL_INSTALL_REGISTRY),
+				"--set",
+				"platform.build.registry.insecure=true",
+				"-n",
+				ns,
+			),
+		)
+
+		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
+		Eventually(OperatorImage(ns)).Should(ContainSubstring(releaseVersion))
+		Eventually(CRDs()).Should(HaveLen(ExpectedCRDs))
+
+		//Test a simple route
+		t.Run("simple route", func(t *testing.T) {
+			name := RandomizedSuffixName("yaml")
+			Expect(KamelRun(ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		})
+
+		// Upgrade CRDs with kustomize
+		ExpectExecSucceed(t,
+			exec.Command(
+				"kubectl",
+				"replace",
+				"-f",
+				"../../../helm/camel-k/crds/",
+				"-n",
+				ns,
+			),
+		)
+
+		// Upgrade operator to current version
+		ExpectExecSucceed(t, Make(fmt.Sprintf("CUSTOM_IMAGE=%s", customImage), "set-version"))
+		ExpectExecSucceed(t, Make("release-helm"))
+		ExpectExecSucceed(t,
+			exec.Command(
+				"helm",
+				"upgrade",
+				"camel-k",
+				fmt.Sprintf("../../../docs/charts/camel-k-%s.tgz", defaults.Version),
+				"--set",
+				fmt.Sprintf("platform.build.registry.address=%s", KAMEL_INSTALL_REGISTRY),
+				"--set",
+				"platform.build.registry.insecure=true",
+				"-n",
+				ns,
+				"--force",
+			),
+		)
+
+		Eventually(OperatorPod(ns)).ShouldNot(BeNil())
+		Eventually(OperatorImage(ns)).Should(ContainSubstring(defaults.Version))
+
+		//Test again a simple route
+		t.Run("simple route upgraded", func(t *testing.T) {
+			name := RandomizedSuffixName("yaml")
+			Expect(KamelRun(ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
+			Eventually(IntegrationPodPhase(ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			Eventually(IntegrationLogs(ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		})
+
+		// Uninstall with helm
+		ExpectExecSucceed(t,
+			exec.Command(
+				"helm",
+				"uninstall",
+				"camel-k",
+				"-n",
+				ns,
+			),
+		)
+		Eventually(OperatorPod(ns)).Should(BeNil())
+
+		//  helm does not remove the CRDs
+		Eventually(CRDs()).Should(HaveLen(ExpectedCRDs))
+		ExpectExecSucceed(t,
+			exec.Command(
+				"kubectl",
+				"delete",
+				"-k",
+				"../../../config/crd/",
+				"-n",
+				ns,
+			),
+		)
+		Eventually(CRDs()).Should(HaveLen(0))
+	})
+}

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -96,6 +96,12 @@ import (
 const kubeConfigEnvVar = "KUBECONFIG"
 const ciPID = "/tmp/ci-k8s-pid"
 
+// v1.Build,          v1.Integration
+// v1.IntegrationKit, v1.IntegrationPlatform
+// v1.Kamelet,  v1.Pipe,
+// v1alpha1.Kamelet, v1alpha1.KameletBinding
+const ExpectedCRDs = 8
+
 var TestTimeoutShort = 1 * time.Minute
 var TestTimeoutMedium = 5 * time.Minute
 var TestTimeoutLong = 15 * time.Minute

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -102,6 +102,24 @@ const ciPID = "/tmp/ci-k8s-pid"
 // v1alpha1.Kamelet, v1alpha1.KameletBinding
 const ExpectedCRDs = 8
 
+// camel-k-operator,             camel-k-operator-events,
+// camel-k-operator-knative,     camel-k-operator-leases,
+// camel-k-operator-podmonitors, camel-k-operator-strimzi,
+// camel-k-operator-keda
+const ExpectedKubePromoteRoles = 7
+
+// camel-k-edit
+// camel-k-operator-custom-resource-definitions
+// camel-k-operator-bind-addressable-resolver
+// camel-k-operator-local-registry
+const ExpectedKubeClusterRoles = 4
+
+// camel-k-operator-openshift
+const ExpectedOSPromoteRoles = 1
+
+// camel-k-operator-console-openshift
+const ExpectedOSClusterRoles = 1
+
 var TestTimeoutShort = 1 * time.Minute
 var TestTimeoutMedium = 5 * time.Minute
 var TestTimeoutLong = 15 * time.Minute

--- a/helm/camel-k/README.md
+++ b/helm/camel-k/README.md
@@ -56,15 +56,38 @@ additional parameters that can be set during installation.
 
 > **Tip**: List all releases using `helm list`
 
+## Upgrading the Chart
+
+If you are upgrading the `camel-k` Deployment, you should always use a specific version of the chart and pre-install the CRDS:
+
+```bash
+# Upgrade the CRDs
+$ curl -LO "https://github.com/apache/camel-k/raw/main/docs/charts/camel-k-x.y.z.tgz"
+$ tar xvzf camel-k-x.y.z.tgz
+$ kubectl replace -f camel-k/crds
+# Upgrade the `camel-k` Deployment
+$ helm upgrade camel-k/camel-k --version x.y.z
+```
+
+> **Note**: If you are using a custom ClusterRole instead of the default one `camel-k:edit` from `camel-k/crds/cluster-role.yaml` you should handle it appropriately.
+
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `camel-k` Deployment:
 
 ```bash
-$ helm delete camel-k
+$ helm uninstall camel-k
 ```
 
-The command removes all the Kubernetes resources installed.
+The command removes all of the Kubernetes resources installed, except the CRDs.
+
+To remove them:
+```bash
+$ curl -LO "https://github.com/apache/camel-k/raw/main/docs/charts/camel-k-x.y.z.tgz"
+$ tar xvzf camel-k-x.y.z.tgz
+$ kubectl delete -f camel-k/crds
+```
 
 ## Configuration
 


### PR DESCRIPTION
Ref #4923 

Add helm upgrade test using manual upgrade of CRDs and update the documentation.

**Release Note**
```release-note
fix: Helm upgrade procedure with CRD management
```
