### PR TITLE
fix(e2e): Kustomize registry check

### DIFF
--- a/.github/actions/kamel-config-cluster-kind/action.yml
+++ b/.github/actions/kamel-config-cluster-kind/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - id: install-cluster
       name: Install Cluster
-      uses: container-tools/kind-action@v2.0.1
+      uses: container-tools/kind-action@v2.0.2
       if: ${{ env.CLUSTER_KIND_CONFIGURED != 'true' }}
       with:
         version: v0.19.0


### PR DESCRIPTION
Ref #4954 

Ensure IP is ready before checking its status configuration


**Release Note**
```release-note
fix(e2e): Kustomize registry check
```
