### PR TITLE
[Backport 2.1.x]: chore(ci): upgrade release-action action

### DIFF
--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -118,7 +118,7 @@ runs:
 
     - name: Create Release
       id: create_release
-      uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37
+      uses: ncipollo/release-action@1e3e9c6637e5566e185b7ab66f187539c5a76da7
       with:
         artifacts: "./camel-k-client*.tar.gz,sbom.json"
         body: |


### PR DESCRIPTION
Backport from #5182




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(ci): upgrade release-action action
```
