### PR TITLE
fix(test): add apache-snapshot repository as the test may run agains a camel-k-runtime snaphost release

### DIFF
--- a/pkg/controller/integrationplatform/catalog.go
+++ b/pkg/controller/integrationplatform/catalog.go
@@ -65,7 +65,7 @@ func (action *catalogAction) Handle(ctx context.Context, platform *v1.Integratio
 				v1.IntegrationPlatformConditionCamelCatalogAvailable,
 				corev1.ConditionFalse,
 				v1.IntegrationPlatformConditionCamelCatalogAvailableReason,
-				fmt.Sprintf("camel catalog %s not available, please review given runtime version", runtimeSpec.Version))
+				fmt.Sprintf("camel catalog %s not available, please review given runtime version. Error: %s", runtimeSpec.Version, err))
 
 			return platform, nil
 		}


### PR DESCRIPTION
The nightly check is failing when camel-k-runtime is a snapshot release, so the apache snapshot repository must be added to the settings.xml when testing.
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
