### PR TITLE
fix(ci): Comment PR github action issues uses octokit 

### DIFF
--- a/.github/workflows/comment-pr.yaml
+++ b/.github/workflows/comment-pr.yaml
@@ -51,14 +51,14 @@ jobs:
             diff = Math.round((coverage - main_cov_num + Number.EPSILON) * 100) / 100
 
             if(diff > 0){
-              await github.issues.createComment({
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,
                 body: ':heavy_check_mark: Unit test coverage report - coverage increased from ' + main_cov_num + '% to ' + coverage + '% (**+' + diff + '%**)'
               })
             }else if(diff < 0){
-              await github.issues.createComment({
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,


### PR DESCRIPTION
Fix comment PR github actions workflow (github.issues).




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ci): Comment PR github action issues uses octokit 
```
