### PR TITLE
Add support to properly run out of cluster

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -165,8 +165,8 @@ func Run(healthPort, monitoringPort int32, leaderElection bool, leaderElectionID
 		// in which case it's not possible to determine a namespace.
 		operatorNamespace = watchNamespace
 		if operatorNamespace == "" {
-			leaderElection = false
-			log.Info("unable to determine namespace for leader election")
+			// We cannot go forward anyhow since later on we need a namespace to create resources
+			exitOnError(fmt.Errorf("Cannot continue as we need a namespace to be defined. Use either NAMESPACE or WATCH_NAMESPACE"), "")
 		}
 	}
 
@@ -295,7 +295,8 @@ func getOperatorImage(ctx context.Context, c ctrl.Reader) (string, error) {
 	ns := platform.GetOperatorNamespace()
 	name := platform.GetOperatorPodName()
 	if ns == "" || name == "" {
-		return "", nil
+		// We are most likely running out of cluster. Let's take a chance and use the default value
+		return defaults.OperatorImage(), nil
 	}
 
 	pod := corev1.Pod{}


### PR DESCRIPTION
This PR intends to solve some issue encountered while running the operator out of cluster. 

##  Current namespace requirement

We must be able to find the current namespace. If not is specified/detected we cannot keep going on as we will eventually require the namespace to be defined to create the integration plaform objects. 

The proposed solution is to not allow both NAMESPACE and WATCH_NAMESPACE to be empty as it creates an issue.

## Current operator image detection

The other issue, it that when running out of cluster, we inherently cannot, when requested, detect the current image as we are not in a pod.

The proposed solution is to simply return the default operator image and never return an empty image as it is used later in the operator execution.

**Release Note**
```release-note
NONE
```
