### PR TITLE
fix(ci): Rollback kind image

### DIFF
--- a/.github/actions/kamel-config-cluster-kind/action.yml
+++ b/.github/actions/kamel-config-cluster-kind/action.yml
@@ -27,7 +27,7 @@ runs:
       if: ${{ env.CLUSTER_KIND_CONFIGURED != 'true' }}
       with:
         version: v0.19.0
-        node_image: kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b
+        node_image: kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
         cpu: 3
 
     - id: info


### PR DESCRIPTION
Rollback kind image change done in [#4946](https://github.com/apache/camel-k/pull/4946) that might be the root cause for custom operator e2e test failure on metrics.

![Capture d’écran du 2023-12-04 14-50-10](https://github.com/apache/camel-k/assets/6067789/883ec447-52db-4c38-b990-c540cab2b5ee)



**Release Note**
```release-note
NONE
```
