### PR TITLE
fix(e2e): Error in check crd support script

### DIFF
--- a/script/check_crd_api_support.sh
+++ b/script/check_crd_api_support.sh
@@ -53,9 +53,9 @@ fi
 crd_version=$("${client}" explain customresourcedefinitions | grep VERSION | awk '{print $2}')
 api="apiextensions.k8s.io"
 
-if [ "${crd_version}" == "${api}/v1beta1" ]; then
+if [ "${crd_version}" == "${api}/v1beta1" ] || [ "${crd_version}" == "v1beta1" ]; then
 	echo "ERROR: CRD API version is too old to install camel-k in this way. Try using the client CLI app, which is able to convert the APIs."
-elif [ "${crd_version}" != "${api}/v1" ]; then
+elif [ "${crd_version}" != "${api}/v1" ] && [ "${crd_version}" != "v1" ]; then
 	echo "ERROR: CRD API version '${crd_version}' is not supported."
 else
 	echo "OK"


### PR DESCRIPTION
Closes #4929 

kubectl and oc CLI answers with different result to explain command:
```bash
$"kubectl" explain customresourcedefinitions | grep VERSION | awk '{print $2}'
v1
$ "oc" explain customresourcedefinitions | grep VERSION | awk '{print $2}'
apiextensions.k8s.io/v1
```

Root cause:
```bash
$ kubectl explain customresourcedefinitions
GROUP:      apiextensions.k8s.io
KIND:       CustomResourceDefinition
VERSION:    v1

$ oc explain customresourcedefinitions
KIND:     CustomResourceDefinition
VERSION:  apiextensions.k8s.io/v1
```

**Release Note**
```release-note
fix(e2e): Error in check crd support script
```
