### PR TITLE
fix(#5007): Jib publish strategy registry secret

### DIFF
--- a/pkg/util/jib/configuration.go
+++ b/pkg/util/jib/configuration.go
@@ -41,6 +41,9 @@ const JibDigestFile = "target/jib-image.digest"
 const JibMavenPluginVersionDefault = "3.3.2"
 const JibLayerFilterExtensionMavenVersionDefault = "0.3.0"
 
+// See: https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md#using-docker-configuration-files
+const JibRegistryConfigEnvVar = "DOCKER_CONFIG"
+
 type JibBuild struct {
 	Plugins []maven.Plugin `xml:"plugins>plugin,omitempty"`
 }


### PR DESCRIPTION
Ref #5007 

Manage registry secret for Jib strategy in a similar way that spectrum strategy does.

**Release Note**
```release-note
fix(#5007): Jib publish strategy registry secret
```
