### PR TITLE
chore(traits): store executed traits

### DIFF
--- a/pkg/controller/integration/kits.go
+++ b/pkg/controller/integration/kits.go
@@ -123,7 +123,7 @@ func integrationMatches(ctx context.Context, c client.Client, integration *v1.In
 		return false, err
 	}
 
-	itc, err := trait.NewSpecTraitsOptionsForIntegrationAndPlatform(integration, pl)
+	itc, err := trait.NewStatusTraitsOptionsForIntegrationAndPlatform(integration, pl)
 	if err != nil {
 		return false, err
 	}
@@ -217,7 +217,7 @@ func hasMatchingTraits(traitMap trait.Options, kitTraitMap trait.Options) (bool,
 		it, ok1 := traitMap.Get(id)
 		kt, ok2 := kitTraitMap.Get(id)
 
-		if !ok1 && !ok2 {
+		if (!ok1 || len(it) == 0) && (!ok2 || len(kt) == 0) {
 			continue
 		}
 

--- a/pkg/controller/integration/kits_test.go
+++ b/pkg/controller/integration/kits_test.go
@@ -503,3 +503,37 @@ func integrationAndKitHaveSameTraits(i1 *v1.Integration, i2 *v1.IntegrationKit) 
 
 	return trait.Equals(ikOpts, itOpts), nil
 }
+
+func TestHasMathchingTraitsEmpty(t *testing.T) {
+	opt1 := trait.Options{
+		"builder": {},
+		"camel": {
+			"runtimeVersion": "1.2.3",
+		},
+		"quarkus": {},
+	}
+	opt2 := trait.Options{
+		"camel": {
+			"runtimeVersion": "1.2.3",
+		},
+	}
+	opt3 := trait.Options{
+		"camel": {
+			"runtimeVersion": "1.2.3",
+		},
+	}
+	opt4 := trait.Options{
+		"camel": {
+			"runtimeVersion": "3.2.1",
+		},
+	}
+	b1, err := hasMatchingTraits(opt1, opt2)
+	assert.Nil(t, err)
+	assert.True(t, b1)
+	b2, err := hasMatchingTraits(opt1, opt4)
+	assert.Nil(t, err)
+	assert.False(t, b2)
+	b3, err := hasMatchingTraits(opt2, opt3)
+	assert.Nil(t, err)
+	assert.True(t, b3)
+}

--- a/pkg/trait/quarkus.go
+++ b/pkg/trait/quarkus.go
@@ -308,7 +308,7 @@ func propagateKitTraits(e *Environment) v1.IntegrationKitTraits {
 		propagate(fmt.Sprintf("integration profile %q", e.IntegrationProfile.Name), e.IntegrationProfile.Status.Traits, &kitTraits, e)
 	}
 
-	propagate(fmt.Sprintf("integration %q", e.Integration.Name), e.Integration.Spec.Traits, &kitTraits, e)
+	propagate(fmt.Sprintf("integration %q", e.Integration.Name), e.Integration.Status.Traits, &kitTraits, e)
 
 	return kitTraits
 }

--- a/pkg/trait/quarkus_test.go
+++ b/pkg/trait/quarkus_test.go
@@ -224,3 +224,21 @@ func TestGetLanguageSettingsWithLoaders(t *testing.T) {
 	assert.Equal(t, languageSettings{native: false, sourcesRequiredAtBuildTime: true}, getLanguageSettings(environment, v1.LanguageKotlin))
 	assert.Equal(t, languageSettings{native: true, sourcesRequiredAtBuildTime: false}, getLanguageSettings(environment, v1.LanguageJavaShell))
 }
+
+func TestPropagateStatusTraits(t *testing.T) {
+	quarkusTrait, environment := createNominalQuarkusTest()
+	environment.IntegrationKit = nil
+	environment.Integration = &v1.Integration{
+		Spec: v1.IntegrationSpec{},
+		Status: v1.IntegrationStatus{
+			Traits: v1.Traits{
+				Camel: &traitv1.CamelTrait{
+					RuntimeVersion: "1.2.3",
+				},
+			},
+		},
+	}
+
+	newKit := quarkusTrait.newIntegrationKit(environment, fastJarPackageType)
+	assert.Equal(t, "1.2.3", newKit.Spec.Traits.Camel.RuntimeVersion)
+}

--- a/pkg/trait/trait.go
+++ b/pkg/trait/trait.go
@@ -87,12 +87,20 @@ func Apply(ctx context.Context, c client.Client, integration *v1.Integration, ki
 		ilog.Debug("Applied traits to Integration", "integration", integration.Name, "namespace", integration.Namespace)
 		// The spec.traits may have been altered by other traits execution. We can save here the status for future
 		// reference
-		integration.Status.Traits = integration.Spec.Traits
+		execItTraits, err := environment.executedIntegrationTraits()
+		if err != nil {
+			return environment, err
+		}
+		integration.Status.Traits = *execItTraits
 	case kit != nil:
 		ilog.Debug("Applied traits to Integration kit", "integration kit", kit.Name, "namespace", kit.Namespace)
 		// The spec.traits may have been altered by other traits execution We can save here the status for future
 		// reference
-		kit.Status.Traits = kit.Spec.Traits
+		execIkTraits, err := environment.executedIntegrationKitTraits()
+		if err != nil {
+			return environment, err
+		}
+		kit.Status.Traits = *execIkTraits
 	default:
 		ilog.Debug("Applied traits")
 	}

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -19,6 +19,7 @@ package trait
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -252,6 +253,43 @@ func (e *Environment) GetTrait(id ID) Trait {
 	}
 
 	return nil
+}
+
+// executedIntegrationTraits returns the executed traits as v1.Traits struct (likely used by Integration).
+func (e *Environment) executedIntegrationTraits() (*v1.Traits, error) {
+	serialized, err := e.serializeExecutedTraits()
+	if err != nil {
+		return nil, err
+	}
+	var traits v1.Traits
+	if err = json.Unmarshal(serialized, &traits); err != nil {
+		return nil, err
+	}
+
+	return &traits, nil
+}
+
+// serializeExecutedTraits serializes in json the traits executed by the Environment.
+func (e *Environment) serializeExecutedTraits() ([]byte, error) {
+	mappedTraits := make(map[ID]interface{})
+	for _, t := range e.ExecutedTraits {
+		mappedTraits[t.ID()] = t
+	}
+	return json.Marshal(mappedTraits)
+}
+
+// executedIntegrationTraits returns the executed traits as v1.IntegrationKitTraits struct (likely used by IntegrationKit).
+func (e *Environment) executedIntegrationKitTraits() (*v1.IntegrationKitTraits, error) {
+	serialized, err := e.serializeExecutedTraits()
+	if err != nil {
+		return nil, err
+	}
+	var traits v1.IntegrationKitTraits
+	if err = json.Unmarshal(serialized, &traits); err != nil {
+		return nil, err
+	}
+
+	return &traits, nil
 }
 
 func (e *Environment) IntegrationInPhase(phases ...v1.IntegrationPhase) bool {

--- a/pkg/trait/trait_types_test.go
+++ b/pkg/trait/trait_types_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 )
 
 func TestMultilinePropertiesHandled(t *testing.T) {
@@ -152,4 +153,76 @@ func TestVolumeWithKeyOnly(t *testing.T) {
 	assert.Equal(t, 1, len(items))
 	assert.Equal(t, "SomeKey", items[0].Key)
 	assert.Equal(t, "SomeKey", items[0].Path)
+}
+
+func TestSerializeExecutedIntegrationTraits(t *testing.T) {
+	e := Environment{
+		ExecutedTraits: []Trait{
+			&camelTrait{
+				BasePlatformTrait: NewBasePlatformTrait("camel", 200),
+				CamelTrait: traitv1.CamelTrait{
+					RuntimeVersion: "1.2.3",
+				},
+			},
+			&quarkusTrait{
+				BasePlatformTrait: NewBasePlatformTrait("quarkus", 500),
+				QuarkusTrait: traitv1.QuarkusTrait{
+					Modes: []traitv1.QuarkusMode{
+						traitv1.JvmQuarkusMode,
+					},
+				},
+			},
+		},
+	}
+
+	expectedSerializedTraits := &v1.Traits{
+		Camel: &traitv1.CamelTrait{
+			RuntimeVersion: "1.2.3",
+		},
+		Quarkus: &traitv1.QuarkusTrait{
+			Modes: []traitv1.QuarkusMode{
+				traitv1.JvmQuarkusMode,
+			},
+		},
+	}
+
+	execTraits, err := e.executedIntegrationTraits()
+	assert.Nil(t, err)
+	assert.Equal(t, expectedSerializedTraits, execTraits)
+}
+
+func TestSerializeExecutedIntegrationKitTraits(t *testing.T) {
+	e := Environment{
+		ExecutedTraits: []Trait{
+			&camelTrait{
+				BasePlatformTrait: NewBasePlatformTrait("camel", 200),
+				CamelTrait: traitv1.CamelTrait{
+					RuntimeVersion: "1.2.3",
+				},
+			},
+			&quarkusTrait{
+				BasePlatformTrait: NewBasePlatformTrait("quarkus", 500),
+				QuarkusTrait: traitv1.QuarkusTrait{
+					Modes: []traitv1.QuarkusMode{
+						traitv1.JvmQuarkusMode,
+					},
+				},
+			},
+		},
+	}
+
+	expectedSerializedTraits := &v1.IntegrationKitTraits{
+		Camel: &traitv1.CamelTrait{
+			RuntimeVersion: "1.2.3",
+		},
+		Quarkus: &traitv1.QuarkusTrait{
+			Modes: []traitv1.QuarkusMode{
+				traitv1.JvmQuarkusMode,
+			},
+		},
+	}
+
+	execTraits, err := e.executedIntegrationKitTraits()
+	assert.Nil(t, err)
+	assert.Equal(t, expectedSerializedTraits, execTraits)
 }

--- a/pkg/trait/util.go
+++ b/pkg/trait/util.go
@@ -450,7 +450,7 @@ func newTraitsOptions(opts Options, objectMeta *metav1.ObjectMeta) (Options, err
 	return opts, nil
 }
 
-func NewSpecTraitsOptionsForIntegrationAndPlatform(i *v1.Integration, pl *v1.IntegrationPlatform) (Options, error) {
+func NewStatusTraitsOptionsForIntegrationAndPlatform(i *v1.Integration, pl *v1.IntegrationPlatform) (Options, error) {
 	var options Options
 	var err error
 	if pl != nil {
@@ -462,7 +462,7 @@ func NewSpecTraitsOptionsForIntegrationAndPlatform(i *v1.Integration, pl *v1.Int
 		options = Options{}
 	}
 
-	m1, err := ToTraitMap(i.Spec.Traits)
+	m1, err := ToTraitMap(i.Status.Traits)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -119,9 +119,6 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 	if err := computeForTraits(hash, integration.Spec.Traits); err != nil {
 		return "", err
 	}
-	if err := computeForTraits(hash, integration.Status.Traits); err != nil {
-		return "", err
-	}
 
 	// Integration traits as annotations
 	for _, k := range sortedTraitAnnotationsKeys(integration) {

--- a/pkg/util/digest/digest_test.go
+++ b/pkg/util/digest/digest_test.go
@@ -160,44 +160,10 @@ func TestDigestMatchingTraitsUpdated(t *testing.T) {
 		},
 	}
 
-	itStatusOnlyTraitUpdated := v1.Integration{
-		Spec: v1.IntegrationSpec{},
-		Status: v1.IntegrationStatus{
-			Traits: v1.Traits{
-				Camel: &trait.CamelTrait{
-					Properties: []string{"hello=world2"},
-				},
-			},
-		},
-	}
-
 	itDigest, err := ComputeForIntegration(&it, nil, nil)
 	assert.Nil(t, err)
 	itSpecOnlyTraitUpdatedDigest, err := ComputeForIntegration(&itSpecOnlyTraitUpdated, nil, nil)
 	assert.Nil(t, err)
-	itStatusOnlyTraitUpdatedDigest, err := ComputeForIntegration(&itStatusOnlyTraitUpdated, nil, nil)
-	assert.Nil(t, err)
 
 	assert.NotEqual(t, itSpecOnlyTraitUpdatedDigest, itDigest, "Digests must not be equal")
-	assert.NotEqual(t, itStatusOnlyTraitUpdatedDigest, itDigest, "Digests must not be equal")
-	assert.Equal(t, itSpecOnlyTraitUpdatedDigest, itStatusOnlyTraitUpdatedDigest, "Digests must be equal")
-}
-
-func TestSpecStatusDrift(t *testing.T) {
-	it := v1.Integration{}
-	it.Spec.Traits.Camel = &trait.CamelTrait{}
-	it.Status.Traits.Camel = &trait.CamelTrait{}
-
-	it.Spec.Traits.Camel.Properties = []string{"hello=world1"}
-	d1, err := ComputeForIntegration(&it, nil, nil)
-	assert.Nil(t, err)
-	it.Status.Traits.Camel.Properties = []string{"hello=world2"}
-	d2, err := ComputeForIntegration(&it, nil, nil)
-	assert.Nil(t, err)
-	it.Spec.Traits.Camel.Properties = []string{"hello=world3"}
-	d3, err := ComputeForIntegration(&it, nil, nil)
-	assert.Nil(t, err)
-
-	assert.NotEqual(t, d2, d1, "d2 must not be equal to d1")
-	assert.NotEqual(t, d3, d2, "d3 must not be equal to d2")
 }


### PR DESCRIPTION
<!-- Description -->

This PR addresses a wrong assumption I made in the development of #5153 where we were naively storing the spec after their execution. However, this is not necessarily true, as the trait execution may change certain parameters originally introduced by the user. With this PR we store correctly the executed traits and we make sure to use the `.status.trait` where it would be required for Integration comparisons.

This PR also proves another wrong assumption I made during the development of #5180 where we introduced a check for a possible drift in the `.status.trait`. However, this should never be checked for a change as it's an internal status controlled by the operator and it would wrongly trigger a new rebuild when the operator stores the `.status.trait` value. The operator should normally monitor for changes in the `.spec` only in this case in order to trigger a rebuild if it is required.



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(traits): store executed traits
```
