### PR TITLE
feat(#5103): Adding nodeSelector to the operator helm chart

### DIFF
--- a/helm/camel-k/README.md
+++ b/helm/camel-k/README.md
@@ -117,6 +117,7 @@ The following table lists the most commonly configured parameters of the Camel K
 | `platform.cluster`                     | The kind of Kubernetes cluster (Kubernetes or OpenShift)                  | `Kubernetes`                   |
 | `platform.profile`                     | The trait profile to use (Knative, Kubernetes or OpenShift)               | auto                           |
 | `operator.global`                      | Indicates if the operator should watch all namespaces                     | `false`                        |
+| `operator.nodeSelector`                | The nodeSelector to use for the operator                                  |                                |
 | `operator.resources`                   | The resource requests and limits to use for the operator                  |                                |
 | `operator.securityContext`             | The (container-related) securityContext to use for the operator           |                                |
 | `operator.tolerations`                 | The list of tolerations to use for the operator                           |                                |

--- a/helm/camel-k/templates/operator.yaml
+++ b/helm/camel-k/templates/operator.yaml
@@ -104,6 +104,10 @@ spec:
               drop:
               - ALL
           {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: camel-k-operator
       {{- with .Values.operator.tolerations }}
       tolerations:

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -28,6 +28,7 @@ operator:
   resources: {}
   securityContext: {}
   tolerations: []
+  nodeSelector: {}
   logLevel: "info"
 
   ## Deployment annotations


### PR DESCRIPTION
<!-- Description -->

This resolves #5103 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
It is now possible to set the operator nodeSelector in the helm values file.
```
