### PR TITLE
fix(ci): Sanitize PR head.ref

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,10 +37,11 @@ jobs:
         env:
           CI_USER: "github-actions[bot]"
           CI_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+          PR_HEAD: "${{ github.event.pull_request.head.ref }}"
         run: |
           git clone ${{ github.event.pull_request.head.repo.clone_url }}
           cd ${{ github.event.pull_request.head.repo.name }}
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git checkout $PR_HEAD
 
           git config --local user.email "$CI_EMAIL"
           git config --local user.name "$CI_USER"


### PR DESCRIPTION
<!-- Description -->

This fixes a minor GitHub Actions workflow injection vulnerability by sanitizing the branch name from the PR head.

I'm just making a PR because most risk is mitigated as the workflow does not use secrets and the `GITHUB_TOKEN` permissions are restricted to `pull-requests: write` and `issues: write`. The worst an attacker could do is modify other PR descriptions, titles, mess with issues - a nuisance but not a supply chain attack.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
