### PR TITLE
Compute digest of configmap and secret from its data

### DIFF
--- a/e2e/common/config/config_reload_test.go
+++ b/e2e/common/config/config_reload_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 
@@ -118,15 +117,15 @@ func TestSecretHotReload(t *testing.T) {
 	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 }
 
-func TestConfigmapHotReloadDefaultDigest(t *testing.T) {
-	CheckConfigmapDigest(t, false)
+func TestConfigmapWithOwnerRefHotReloadDefault(t *testing.T) {
+	CheckConfigmapWithOwnerRef(t, false)
 }
 
-func TestConfigmapHotReloadDigest(t *testing.T) {
-	CheckConfigmapDigest(t, true)
+func TestConfigmapWithOwnerRefHotReload(t *testing.T) {
+	CheckConfigmapWithOwnerRef(t, true)
 }
 
-func CheckConfigmapDigest(t *testing.T, hotreload bool) {
+func CheckConfigmapWithOwnerRef(t *testing.T, hotreload bool) {
 	RegisterTestingT(t)
 	name := RandomizedSuffixName("config-configmap-route")
 	cmName := RandomizedSuffixName("my-hot-cm-")
@@ -138,33 +137,20 @@ func CheckConfigmapDigest(t *testing.T, hotreload bool) {
 		"-t",
 		"mount.hot-reload="+strconv.FormatBool(hotreload),
 	).Execute()).To(Succeed())
-	uid := Integration(ns, name)().UID
-	ikName := Integration(ns, name)().Status.IntegrationKit.Name
-	Eventually(KitPhase(ns, ikName), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
-
-	digest := Integration(ns, name)().Status.Digest
 
 	Eventually(IntegrationPhase(ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseError))
 	var cmData = make(map[string]string)
 	cmData["my-configmap-key"] = "my configmap content"
-	CreatePlainTextConfigmapWithOwnerRef(ns, cmName, cmData, name, uid)
+	CreatePlainTextConfigmapWithOwnerRef(ns, cmName, cmData, name, Integration(ns, name)().UID)
 	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	Eventually(IntegrationPhase(ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseRunning))
 	Eventually(IntegrationLogs(ns, name), TestTimeoutLong).Should(ContainSubstring("my configmap content"))
-
-	digest2 := Integration(ns, name)().Status.Digest
-	assert.NotEqual(t, digest, digest2)
-
 	cmData["my-configmap-key"] = "my configmap content updated"
 	UpdatePlainTextConfigmap(ns, cmName, cmData)
 	if hotreload {
 		Eventually(IntegrationLogs(ns, name), TestTimeoutLong).Should(ContainSubstring("my configmap content updated"))
-		assert.NotEqual(t, digest2, Integration(ns, name)().Status.Digest)
 	} else {
 		Eventually(IntegrationLogs(ns, name), TestTimeoutLong).Should(Not(ContainSubstring("my configmap content updated")))
-		assert.Equal(t, digest2, Integration(ns, name)().Status.Digest)
 	}
-
 	Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 	DeleteConfigmap(ns, cmName)
 }

--- a/e2e/common/config/config_reload_test.go
+++ b/e2e/common/config/config_reload_test.go
@@ -141,11 +141,11 @@ func CheckConfigmapWithOwnerRef(t *testing.T, hotreload bool) {
 	Eventually(IntegrationPhase(ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseError))
 	var cmData = make(map[string]string)
 	cmData["my-configmap-key"] = "my configmap content"
-	CreatePlainTextConfigmapWithOwnerRef(ns, cmName, cmData, name, Integration(ns, name)().UID)
+	CreatePlainTextConfigmapWithOwnerRefWithLabels(ns, cmName, cmData, name, Integration(ns, name)().UID, map[string]string{"camel.apache.org/integration": "test"})
 	Eventually(IntegrationPodPhase(ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 	Eventually(IntegrationLogs(ns, name), TestTimeoutLong).Should(ContainSubstring("my configmap content"))
 	cmData["my-configmap-key"] = "my configmap content updated"
-	UpdatePlainTextConfigmap(ns, cmName, cmData)
+	UpdatePlainTextConfigmapWithLabels(ns, cmName, cmData, map[string]string{"camel.apache.org/integration": "test"})
 	if hotreload {
 		Eventually(IntegrationLogs(ns, name), TestTimeoutLong).Should(ContainSubstring("my configmap content updated"))
 	} else {

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1606,7 +1606,7 @@ func CreatePlainTextConfigmapWithLabels(ns string, name string, data map[string]
 	return TestClient().Create(TestContext, &cm)
 }
 
-func CreatePlainTextConfigmapWithOwnerRef(ns string, name string, data map[string]string, orname string, uid types.UID) error {
+func CreatePlainTextConfigmapWithOwnerRefWithLabels(ns string, name string, data map[string]string, orname string, uid types.UID, labels map[string]string) error {
 	cm := corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
@@ -1624,6 +1624,7 @@ func CreatePlainTextConfigmapWithOwnerRef(ns string, name string, data map[strin
 				BlockOwnerDeletion: pointer.Bool(true),
 			},
 			},
+			Labels: labels,
 		},
 		Data: data,
 	}

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1606,6 +1606,30 @@ func CreatePlainTextConfigmapWithLabels(ns string, name string, data map[string]
 	return TestClient().Create(TestContext, &cm)
 }
 
+func CreatePlainTextConfigmapWithOwnerRef(ns string, name string, data map[string]string, orname string, uid types.UID) error {
+	cm := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         v1.SchemeGroupVersion.String(),
+				Kind:               "Integration",
+				Name:               orname,
+				UID:                uid,
+				Controller:         pointer.Bool(true),
+				BlockOwnerDeletion: pointer.Bool(true),
+			},
+			},
+		},
+		Data: data,
+	}
+	return TestClient().Create(TestContext, &cm)
+}
+
 func UpdatePlainTextConfigmap(ns string, name string, data map[string]string) error {
 	return UpdatePlainTextConfigmapWithLabels(ns, name, data, nil)
 }

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -157,6 +157,19 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 					}
 				}
 			}
+			//BinaryData with sorted keys
+			if cm.BinaryData != nil {
+				keys := make([]string, 0, len(cm.BinaryData))
+				for k := range cm.BinaryData {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, cm.BinaryData[k]))); err != nil {
+						return "", err
+					}
+				}
+			}
 		}
 	}
 
@@ -176,19 +189,6 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 				sort.Strings(keys)
 				for _, k := range keys {
 					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, s.Data[k]))); err != nil {
-						return "", err
-					}
-				}
-			}
-			//StringData with sorted keys
-			if s.StringData != nil {
-				keys2 := make([]string, 0, len(s.StringData))
-				for k := range s.StringData {
-					keys2 = append(keys2, k)
-				}
-				sort.Strings(keys2)
-				for _, k := range keys2 {
-					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, s.StringData[k]))); err != nil {
 						return "", err
 					}
 				}

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -136,15 +136,63 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 		}
 	}
 
-	// Configmap and secret content
+	// Configmap content
 	for _, cm := range configmaps {
-		if _, err := hash.Write([]byte(cm.String())); err != nil {
-			return "", err
+		if cm != nil {
+			//name, ns
+			if _, err := hash.Write([]byte(fmt.Sprintf("#{cm.Name}/#{cm.Namespace}"))); err != nil {
+				return "", err
+			}
+			//Data with sorted keys
+			if cm.Data != nil {
+				//sort keys
+				keys := make([]string, 0, len(cm.Data))
+				for k := range cm.Data {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, cm.Data[k]))); err != nil {
+						return "", err
+					}
+				}
+			}
 		}
 	}
+
+	//Secret content
 	for _, s := range secrets {
-		if _, err := hash.Write([]byte(s.String())); err != nil {
-			return "", err
+		if s != nil {
+			//name, ns
+			if _, err := hash.Write([]byte(fmt.Sprintf("#{s.Name}/#{s.Namespace}"))); err != nil {
+				return "", err
+			}
+			//Data with sorted keys
+			if s.Data != nil {
+				keys := make([]string, 0, len(s.Data))
+				for k := range s.Data {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, s.Data[k]))); err != nil {
+						return "", err
+					}
+				}
+			}
+			//StringData with sorted keys
+			if s.StringData != nil {
+				keys2 := make([]string, 0, len(s.StringData))
+				for k := range s.Data {
+					keys2 = append(keys2, k)
+				}
+				sort.Strings(keys2)
+				for _, k := range keys2 {
+					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, s.StringData[k]))); err != nil {
+						return "", err
+					}
+				}
+			}
 		}
 	}
 

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -183,7 +183,7 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 			//StringData with sorted keys
 			if s.StringData != nil {
 				keys2 := make([]string, 0, len(s.StringData))
-				for k := range s.Data {
+				for k := range s.StringData {
 					keys2 = append(keys2, k)
 				}
 				sort.Strings(keys2)

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -24,7 +24,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"hash"
 	"io"
 	"path/filepath"
@@ -37,6 +36,8 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/dsl"
 	corev1 "k8s.io/api/core/v1"
+
+	"fmt"
 )
 
 const (
@@ -139,13 +140,13 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 	// Configmap content
 	for _, cm := range configmaps {
 		if cm != nil {
-			//name, ns
-			if _, err := hash.Write([]byte(fmt.Sprintf("#{cm.Name}/#{cm.Namespace}"))); err != nil {
+			// name, ns
+			if _, err := hash.Write([]byte(fmt.Sprintf("%s/%s", cm.Name, cm.Namespace))); err != nil {
 				return "", err
 			}
-			//Data with sorted keys
+			// Data with sorted keys
 			if cm.Data != nil {
-				//sort keys
+				// sort keys
 				keys := make([]string, 0, len(cm.Data))
 				for k := range cm.Data {
 					keys = append(keys, k)
@@ -157,7 +158,7 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 					}
 				}
 			}
-			//BinaryData with sorted keys
+			// BinaryData with sorted keys
 			if cm.BinaryData != nil {
 				keys := make([]string, 0, len(cm.BinaryData))
 				for k := range cm.BinaryData {
@@ -173,14 +174,14 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 		}
 	}
 
-	//Secret content
+	// Secret content
 	for _, s := range secrets {
 		if s != nil {
-			//name, ns
-			if _, err := hash.Write([]byte(fmt.Sprintf("#{s.Name}/#{s.Namespace}"))); err != nil {
+			// name, ns
+			if _, err := hash.Write([]byte(fmt.Sprintf("%s/%s", s.Name, s.Namespace))); err != nil {
 				return "", err
 			}
-			//Data with sorted keys
+			// Data with sorted keys
 			if s.Data != nil {
 				keys := make([]string, 0, len(s.Data))
 				for k := range s.Data {

--- a/pkg/util/digest/digest_test.go
+++ b/pkg/util/digest/digest_test.go
@@ -18,11 +18,14 @@ limitations under the License.
 package digest
 
 import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
-	"os"
-	"testing"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +80,7 @@ func TestDigestUsesConfigmap(t *testing.T) {
 	}
 
 	digest1, err := ComputeForIntegration(&it, nil, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cm := corev1.ConfigMap{
 		Data: map[string]string{
@@ -87,16 +90,16 @@ func TestDigestUsesConfigmap(t *testing.T) {
 	cms := []*corev1.ConfigMap{&cm}
 
 	digest2, err := ComputeForIntegration(&it, cms, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, digest1, digest2)
 
 	cm.Data["foo"] = "bar updated"
 	digest3, err := ComputeForIntegration(&it, cms, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, digest2, digest3)
 
 	digest4, err := ComputeForIntegration(&it, cms, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, digest4, digest3)
 }
 
@@ -113,7 +116,7 @@ func TestDigestUsesSecret(t *testing.T) {
 	}
 
 	digest1, err := ComputeForIntegration(&it, nil, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sec := corev1.Secret{
 		Data: map[string][]byte{
@@ -127,11 +130,11 @@ func TestDigestUsesSecret(t *testing.T) {
 	secrets := []*corev1.Secret{&sec}
 
 	digest2, err := ComputeForIntegration(&it, nil, secrets)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, digest1, digest2)
 
 	sec.Data["foo"] = []byte("bar updated")
 	digest3, err := ComputeForIntegration(&it, nil, secrets)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, digest2, digest3)
 }

--- a/pkg/util/digest/digest_test.go
+++ b/pkg/util/digest/digest_test.go
@@ -18,9 +18,6 @@ limitations under the License.
 package digest
 
 import (
-	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
 	"os"
 	"testing"
 
@@ -62,85 +59,4 @@ func TestDigestSHA1FromTempFile(t *testing.T) {
 	sha1, err := ComputeSHA1(tmpFile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, "OXPdxTeLf5rqnsqvTi0CgmWoN/0=", sha1)
-}
-
-func TestDigestUsesConfigmap(t *testing.T) {
-	it := v1.Integration{
-		Spec: v1.IntegrationSpec{
-			Traits: v1.Traits{
-				Mount: &trait.MountTrait{
-					Configs:   []string{"configmap:cm"},
-					HotReload: pointer.Bool(true),
-				},
-			},
-		},
-	}
-
-	digest1, err := ComputeForIntegration(&it, nil, nil)
-	assert.NoError(t, err)
-
-	cm := corev1.ConfigMap{
-		Data: map[string]string{
-			"foo": "bar",
-		},
-	}
-	cms := []*corev1.ConfigMap{&cm}
-
-	digest2, err := ComputeForIntegration(&it, cms, nil)
-	assert.NoError(t, err)
-	assert.NotEqual(t, digest1, digest2)
-
-	cm.Data["foo"] = "bar updated"
-	digest3, err := ComputeForIntegration(&it, cms, nil)
-	assert.NoError(t, err)
-	assert.NotEqual(t, digest2, digest3)
-
-	digest4, err := ComputeForIntegration(&it, cms, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, digest4, digest3)
-}
-
-func TestDigestUsesSecret(t *testing.T) {
-	it := v1.Integration{
-		Spec: v1.IntegrationSpec{
-			Traits: v1.Traits{
-				Mount: &trait.MountTrait{
-					Configs:   []string{"secret:mysec"},
-					HotReload: pointer.Bool(true),
-				},
-			},
-		},
-	}
-
-	digest1, err := ComputeForIntegration(&it, nil, nil)
-	assert.NoError(t, err)
-
-	sec := corev1.Secret{
-		Data: map[string][]byte{
-			"foo": []byte("bar"),
-		},
-		StringData: map[string]string{
-			"foo2": "bar2",
-		},
-	}
-
-	secrets := []*corev1.Secret{&sec}
-
-	digest2, err := ComputeForIntegration(&it, nil, secrets)
-	assert.NoError(t, err)
-	assert.NotEqual(t, digest1, digest2)
-
-	sec.Data["foo"] = []byte("bar updated")
-	digest3, err := ComputeForIntegration(&it, nil, secrets)
-	assert.NoError(t, err)
-	assert.NotEqual(t, digest2, digest3)
-
-	sec.StringData["foo2"] = "bar2 updated"
-	digest4, err := ComputeForIntegration(&it, nil, secrets)
-	assert.NoError(t, err)
-	assert.NotEqual(t, digest3, digest4)
-
-	digest5, err := ComputeForIntegration(&it, nil, secrets)
-	assert.NoError(t, err)
-	assert.Equal(t, digest4, digest5)
 }

--- a/pkg/util/digest/digest_test.go
+++ b/pkg/util/digest/digest_test.go
@@ -18,6 +18,9 @@ limitations under the License.
 package digest
 
 import (
+	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 	"os"
 	"testing"
 
@@ -59,4 +62,85 @@ func TestDigestSHA1FromTempFile(t *testing.T) {
 	sha1, err := ComputeSHA1(tmpFile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, "OXPdxTeLf5rqnsqvTi0CgmWoN/0=", sha1)
+}
+
+func TestDigestUsesConfigmap(t *testing.T) {
+	it := v1.Integration{
+		Spec: v1.IntegrationSpec{
+			Traits: v1.Traits{
+				Mount: &trait.MountTrait{
+					Configs:   []string{"configmap:cm"},
+					HotReload: pointer.Bool(true),
+				},
+			},
+		},
+	}
+
+	digest1, err := ComputeForIntegration(&it, nil, nil)
+	assert.NoError(t, err)
+
+	cm := corev1.ConfigMap{
+		Data: map[string]string{
+			"foo": "bar",
+		},
+	}
+	cms := []*corev1.ConfigMap{&cm}
+
+	digest2, err := ComputeForIntegration(&it, cms, nil)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest1, digest2)
+
+	cm.Data["foo"] = "bar updated"
+	digest3, err := ComputeForIntegration(&it, cms, nil)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest2, digest3)
+
+	digest4, err := ComputeForIntegration(&it, cms, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, digest4, digest3)
+}
+
+func TestDigestUsesSecret(t *testing.T) {
+	it := v1.Integration{
+		Spec: v1.IntegrationSpec{
+			Traits: v1.Traits{
+				Mount: &trait.MountTrait{
+					Configs:   []string{"secret:mysec"},
+					HotReload: pointer.Bool(true),
+				},
+			},
+		},
+	}
+
+	digest1, err := ComputeForIntegration(&it, nil, nil)
+	assert.NoError(t, err)
+
+	sec := corev1.Secret{
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+		StringData: map[string]string{
+			"foo2": "bar2",
+		},
+	}
+
+	secrets := []*corev1.Secret{&sec}
+
+	digest2, err := ComputeForIntegration(&it, nil, secrets)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest1, digest2)
+
+	sec.Data["foo"] = []byte("bar updated")
+	digest3, err := ComputeForIntegration(&it, nil, secrets)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest2, digest3)
+
+	sec.StringData["foo2"] = "bar2 updated"
+	digest4, err := ComputeForIntegration(&it, nil, secrets)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest3, digest4)
+
+	digest5, err := ComputeForIntegration(&it, nil, secrets)
+	assert.NoError(t, err)
+	assert.Equal(t, digest4, digest5)
 }

--- a/pkg/util/digest/digest_test.go
+++ b/pkg/util/digest/digest_test.go
@@ -18,6 +18,9 @@ limitations under the License.
 package digest
 
 import (
+	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 	"os"
 	"testing"
 
@@ -59,4 +62,76 @@ func TestDigestSHA1FromTempFile(t *testing.T) {
 	sha1, err := ComputeSHA1(tmpFile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, "OXPdxTeLf5rqnsqvTi0CgmWoN/0=", sha1)
+}
+
+func TestDigestUsesConfigmap(t *testing.T) {
+	it := v1.Integration{
+		Spec: v1.IntegrationSpec{
+			Traits: v1.Traits{
+				Mount: &trait.MountTrait{
+					Configs:   []string{"configmap:cm"},
+					HotReload: pointer.Bool(true),
+				},
+			},
+		},
+	}
+
+	digest1, err := ComputeForIntegration(&it, nil, nil)
+	assert.NoError(t, err)
+
+	cm := corev1.ConfigMap{
+		Data: map[string]string{
+			"foo": "bar",
+		},
+	}
+	cms := []*corev1.ConfigMap{&cm}
+
+	digest2, err := ComputeForIntegration(&it, cms, nil)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest1, digest2)
+
+	cm.Data["foo"] = "bar updated"
+	digest3, err := ComputeForIntegration(&it, cms, nil)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest2, digest3)
+
+	digest4, err := ComputeForIntegration(&it, cms, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, digest4, digest3)
+}
+
+func TestDigestUsesSecret(t *testing.T) {
+	it := v1.Integration{
+		Spec: v1.IntegrationSpec{
+			Traits: v1.Traits{
+				Mount: &trait.MountTrait{
+					Configs:   []string{"secret:mysec"},
+					HotReload: pointer.Bool(true),
+				},
+			},
+		},
+	}
+
+	digest1, err := ComputeForIntegration(&it, nil, nil)
+	assert.NoError(t, err)
+
+	sec := corev1.Secret{
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+		StringData: map[string]string{
+			"foo2": "bar2",
+		},
+	}
+
+	secrets := []*corev1.Secret{&sec}
+
+	digest2, err := ComputeForIntegration(&it, nil, secrets)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest1, digest2)
+
+	sec.Data["foo"] = []byte("bar updated")
+	digest3, err := ComputeForIntegration(&it, nil, secrets)
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest2, digest3)
 }


### PR DESCRIPTION
Proposal of fix to https://github.com/apache/camel-k/issues/5114 - use Name, Namespace and Data/StringData to compute digest of Configmap and Secret.