### PR TITLE
chore(knative): configure via properties

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -7183,7 +7183,6 @@ Automatically deploy the integration as Knative service when all conditions hold
 The Knative trait automatically discovers addresses of Knative resources and inject them into the
 running integration.
 
-The full Knative configuration is injected in the CAMEL_KNATIVE_CONFIGURATION in JSON format.
 The Camel Knative component will then use the full configuration to configure the routes.
 
 The trait is enabled by default when the Knative profile is active.

--- a/docs/modules/traits/pages/knative.adoc
+++ b/docs/modules/traits/pages/knative.adoc
@@ -4,7 +4,6 @@
 The Knative trait automatically discovers addresses of Knative resources and inject them into the
 running integration.
 
-The full Knative configuration is injected in the CAMEL_KNATIVE_CONFIGURATION in JSON format.
 The Camel Knative component will then use the full configuration to configure the routes.
 
 The trait is enabled by default when the Knative profile is active.

--- a/pkg/apis/camel/v1/knative/types.go
+++ b/pkg/apis/camel/v1/knative/types.go
@@ -38,6 +38,7 @@ type CamelServiceDefinition struct {
 	URL         string            `json:"url,omitempty"`
 	Path        string            `json:"path,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+	SinkBinding bool              `json:"sinkBinding,omitempty"`
 }
 
 // CamelEndpointKind -- .

--- a/pkg/apis/camel/v1/knative/types_support_test.go
+++ b/pkg/apis/camel/v1/knative/types_support_test.go
@@ -1,0 +1,61 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knative
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetSinkBinding(t *testing.T) {
+	camelEnv := NewCamelEnvironment()
+	svc1, err := BuildCamelServiceDefinition(
+		"test",
+		CamelEndpointKindSink,
+		CamelServiceTypeChannel,
+		url.URL{},
+		"apiVersion",
+		"InMemoryChannel",
+	)
+	assert.Nil(t, err)
+	camelEnv.Services = append(camelEnv.Services, svc1)
+	svc := camelEnv.FindService("test",
+		CamelEndpointKindSink,
+		CamelServiceTypeChannel,
+		"apiVersion",
+		"InMemoryChannel",
+	)
+	assert.NotNil(t, svc)
+	assert.False(t, svc.SinkBinding)
+	camelEnv.SetSinkBinding("test",
+		CamelEndpointKindSink,
+		CamelServiceTypeChannel,
+		"apiVersion",
+		"InMemoryChannel",
+	)
+	svc = camelEnv.FindService("test",
+		CamelEndpointKindSink,
+		CamelServiceTypeChannel,
+		"apiVersion",
+		"InMemoryChannel",
+	)
+	assert.NotNil(t, svc)
+	assert.True(t, svc.SinkBinding)
+}

--- a/pkg/apis/camel/v1/trait/knative.go
+++ b/pkg/apis/camel/v1/trait/knative.go
@@ -20,7 +20,6 @@ package trait
 // The Knative trait automatically discovers addresses of Knative resources and inject them into the
 // running integration.
 //
-// The full Knative configuration is injected in the CAMEL_KNATIVE_CONFIGURATION in JSON format.
 // The Camel Knative component will then use the full configuration to configure the routes.
 //
 // The trait is enabled by default when the Knative profile is active.

--- a/pkg/trait/knative_service_test.go
+++ b/pkg/trait/knative_service_test.go
@@ -35,7 +35,6 @@ import (
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
-	"github.com/apache/camel-k/v2/pkg/util/envvar"
 	"github.com/apache/camel-k/v2/pkg/util/gzip"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/test"
@@ -124,7 +123,6 @@ func TestKnativeService(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, environment.ExecutedTraits)
 	assert.NotNil(t, environment.GetTrait("knative"))
-	assert.NotNil(t, envvar.Get(environment.EnvVars, "CAMEL_KNATIVE_CONFIGURATION"))
 	assert.Equal(t, 4, environment.Resources.Size())
 
 	s := environment.Resources.GetKnativeService(func(service *serving.Service) bool {

--- a/pkg/trait/knative_test.go
+++ b/pkg/trait/knative_test.go
@@ -18,6 +18,9 @@ limitations under the License.
 package trait
 
 import (
+	"fmt"
+	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,7 +41,6 @@ import (
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/client"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
-	"github.com/apache/camel-k/v2/pkg/util/envvar"
 	k8sutils "github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/test"
 )
@@ -117,11 +119,7 @@ func TestKnativeEnvConfigurationFromTrait(t *testing.T) {
 	err = tr.Apply(&environment)
 	assert.Nil(t, err)
 
-	kc := envvar.Get(environment.EnvVars, "CAMEL_KNATIVE_CONFIGURATION")
-	assert.NotNil(t, kc)
-
-	ne := knativeapi.NewCamelEnvironment()
-	err = ne.Deserialize(kc.Value)
+	ne, err := fromCamelProperties(environment.ApplicationProperties)
 	assert.Nil(t, err)
 
 	cSource1 := ne.FindService("channel-source-1", knativeapi.CamelEndpointKindSource, knativeapi.CamelServiceTypeChannel, "messaging.knative.dev/v1", "Channel")
@@ -239,11 +237,7 @@ func TestKnativeEnvConfigurationFromSource(t *testing.T) {
 	err = tr.Apply(&environment)
 	assert.Nil(t, err)
 
-	kc := envvar.Get(environment.EnvVars, "CAMEL_KNATIVE_CONFIGURATION")
-	assert.NotNil(t, kc)
-
-	ne := knativeapi.NewCamelEnvironment()
-	err = ne.Deserialize(kc.Value)
+	ne, err := fromCamelProperties(environment.ApplicationProperties)
 	assert.Nil(t, err)
 
 	source := ne.FindService("s3fileMover1", knativeapi.CamelEndpointKindSource, knativeapi.CamelServiceTypeEndpoint, "serving.knative.dev/v1", "Service")
@@ -351,60 +345,6 @@ func TestKnativePlatformHttpDependencies(t *testing.T) {
 			assert.Contains(t, environment.Integration.Status.Dependencies, "mvn:org.apache.camel.quarkus:camel-quarkus-platform-http")
 		})
 	}
-}
-
-func TestKnativeConfigurationSorting(t *testing.T) {
-	// unsorted on purpose
-	sources := []v1.SourceSpec{
-		{
-			DataSpec: v1.DataSpec{
-				Name:    "s1.groovy",
-				Content: `from('knative:channel/channel-source-2').log('${body}')`,
-			},
-			Language: v1.LanguageGroovy,
-		},
-		{
-			DataSpec: v1.DataSpec{
-				Name:    "s2.groovy",
-				Content: `from('knative:channel/channel-source-4').log('${body}')`,
-			},
-			Language: v1.LanguageGroovy,
-		},
-		{
-			DataSpec: v1.DataSpec{
-				Name:    "s3.groovy",
-				Content: `from('knative:channel/channel-source-1').log('${body}')`,
-			},
-			Language: v1.LanguageGroovy,
-		},
-		{
-			DataSpec: v1.DataSpec{
-				Name:    "s4.groovy",
-				Content: `from('knative:channel/channel-source-3').log('${body}')`,
-			},
-			Language: v1.LanguageGroovy,
-		},
-	}
-
-	environment := NewFakeEnvironment(t, v1.SourceSpec{})
-	environment.Integration.Status.Phase = v1.IntegrationPhaseRunning
-	environment.Integration.Spec.Sources = sources
-
-	c, err := SortChannelFakeClient("ns")
-	assert.Nil(t, err)
-	tc := NewCatalog(c)
-	err = tc.Configure(&environment)
-	assert.Nil(t, err)
-	conditions, _ := tc.apply(&environment)
-	assert.Empty(t, conditions)
-	// no matter if there is any other trait error
-	camelEnv := knativeapi.NewCamelEnvironment()
-	err = camelEnv.Deserialize(envvar.Get(environment.EnvVars, "CAMEL_KNATIVE_CONFIGURATION").Value)
-	assert.Nil(t, err)
-	assert.Equal(t, "channel-source-1", camelEnv.Services[0].Name)
-	assert.Equal(t, "channel-source-2", camelEnv.Services[1].Name)
-	assert.Equal(t, "channel-source-3", camelEnv.Services[2].Name)
-	assert.Equal(t, "channel-source-4", camelEnv.Services[3].Name)
 }
 
 func NewFakeEnvironment(t *testing.T, source v1.SourceSpec) Environment {
@@ -708,4 +648,67 @@ func SortChannelFakeClient(namespace string) (client.Client, error) {
 			},
 		},
 	)
+}
+
+func TestKnativeSinkBinding(t *testing.T) {
+	source := v1.SourceSpec{
+		DataSpec: v1.DataSpec{
+			Name:    "sink.groovy",
+			Content: `from('timer:foo').to('knative:channel/channel-sink-1?apiVersion=messaging.knative.dev%2Fv1&kind=Channel')`,
+		},
+		Language: v1.LanguageGroovy,
+	}
+
+	environment := NewFakeEnvironment(t, source)
+	environment.Integration.Status.Phase = v1.IntegrationPhaseDeploying
+
+	c, err := NewFakeClient("ns")
+	assert.Nil(t, err)
+
+	tc := NewCatalog(c)
+
+	err = tc.Configure(&environment)
+	assert.Nil(t, err)
+
+	_, err = tc.apply(&environment)
+	assert.Nil(t, err)
+	baseProp := "camel.component.knative.environment.resources[0]"
+	assert.Equal(t, "channel-sink-1", environment.ApplicationProperties[baseProp+".name"])
+	assert.Equal(t, "${K_SINK}", environment.ApplicationProperties[baseProp+".url"])
+	assert.Equal(t, "${K_CE_OVERRIDES}", environment.ApplicationProperties[baseProp+".ceOverrides"])
+	assert.Equal(t, "channel", environment.ApplicationProperties[baseProp+".type"])
+	assert.Equal(t, "Channel", environment.ApplicationProperties[baseProp+".objectKind"])
+	assert.Equal(t, "messaging.knative.dev/v1", environment.ApplicationProperties[baseProp+".objectApiVersion"])
+	assert.Equal(t, "sink", environment.ApplicationProperties[baseProp+".endpointKind"])
+}
+
+// fromCamelProperties deserialize from properties to environment.
+func fromCamelProperties(appProps map[string]string) (*knativeapi.CamelEnvironment, error) {
+	env := knativeapi.NewCamelEnvironment()
+	re := regexp.MustCompile(`camel.component.knative.environment.resources\[(\d+)\].name`)
+	for k, v := range appProps {
+		if re.MatchString(k) {
+			index := re.FindStringSubmatch(k)[1]
+			baseComp := fmt.Sprintf("camel.component.knative.environment.resources[%s]", index)
+			url, err := url.Parse(appProps[fmt.Sprintf("%s.url", baseComp)])
+			if err != nil {
+				return nil, err
+			}
+			svc, err := knativeapi.BuildCamelServiceDefinition(
+				v,
+				knativeapi.CamelEndpointKind(appProps[fmt.Sprintf("%s.endpointKind", baseComp)]),
+				knativeapi.CamelServiceType(appProps[fmt.Sprintf("%s.type", baseComp)]),
+				*url,
+				appProps[fmt.Sprintf("%s.objectApiVersion", baseComp)],
+				appProps[fmt.Sprintf("%s.objectKind", baseComp)],
+			)
+			if err != nil {
+				return nil, err
+			}
+			svc.Metadata[knativeapi.CamelMetaKnativeReply] = appProps[fmt.Sprintf("%s.reply", baseComp)]
+			env.Services = append(env.Services, svc)
+		}
+	}
+
+	return &env, nil
 }


### PR DESCRIPTION
<!-- Description -->

With this PR we move the configuration from the env var to the properties.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(knative): configure via properties
```
