### PR TITLE
[Backport 2.1.x] fix(e2e): Error in check crd support script

### DIFF
--- a/script/check_crd_api_support.sh
+++ b/script/check_crd_api_support.sh
@@ -53,9 +53,9 @@ fi
 crd_version=$("${client}" explain customresourcedefinitions | grep VERSION | awk '{print $2}')
 api="apiextensions.k8s.io"
 
-if [ "${crd_version}" == "${api}/v1beta1" ]; then
+if [ "${crd_version}" == "${api}/v1beta1" ] || [ "${crd_version}" == "v1beta1" ]; then
 	echo "ERROR: CRD API version is too old to install camel-k in this way. Try using the client CLI app, which is able to convert the APIs."
-elif [ "${crd_version}" != "${api}/v1" ]; then
+elif [ "${crd_version}" != "${api}/v1" ] && [ "${crd_version}" != "v1" ]; then
 	echo "ERROR: CRD API version '${crd_version}' is not supported."
 else
 	echo "OK"


### PR DESCRIPTION
Backport fix #4930 

**Release Note**
```release-note
fix(e2e): Error in check crd support script
```
