### PR TITLE
chore: Improve YAKS E2E tests

### DIFF
--- a/e2e/yaks/common/apache-kamelet-catalog/kamelet.feature
+++ b/e2e/yaks/common/apache-kamelet-catalog/kamelet.feature
@@ -8,3 +8,6 @@ Feature: Camel K can run Kamelets from default catalog
   Scenario: Integrations can use default catalog
     Given Camel K integration logger is running
     Then Camel K integration logger should print Camel K
+
+  Scenario: Remove resources
+    Given delete Camel K integration logger

--- a/e2e/yaks/common/kamelet-beans/kamelet.feature
+++ b/e2e/yaks/common/kamelet-beans/kamelet.feature
@@ -1,8 +1,6 @@
 Feature: Kamelets can declare local beans
 
   Background:
-    Given Disable auto removal of Kamelet resources
-    Given Disable auto removal of Kubernetes resources
     Given Camel K resource polling configuration
       | maxAttempts          | 40   |
       | delayBetweenAttempts | 3000 |

--- a/e2e/yaks/common/kamelet-binding-autoload/kamelet-autoload.feature
+++ b/e2e/yaks/common/kamelet-binding-autoload/kamelet-autoload.feature
@@ -18,4 +18,7 @@ Feature: Camel K can load default secrets for Kamelets
     And HTTP server timeout is 600000 ms
     Then expect HTTP request body: default
     And receive POST /default
-    And delete KameletBinding binding
+
+ Scenario: Remove resources
+    Given delete Kubernetes service stub-service
+    Given delete KameletBinding binding

--- a/e2e/yaks/common/kamelet-binding-broker/kamelet.feature
+++ b/e2e/yaks/common/kamelet-binding-broker/kamelet.feature
@@ -8,3 +8,7 @@ Feature: Camel K can bind Kamelets to the broker
   Scenario: Sending event to the custom broker with KameletBinding
     Given Camel K integration logger-sink-binding is running
     Then Camel K integration logger-sink-binding should print message: Hello Custom Event from sample-broker
+
+  Scenario: Remove resources
+    Given delete Camel K integration timer-source-binding
+    Given delete Camel K integration logger-sink-binding

--- a/e2e/yaks/common/kamelet-binding-http/kamelet.feature
+++ b/e2e/yaks/common/kamelet-binding-http/kamelet.feature
@@ -9,3 +9,7 @@ Feature: Camel K can bind Kamelets via HTTP
     Given Camel K integration display is running
     Then Camel K integration display should print type: org.apache.camel.event
     Then Camel K integration display should print Hello
+
+  Scenario: Remove resources
+    Given delete Camel K integration display
+    Given delete KameletBinding timer-source-binding-display

--- a/e2e/yaks/common/kamelet-binding-property-encoding/properties.feature
+++ b/e2e/yaks/common/kamelet-binding-property-encoding/properties.feature
@@ -23,4 +23,7 @@ Feature: Ensure that Kamelets support multiline configuration
     """
     And expect HTTP request header: Content-Type="application/json;charset=UTF-8"
     And receive POST /events
-    And delete KameletBinding properties-binding
+
+  Scenario: Remove resources
+    Given delete Kubernetes service probe-service
+    Given delete KameletBinding properties-binding

--- a/e2e/yaks/common/kamelet-binding/kamelet.feature
+++ b/e2e/yaks/common/kamelet-binding/kamelet.feature
@@ -8,3 +8,7 @@ Feature: Camel K can bind Kamelets
   Scenario: Running integration using a simple Kamelet with KameletBinding
     Given Camel K integration logger-sink-binding is running
     Then Camel K integration logger-sink-binding should print message: Hello Kamelets
+
+  Scenario: Remove resources
+    Given delete Camel K integration timer-source-binding
+    Given delete Camel K integration logger-sink-binding

--- a/e2e/yaks/common/kamelet-data-types/kamelet-data-types.feature
+++ b/e2e/yaks/common/kamelet-data-types/kamelet-data-types.feature
@@ -16,3 +16,7 @@ Feature: Kamelets with data types
     Given Camel K integration timer-to-log is running
     Then Camel K integration timer-to-log should print BodyType: byte[], Body: Hello from Camel K!
     Then Camel K integration timer-to-log should print BodyType: String, Body: Hello from Camel K!
+
+  Scenario: Remove resources
+    Given delete KameletBinding event-binding
+    Given delete KameletBinding timer-to-log

--- a/e2e/yaks/common/kamelet-no-properties/kamelet-no-props.feature
+++ b/e2e/yaks/common/kamelet-no-properties/kamelet-no-props.feature
@@ -26,3 +26,7 @@ from:
     Then KameletBinding no-props-source-uri should be available
     Then Camel K integration no-props-source-uri should be running
     Then Camel K integration no-props-source-uri should print Hello World
+
+  Scenario: Remove resources
+    Given delete Kubernetes service greeting-service
+    Given delete KameletBinding no-props-source-uri

--- a/e2e/yaks/common/kamelet-steps/steps-binding.feature
+++ b/e2e/yaks/common/kamelet-steps/steps-binding.feature
@@ -8,3 +8,6 @@ Feature: KameletBindings can have multiple processing steps
   Scenario: Data is transformed by the steps
     Given Camel K integration steps-binding is running
     Then Camel K integration steps-binding should print Hello Apache Camel
+
+  Scenario: Remove resources
+    Given delete Camel K integration steps-binding

--- a/e2e/yaks/common/kamelet/kamelet.feature
+++ b/e2e/yaks/common/kamelet/kamelet.feature
@@ -8,3 +8,6 @@ Feature: Camel K can run Kamelets
   Scenario: Integrations can use multiple kamelets
     Given Camel K integration source-sink is running
     Then Camel K integration source-sink should print nice echo: Camel K
+
+  Scenario: Remove resources
+    Given delete Camel K integration source-sink

--- a/e2e/yaks/common/knative-broker/knative-broker.feature
+++ b/e2e/yaks/common/knative-broker/knative-broker.feature
@@ -52,5 +52,7 @@ Feature: Camel K can correctly filter messages from broker
     And Camel K integration receiver should not print From evt1: event-all
     And Camel K integration receiver should not print From evt2: event-1
     And Camel K integration receiver should not print From evt2: event-all
-    And delete Camel K integration sender
-    And delete Camel K integration receiver
+
+  Scenario: Remove resources
+    Given delete Camel K integration sender
+    Given delete Camel K integration receiver

--- a/e2e/yaks/common/knative-sinkbinding/sinkbinding.feature
+++ b/e2e/yaks/common/knative-sinkbinding/sinkbinding.feature
@@ -8,3 +8,7 @@ Feature: Camel K can run source in sinkbinding mode
   Scenario: Integration gets the message from the sinkbinding source
     Given Camel K integration receiver is running
     Then Camel K integration receiver should print HELLO SINKBINDING
+
+  Scenario: Remove resources
+    Given delete Camel K integration source
+    Given delete Camel K integration receiver


### PR DESCRIPTION
- Make sure to remove resources after test
- Avoids reconciling of leftover resources in Camel K operator logs
- Either use auto removal or explicitly remove resources