### PR TITLE
fix(#5047): Update Quarkus service discovery setting for data type transformer

### DIFF
--- a/pkg/builder/quarkus.go
+++ b/pkg/builder/quarkus.go
@@ -178,8 +178,9 @@ func GenerateQuarkusProjectCommon(runtimeVersion string, quarkusVersion string, 
 	// proxies which in some case may fail.
 	buildProperties["quarkus.camel.routes-discovery.enabled"] = "false"
 
-	// required for Kamelets utils to resolve data type converters at runtime
-	buildProperties["quarkus.camel.service.discovery.include-patterns"] = "META-INF/services/org/apache/camel/datatype/converter/*"
+	// required for to resolve data type transformers at runtime with service discovery
+	// the different Camel runtimes use different resource paths for the service lookup
+	buildProperties["quarkus.camel.service.discovery.include-patterns"] = "META-INF/services/org/apache/camel/datatype/converter/*,META-INF/services/org/apache/camel/datatype/transformer/*,META-INF/services/org/apache/camel/transformer/*"
 
 	// copy all user defined quarkus.camel build time properties to the quarkus-maven-plugin build properties
 	for key, value := range buildTimeProperties {

--- a/script/camel-k-runtime-archetype/pom.xml
+++ b/script/camel-k-runtime-archetype/pom.xml
@@ -67,7 +67,7 @@
               <properties>
                 <quarkus.banner.enabled>false</quarkus.banner.enabled>
                 <quarkus.camel.routes-discovery.enabled>false</quarkus.camel.routes-discovery.enabled>
-                <quarkus.camel.service.discovery.include-patterns>META-INF/services/org/apache/camel/datatype/converter/*</quarkus.camel.service.discovery.include-patterns>
+                <quarkus.camel.service.discovery.include-patterns>META-INF/services/org/apache/camel/datatype/converter/*,META-INF/services/org/apache/camel/datatype/transformer/*,META-INF/services/org/apache/camel/transformer/*</quarkus.camel.service.discovery.include-patterns>
               </properties>
             </configuration>
           </execution>


### PR DESCRIPTION
- Make sure to support factory finder service discovery resource paths for data type transformers in different Camel runtimes
- Enables Pipes to use data type transformers that get resolved during runtime with service discovery
- Camel 3.x uses `META-INF/services/org/apache/camel/datatype/converter/*`
- Camel 4.0 uses `META-INF/services/org/apache/camel/datatype/transformer/*`
- Camel 4.2 uses `META-INF/services/org/apache/camel/transformer/*`

**Release Note**
```release-note
fix(#5047): Update Quarkus service discovery setting for data type transformer
```
