### PR TITLE
fix(quarkus): build time properties into file

### DIFF
--- a/pkg/builder/quarkus.go
+++ b/pkg/builder/quarkus.go
@@ -126,24 +126,21 @@ func loadCamelQuarkusCatalog(ctx *builderContext) error {
 }
 
 func generateQuarkusProject(ctx *builderContext) error {
-	p := GenerateQuarkusProjectCommon(
+	p := generateQuarkusProjectCommon(
 		ctx.Build.Runtime.Version,
 		ctx.Build.Runtime.Metadata["quarkus.version"],
-		ctx.Build.Maven.Properties)
-
+	)
 	// Add Maven build extensions
 	p.Build.Extensions = ctx.Build.Maven.Extension
-
 	// Add Maven repositories
 	p.Repositories = append(p.Repositories, ctx.Build.Maven.Repositories...)
 	p.PluginRepositories = append(p.PluginRepositories, ctx.Build.Maven.Repositories...)
-
 	ctx.Maven.Project = p
 
 	return nil
 }
 
-func GenerateQuarkusProjectCommon(runtimeVersion string, quarkusVersion string, buildTimeProperties map[string]string) maven.Project {
+func generateQuarkusProjectCommon(runtimeVersion string, quarkusPlatformVersion string) maven.Project {
 	p := maven.NewProjectWithGAV("org.apache.camel.k.integration", "camel-k-integration", defaults.Version)
 	p.DependencyManagement = &maven.DependencyManagement{Dependencies: make([]maven.Dependency, 0)}
 	p.Dependencies = make([]maven.Dependency, 0)
@@ -163,48 +160,18 @@ func GenerateQuarkusProjectCommon(runtimeVersion string, quarkusVersion string, 
 		},
 	)
 
-	// Add all the properties from the build configuration
-	p.Properties.AddAll(buildTimeProperties)
-
-	// Quarkus build time properties
-	buildProperties := make(map[string]string)
-
-	// disable quarkus banner
-	buildProperties["quarkus.banner.enabled"] = "false"
-
-	// camel-quarkus does route discovery at startup, but we don't want
-	// this to happen as routes are loaded at runtime and looking for
-	// routes at build time may try to load camel-k-runtime routes builder
-	// proxies which in some case may fail.
-	buildProperties["quarkus.camel.routes-discovery.enabled"] = "false"
-
-	// required for to resolve data type transformers at runtime with service discovery
-	// the different Camel runtimes use different resource paths for the service lookup
-	buildProperties["quarkus.camel.service.discovery.include-patterns"] = "META-INF/services/org/apache/camel/datatype/converter/*,META-INF/services/org/apache/camel/datatype/transformer/*,META-INF/services/org/apache/camel/transformer/*"
-
-	// copy all user defined quarkus.camel build time properties to the quarkus-maven-plugin build properties
-	for key, value := range buildTimeProperties {
-		if strings.HasPrefix(key, "quarkus.camel.") {
-			buildProperties[key] = value
-		}
-	}
-
-	configuration := v1.PluginProperties{}
-	configuration.AddProperties("properties", buildProperties)
-
 	// Plugins
 	p.Build.Plugins = append(p.Build.Plugins,
 		maven.Plugin{
 			GroupID:    "io.quarkus",
 			ArtifactID: "quarkus-maven-plugin",
-			Version:    quarkusVersion,
+			Version:    quarkusPlatformVersion,
 			Executions: []maven.Execution{
 				{
 					ID: "build-integration",
 					Goals: []string{
 						"build",
 					},
-					Configuration: configuration,
 				},
 			},
 		},
@@ -228,7 +195,7 @@ func buildQuarkusRunner(ctx *builderContext) error {
 		)
 	}
 
-	err := BuildQuarkusRunnerCommon(ctx.C, mc, ctx.Maven.Project)
+	err := BuildQuarkusRunnerCommon(ctx.C, mc, ctx.Maven.Project, ctx.Build.Maven.Properties)
 	if err != nil {
 		return err
 	}
@@ -236,28 +203,46 @@ func buildQuarkusRunner(ctx *builderContext) error {
 	return nil
 }
 
-func BuildQuarkusRunnerCommon(ctx context.Context, mc maven.Context, project maven.Project) error {
+func BuildQuarkusRunnerCommon(ctx context.Context, mc maven.Context, project maven.Project, applicationProperties map[string]string) error {
 	resourcesPath := filepath.Join(mc.Path, "src", "main", "resources")
 	if err := os.MkdirAll(resourcesPath, os.ModePerm); err != nil {
 		return fmt.Errorf("failure while creating resource folder: %w", err)
 	}
-
-	// Generate an empty application.properties so that there will be something in
-	// target/classes as if such directory does not exist, the quarkus maven plugin
-	// may fail the build.
-	// In the future there should be a way to provide build information from secrets,
-	// configmap, etc.
-	if _, err := os.OpenFile(filepath.Join(resourcesPath, "application.properties"), os.O_RDWR|os.O_CREATE, 0666); err != nil {
-		return fmt.Errorf("failure while creating application.properties: %w", err)
+	if err := computeApplicationProperties(filepath.Join(resourcesPath, "application.properties"), applicationProperties); err != nil {
+		return err
 	}
-
 	mc.AddArgument("package")
-
 	// Run the Maven goal
 	if err := project.Command(mc).Do(ctx); err != nil {
 		return fmt.Errorf("failure while building project: %w", err)
 	}
 
+	return nil
+}
+
+func computeApplicationProperties(appPropertiesPath string, applicationProperties map[string]string) error {
+	f, err := os.OpenFile(appPropertiesPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("failure while creating application.properties: %w", err)
+	}
+	if applicationProperties == nil {
+		// Default build time properties
+		applicationProperties = make(map[string]string)
+	}
+	// disable quarkus banner
+	applicationProperties["quarkus.banner.enabled"] = "false"
+	// required for to resolve data type transformers at runtime with service discovery
+	// the different Camel runtimes use different resource paths for the service lookup
+	applicationProperties["quarkus.camel.service.discovery.include-patterns"] = "META-INF/services/org/apache/camel/datatype/converter/*,META-INF/services/org/apache/camel/datatype/transformer/*,META-INF/services/org/apache/camel/transformer/*"
+	// Workaround to prevent JS runtime errors, see https://github.com/apache/camel-quarkus/issues/5678
+	applicationProperties["quarkus.class-loading.parent-first-artifacts"] = "org.graalvm.regex:regex"
+	defer f.Close()
+	// Fill with properties coming from user configuration
+	for k, v := range applicationProperties {
+		if _, err := f.WriteString(fmt.Sprintf("%s=%s\n", k, v)); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/builder/quarkus_test.go
+++ b/pkg/builder/quarkus_test.go
@@ -1,0 +1,218 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/v2/pkg/util/camel"
+	"github.com/apache/camel-k/v2/pkg/util/defaults"
+	"github.com/apache/camel-k/v2/pkg/util/test"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGenerateQuarkusProjectCommon(t *testing.T) {
+	p := generateQuarkusProjectCommon("1.2.3", "4.5.6")
+	assert.Equal(t, "org.apache.camel.k.integration", p.GroupID)
+	assert.Equal(t, "camel-k-integration", p.ArtifactID)
+	assert.Equal(t, defaults.Version, p.Version)
+	assert.Equal(t, "fast-jar", p.Properties["quarkus.package.type"])
+	assert.Equal(t, "org.apache.camel.k", p.DependencyManagement.Dependencies[0].GroupID)
+	assert.Equal(t, "camel-k-runtime-bom", p.DependencyManagement.Dependencies[0].ArtifactID)
+	assert.Equal(t, "1.2.3", p.DependencyManagement.Dependencies[0].Version)
+	assert.Equal(t, "pom", p.DependencyManagement.Dependencies[0].Type)
+	assert.Equal(t, "import", p.DependencyManagement.Dependencies[0].Scope)
+	assert.Equal(t, "io.quarkus", p.Build.Plugins[0].GroupID)
+	assert.Equal(t, "quarkus-maven-plugin", p.Build.Plugins[0].ArtifactID)
+	assert.Equal(t, "4.5.6", p.Build.Plugins[0].Version)
+}
+
+func TestLoadCamelQuarkusCatalogMissing(t *testing.T) {
+	c, err := test.NewFakeClient()
+	assert.Nil(t, err)
+	builderContext := builderContext{
+		Client:    c,
+		C:         context.TODO(),
+		Namespace: "test",
+		Build: v1.BuilderTask{
+			Runtime: v1.RuntimeSpec{
+				Version:  "1.2.3",
+				Provider: "Quarkus",
+			},
+		},
+	}
+	err = loadCamelQuarkusCatalog(&builderContext)
+	assert.NotNil(t, err)
+	assert.Equal(t, "unable to find catalog matching version requirement: runtime=1.2.3, provider=Quarkus", err.Error())
+}
+
+func TestLoadCamelQuarkusCatalogOk(t *testing.T) {
+	runtimeCatalog := v1.RuntimeSpec{
+		Version:      "1.2.3",
+		Provider:     "Quarkus",
+		Dependencies: make([]v1.MavenArtifact, 0),
+	}
+	c, err := test.NewFakeClient(&v1.CamelCatalog{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-fake-catalog",
+		},
+		Spec: v1.CamelCatalogSpec{
+			Runtime: runtimeCatalog,
+		},
+	})
+	assert.Nil(t, err)
+	builderContext := builderContext{
+		Client:    c,
+		C:         context.TODO(),
+		Namespace: "default",
+		Build: v1.BuilderTask{
+			Runtime: v1.RuntimeSpec{
+				Version:  "1.2.3",
+				Provider: "Quarkus",
+			},
+		},
+	}
+	err = loadCamelQuarkusCatalog(&builderContext)
+	assert.Nil(t, err)
+	assert.Equal(t, runtimeCatalog, builderContext.Catalog.Runtime)
+}
+
+func TestGenerateQuarkusProjectWithBuildTimeProperties(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "go-test-camel-k-quarkus-with-props")
+	assert.Nil(t, err)
+	defaultCatalog, err := camel.DefaultCatalog()
+	assert.Nil(t, err)
+
+	mavenProps := v1.Properties{}
+	mavenProps.Add("quarkus.camel.hello", "world")
+	mavenProps.Add("quarkus.camel.\"shouldnt\"", "fail")
+	mavenProps.Add("my-build-time-var", "my-build-time-val")
+	mavenProps.Add("my-build-time\var2", "my-build-time-val2")
+	builderContext := builderContext{
+		C:         context.TODO(),
+		Path:      tmpDir,
+		Namespace: "test",
+		Build: v1.BuilderTask{
+			Runtime: defaultCatalog.Runtime,
+			Maven: v1.MavenBuildSpec{
+				MavenSpec: v1.MavenSpec{
+					Properties: mavenProps,
+				},
+			},
+		},
+	}
+
+	err = generateQuarkusProject(&builderContext)
+	assert.Nil(t, err)
+	// use local Maven executable in tests
+	t.Setenv("MAVEN_WRAPPER", "false")
+	_, ok := os.LookupEnv("MAVEN_CMD")
+	if !ok {
+		t.Setenv("MAVEN_CMD", "mvn")
+	}
+	err = buildQuarkusRunner(&builderContext)
+	assert.Nil(t, err)
+	appProps, err := os.ReadFile(filepath.Join(tmpDir, "maven", "src", "main", "resources", "application.properties"))
+	assert.Nil(t, err)
+	assert.Contains(t, string(appProps), "quarkus.camel.hello=world\n")
+	assert.Contains(t, string(appProps), "quarkus.camel.\"shouldnt\"=fail\n")
+	assert.Contains(t, string(appProps), "my-build-time-var=my-build-time-val\n")
+	assert.Contains(t, string(appProps), "my-build-time\var2=my-build-time-val2\n")
+	// At this stage a maven project should have been executed. Verify the package was created.
+	_, err = os.Stat(filepath.Join(tmpDir, "maven", "target", "camel-k-integration-"+defaults.Version+".jar"))
+	assert.Nil(t, err)
+}
+
+func TestBuildQuarkusRunner(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "go-test-camel-k-quarkus")
+	assert.Nil(t, err)
+	defaultCatalog, err := camel.DefaultCatalog()
+	assert.Nil(t, err)
+	c, err := test.NewFakeClient(&v1.CamelCatalog{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "camel-catalog-" + defaults.DefaultRuntimeVersion,
+		},
+		Spec: v1.CamelCatalogSpec{
+			Runtime: defaultCatalog.Runtime,
+		},
+	})
+	assert.Nil(t, err)
+	mavenProps := v1.Properties{}
+	mavenProps.Add("camel.hello", "world")
+	builderContext := builderContext{
+		Client:    c,
+		Catalog:   defaultCatalog,
+		C:         context.TODO(),
+		Path:      tmpDir,
+		Namespace: "test",
+		Build: v1.BuilderTask{
+			Runtime: defaultCatalog.Runtime,
+			Maven: v1.MavenBuildSpec{
+				MavenSpec: v1.MavenSpec{
+					Properties: mavenProps,
+				},
+			},
+			Dependencies: []string{"mvn:org.apache.camel.k:camel-k-runtime"},
+		},
+	}
+	err = generateQuarkusProject(&builderContext)
+	assert.Nil(t, err)
+	err = injectDependencies(&builderContext)
+	assert.Nil(t, err)
+	err = sanitizeDependencies(&builderContext)
+	assert.Nil(t, err)
+	// use local Maven executable in tests
+	t.Setenv("MAVEN_WRAPPER", "false")
+	_, ok := os.LookupEnv("MAVEN_CMD")
+	if !ok {
+		t.Setenv("MAVEN_CMD", "mvn")
+	}
+	err = buildQuarkusRunner(&builderContext)
+	assert.Nil(t, err)
+	// Verify default application properties
+	appProps, err := os.ReadFile(filepath.Join(tmpDir, "maven", "src", "main", "resources", "application.properties"))
+	assert.Nil(t, err)
+	assert.Contains(t, string(appProps), "camel.hello=world\n")
+	assert.Contains(t, string(appProps), "quarkus.banner.enabled=false\n")
+	assert.Contains(t, string(appProps), "quarkus.camel.service.discovery.include-patterns=META-INF/services/org/apache/camel/datatype/converter/*,META-INF/services/org/apache/camel/datatype/transformer/*,META-INF/services/org/apache/camel/transformer/*\n")
+	assert.Contains(t, string(appProps), "quarkus.class-loading.parent-first-artifacts=org.graalvm.regex:regex\n")
+	// At this stage a maven project should have been executed. Verify the package was created.
+	_, err = os.Stat(filepath.Join(tmpDir, "maven", "target", "camel-k-integration-"+defaults.Version+".jar"))
+	assert.Nil(t, err)
+
+	// We use this same unit test to verify dependencies generated
+	// (and spare some build time to avoid running another maven process)
+	err = computeQuarkusDependencies(&builderContext)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, builderContext.Artifacts)
+	camelRuntimeDepFound := false
+	expectedArtifact := fmt.Sprintf("org.apache.camel.k.camel-k-runtime-%s.jar", defaults.DefaultRuntimeVersion)
+	for _, artifact := range builderContext.Artifacts {
+		if artifact.ID == expectedArtifact {
+			camelRuntimeDepFound = true
+			break
+		}
+	}
+	assert.True(t, camelRuntimeDepFound, "Did not find expected artifact: %s", expectedArtifact)
+}


### PR DESCRIPTION
Moving from maven based approach to a file approach in order to let be able to use any character which may be a limitation in pom.xml

Closes #5195

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(quarkus): build time properties into file
```
