### PR TITLE
Allow to use the Toolimage specified in the provided buildconfig

### DIFF
--- a/pkg/controller/integrationkit/build.go
+++ b/pkg/controller/integrationkit/build.go
@@ -133,8 +133,10 @@ func (action *buildAction) handleBuildSubmitted(ctx context.Context, kit *v1.Int
 			}
 		}
 		// The build operation, when executed as a Pod, should be executed by a container image containing the
-		// `kamel builder` command. Likely the same image running the operator should be fine.
-		buildConfig.ToolImage = platform.OperatorImage
+		// `kamel builder` command. If not specified, likely the same image running the operator should be fine.
+		if buildConfig.ToolImage == "" {
+			buildConfig.ToolImage = platform.OperatorImage
+		}
 		buildConfig.BuilderPodNamespace = operatorNamespace
 		v1.SetBuilderConfigurationTasks(env.Pipeline, buildConfig)
 


### PR DESCRIPTION
This PR proposed to honor the configurationBuild field that can be used to provide a custom builder image. 

Currently we provide a field `ToolImage` that can be used to specify the image used by the builder. In the code, we specifically ignore the provided image and impose the operator image. 

The proposed changes will only use the operator image if the `ToolImage` field is not specified. 

In our current settings, it is actually the same behaviour that was expressed: we use the operator image as the `ToolImage` field. 

We could also deprecate the `ToolImage` field to express that the usage will not be honoured. 

**Release Note**
```release-note
NONE
```
