### PR TITLE
[Backport 2.2.x]: fix(doc): Add warning on cron trait for native build

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -6126,6 +6126,8 @@ in order to save resources when the integration does not need to be executed.
 
 Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 
+WARNING: In case of native build-mode defined in xref:traits:quarkus.adoc[quarkus] trait, the component can't be customized.
+
 The rules for using a Kubernetes CronJob are the following:
 
   - `timer`: when period is set in milliseconds with no remaining seconds, for example 120000. If there is any second left as in 121000 (120s and 1s) or the presence of any of these parameters (delay, repeatCount, time) then a CronJob  won't be created, but a standard deployment.

--- a/docs/modules/traits/pages/cron.adoc
+++ b/docs/modules/traits/pages/cron.adoc
@@ -10,6 +10,8 @@ in order to save resources when the integration does not need to be executed.
 
 Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 
+WARNING: In case of native build-mode defined in xref:traits:quarkus.adoc[quarkus] trait, the component can't be customized.
+
 The rules for using a Kubernetes CronJob are the following:
 
   - `timer`: when period is set in milliseconds with no remaining seconds, for example 120000. If there is any second left as in 121000 (120s and 1s) or the presence of any of these parameters (delay, repeatCount, time) then a CronJob  won't be created, but a standard deployment.

--- a/pkg/apis/camel/v1/trait/cron.go
+++ b/pkg/apis/camel/v1/trait/cron.go
@@ -26,6 +26,8 @@ package trait
 //
 // Integrations that start from the following components are evaluated by the cron trait: `timer`, `cron`, `quartz`.
 //
+// WARNING: In case of native build-mode defined in xref:traits:quarkus.adoc[quarkus] trait, the component can't be customized.
+//
 // The rules for using a Kubernetes CronJob are the following:
 //
 //   - `timer`: when period is set in milliseconds with no remaining seconds, for example 120000. If there is any second left as in 121000 (120s and 1s) or the presence of any of these parameters (delay, repeatCount, time) then a CronJob  won't be created, but a standard deployment.

--- a/resources/traits.yaml
+++ b/resources/traits.yaml
@@ -390,14 +390,15 @@ traits:
     For such tasks, the cron trait can materialize the integration as a Kubernetes
     CronJob instead of a standard deployment, in order to save resources when the
     integration does not need to be executed. Integrations that start from the following
-    components are evaluated by the cron trait: `timer`, `cron`, `quartz`. The rules
-    for using a Kubernetes CronJob are the following: - `timer`: when period is set
-    in milliseconds with no remaining seconds, for example 120000. If there is any
-    second left as in 121000 (120s and 1s) or the presence of any of these parameters
-    (delay, repeatCount, time) then a CronJob  won''t be created, but a standard deployment.
-    - `cron`, `quartz`: when the cron expression does not contain seconds (or the
-    "seconds" part is set to 0). E.g. `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?`
-    or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.'
+    components are evaluated by the cron trait: `timer`, `cron`, `quartz`. WARNING:
+    In case of native build-mode defined in xref:traits:quarkus.adoc[quarkus] trait,
+    the component can''t be customized. The rules for using a Kubernetes CronJob are
+    the following: - `timer`: when period is set in milliseconds with no remaining
+    seconds, for example 120000. If there is any second left as in 121000 (120s and
+    1s) or the presence of any of these parameters (delay, repeatCount, time) then
+    a CronJob  won''t be created, but a standard deployment. - `cron`, `quartz`: when
+    the cron expression does not contain seconds (or the "seconds" part is set to
+    0). E.g. `cron:tab?schedule=0/2${plus}*{plus}*{plus}*{plus}?` or `quartz:trigger?cron=0{plus}0/2{plus}*{plus}*{plus}*{plus}?`.'
   properties:
   - name: enabled
     type: bool


### PR DESCRIPTION
Backport from https://github.com/apache/camel-k/pull/5127




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(doc): Add warning on cron trait for native build
```
