### PR TITLE
fix(build): don't override user provided resources

### DIFF
--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -442,3 +442,10 @@ func TestBuilderDeprecatedParams(t *testing.T) {
 	assert.Equal(t, "builder:100Mi", builderTrait.TasksLimitMemory[0])
 	assert.Equal(t, "builder:100Mi", builderTrait.TasksRequestMemory[0])
 }
+
+func TestExistsTaskRequest(t *testing.T) {
+	tasks := []string{"quarkus-native:1000m", "builder:1000m", "shouldfail"}
+	assert.True(t, existsTaskRequest(tasks, "quarkus-native"))
+	assert.False(t, existsTaskRequest(tasks, "quarkus"))
+	assert.False(t, existsTaskRequest(tasks, "shouldfail"))
+}


### PR DESCRIPTION
Closes #4956

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(build): don't override user provided resources
```
