### PR TITLE
fix(#5001): Execute Quarkus JVM buildMode before native buildMode

### DIFF
--- a/pkg/trait/quarkus.go
+++ b/pkg/trait/quarkus.go
@@ -210,6 +210,10 @@ func (t *quarkusTrait) applyWhileBuildingKit(e *Environment) {
 		kit := t.newIntegrationKit(e, packageType(t.Modes[0]))
 		e.IntegrationKits = append(e.IntegrationKits, *kit)
 	default:
+		// execute jvm mode before native mode
+		sort.Slice(t.Modes, func(i, j int) bool {
+			return t.Modes[i] != traitv1.NativeQuarkusMode
+		})
 		for _, md := range t.Modes {
 			kit := t.newIntegrationKit(e, packageType(md))
 			if kit.Spec.Traits.Quarkus == nil {


### PR DESCRIPTION
<!-- Description -->

Makes sure JVM mode is executed before native mode.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

fixes: #5001

**Release Note**
```release-note
fix(#5001): Execute Quarkus JVM buildMode before native buildMode
```
