### PR TITLE
fix(github actions): restircted image-pull-policy-always patch apply …

### DIFF
--- a/.github/actions/kamel-build-bundle/build-bundle-image.sh
+++ b/.github/actions/kamel-build-bundle/build-bundle-image.sh
@@ -96,7 +96,7 @@ fi
 # Use kustomize to patch the deployment resource
 #
 pushd config/manager > /dev/null
-kustomize edit add patch --path patch-image-pull-policy-always.yaml --kind Deployment
+kustomize edit add patch --path patch-image-pull-policy-always.yaml --kind Deployment --name camel-k-operator
 popd
 
 #


### PR DESCRIPTION
…to specific operator container name.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
