### PR TITLE
chore: Rename trait profile funcs

### DIFF
--- a/e2e/knative/knative_platform_test.go
+++ b/e2e/knative/knative_platform_test.go
@@ -60,7 +60,7 @@ func TestKnativePlatformDetection(t *testing.T) {
 			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml", "--profile", string(cluster)).Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 			Eventually(IntegrationLogs(ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			Eventually(IntegrationProfile(ns, "yaml"), TestTimeoutShort).Should(Equal(v1.TraitProfile(string(cluster))))
+			Eventually(IntegrationTraitProfile(ns, "yaml"), TestTimeoutShort).Should(Equal(v1.TraitProfile(string(cluster))))
 			// Change something in the integration to produce a redeploy
 			Expect(UpdateIntegration(ns, "yaml", func(it *v1.Integration) {
 				it.Spec.Profile = ""
@@ -77,7 +77,7 @@ func TestKnativePlatformDetection(t *testing.T) {
 			Eventually(IntegrationPhase(ns, "yaml")).Should(Equal(v1.IntegrationPhaseRunning))
 			Eventually(IntegrationLogs(ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!!!"))
 			// It should keep the old profile saved in status
-			Eventually(IntegrationProfile(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.TraitProfile(cluster)))
+			Eventually(IntegrationTraitProfile(ns, "yaml"), TestTimeoutMedium).Should(Equal(v1.TraitProfile(cluster)))
 
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
@@ -85,7 +85,7 @@ func TestKnativePlatformDetection(t *testing.T) {
 		t.Run("run yaml on automatic profile", func(t *testing.T) {
 			Expect(KamelRunWithID(operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
 			Eventually(IntegrationPodPhase(ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			Eventually(IntegrationProfile(ns, "yaml"), TestTimeoutShort).Should(Equal(v1.TraitProfileKnative))
+			Eventually(IntegrationTraitProfile(ns, "yaml"), TestTimeoutShort).Should(Equal(v1.TraitProfileKnative))
 			Expect(Kamel("delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 	})

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1053,7 +1053,7 @@ func IntegrationVersion(ns string, name string) func() string {
 	}
 }
 
-func IntegrationProfile(ns string, name string) func() v1.TraitProfile {
+func IntegrationTraitProfile(ns string, name string) func() v1.TraitProfile {
 	return func() v1.TraitProfile {
 		it := Integration(ns, name)()
 		if it == nil {

--- a/pkg/controller/integration/platform_setup.go
+++ b/pkg/controller/integration/platform_setup.go
@@ -63,7 +63,7 @@ func (action *platformSetupAction) Handle(ctx context.Context, integration *v1.I
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return nil, err
 	} else if pl != nil {
-		profile, err := determineBestProfile(action.client, integration, pl)
+		profile, err := determineBestTraitProfile(action.client, integration, pl)
 		if err != nil {
 			return nil, err
 		}
@@ -80,8 +80,8 @@ func (action *platformSetupAction) Handle(ctx context.Context, integration *v1.I
 	return integration, nil
 }
 
-// DetermineBestProfile tries to detect the best trait profile for the integration.
-func determineBestProfile(c client.Client, integration *v1.Integration, p *v1.IntegrationPlatform) (v1.TraitProfile, error) {
+// determineBestTraitProfile tries to detect the best trait profile for the integration.
+func determineBestTraitProfile(c client.Client, integration *v1.Integration, p *v1.IntegrationPlatform) (v1.TraitProfile, error) {
 	if integration.Spec.Profile != "" {
 		return integration.Spec.Profile, nil
 	}
@@ -102,5 +102,5 @@ func determineBestProfile(c client.Client, integration *v1.Integration, p *v1.In
 	} else if ok {
 		return v1.TraitProfileKnative, nil
 	}
-	return platform.GetProfile(p), nil
+	return platform.GetTraitProfile(p), nil
 }

--- a/pkg/controller/kameletbinding/integration.go
+++ b/pkg/controller/kameletbinding/integration.go
@@ -86,7 +86,7 @@ func CreateIntegrationFor(ctx context.Context, c client.Client, binding *v1alpha
 		it.Spec.Replicas = &replicas
 	}
 
-	profile, err := determineProfile(ctx, c, binding)
+	profile, err := determineTraitProfile(ctx, c, binding)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func configureKameletBinding(integration *v1.Integration, bindings ...*bindings.
 	return nil
 }
 
-func determineProfile(ctx context.Context, c client.Client, binding *v1alpha1.KameletBinding) (v1.TraitProfile, error) {
+func determineTraitProfile(ctx context.Context, c client.Client, binding *v1alpha1.KameletBinding) (v1.TraitProfile, error) {
 	if binding.Spec.Integration != nil && binding.Spec.Integration.Profile != "" {
 		return binding.Spec.Integration.Profile, nil
 	}
@@ -255,7 +255,7 @@ func determineProfile(ctx context.Context, c client.Client, binding *v1alpha1.Ka
 	}
 	if pl != nil {
 		// Determine profile from cluster type
-		plProfile := platform.GetProfile(pl)
+		plProfile := platform.GetTraitProfile(pl)
 		if plProfile != "" {
 			return plProfile, nil
 		}

--- a/pkg/controller/pipe/integration.go
+++ b/pkg/controller/pipe/integration.go
@@ -42,7 +42,7 @@ var (
 	endpointTypeSinkContext   = bindings.EndpointContext{Type: v1.EndpointTypeSink}
 )
 
-// CreateIntegrationFor creates and Integration from the a Pipe.
+// CreateIntegrationFor creates and Integration from a Pipe.
 func CreateIntegrationFor(ctx context.Context, c client.Client, binding *v1.Pipe) (*v1.Integration, error) {
 	controller := true
 	blockOwnerDeletion := true
@@ -88,7 +88,7 @@ func CreateIntegrationFor(ctx context.Context, c client.Client, binding *v1.Pipe
 		it.Spec.Replicas = &replicas
 	}
 
-	profile, err := determineProfile(ctx, c, binding)
+	profile, err := determineTraitProfile(ctx, c, binding)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func configureBinding(integration *v1.Integration, bindings ...*bindings.Binding
 	return nil
 }
 
-func determineProfile(ctx context.Context, c client.Client, binding *v1.Pipe) (v1.TraitProfile, error) {
+func determineTraitProfile(ctx context.Context, c client.Client, binding *v1.Pipe) (v1.TraitProfile, error) {
 	if binding.Spec.Integration != nil && binding.Spec.Integration.Profile != "" {
 		return binding.Spec.Integration.Profile, nil
 	}
@@ -258,7 +258,7 @@ func determineProfile(ctx context.Context, c client.Client, binding *v1.Pipe) (v
 	}
 	if pl != nil {
 		// Determine profile from cluster type
-		plProfile := platform.GetProfile(pl)
+		plProfile := platform.GetTraitProfile(pl)
 		if plProfile != "" {
 			return plProfile, nil
 		}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -205,8 +205,8 @@ func IsSecondary(p *v1.IntegrationPlatform) bool {
 	return false
 }
 
-// GetProfile returns the current profile of the platform (if present) or returns the default one for the cluster.
-func GetProfile(p *v1.IntegrationPlatform) v1.TraitProfile {
+// GetTraitProfile returns the current profile of the platform (if present) or returns the default one for the cluster.
+func GetTraitProfile(p *v1.IntegrationPlatform) v1.TraitProfile {
 	if p.Status.Profile != "" {
 		return p.Status.Profile
 	} else if p.Spec.Profile != "" {

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -318,7 +318,7 @@ func (e *Environment) DetermineProfile() v1.TraitProfile {
 	}
 
 	if e.Platform != nil {
-		return platform.GetProfile(e.Platform)
+		return platform.GetTraitProfile(e.Platform)
 	}
 
 	return v1.DefaultTraitProfile


### PR DESCRIPTION
Be more accurate in func naming regarding TraitProfile. This is a preparation to changes in #5097 where a IntegrationProfile may be introduced. Avoids func name clash with TraitProfile

**Release Note**
```release-note
NONE
```
