### PR TITLE
chore(ci): Upgrade kind action and image to kubernetes 1.27

### DIFF
--- a/.github/actions/kamel-config-cluster-kind/action.yml
+++ b/.github/actions/kamel-config-cluster-kind/action.yml
@@ -27,7 +27,7 @@ runs:
       if: ${{ env.CLUSTER_KIND_CONFIGURED != 'true' }}
       with:
         version: v0.19.0
-        node_image: kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
+        node_image: kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b
         cpu: 3
 
     - id: info


### PR DESCRIPTION
Follow up on temporary kine-action version https://github.com/apache/camel-k/pull/4849 

Upgrade:
* kind-action to v2.0.2 with registry improvment
* kindest image to kubernetes 1.27 for [kind 1.19.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.19.0)


**Release Note**
```release-note
chore(ci): Upgrade kind action and image to kubernetes 1.27
```
