### PR TITLE
Remove index table which is not refering to any table

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -64,9 +64,6 @@ From Camel K version 2 onward you will be able to use any Camel K Runtime. Each 
 
 Below you can find a list of the main dependencies and APIs used by Camel K and the related compatibility.
 
-//cannot use top level index.adoc as the page with the query is always omitted.
-indexTable::[version="*",relative="running/running.adoc",cellformats="util.ckRef(pageComponentDisplayVersion, pageComponentVersion)|camelKRuntimeVersion|util.camelQuarkusRef(camelQuarkusVersion, camelQuarkusDocsVersion)|util.camelRef(camelVersion, camelDocsVersion)|util.quarkusRef(quarkusVersion)|util.kameletsRef(camelKameletsVersion, camelKameletsDocsVersion)|lts|ck.branch(pageComponentVersion)", requires={requires},transform=util.sortCompatibilityItems]
-
 [caption=]
 .Kubernetes and other dependencies
 [width="100%",cols="4,2,2,2,2,2,2",options="header"]


### PR DESCRIPTION
it is fixing camel-website build which had error:

```
 ➤ YN0000: [build:antora  ] [build:antora-perf] [09:37:43.441] WARN
(asciidoctor):
➤ YN0000: [build:antora  ] [build:antora-perf]     file:
docs/modules/ROOT/pages/index.adoc
➤ YN0000: [build:antora  ] [build:antora-perf]     source:
https://github.com/apache/camel-k.git (refname: main, start path: docs)
➤ YN0000: [build:antora  ] [build:antora-perf]     msg: {
➤ YN0000: [build:antora  ] [build:antora-perf]       "msg":
"jsonpathTable block macro must follow a table, not a paragraph",
➤ YN0000: [build:antora  ] [build:antora-perf]       "useId": 0,
➤ YN0000: [build:antora  ] [build:antora-perf]
"@djencks/asciidoctor-antora-indexer": "indexTable"
➤ YN0000: [build:antora  ] [build:antora-perf]     }
```

relates to #4886

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
