### PR TITLE
Fix: TestCreateCatalog fail when runtime is 3.6.0-SNAPSHOT

### DIFF
--- a/pkg/controller/integrationplatform/catalog_test.go
+++ b/pkg/controller/integrationplatform/catalog_test.go
@@ -80,7 +80,7 @@ func TestCreateCatalog(t *testing.T) {
 	ip.Spec.Build.Registry.Address = defaults.OpenShiftRegistryAddress
 
 	ip.Status.Phase = v1.IntegrationPlatformPhaseCreateCatalog
-	ip.Spec.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
+	ip.Spec.Build.RuntimeVersion = "3.2.3"
 
 	c, err := test.NewFakeClient(&ip)
 	assert.Nil(t, err)


### PR DESCRIPTION
Fix https://github.com/apache/camel-k/issues/5099

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
