### PR TITLE
fix(#4776): Fix catalog loading in camel trait

### DIFF
--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -61,7 +61,11 @@ func (t *camelTrait) InfluencesBuild(this, prev map[string]interface{}) bool {
 
 func (t *camelTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 	if t.RuntimeVersion == "" {
-		t.RuntimeVersion = determineRuntimeVersion(e)
+		if runtimeVersion, err := determineRuntimeVersion(e); err != nil {
+			return false, nil, err
+		} else {
+			t.RuntimeVersion = runtimeVersion
+		}
 	}
 
 	// Don't run this trait for a synthetic Integration
@@ -100,8 +104,8 @@ func (t *camelTrait) Apply(e *Environment) error {
 }
 
 func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) error {
-	ns := e.DetermineCatalogNamespace()
-	if ns == "" {
+	catalogNamespace := e.DetermineCatalogNamespace()
+	if catalogNamespace == "" {
 		return errors.New("unable to determine namespace")
 	}
 
@@ -110,7 +114,7 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 		Provider: v1.RuntimeProviderQuarkus,
 	}
 
-	catalog, err := camel.LoadCatalog(e.Ctx, e.Client, ns, runtime)
+	catalog, err := camel.LoadCatalog(e.Ctx, e.Client, catalogNamespace, runtime)
 	if err != nil {
 		return err
 	}
@@ -123,7 +127,7 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 			ctx, cancel := context.WithTimeout(e.Ctx, e.Platform.Status.Build.GetTimeout().Duration)
 			defer cancel()
 			catalog, err = camel.GenerateCatalog(ctx, e.Client,
-				ns, e.Platform.Status.Build.Maven, runtime, []maven.Dependency{})
+				catalogNamespace, e.Platform.Status.Build.Maven, runtime, []maven.Dependency{})
 			if err != nil {
 				return err
 			}
@@ -131,7 +135,7 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 			// sanitize catalog name
 			catalogName := "camel-catalog-" + strings.ToLower(runtimeVersion)
 
-			cx := v1.NewCamelCatalogWithSpecs(ns, catalogName, catalog.CamelCatalogSpec)
+			cx := v1.NewCamelCatalogWithSpecs(catalogNamespace, catalogName, catalog.CamelCatalogSpec)
 			cx.Labels = make(map[string]string)
 			cx.Labels["app"] = "camel-k"
 			cx.Labels["camel.apache.org/runtime.version"] = runtime.Version
@@ -143,7 +147,7 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 					// It's still possible that catalog wasn't yet found at the time of loading
 					// but then created in the background before the client tries to create it.
 					// In this case, simply try loading again and reuse the existing catalog.
-					catalog, err = camel.LoadCatalog(e.Ctx, e.Client, ns, runtime)
+					catalog, err = camel.LoadCatalog(e.Ctx, e.Client, catalogNamespace, runtime)
 					if err != nil {
 						// unexpected error
 						return fmt.Errorf("catalog %q already exists but unable to load: %w", catalogName, err)
@@ -157,13 +161,13 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment, runtimeVersion string) 
 				}
 			}
 
-			// verify that the catalog was generated
+			// verify that the catalog has been generated
 			ct, err := kubernetes.GetUnstructured(
 				e.Ctx,
 				e.Client,
 				schema.GroupVersionKind{Group: "camel.apache.org", Version: "v1", Kind: "CamelCatalog"},
 				catalogName,
-				e.Integration.Namespace,
+				catalogNamespace,
 			)
 			if ct == nil || err != nil {
 				return fmt.Errorf("unable to create catalog runtime=%s, provider=%s, name=%s: %w",
@@ -266,15 +270,15 @@ func (t *camelTrait) computeConfigMaps(e *Environment) []ctrl.Object {
 	return maps
 }
 
-func determineRuntimeVersion(e *Environment) string {
+func determineRuntimeVersion(e *Environment) (string, error) {
 	if e.Integration != nil && e.Integration.Status.RuntimeVersion != "" {
-		return e.Integration.Status.RuntimeVersion
+		return e.Integration.Status.RuntimeVersion, nil
 	}
 	if e.IntegrationKit != nil && e.IntegrationKit.Status.RuntimeVersion != "" {
-		return e.IntegrationKit.Status.RuntimeVersion
+		return e.IntegrationKit.Status.RuntimeVersion, nil
 	}
 	if e.Platform != nil && e.Platform.Status.Build.RuntimeVersion != "" {
-		return e.Platform.Status.Build.RuntimeVersion
+		return e.Platform.Status.Build.RuntimeVersion, nil
 	}
-	return ""
+	return "", errors.New("unable to determine runtime version")
 }


### PR DESCRIPTION
- When new runtime version is used on integration the camel trait creates the catalog if it does not exist already
- Use proper catalog namespace to verify that the catalog resource has been created during the camel trait execution

Fixes #4776 

**Release Note**
```release-note
NONE
```
