### PR TITLE
chore(ci): Upgrade kind-action to 2.0.2

### DIFF
--- a/.github/actions/kamel-config-cluster-kind/action.yml
+++ b/.github/actions/kamel-config-cluster-kind/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - id: install-cluster
       name: Install Cluster
-      uses: container-tools/kind-action@v2.0.1
+      uses: container-tools/kind-action@v2.0.2
       if: ${{ env.CLUSTER_KIND_CONFIGURED != 'true' }}
       with:
         version: v0.19.0


### PR DESCRIPTION
Ref #4954

Only upgrade kind-action to 2.0.2

**Release Note**
```release-note
chore(ci): Upgrade kind-action to 2.0.2
```
