### PR TITLE
chore: use constants for config types

### DIFF
--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -33,6 +33,10 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/property"
 )
 
+const (
+	CamelPropertiesType = "camel-properties"
+)
+
 type camelTrait struct {
 	BasePlatformTrait
 	traitv1.CamelTrait `property:",squash"`
@@ -172,7 +176,7 @@ func (t *camelTrait) computeConfigMaps(e *Environment) []ctrl.Object {
 					Labels: map[string]string{
 						v1.IntegrationLabel:                e.Integration.Name,
 						"camel.apache.org/properties.type": "user",
-						kubernetes.ConfigMapTypeLabel:      "camel-properties",
+						kubernetes.ConfigMapTypeLabel:      CamelPropertiesType,
 					},
 				},
 				Data: map[string]string{
@@ -200,10 +204,10 @@ func (t *camelTrait) computeConfigMaps(e *Environment) []ctrl.Object {
 					v1.IntegrationLabel: e.Integration.Name,
 				},
 				Annotations: map[string]string{
-					"camel.apache.org/source.language":    string(s.InferLanguage()),
-					"camel.apache.org/source.loader":      s.Loader,
-					"camel.apache.org/source.name":        s.Name,
-					"camel.apache.org/source.compression": strconv.FormatBool(s.Compression),
+					sourceLanguageAnnotation:    string(s.InferLanguage()),
+					sourceLoaderAnnotation:      s.Loader,
+					sourceNameAnnotation:        s.Name,
+					sourceCompressionAnnotation: strconv.FormatBool(s.Compression),
 				},
 			},
 			Data: map[string]string{

--- a/pkg/trait/camel_test.go
+++ b/pkg/trait/camel_test.go
@@ -200,7 +200,7 @@ func TestApplyCamelTraitWithSources(t *testing.T) {
 
 	assert.Equal(t, 1, environment.Resources.Size())
 	sourceCm := environment.Resources.GetConfigMap(func(cm *corev1.ConfigMap) bool {
-		return cm.Name == "some-integration-source-000" && cm.Annotations["camel.apache.org/source.language"] == "xml" && cm.Annotations["camel.apache.org/source.name"] == "source2.xml"
+		return cm.Name == "some-integration-source-000" && cm.Annotations[sourceLanguageAnnotation] == "xml" && cm.Annotations[sourceNameAnnotation] == "source2.xml"
 	})
 	assert.NotNil(t, sourceCm)
 	assert.Equal(t, map[string]string{

--- a/pkg/trait/kamelets.go
+++ b/pkg/trait/kamelets.go
@@ -374,12 +374,12 @@ func initializeConfigmapKameletSource(source v1.SourceSpec, hash, name, namespac
 				"camel.apache.org/kamelet":     kamName,
 			},
 			Annotations: map[string]string{
-				"camel.apache.org/source.language":    string(source.Language),
-				"camel.apache.org/source.name":        name,
-				"camel.apache.org/source.compression": strconv.FormatBool(source.Compression),
-				"camel.apache.org/source.generated":   "true",
-				"camel.apache.org/source.type":        string(source.Type),
-				"camel.apache.org/source.digest":      hash,
+				sourceLanguageAnnotation:            string(source.Language),
+				sourceNameAnnotation:                name,
+				sourceCompressionAnnotation:         strconv.FormatBool(source.Compression),
+				"camel.apache.org/source.generated": "true",
+				"camel.apache.org/source.type":      string(source.Type),
+				"camel.apache.org/source.digest":    hash,
 			},
 		},
 		Data: map[string]string{

--- a/pkg/trait/kamelets_support.go
+++ b/pkg/trait/kamelets_support.go
@@ -27,6 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const KameletBundleType = "kamelets-bundle"
+
 type kameletBundle struct {
 	kamelets []*v1.Kamelet
 }
@@ -76,11 +78,11 @@ func newBundleConfigmap(name, namespace string, id int) *corev1.ConfigMap {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("kamelets-bundle-%s-%03d", name, id),
+			Name:      fmt.Sprintf("%s-%s-%03d", KameletBundleType, name, id),
 			Namespace: namespace,
 			Labels: map[string]string{
 				v1.IntegrationLabel:           name,
-				kubernetes.ConfigMapTypeLabel: "kamelets-bundle",
+				kubernetes.ConfigMapTypeLabel: KameletBundleType,
 			},
 			Annotations: map[string]string{
 				kubernetes.ConfigMapAutogenLabel: "true",

--- a/pkg/trait/openapi.go
+++ b/pkg/trait/openapi.go
@@ -293,12 +293,12 @@ func (t *openAPITrait) createNewOpenAPIConfigMap(e *Environment, resource v1.Dat
 				v1.IntegrationLabel: e.Integration.Name,
 			},
 			Annotations: map[string]string{
-				"camel.apache.org/source.language":    string(v1.LanguageXML),
-				"camel.apache.org/source.name":        resource.Name,
-				"camel.apache.org/source.compression": strconv.FormatBool(resource.Compression),
-				"camel.apache.org/source.generated":   "true",
-				"camel.apache.org/source.type":        "openapi",
-				"camel.apache.org/source.digest":      hash,
+				sourceLanguageAnnotation:            string(v1.LanguageXML),
+				sourceNameAnnotation:                resource.Name,
+				sourceCompressionAnnotation:         strconv.FormatBool(resource.Compression),
+				"camel.apache.org/source.generated": "true",
+				"camel.apache.org/source.type":      "openapi",
+				"camel.apache.org/source.digest":    hash,
 			},
 		},
 		Data: map[string]string{

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -35,7 +35,6 @@ import (
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/client"
 	"github.com/apache/camel-k/v2/pkg/platform"
-	"github.com/apache/camel-k/v2/pkg/util"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/log"
@@ -45,6 +44,11 @@ import (
 const (
 	True  = "true"
 	False = "false"
+
+	sourceLanguageAnnotation    = "camel.apache.org/source.language"
+	sourceLoaderAnnotation      = "camel.apache.org/source.loader"
+	sourceNameAnnotation        = "camel.apache.org/source.name"
+	sourceCompressionAnnotation = "camel.apache.org/source.compression"
 )
 
 // Identifiable represent an identifiable type.
@@ -418,7 +422,7 @@ func (e *Environment) computeApplicationProperties() (*corev1.ConfigMap, error) 
 				Labels: map[string]string{
 					v1.IntegrationLabel:                e.Integration.Name,
 					"camel.apache.org/properties.type": "application",
-					kubernetes.ConfigMapTypeLabel:      "camel-properties",
+					kubernetes.ConfigMapTypeLabel:      CamelPropertiesType,
 				},
 			},
 			Data: map[string]string{
@@ -511,8 +515,9 @@ func (e *Environment) configureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 	// Resources (likely application properties or kamelets)
 	if e.Resources != nil {
 		e.Resources.VisitConfigMap(func(configMap *corev1.ConfigMap) {
-			// Camel properties
-			if configMap.Labels[kubernetes.ConfigMapTypeLabel] == "camel-properties" {
+			switch configMap.Labels[kubernetes.ConfigMapTypeLabel] {
+			case CamelPropertiesType:
+				// Camel properties
 				propertiesType := configMap.Labels["camel.apache.org/properties.type"]
 				resName := propertiesType + ".properties"
 
@@ -534,10 +539,10 @@ func (e *Environment) configureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]c
 				} else {
 					log.WithValues("Function", "trait.configureVolumesAndMounts").Infof("Warning: could not determine camel properties type %s", propertiesType)
 				}
-			} else if configMap.Labels[kubernetes.ConfigMapTypeLabel] == "kamelets-bundle" {
+			case KameletBundleType:
 				// Kamelets bundle configmap
 				kameletMountPoint := configMap.Annotations[kameletMountPointAnnotation]
-				refName := "kamelets-bundle"
+				refName := KameletBundleType
 				vol := getVolume(refName, "configmap", configMap.Name, "", "")
 				mnt := getMount(refName, kameletMountPoint, "", true)
 
@@ -728,17 +733,4 @@ func (e *Environment) getIntegrationContainerPort() *corev1.ContainerPort {
 	}
 
 	return nil
-}
-
-// nolint: unused
-func (e *Environment) getAllInterceptors() []string {
-	res := make([]string, 0)
-	util.StringSliceUniqueConcat(&res, e.Interceptors)
-
-	if e.Integration != nil {
-		for _, s := range e.Integration.AllSources() {
-			util.StringSliceUniqueConcat(&res, s.Interceptors)
-		}
-	}
-	return res
 }


### PR DESCRIPTION
<!-- Description -->

Cleaning PR to include some constant instead of hardcoded values.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore: use constants for config types
```
