### PR TITLE
fix(trait) Fixed a scientific notation issue with camel when generating yaml

### DIFF
--- a/pkg/util/dsl/flow.go
+++ b/pkg/util/dsl/flow.go
@@ -62,8 +62,9 @@ func ToYamlDSL(flows []v1.Flow) ([]byte, error) {
 		return nil, err
 	}
 	jsondata := make([]map[string]interface{}, 0)
-	err = json.Unmarshal(data, &jsondata)
-	if err != nil {
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	if err := d.Decode(&jsondata); err != nil {
 		return nil, fmt.Errorf("error unmarshalling json: %w", err)
 	}
 	yamldata, err := yaml2.Marshal(&jsondata)

--- a/pkg/util/dsl/flow_test.go
+++ b/pkg/util/dsl/flow_test.go
@@ -28,6 +28,8 @@ import (
 func TestReadWriteYaml(t *testing.T) {
 	// yaml in conventional form as marshalled by the go runtime
 	yaml := `- from:
+    parameters:
+      period: 3600001
     steps:
     - to: log:info
     uri: timer:tick


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->
There was a similar issue before:
https://github.com/apache/camel-k/issues/2616

However, in the new CRD version(v1), this issue has not been resolved.
![image](https://github.com/apache/camel-k/assets/12069428/9409f196-4434-42ea-9521-0d29e2fc57d0)

After operator reads and regenerates yaml from CRD, there is still a problem with scientific notation. This issue is currently fixed

**Release Note**
```release-note
NONE
```
