### PR TITLE
fix(ctrl): monitor Pod ready condition

### DIFF
--- a/pkg/controller/integration/monitor_cronjob.go
+++ b/pkg/controller/integration/monitor_cronjob.go
@@ -77,7 +77,7 @@ func (c *cronJobController) getPodSpec() corev1.PodSpec {
 	return c.obj.Spec.JobTemplate.Spec.Template.Spec
 }
 
-func (c *cronJobController) updateReadyCondition(readyPods []corev1.Pod) bool {
+func (c *cronJobController) updateReadyCondition(readyPods int) bool {
 	switch {
 	case c.obj.Status.LastScheduleTime == nil:
 		c.integration.SetReadyCondition(corev1.ConditionTrue,

--- a/pkg/controller/integration/monitor_deployment.go
+++ b/pkg/controller/integration/monitor_deployment.go
@@ -59,14 +59,14 @@ func (c *deploymentController) getPodSpec() corev1.PodSpec {
 	return c.obj.Spec.Template.Spec
 }
 
-func (c *deploymentController) updateReadyCondition(readyPods []corev1.Pod) bool {
+func (c *deploymentController) updateReadyCondition(readyPods int) bool {
 	replicas := int32(1)
 	if r := c.integration.Spec.Replicas; r != nil {
 		replicas = *r
 	}
 	// The Deployment status reports updated and ready replicas separately,
 	// so that the number of ready replicas also accounts for older versions.
-	readyReplicas := int32(len(readyPods))
+	readyReplicas := int32(readyPods)
 	switch {
 	case readyReplicas >= replicas:
 		// The Integration is considered ready when the number of replicas

--- a/pkg/controller/integration/monitor_knative.go
+++ b/pkg/controller/integration/monitor_knative.go
@@ -51,7 +51,7 @@ func (c *knativeServiceController) getPodSpec() corev1.PodSpec {
 	return c.obj.Spec.Template.Spec.PodSpec
 }
 
-func (c *knativeServiceController) updateReadyCondition(readyPods []corev1.Pod) bool {
+func (c *knativeServiceController) updateReadyCondition(readyPods int) bool {
 	ready := kubernetes.GetKnativeServiceCondition(*c.obj, servingv1.ServiceConditionReady)
 	if ready.IsTrue() {
 		c.integration.SetReadyCondition(corev1.ConditionTrue,


### PR DESCRIPTION
When the user uses a startup probe, the Integration won't turn as running until the condition is reached

Closes #4977

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ctrl): monitor Pod ready condition
```
