### PR TITLE
Add support for KUBECONFIG with multiple files

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,8 +18,6 @@ limitations under the License.
 package client
 
 import (
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -28,14 +26,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -45,7 +40,6 @@ import (
 	camel "github.com/apache/camel-k/v2/pkg/client/camel/clientset/versioned"
 	camelv1 "github.com/apache/camel-k/v2/pkg/client/camel/clientset/versioned/typed/camel/v1"
 	camelv1alpha1 "github.com/apache/camel-k/v2/pkg/client/camel/clientset/versioned/typed/camel/v1alpha1"
-	"github.com/apache/camel-k/v2/pkg/util"
 )
 
 const (
@@ -220,46 +214,17 @@ func getDefaultKubeConfigFile() (string, error) {
 
 // GetCurrentNamespace --.
 func GetCurrentNamespace(kubeconfig string) (string, error) {
-	if kubeconfig == "" {
-		kubeContainer, err := shouldUseContainerMode()
-		if err != nil {
-			return "", err
-		}
-		if kubeContainer {
-			return getNamespaceFromKubernetesContainer()
-		}
-	}
-	if kubeconfig == "" {
-		var err error
-		kubeconfig, err = getDefaultKubeConfigFile()
-		if err != nil {
-			logrus.Errorf("Cannot get information about current user: %v", err)
-		}
-	}
-	if kubeconfig == "" {
-		return "default", nil
+
+	if kubeconfig != "" {
+		os.Setenv(clientcmd.RecommendedConfigPathEnvVar, kubeconfig)
 	}
 
-	data, err := util.ReadFile(kubeconfig)
+	configLoader := clientcmd.NewDefaultClientConfigLoadingRules()
+	config, err := configLoader.Load()
 	if err != nil {
 		return "", err
 	}
-	conf := clientcmdapi.NewConfig()
-	if len(data) == 0 {
-		return "", errors.New("kubernetes config file is empty")
-	}
-
-	decoded, _, err := clientcmdlatest.Codec.Decode(data, &schema.GroupVersionKind{Version: clientcmdlatest.Version, Kind: "Config"}, conf)
-	if err != nil {
-		return "", err
-	}
-
-	clientcmdconfig, ok := decoded.(*clientcmdapi.Config)
-	if !ok {
-		return "", fmt.Errorf("type assertion failed: %v", decoded)
-	}
-
-	cc := clientcmd.NewDefaultClientConfig(*clientcmdconfig, &clientcmd.ConfigOverrides{})
+	cc := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{})
 	ns, _, err := cc.Namespace()
 	return ns, err
 }


### PR DESCRIPTION
This PR intends to solve the issue where a kubeconfig containing multiple files could not be used with Kamel. 

As defined in https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#linux-1


**Release Note**
```release-note
Add support to allow Kubeconfig to contain multiple file when using Kamel
```

Fixes  #5107