### PR TITLE
fix(trait): watch for resource versions...

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -7704,7 +7704,8 @@ bool
 
 
 Enable "hot reload" when a secret/configmap mounted is edited (default `false`). The configmap/secret must be
-marked with `camel.apache.org/integration` label to be taken in account.
+marked with `camel.apache.org/integration` label to be taken in account. The resource will be watched for any kind change, also for
+changes in metadata.
 
 |`scanKameletsImplicitLabelSecrets` +
 bool

--- a/docs/modules/traits/pages/mount.adoc
+++ b/docs/modules/traits/pages/mount.adoc
@@ -48,7 +48,8 @@ Syntax: [configmap\|secret]:name[/key][@path], where name represents the resourc
 | mount.hot-reload
 | bool
 | Enable "hot reload" when a secret/configmap mounted is edited (default `false`). The configmap/secret must be
-marked with `camel.apache.org/integration` label to be taken in account.
+marked with `camel.apache.org/integration` label to be taken in account. The resource will be watched for any kind change, also for
+changes in metadata.
 
 | mount.scan-kamelets-implicit-label-secrets
 | bool

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -1476,7 +1476,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -3358,7 +3359,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)

--- a/helm/camel-k/crds/crd-integration-profile.yaml
+++ b/helm/camel-k/crds/crd-integration-profile.yaml
@@ -1358,7 +1358,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -3129,7 +3130,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -7377,7 +7377,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -9106,7 +9107,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -7674,7 +7674,8 @@ spec:
                             description: Enable "hot reload" when a secret/configmap
                               mounted is edited (default `false`). The configmap/secret
                               must be marked with `camel.apache.org/integration` label
-                              to be taken in account.
+                              to be taken in account. The resource will be watched
+                              for any kind change, also for changes in metadata.
                             type: boolean
                           resources:
                             description: 'A list of resources (text or binary content)

--- a/helm/camel-k/crds/crd-pipe.yaml
+++ b/helm/camel-k/crds/crd-pipe.yaml
@@ -7672,7 +7672,8 @@ spec:
                             description: Enable "hot reload" when a secret/configmap
                               mounted is edited (default `false`). The configmap/secret
                               must be marked with `camel.apache.org/integration` label
-                              to be taken in account.
+                              to be taken in account. The resource will be watched
+                              for any kind change, also for changes in metadata.
                             type: boolean
                           resources:
                             description: 'A list of resources (text or binary content)

--- a/pkg/apis/camel/v1/trait/mount.go
+++ b/pkg/apis/camel/v1/trait/mount.go
@@ -36,7 +36,8 @@ type MountTrait struct {
 	// A list of Persistent Volume Claims to be mounted. Syntax: [pvcname:/container/path]
 	Volumes []string `property:"volumes" json:"volumes,omitempty"`
 	// Enable "hot reload" when a secret/configmap mounted is edited (default `false`). The configmap/secret must be
-	// marked with `camel.apache.org/integration` label to be taken in account.
+	// marked with `camel.apache.org/integration` label to be taken in account. The resource will be watched for any kind change, also for
+	// changes in metadata.
 	HotReload *bool `property:"hot-reload" json:"hotReload,omitempty"`
 	// Deprecated: include your properties in an explicit property file backed by a secret.
 	// Let the operator to scan for secret labeled with `camel.apache.org/kamelet` and `camel.apache.org/kamelet.configuration`.

--- a/pkg/controller/integration/build_kit.go
+++ b/pkg/controller/integration/build_kit.go
@@ -46,7 +46,7 @@ func (action *buildKitAction) CanHandle(integration *v1.Integration) bool {
 func (action *buildKitAction) Handle(ctx context.Context, integration *v1.Integration) (*v1.Integration, error) {
 	// TODO: we may need to add a timeout strategy, i.e give up after some time in case of an unrecoverable error.
 
-	secrets, configmaps := getIntegrationSecretsAndConfigmaps(ctx, action.client, integration)
+	secrets, configmaps := getIntegrationSecretAndConfigmapResourceVersions(ctx, action.client, integration)
 	hash, err := digest.ComputeForIntegration(integration, configmaps, secrets)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/integration/integration_controller.go
+++ b/pkg/controller/integration/integration_controller.go
@@ -595,7 +595,7 @@ func (r *reconcileIntegration) Reconcile(ctx context.Context, request reconcile.
 }
 
 func (r *reconcileIntegration) update(ctx context.Context, base *v1.Integration, target *v1.Integration, log *log.Logger) error {
-	secrets, configmaps := getIntegrationSecretsAndConfigmaps(ctx, r.client, target)
+	secrets, configmaps := getIntegrationSecretAndConfigmapResourceVersions(ctx, r.client, target)
 	d, err := digest.ComputeForIntegration(target, configmaps, secrets)
 	if err != nil {
 		return err

--- a/pkg/controller/integration/monitor.go
+++ b/pkg/controller/integration/monitor.go
@@ -30,6 +30,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/utils/pointer"
 
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,6 +42,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/digest"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	utilResource "github.com/apache/camel-k/v2/pkg/util/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NewMonitorAction is an action used to monitor manager Integrations.
@@ -228,7 +230,7 @@ func isInIntegrationKitFailed(status v1.IntegrationStatus) bool {
 }
 
 func (action *monitorAction) checkDigestAndRebuild(ctx context.Context, integration *v1.Integration, kit *v1.IntegrationKit) (*v1.Integration, error) {
-	secrets, configmaps := getIntegrationSecretsAndConfigmaps(ctx, action.client, integration)
+	secrets, configmaps := getIntegrationSecretAndConfigmapResourceVersions(ctx, action.client, integration)
 	hash, err := digest.ComputeForIntegration(integration, configmaps, secrets)
 	if err != nil {
 		return nil, err
@@ -279,29 +281,40 @@ func isIntegrationKitResetRequired(integration *v1.Integration, kit *v1.Integrat
 	return false
 }
 
-func getIntegrationSecretsAndConfigmaps(ctx context.Context, client client.Client, integration *v1.Integration) ([]*corev1.Secret, []*corev1.ConfigMap) {
-	configmaps := make([]*corev1.ConfigMap, 0)
-	secrets := make([]*corev1.Secret, 0)
-	if integration.Spec.Traits.Mount != nil {
-		for _, c := range integration.Spec.Traits.Mount.Configs {
+// getIntegrationSecretAndConfigmapResourceVersions returns the list of resource versions only useful to watch for changes.
+func getIntegrationSecretAndConfigmapResourceVersions(ctx context.Context, client client.Client, integration *v1.Integration) ([]string, []string) {
+	configmaps := make([]string, 0)
+	secrets := make([]string, 0)
+	if integration.Spec.Traits.Mount != nil && pointer.BoolDeref(integration.Spec.Traits.Mount.HotReload, false) {
+		mergedResources := make([]string, 0)
+		mergedResources = append(mergedResources, integration.Spec.Traits.Mount.Configs...)
+		mergedResources = append(mergedResources, integration.Spec.Traits.Mount.Resources...)
+		for _, c := range mergedResources {
 			if conf, parseErr := utilResource.ParseConfig(c); parseErr == nil {
 				if conf.StorageType() == utilResource.StorageTypeConfigmap {
-					configmap := kubernetes.LookupConfigmap(ctx, client, integration.Namespace, conf.Name())
-					configmaps = append(configmaps, configmap)
+					cm := corev1.ConfigMap{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "ConfigMap",
+							APIVersion: corev1.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: integration.Namespace,
+							Name:      conf.Name(),
+						},
+					}
+					configmaps = append(configmaps, kubernetes.LookupResourceVersion(ctx, client, &cm))
 				} else if conf.StorageType() == utilResource.StorageTypeSecret {
-					secret := kubernetes.LookupSecret(ctx, client, integration.Namespace, conf.Name())
-					secrets = append(secrets, secret)
-				}
-			}
-		}
-		for _, r := range integration.Spec.Traits.Mount.Resources {
-			if conf, parseErr := utilResource.ParseConfig(r); parseErr == nil {
-				if conf.StorageType() == utilResource.StorageTypeConfigmap {
-					configmap := kubernetes.LookupConfigmap(ctx, client, integration.Namespace, conf.Name())
-					configmaps = append(configmaps, configmap)
-				} else if conf.StorageType() == utilResource.StorageTypeSecret {
-					secret := kubernetes.LookupSecret(ctx, client, integration.Namespace, conf.Name())
-					secrets = append(secrets, secret)
+					sec := corev1.Secret{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Secret",
+							APIVersion: corev1.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: integration.Namespace,
+							Name:      conf.Name(),
+						},
+					}
+					secrets = append(secrets, kubernetes.LookupResourceVersion(ctx, client, &sec))
 				}
 			}
 		}

--- a/pkg/controller/integration/monitor_test.go
+++ b/pkg/controller/integration/monitor_test.go
@@ -1,0 +1,85 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
+
+	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
+	"github.com/apache/camel-k/v2/pkg/util/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIntegrationSecretAndConfigmapResourceVersions(t *testing.T) {
+	cm := kubernetes.NewConfigMap("default", "cm-test", "test.txt", "test.txt", "xyz", nil)
+	sec := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sec-test",
+			Namespace: "default",
+		},
+		Immutable: pointer.Bool(true),
+	}
+	sec.Data = map[string][]byte{
+		"test.txt": []byte("hello"),
+	}
+	it := &v1.Integration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-it",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       v1.IntegrationKind,
+		},
+		Spec: v1.IntegrationSpec{
+			Traits: v1.Traits{
+				Mount: &trait.MountTrait{
+					Configs:   []string{"configmap:cm-test"},
+					Resources: []string{"secret:sec-test"},
+				},
+			},
+		},
+	}
+	c, err := test.NewFakeClient(cm, sec)
+	assert.Nil(t, err)
+	// Default hot reload (false)
+	configmaps, secrets := getIntegrationSecretAndConfigmapResourceVersions(context.TODO(), c, it)
+	assert.Len(t, configmaps, 0)
+	assert.Len(t, secrets, 0)
+	// Enabled hot reload (true)
+	it.Spec.Traits.Mount.HotReload = pointer.Bool(true)
+	configmaps, secrets = getIntegrationSecretAndConfigmapResourceVersions(context.TODO(), c, it)
+	assert.Len(t, configmaps, 1)
+	assert.Len(t, secrets, 1)
+	// We cannot guess resource version value. It should be enough to have any non empty value though.
+	assert.NotEqual(t, "", configmaps[0])
+	assert.NotEqual(t, "", secrets[0])
+}

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -1476,7 +1476,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -3358,7 +3359,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -1358,7 +1358,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -3129,7 +3130,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -7377,7 +7377,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)
@@ -9106,7 +9107,8 @@ spec:
                         description: Enable "hot reload" when a secret/configmap mounted
                           is edited (default `false`). The configmap/secret must be
                           marked with `camel.apache.org/integration` label to be taken
-                          in account.
+                          in account. The resource will be watched for any kind change,
+                          also for changes in metadata.
                         type: boolean
                       resources:
                         description: 'A list of resources (text or binary content)

--- a/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
@@ -7674,7 +7674,8 @@ spec:
                             description: Enable "hot reload" when a secret/configmap
                               mounted is edited (default `false`). The configmap/secret
                               must be marked with `camel.apache.org/integration` label
-                              to be taken in account.
+                              to be taken in account. The resource will be watched
+                              for any kind change, also for changes in metadata.
                             type: boolean
                           resources:
                             description: 'A list of resources (text or binary content)

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -7672,7 +7672,8 @@ spec:
                             description: Enable "hot reload" when a secret/configmap
                               mounted is edited (default `false`). The configmap/secret
                               must be marked with `camel.apache.org/integration` label
-                              to be taken in account.
+                              to be taken in account. The resource will be watched
+                              for any kind change, also for changes in metadata.
                             type: boolean
                           resources:
                             description: 'A list of resources (text or binary content)

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -35,7 +35,6 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/dsl"
-	corev1 "k8s.io/api/core/v1"
 
 	"fmt"
 )
@@ -47,7 +46,7 @@ const (
 
 // ComputeForIntegration a digest of the fields that are relevant for the deployment
 // Produces a digest that can be used as docker image tag.
-func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.ConfigMap, secrets []*corev1.Secret) (string, error) {
+func ComputeForIntegration(integration *v1.Integration, configmapVersions []string, secretVersions []string) (string, error) {
 	hash := sha256.New()
 	// Integration version is relevant
 	if _, err := hash.Write([]byte(integration.Status.Version)); err != nil {
@@ -131,63 +130,19 @@ func ComputeForIntegration(integration *v1.Integration, configmaps []*corev1.Con
 		}
 	}
 
-	// Configmap content
-	for _, cm := range configmaps {
-		if cm != nil {
-			// prepare string from cm
-			var cmToString strings.Builder
-			// name, ns
-			cmToString.WriteString(fmt.Sprintf("%s/%s", cm.Name, cm.Namespace))
-			// Data with sorted keys
-			if cm.Data != nil {
-				// sort keys
-				keys := make([]string, 0, len(cm.Data))
-				for k := range cm.Data {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
-				for _, k := range keys {
-					cmToString.WriteString(fmt.Sprintf("%s=%v,", k, cm.Data[k]))
-				}
-			}
-			// BinaryData with sorted keys
-			if cm.BinaryData != nil {
-				keys := make([]string, 0, len(cm.BinaryData))
-				for k := range cm.BinaryData {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
-				for _, k := range keys {
-					cmToString.WriteString(fmt.Sprintf("%s=%v,", k, cm.BinaryData[k]))
-				}
-			}
-			// write prepared string to hash
-			if _, err := hash.Write([]byte(cmToString.String())); err != nil {
+	// Configmap versions
+	for _, cm := range configmapVersions {
+		if cm != "" {
+			if _, err := hash.Write([]byte(cm)); err != nil {
 				return "", err
 			}
 		}
 	}
 
-	// Secret content
-	for _, s := range secrets {
-		if s != nil {
-			// prepare string from secret
-			var secretToString strings.Builder
-			// name, ns
-			secretToString.WriteString(fmt.Sprintf("%s/%s", s.Name, s.Namespace))
-			// Data with sorted keys
-			if s.Data != nil {
-				keys := make([]string, 0, len(s.Data))
-				for k := range s.Data {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
-				for _, k := range keys {
-					secretToString.WriteString(fmt.Sprintf("%s=%v,", k, s.Data[k]))
-				}
-			}
-			// write prepared secret to hash
-			if _, err := hash.Write([]byte(secretToString.String())); err != nil {
+	// Secret versions
+	for _, s := range secretVersions {
+		if s != "" {
+			if _, err := hash.Write([]byte(s)); err != nil {
 				return "", err
 			}
 		}

--- a/pkg/util/digest/digest_test.go
+++ b/pkg/util/digest/digest_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -81,19 +80,13 @@ func TestDigestUsesConfigmap(t *testing.T) {
 
 	digest1, err := ComputeForIntegration(&it, nil, nil)
 	require.NoError(t, err)
-
-	cm := corev1.ConfigMap{
-		Data: map[string]string{
-			"foo": "bar",
-		},
-	}
-	cms := []*corev1.ConfigMap{&cm}
+	cms := []string{"123456"}
 
 	digest2, err := ComputeForIntegration(&it, cms, nil)
 	require.NoError(t, err)
 	assert.NotEqual(t, digest1, digest2)
 
-	cm.Data["foo"] = "bar updated"
+	cms = []string{"1234567"}
 	digest3, err := ComputeForIntegration(&it, cms, nil)
 	require.NoError(t, err)
 	assert.NotEqual(t, digest2, digest3)
@@ -117,23 +110,12 @@ func TestDigestUsesSecret(t *testing.T) {
 
 	digest1, err := ComputeForIntegration(&it, nil, nil)
 	require.NoError(t, err)
-
-	sec := corev1.Secret{
-		Data: map[string][]byte{
-			"foo": []byte("bar"),
-		},
-		StringData: map[string]string{
-			"foo2": "bar2",
-		},
-	}
-
-	secrets := []*corev1.Secret{&sec}
-
+	secrets := []string{"123456"}
 	digest2, err := ComputeForIntegration(&it, nil, secrets)
 	require.NoError(t, err)
 	assert.NotEqual(t, digest1, digest2)
 
-	sec.Data["foo"] = []byte("bar updated")
+	secrets = []string{"1234567"}
 	digest3, err := ComputeForIntegration(&it, nil, secrets)
 	require.NoError(t, err)
 	assert.NotEqual(t, digest2, digest3)

--- a/pkg/util/kubernetes/lookup.go
+++ b/pkg/util/kubernetes/lookup.go
@@ -52,6 +52,15 @@ func LookupConfigmap(ctx context.Context, c client.Client, ns string, name strin
 	return &cm
 }
 
+// LookupResourceVersion will look for any k8s resource with a given name in a given namespace, returning its resource version only.
+// It makes this safe against any resource that the operator is not allowed to inspect.
+func LookupResourceVersion(ctx context.Context, c client.Client, object ctrl.Object) string {
+	if err := c.Get(ctx, ctrl.ObjectKeyFromObject(object), object); err != nil {
+		return ""
+	}
+	return object.GetResourceVersion()
+}
+
 // LookupSecret will look for any k8s Secret with a given name in a given namespace.
 func LookupSecret(ctx context.Context, c client.Client, ns string, name string) *corev1.Secret {
 	secret := corev1.Secret{


### PR DESCRIPTION
...instead of for their content.

With this PR we fix a potentially risky behavior, as we were inspecting Configmap/Secrets content to address any change. Instead of looking directly the content, we watch for the changing resource version, which should be the way provided by the platform to know when a resource has changed without inspecting its content.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): watch for resource versions
```
