### PR TITLE
Bump Fabric8, use the BOM and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,7 @@ updates:
       - dependency-name: "k8s.io/client-go"
       - dependency-name: "k8s.io/kubectl"
       - dependency-name: "sigs.k8s.io/controller-runtime"
+  - directory: "/java/crds"
+    package-ecosystem: "maven"
+    schedule:
+      interval: "weekly"

--- a/java/crds/pom.xml
+++ b/java/crds/pom.xml
@@ -36,9 +36,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
 
-    <lombok-version>1.18.30</lombok-version>
-    <sundrio-version>0.103.0</sundrio-version>
-    <fabric8-version>6.9.2</fabric8-version>
+    <fabric8-version>6.10.0</fabric8-version>
     <maven-surefire-plugin-version>3.0.0-M8</maven-surefire-plugin-version>
   </properties>
 
@@ -91,13 +89,11 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
-      <version>${sundrio-version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>${lombok-version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
<!-- Description -->

Cleanup PR, to use the new Fabric8 BOM to get the aligned versions of `sundrio` and `lombok`.
I noticed that fabric8 was not getting updated and added an entry to dependabot.
