### PR TITLE
fix(e2e): stricter pipe test check

### DIFF
--- a/e2e/common/misc/pipe_test.go
+++ b/e2e/common/misc/pipe_test.go
@@ -50,12 +50,14 @@ func TestPipe(t *testing.T) {
 				"-p", "source.message=throw Error",
 				"-p", "sink.loggerName=integrationLogger",
 				"-p", "error-handler.loggerName=kameletErrorHandler",
+				// Needed in the test to make sure to do the right string comparison later
+				"-t", "logging.color=false",
 				"--name", "throw-error-binding",
 			).Execute()).To(Succeed())
 
 			Eventually(IntegrationPodPhase(ns, "throw-error-binding"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			Eventually(IntegrationLogs(ns, "throw-error-binding"), TestTimeoutShort).Should(ContainSubstring("kameletErrorHandler"))
-			Eventually(IntegrationLogs(ns, "throw-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("integrationLogger"))
+			Eventually(IntegrationLogs(ns, "throw-error-binding"), TestTimeoutShort).Should(ContainSubstring("[kameletErrorHandler] (Camel (camel-1) thread #1 - timer://tick)"))
+			Eventually(IntegrationLogs(ns, "throw-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("[integrationLogger] (Camel (camel-1) thread #1 - timer://tick)"))
 
 		})
 
@@ -67,12 +69,14 @@ func TestPipe(t *testing.T) {
 				"-p", "source.message=true",
 				"-p", "sink.loggerName=integrationLogger",
 				"-p", "error-handler.loggerName=kameletErrorHandler",
+				// Needed in the test to make sure to do the right string comparison later
+				"-t", "logging.color=false",
 				"--name", "no-error-binding",
 			).Execute()).To(Succeed())
 
 			Eventually(IntegrationPodPhase(ns, "no-error-binding"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			Eventually(IntegrationLogs(ns, "no-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("kameletErrorHandler"))
-			Eventually(IntegrationLogs(ns, "no-error-binding"), TestTimeoutShort).Should(ContainSubstring("integrationLogger"))
+			Eventually(IntegrationLogs(ns, "no-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("[kameletErrorHandler] (Camel (camel-1) thread #1 - timer://tick)"))
+			Eventually(IntegrationLogs(ns, "no-error-binding"), TestTimeoutShort).Should(ContainSubstring("[integrationLogger] (Camel (camel-1) thread #1 - timer://tick)"))
 
 		})
 	})

--- a/pkg/trait/error_handler.go
+++ b/pkg/trait/error_handler.go
@@ -67,7 +67,7 @@ func (t *errorHandlerTrait) Apply(e *Environment) error {
 			t.addErrorHandlerDependencies(e, defaultErrorHandlerURI)
 		}
 
-		return t.addErrorHandlerAsSource(e)
+		return t.addGlobalErrorHandlerAsSource(e)
 	}
 	return nil
 }
@@ -84,7 +84,7 @@ func (t *errorHandlerTrait) addErrorHandlerDependencies(e *Environment, uri stri
 	}
 }
 
-func (t *errorHandlerTrait) addErrorHandlerAsSource(e *Environment) error {
+func (t *errorHandlerTrait) addGlobalErrorHandlerAsSource(e *Environment) error {
 	flowErrorHandler := map[string]interface{}{
 		"error-handler": map[string]string{
 			"ref-error-handler": t.ErrorHandlerRef,


### PR DESCRIPTION
<!-- Description -->
Change the func name to highlight the fact the ErrorHandler is a global one. Additionally we make a stricter check to make sure that the simple look into the log for the body logged is what we expect instead of a generic string which may be part of the log somewhere else.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): stricter pipe test check
```
