### PR TITLE
fix(core): Fix tooling image on multi-arch

### DIFF
--- a/pkg/controller/integrationkit/build.go
+++ b/pkg/controller/integrationkit/build.go
@@ -134,7 +134,7 @@ func (action *buildAction) handleBuildSubmitted(ctx context.Context, kit *v1.Int
 		}
 		// The build operation, when executed as a Pod, should be executed by a container image containing the
 		// `kamel builder` command. Likely the same image running the operator should be fine.
-		buildConfig.ToolImage = defaults.OperatorImage()
+		buildConfig.ToolImage = platform.OperatorImage
 		buildConfig.BuilderPodNamespace = operatorNamespace
 		v1.SetBuilderConfigurationTasks(env.Pipeline, buildConfig)
 


### PR DESCRIPTION
Ref #4988 

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(core): Fix tooling image on multi-arch
```
