### PR TITLE
fix(e2e): quarkus native is memory eager

### DIFF
--- a/e2e/native/native_binding_test.go
+++ b/e2e/native/native_binding_test.go
@@ -35,7 +35,10 @@ func TestNativeBinding(t *testing.T) {
 		operatorID := "camel-k-native-binding"
 		Expect(KamelInstallWithIDAndKameletCatalog(operatorID, ns,
 			"--build-timeout", "90m0s",
-			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=6g",
+			"--maven-cli-option", "-V",
+			"--maven-cli-option", "--no-transfer-progress",
+			"--maven-cli-option", "-Dstyle.color=never",
+			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=10g",
 		).Execute()).To(Succeed())
 		Eventually(PlatformPhase(ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 		message := "Magicstring!"
@@ -46,7 +49,6 @@ func TestNativeBinding(t *testing.T) {
 				"log-sink",
 				"-p", "source.message="+message,
 				"--annotation", "trait.camel.apache.org/quarkus.build-mode=native",
-				"--annotation", "trait.camel.apache.org/builder.tasks-limit-memory=quarkus-native:6.5Gi",
 				"--name", bindingName,
 			).Execute()).To(Succeed())
 

--- a/e2e/native/native_test.go
+++ b/e2e/native/native_test.go
@@ -38,7 +38,10 @@ func TestNativeIntegrations(t *testing.T) {
 		operatorID := "camel-k-quarkus-native"
 		Expect(KamelInstallWithID(operatorID, ns,
 			"--build-timeout", "90m0s",
-			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=6g",
+			"--maven-cli-option", "-V",
+			"--maven-cli-option", "--no-transfer-progress",
+			"--maven-cli-option", "-Dstyle.color=never",
+			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=10g",
 		).Execute()).To(Succeed())
 		Eventually(PlatformPhase(ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
@@ -46,7 +49,6 @@ func TestNativeIntegrations(t *testing.T) {
 			name := RandomizedSuffixName("unsupported-js")
 			Expect(KamelRunWithID(operatorID, ns, "files/JavaScript.js", "--name", name,
 				"-t", "quarkus.build-mode=native",
-				"-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi",
 			).Execute()).To(Succeed())
 
 			Eventually(IntegrationPhase(ns, name)).Should(Equal(v1.IntegrationPhaseError))

--- a/e2e/native/native_with_sources_test.go
+++ b/e2e/native/native_with_sources_test.go
@@ -37,7 +37,10 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 		operatorID := "camel-k-quarkus-high-memory-native"
 		Expect(KamelInstallWithID(operatorID, ns,
 			"--build-timeout", "90m0s",
-			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=9g",
+			"--maven-cli-option", "-V",
+			"--maven-cli-option", "--no-transfer-progress",
+			"--maven-cli-option", "-Dstyle.color=never",
+			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=13g",
 		).Execute()).To(Succeed())
 		Eventually(PlatformPhase(ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
@@ -49,7 +52,6 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 			name := javaNativeName
 			Expect(KamelRunWithID(operatorID, ns, "files/Java.java", "--name", name,
 				"-t", "quarkus.build-mode=native",
-				"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
 			).Execute()).To(Succeed())
 
 			Eventually(IntegrationPodPhase(ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))


### PR DESCRIPTION
In the latest releases it seems it requires at least 30% more in memory usage.

Closes #4723

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
