### PR TITLE
fix(core): Fix docker hub registry configuration

### DIFF
--- a/docs/modules/ROOT/pages/installation/registry/dockerhub.adoc
+++ b/docs/modules/ROOT/pages/installation/registry/dockerhub.adoc
@@ -13,8 +13,9 @@ kamel install --registry docker.io --organization your-user-id-or-org --registry
 The `--registry-auth-username` and `--registry-auth-password` flags are used by the `kamel` CLI to create a Kubernetes secret
 that holds your credentials for authenticating against the Docker registry.
 
-In the general case, the `--registry-auth-server` should be used, but it can be omitted for Docker Hub because it's
-automatically set to `https://index.docker.io/v1/`.
+In the general case, the `--registry-auth-server` should be used ad it's automatically set to `https://index.docker.io/v1/`. Depending on the xref:installation/registry/registry.adoc[publish strategy] you are using you will need to adapt you credentials with the `--registry-auth-server` flag. **Spectrum** expect `https://index.docker.io/v1/` while **Jib** expect `docker.io`.
+
+NOTE: **Jib** works with Docker Hub in API v2 out of the box while **Spectrum** needs some adaptations for it to work.
 
 == Alternative Methods
 
@@ -25,6 +26,7 @@ Or you can also decide to create it using `kubectl`, with the following command:
 ----
 kubectl create secret docker-registry your-secret-name --docker-username your-user --docker-password your-pass
 ----
+
 
 Another possibility is to upload to the cluster your entire list of push/pull secrets:
 
@@ -42,3 +44,5 @@ After you've created the secret, you can link it to Camel K during installation:
 ----
 kamel install --registry docker.io --organization your-user-id-or-org --registry-secret your-secret-name
 ----
+
+As with the default method, this depends on the xref:installation/registry/registry.adoc[publish strategy] you are using. So make sure any credential contains the valid authentication servers: `https://index.docker.io/v1/` for **Spectrum** and `docker.io` for **Jib**.

--- a/pkg/util/registry/registry_test.go
+++ b/pkg/util/registry/registry_test.go
@@ -36,7 +36,8 @@ func TestAuth_GenerateDockerConfig(t *testing.T) {
 	}
 	conf, err := a.GenerateDockerConfig()
 	assert.Nil(t, err)
-	assert.Equal(t, `{"auths":{"https://index.docker.io/v1/":{"auth":"bmljOg=="}}}`, string(conf))
+	assert.Contains(t, string(conf), `"https://index.docker.io/v1/":{"auth":"bmljOg=="}`)
+	assert.Contains(t, string(conf), `"docker.io":{"auth":"bmljOg=="}`)
 
 	a = Auth{
 		Username: "nic",


### PR DESCRIPTION
Ref #5017 
Ref #5007 

* change default secret generation from CLI for Jib compatibility
* update documentation with configuration for docker hub registry

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(core): Fix docker hub registry configuration
```
