### PR TITLE
fix(traits): use Comparable matches

### DIFF
--- a/docs/modules/ROOT/pages/architecture/traits.adoc
+++ b/docs/modules/ROOT/pages/architecture/traits.adoc
@@ -49,6 +49,15 @@ type Trait interface {
 	IsAllowedInProfile(v1.TraitProfile) bool
 	Order() int
 }
+
+type Comparable interface {
+	Matches(trait Trait) bool
+}
+
+type ComparableTrait interface {
+	Trait
+	Comparable
+}
 ----
 
 Each trait will implement this interface. The most important methods that will be invoked by the xref:architecture/operator.adoc[Operator] are `Configure()` and `Apply()`. Basically, the `Configure()` method will set those inputs aforementioned (each trait has its own). The method is in charge to verify also the correctness of those expected parameters, where it makes sense (i.e., a well expected `Kubernetes` resource name). The function can return a `TraitCondition` object containing any informative or warning condition to be attached to the resulting Integration (for instance, traits forcefully altered by the platform, or deprecation notices).
@@ -59,6 +68,6 @@ The `Order()` method helps in resolving the order of execution of different trai
 
 The `InfluencesKit()`, `IsPlatformTrait()` and `RequiresIntegrationPlatform()` methods are easy to understand. They are used to determine if a trait has to influence an `IntegrationKit` build/initialization, if it's a platform trait (ie, needed by the platform itself) or are requiring the presence of an `IntegrationPlatform`.
 
-The presence of `InfluencesBuild()` will let specify the level of granularity of a trait down to its properties for a rebuild. So, if you need, you can compare the traits properties coming from the `prev` (previous) Integration to decide if it is worth to rebuild an Integration or the trait can reuse the one already provided in `this` version.
+For those traits that `InfluencesKit()` you may need to provide a `Matches(trait Trait)` func in order to specify those trait parameters that influences a build. This is required by the platform to decide if it is worth to rebuild an Integration or the trait can reuse the one already provided.
 
 Finally, through the `IsAllowedInProfile()` method we can override the default behavior (allow the trait for any profile). We must specify the profile we expect for this trait to be executed properly.

--- a/e2e/common/misc/pipe_test.go
+++ b/e2e/common/misc/pipe_test.go
@@ -63,7 +63,7 @@ func TestPipe(t *testing.T) {
 					"--name", "throw-error-binding",
 				).Execute()).To(Succeed())
 
-				g.Eventually(IntegrationPodPhase(t, ns, "throw-error-binding"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationPodPhase(t, ns, "throw-error-binding"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 				g.Eventually(IntegrationLogs(t, ns, "throw-error-binding"), TestTimeoutShort).Should(ContainSubstring("[kameletErrorHandler] (Camel (camel-1) thread #1 - timer://tick)"))
 				g.Eventually(IntegrationLogs(t, ns, "throw-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("[integrationLogger] (Camel (camel-1) thread #1 - timer://tick)"))
 
@@ -82,7 +82,7 @@ func TestPipe(t *testing.T) {
 					"--name", "no-error-binding",
 				).Execute()).To(Succeed())
 
-				g.Eventually(IntegrationPodPhase(t, ns, "no-error-binding"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationPodPhase(t, ns, "no-error-binding"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 				g.Eventually(IntegrationLogs(t, ns, "no-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("[kameletErrorHandler] (Camel (camel-1) thread #1 - timer://tick)"))
 				g.Eventually(IntegrationLogs(t, ns, "no-error-binding"), TestTimeoutShort).Should(ContainSubstring("[integrationLogger] (Camel (camel-1) thread #1 - timer://tick)"))
 
@@ -103,7 +103,7 @@ func TestPipe(t *testing.T) {
 				"--name", "kb-with-traits",
 			).Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, "kb-with-traits"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ns, "kb-with-traits"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationLogs(t, ns, "kb-with-traits"), TestTimeoutShort).Should(ContainSubstring("hello from test"))
 			g.Eventually(IntegrationLogs(t, ns, "kb-with-traits"), TestTimeoutShort).Should(ContainSubstring("integrationLogger"))
 		})

--- a/pkg/controller/integration/kits.go
+++ b/pkg/controller/integration/kits.go
@@ -19,8 +19,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -132,7 +130,7 @@ func integrationMatches(ctx context.Context, c client.Client, integration *v1.In
 		return false, err
 	}
 
-	if match, err := hasMatchingTraits(itc, ikc); !match || err != nil {
+	if match, err := trait.HasMatchingTraits(itc, ikc); !match || err != nil {
 		ilog.Debug("Integration and integration-kit traits do not match", "integration", integration.Name, "integration-kit", kit.Name, "namespace", integration.Namespace)
 		return false, err
 	}
@@ -195,7 +193,7 @@ func kitMatches(kit *v1.IntegrationKit, target *v1.IntegrationKit) (bool, error)
 		return false, err
 	}
 
-	if match, err := hasMatchingTraits(c1, c2); !match || err != nil {
+	if match, err := trait.HasMatchingTraits(c1, c2); !match || err != nil {
 		return false, err
 	}
 	if !util.StringSliceContains(kit.Spec.Dependencies, target.Spec.Dependencies) {
@@ -203,67 +201,6 @@ func kitMatches(kit *v1.IntegrationKit, target *v1.IntegrationKit) (bool, error)
 	}
 
 	return true, nil
-}
-
-func hasMatchingTraits(traitMap trait.Options, kitTraitMap trait.Options) (bool, error) {
-	catalog := trait.NewCatalog(nil)
-
-	for _, t := range catalog.AllTraits() {
-		if t == nil {
-			continue
-		}
-
-		id := string(t.ID())
-		it, ok1 := traitMap.Get(id)
-		kt, ok2 := kitTraitMap.Get(id)
-
-		if !ok1 && !ok2 {
-			continue
-		}
-
-		if t.InfluencesKit() && t.InfluencesBuild(it, kt) {
-			if ct, ok := t.(trait.ComparableTrait); ok {
-				// if it's match trait use its matches method to determine the match
-				if match, err := matchesComparableTrait(ct, it, kt); !match || err != nil {
-					return false, err
-				}
-			} else {
-				if !matchesTrait(it, kt) {
-					return false, nil
-				}
-			}
-		}
-	}
-
-	return true, nil
-}
-
-func matchesComparableTrait(ct trait.ComparableTrait, it map[string]interface{}, kt map[string]interface{}) (bool, error) {
-	t1 := reflect.New(reflect.TypeOf(ct).Elem()).Interface()
-	if err := trait.ToTrait(it, &t1); err != nil {
-		return false, err
-	}
-
-	t2 := reflect.New(reflect.TypeOf(ct).Elem()).Interface()
-	if err := trait.ToTrait(kt, &t2); err != nil {
-		return false, err
-	}
-
-	ct2, ok := t2.(trait.ComparableTrait)
-	if !ok {
-		return false, fmt.Errorf("type assertion failed: %v", t2)
-	}
-	tt1, ok := t1.(trait.Trait)
-	if !ok {
-		return false, fmt.Errorf("type assertion failed: %v", t1)
-	}
-
-	return ct2.Matches(tt1), nil
-}
-
-func matchesTrait(it map[string]interface{}, kt map[string]interface{}) bool {
-	// perform exact match on the two trait maps
-	return reflect.DeepEqual(it, kt)
 }
 
 func hasMatchingSourcesForNative(it *v1.Integration, kit *v1.IntegrationKit) bool {

--- a/pkg/controller/integration/kits_test.go
+++ b/pkg/controller/integration/kits_test.go
@@ -27,7 +27,6 @@ import (
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 
 	"github.com/apache/camel-k/v2/pkg/trait"
-	"github.com/apache/camel-k/v2/pkg/util/log"
 	"github.com/apache/camel-k/v2/pkg/util/test"
 
 	"github.com/stretchr/testify/assert"
@@ -93,10 +92,6 @@ func TestLookupKitForIntegration_DiscardKitsInError(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-
-	a := buildKitAction{}
-	a.InjectLogger(log.Log)
-	a.InjectClient(c)
 
 	kits, err := lookupKitsForIntegration(context.TODO(), c, &v1.Integration{
 		TypeMeta: metav1.TypeMeta{
@@ -221,10 +216,6 @@ func TestLookupKitForIntegration_DiscardKitsWithIncompatibleTraits(t *testing.T)
 
 	require.NoError(t, err)
 
-	a := buildKitAction{}
-	a.InjectLogger(log.Log)
-	a.InjectClient(c)
-
 	kits, err := lookupKitsForIntegration(context.TODO(), c, &v1.Integration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1.SchemeGroupVersion.String(),
@@ -288,9 +279,6 @@ func TestHasMatchingTraits_KitNoTraitShouldNotBePicked(t *testing.T) {
 		},
 	}
 
-	a := buildKitAction{}
-	a.InjectLogger(log.Log)
-
 	ok, err := integrationAndKitHaveSameTraits(integration, kit)
 	require.NoError(t, err)
 	assert.False(t, ok)
@@ -338,9 +326,6 @@ func TestHasMatchingTraits_KitSameTraitShouldBePicked(t *testing.T) {
 			},
 		},
 	}
-
-	a := buildKitAction{}
-	a.InjectLogger(log.Log)
 
 	ok, err := integrationAndKitHaveSameTraits(integration, kit)
 	require.NoError(t, err)

--- a/pkg/controller/integration/monitor.go
+++ b/pkg/controller/integration/monitor.go
@@ -237,7 +237,7 @@ func (action *monitorAction) checkDigestAndRebuild(ctx context.Context, integrat
 	}
 
 	if hash != integration.Status.Digest {
-		action.L.Info("Integration %s digest has changed: resetting its status. Will check if it needs to be rebuilt and restarted.", integration.Name)
+		action.L.Infof("Integration %s digest has changed: resetting its status. Will check if it needs to be rebuilt and restarted.", integration.Name)
 		if isIntegrationKitResetRequired(integration, kit) {
 			integration.SetIntegrationKit(nil)
 		}

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -20,6 +20,7 @@ package trait
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -56,9 +57,33 @@ func (t *builderTrait) InfluencesKit() bool {
 	return true
 }
 
-// InfluencesBuild overrides base class method.
-func (t *builderTrait) InfluencesBuild(this, prev map[string]interface{}) bool {
-	return true
+func (t *builderTrait) Matches(trait Trait) bool {
+	otherTrait, ok := trait.(*builderTrait)
+	if !ok {
+		return false
+	}
+	if t.BaseImage != otherTrait.BaseImage || len(t.Properties) != len(otherTrait.Properties) || len(t.Tasks) != len(otherTrait.Tasks) {
+		return false
+	}
+	// More sofisticated check if len is the same. Sort and compare via slices equal func.
+	// Although the Matches func is used as a support for comparison, it makes sense
+	// to copy the properties and avoid possible inconsistencies caused by the sorting operation.
+	srtThisProps := make([]string, len(t.Properties))
+	srtOtheProps := make([]string, len(otherTrait.Properties))
+	copy(srtThisProps, t.Properties)
+	copy(srtOtheProps, otherTrait.Properties)
+	slices.Sort(srtThisProps)
+	slices.Sort(srtOtheProps)
+	if !slices.Equal(srtThisProps, srtOtheProps) {
+		return false
+	}
+	srtThisTasks := make([]string, len(t.Tasks))
+	srtOtheTasks := make([]string, len(otherTrait.Tasks))
+	copy(srtThisTasks, t.Tasks)
+	copy(srtOtheTasks, otherTrait.Tasks)
+	slices.Sort(srtThisTasks)
+	slices.Sort(srtOtheTasks)
+	return slices.Equal(srtThisTasks, srtOtheTasks)
 }
 
 func (t *builderTrait) Configure(e *Environment) (bool, *TraitCondition, error) {

--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -53,9 +53,13 @@ func (t *camelTrait) InfluencesKit() bool {
 	return true
 }
 
-// InfluencesBuild only when the runtime has changed.
-func (t *camelTrait) InfluencesBuild(this, prev map[string]interface{}) bool {
-	return this["runtimeVersion"] != prev["runtimeVersion"]
+func (t *camelTrait) Matches(trait Trait) bool {
+	otherTrait, ok := trait.(*camelTrait)
+	if !ok {
+		return false
+	}
+
+	return otherTrait.RuntimeVersion == t.RuntimeVersion
 }
 
 func (t *camelTrait) Configure(e *Environment) (bool, *TraitCondition, error) {

--- a/pkg/trait/camel_test.go
+++ b/pkg/trait/camel_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/test"
@@ -207,4 +208,25 @@ func TestApplyCamelTraitWithSources(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"content": "XML Source Code",
 	}, sourceCm.Data)
+}
+
+func TestCamelMatches(t *testing.T) {
+	t1 := camelTrait{
+		BasePlatformTrait: NewBasePlatformTrait("camel", 600),
+		CamelTrait: traitv1.CamelTrait{
+			RuntimeVersion: "1.2.3",
+		},
+	}
+	t2 := camelTrait{
+		BasePlatformTrait: NewBasePlatformTrait("camel", 600),
+		CamelTrait: traitv1.CamelTrait{
+			RuntimeVersion: "1.2.3",
+		},
+	}
+
+	assert.True(t, t1.Matches(&t2))
+	t1.Properties = []string{"hello=world"}
+	assert.True(t, t1.Matches(&t2))
+	t2.RuntimeVersion = "3.2.1"
+	assert.False(t, t1.Matches(&t2))
 }

--- a/pkg/trait/quarkus.go
+++ b/pkg/trait/quarkus.go
@@ -109,23 +109,14 @@ func (t *quarkusTrait) InfluencesKit() bool {
 	return true
 }
 
-// InfluencesBuild overrides base class method.
-func (t *quarkusTrait) InfluencesBuild(this, prev map[string]interface{}) bool {
-	return true
-}
-
-var _ ComparableTrait = &quarkusTrait{}
-
 func (t *quarkusTrait) Matches(trait Trait) bool {
 	qt, ok := trait.(*quarkusTrait)
 	if !ok {
 		return false
 	}
-
 	if len(t.Modes) == 0 && len(qt.Modes) != 0 && !qt.containsMode(traitv1.JvmQuarkusMode) {
 		return false
 	}
-
 	for _, md := range t.Modes {
 		if md == traitv1.JvmQuarkusMode && len(qt.Modes) == 0 {
 			continue
@@ -135,8 +126,17 @@ func (t *quarkusTrait) Matches(trait Trait) bool {
 		}
 		return false
 	}
+	// We need to check if the native base image used is the same
+	thisNativeBaseImage := t.NativeBaseImage
+	if thisNativeBaseImage == "" {
+		thisNativeBaseImage = QuarkusNativeDefaultBaseImageName
+	}
+	otherNativeBaseImage := qt.NativeBaseImage
+	if otherNativeBaseImage == "" {
+		otherNativeBaseImage = QuarkusNativeDefaultBaseImageName
+	}
 
-	return true
+	return thisNativeBaseImage == otherNativeBaseImage
 }
 
 func (t *quarkusTrait) Configure(e *Environment) (bool, *TraitCondition, error) {

--- a/pkg/trait/quarkus_test.go
+++ b/pkg/trait/quarkus_test.go
@@ -225,3 +225,31 @@ func TestGetLanguageSettingsWithLoaders(t *testing.T) {
 	assert.Equal(t, languageSettings{native: false, sourcesRequiredAtBuildTime: true}, getLanguageSettings(environment, v1.LanguageKotlin))
 	assert.Equal(t, languageSettings{native: true, sourcesRequiredAtBuildTime: false}, getLanguageSettings(environment, v1.LanguageJavaShell))
 }
+
+func TestQuarkusMatches(t *testing.T) {
+	qt := quarkusTrait{
+		BasePlatformTrait: NewBasePlatformTrait("quarkus", 600),
+		QuarkusTrait: traitv1.QuarkusTrait{
+			Modes: []traitv1.QuarkusMode{traitv1.JvmQuarkusMode},
+		},
+	}
+	qt2 := quarkusTrait{
+		BasePlatformTrait: NewBasePlatformTrait("quarkus", 600),
+		QuarkusTrait: traitv1.QuarkusTrait{
+			Modes:           []traitv1.QuarkusMode{traitv1.JvmQuarkusMode},
+			NativeBaseImage: QuarkusNativeDefaultBaseImageName,
+		},
+	}
+
+	assert.True(t, qt.Matches(&qt2))
+	qt2.Modes = append(qt2.Modes, traitv1.NativeQuarkusMode)
+	assert.True(t, qt.Matches(&qt2))
+	qt2.Modes = []traitv1.QuarkusMode{traitv1.NativeQuarkusMode}
+	assert.False(t, qt.Matches(&qt2))
+	qt2.Modes = nil
+	assert.True(t, qt.Matches(&qt2))
+	qt2.Modes = []traitv1.QuarkusMode{}
+	assert.True(t, qt.Matches(&qt2))
+	qt2.NativeBaseImage = "docker.io/my-new-native-base"
+	assert.False(t, qt.Matches(&qt2))
+}

--- a/pkg/trait/registry.go
+++ b/pkg/trait/registry.go
@@ -54,11 +54,6 @@ func (t *registryTrait) InfluencesKit() bool {
 	return true
 }
 
-// InfluencesBuild overrides base class method.
-func (t *registryTrait) InfluencesBuild(this, prev map[string]interface{}) bool {
-	return true
-}
-
 func (t *registryTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 	// disabled by default
 	if e.IntegrationKit == nil || !pointer.BoolDeref(t.Enabled, false) {

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -73,11 +73,6 @@ type Trait interface {
 	// InfluencesKit determines if the trait has any influence on Integration Kits
 	InfluencesKit() bool
 
-	// InfluencesBuild defines a low level of granularity for those traits which influences the build.
-	// The trait can specify if any particular trait configuration influences a build or not.
-	// Note: You must override this method if you override `InfluencesKit()`
-	InfluencesBuild(this, prev map[string]interface{}) bool
-
 	// IsPlatformTrait marks all fundamental traits that allow the platform to work
 	IsPlatformTrait() bool
 
@@ -91,10 +86,12 @@ type Trait interface {
 	Order() int
 }
 
+// Comparable is the interface exposing comparable funcs.
 type Comparable interface {
 	Matches(trait Trait) bool
 }
 
+// ComparableTrait is the interface used to compare two traits between them.
 type ComparableTrait interface {
 	Trait
 	Comparable
@@ -151,12 +148,6 @@ func (trait *BaseTrait) InjectClient(c client.Client) {
 
 // InfluencesKit determines if the trait has any influence on Integration Kits.
 func (trait *BaseTrait) InfluencesKit() bool {
-	return false
-}
-
-// InfluencesBuild defines a low level of granularity for those traits which influences the build.
-// The trait can specify if any particular trait configuration influences a build or not.
-func (trait *BaseTrait) InfluencesBuild(this, prev map[string]interface{}) bool {
 	return false
 }
 


### PR DESCRIPTION
Reverting #4512 which introduced a function diverging the match from the original design

This PR aims to fix a diverging design I introduced some times ago. With this one we move back to the original design making correct usage of `Comparable` interface in trait which is used by the operator to distinguish when to reuse or rebuild an Integration based only on certain IntegrationKit traits changes (ie, runtime version, builder properties).

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(traits): use Comparable matches
```
