### PR TITLE
Reduce write to hash, prepare string from secret, configmap

### DIFF
--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -140,10 +140,10 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 	// Configmap content
 	for _, cm := range configmaps {
 		if cm != nil {
+			// prepare string from cm
+			var cmToString strings.Builder
 			// name, ns
-			if _, err := hash.Write([]byte(fmt.Sprintf("%s/%s", cm.Name, cm.Namespace))); err != nil {
-				return "", err
-			}
+			cmToString.WriteString(fmt.Sprintf("%s/%s", cm.Name, cm.Namespace))
 			// Data with sorted keys
 			if cm.Data != nil {
 				// sort keys
@@ -153,9 +153,7 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 				}
 				sort.Strings(keys)
 				for _, k := range keys {
-					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, cm.Data[k]))); err != nil {
-						return "", err
-					}
+					cmToString.WriteString(fmt.Sprintf("%s=%v,", k, cm.Data[k]))
 				}
 			}
 			// BinaryData with sorted keys
@@ -166,10 +164,12 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 				}
 				sort.Strings(keys)
 				for _, k := range keys {
-					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, cm.BinaryData[k]))); err != nil {
-						return "", err
-					}
+					cmToString.WriteString(fmt.Sprintf("%s=%v,", k, cm.BinaryData[k]))
 				}
+			}
+			// write prepared string to hash
+			if _, err := hash.Write([]byte(cmToString.String())); err != nil {
+				return "", err
 			}
 		}
 	}
@@ -177,10 +177,10 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 	// Secret content
 	for _, s := range secrets {
 		if s != nil {
+			// prepare string from secret
+			var secretToString strings.Builder
 			// name, ns
-			if _, err := hash.Write([]byte(fmt.Sprintf("%s/%s", s.Name, s.Namespace))); err != nil {
-				return "", err
-			}
+			secretToString.WriteString(fmt.Sprintf("%s/%s", s.Name, s.Namespace))
 			// Data with sorted keys
 			if s.Data != nil {
 				keys := make([]string, 0, len(s.Data))
@@ -189,10 +189,12 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 				}
 				sort.Strings(keys)
 				for _, k := range keys {
-					if _, err := hash.Write([]byte(fmt.Sprintf("%s=%v,", k, s.Data[k]))); err != nil {
-						return "", err
-					}
+					secretToString.WriteString(fmt.Sprintf("%s=%v,", k, s.Data[k]))
 				}
+			}
+			// write prepared secret to hash
+			if _, err := hash.Write([]byte(secretToString.String())); err != nil {
+				return "", err
 			}
 		}
 	}


### PR DESCRIPTION
Proposal of improvement to https://github.com/apache/camel-k/pull/5115 - reduce number of writes to `hash` object (failing test `TestRunDevMode`)
