### PR TITLE
fix(ci): golang caching is already part of go actions

### DIFF
--- a/.github/actions/e2e-build/action.yml
+++ b/.github/actions/e2e-build/action.yml
@@ -27,14 +27,6 @@ runs:
     name: Prepare Test Environment
     uses: ./.github/actions/kamel-prepare-env
 
-  - name: Cache modules
-    uses: actions/cache@v3
-    with:
-      path: ~/go/pkg/mod
-      key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-      restore-keys: |
-        ${{ runner.os }}-go-
-
   - name: Test
     shell: bash
     run: make

--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -57,13 +57,6 @@ runs:
         cluster-config-data: ${{ inputs.secretE2ECluster }}
         cluster-kube-config-data: ${{ inputs.secretE2EKube }}
         smoke-test-only: true
-    - name: Cache modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
     - name: Get nightly version and update date
       shell: bash
       run: |


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ci): golang caching is already part of go actions
```
