### PR TITLE
chore(ci): Upgrade github ci  actions

### DIFF
--- a/.github/actions/e2e-build/action.yml
+++ b/.github/actions/e2e-build/action.yml
@@ -40,7 +40,7 @@ runs:
       grep -o -P '(?<=\(statements\))(.+)(?=%)' coverage.out | xargs > ./pr/coverage
       echo ${{ github.event.number }} > ./pr/id
 
-  - uses: actions/upload-artifact@v2
+  - uses: actions/upload-artifact@v4
     with:
       name: pr
       path: pr/

--- a/.github/actions/java-build/action.yml
+++ b/.github/actions/java-build/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK ${{ inputs.javaVersion }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: ${{ inputs.javaDistribution }}
         java-version: ${{ inputs.javaVersion }}

--- a/.github/actions/kamel-prepare-env/action.yml
+++ b/.github/actions/kamel-prepare-env/action.yml
@@ -63,7 +63,7 @@ runs:
         df -h
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       if: ${{ env.ENV_PREPARED != 'true' }}
       with:
         java-version: '17'

--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -43,7 +43,7 @@ runs:
   steps:
 
     - name: Set up JDK ${{ inputs.javaVersion }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ inputs.javaVersion }}
         distribution: "temurin"

--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -98,10 +98,10 @@ runs:
         sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
     - name: Set up QEMU (required by multi platform build)
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Login to Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ inputs.secretDockerHubUser }}
         password: ${{ inputs.secretDockerHubPassword }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive

--- a/.github/workflows/comment-pr.yaml
+++ b/.github/workflows/comment-pr.yaml
@@ -17,7 +17,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: 'Download coverage artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -39,7 +39,7 @@ jobs:
       - run: unzip pr.zip
 
       - name: 'Comment on PR'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive
@@ -101,7 +101,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive
@@ -108,7 +108,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive
@@ -132,7 +132,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -46,7 +46,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Build java modules ${{ matrix.ref-branch }} branch

--- a/.github/workflows/knative.yml
+++ b/.github/workflows/knative.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive
@@ -94,7 +94,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive

--- a/.github/workflows/nightly-automatic-updates.yml
+++ b/.github/workflows/nightly-automatic-updates.yml
@@ -38,7 +38,7 @@ jobs:
     name: Automatic updates on ${{ matrix.ref-branch }} branch
     steps:
     - name: "Checkout code"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ matrix.ref-branch }}
         persist-credentials: false

--- a/.github/workflows/nightly-latest-runtime.yml
+++ b/.github/workflows/nightly-latest-runtime.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
     - name: "Checkout code"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ matrix.ref-branch }}
         persist-credentials: false

--- a/.github/workflows/nightly-native-test.yml
+++ b/.github/workflows/nightly-native-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-12
     steps:
     - name: "Checkout code"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ matrix.ref-branch }}
         persist-credentials: false

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout code"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ matrix.ref-branch }}
         persist-credentials: false

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -25,7 +25,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90

--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
         submodules: recursive

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
Global upgrade of following actions:
* actions/setup-java v3 -> v4
* actions/upload-artifact v2 -> v4
* actions/github-script v3 -> v7
* actions/checkout v3 -> v4
* docker/login-action v2 -> v3
* docker/setup-qemu-action v2 -> v3
* actions/stale v3 -> v9


**Release Note**
```release-note
chore(ci): Upgrade github ci  actions
```
