### PR TITLE
fix(e2e): Set default configuration knative http yaks test

### DIFF
--- a/e2e/yaks/common/knative-sinkbinding-http/sinkbinding.feature
+++ b/e2e/yaks/common/knative-sinkbinding-http/sinkbinding.feature
@@ -2,8 +2,8 @@ Feature: Camel K can run source HTTP endpoint in sinkbinding mode
 
   Background:
     Given Kubernetes resource polling configuration
-      | maxAttempts          | 1   |
-      | delayBetweenAttempts | 500 |
+      | maxAttempts          | 40   |
+      | delayBetweenAttempts | 3000 |
 
   Scenario: Integration knative-service starts with no errors
     Given wait for condition=Ready on Kubernetes custom resource integration/rest2channel in integration.camel.apache.org/v1


### PR DESCRIPTION
Change the default polling configuration to the most commonly used one in other yaks feature files to fix the recurring flaky failures of this test.

See: https://github.com/apache/camel-k/actions/runs/7047787985/job/19182852523?pr=4946


**Release Note**
```release-note
fix(e2e): Set default configuration knative http yaks test
```
