### PR TITLE
fix(ctrl): message digest change

### DIFF
--- a/pkg/controller/integration/build_kit.go
+++ b/pkg/controller/integration/build_kit.go
@@ -52,7 +52,7 @@ func (action *buildKitAction) Handle(ctx context.Context, integration *v1.Integr
 		return nil, err
 	}
 	if hash != integration.Status.Digest {
-		action.L.Info("Integration needs a rebuild")
+		action.L.Info("Integration %s digest has changed: resetting its status. Will check if it needs to be rebuilt and restarted.", integration.Name)
 		integration.Initialize()
 		integration.Status.Digest = hash
 		return integration, nil

--- a/pkg/controller/integration/monitor.go
+++ b/pkg/controller/integration/monitor.go
@@ -237,12 +237,10 @@ func (action *monitorAction) checkDigestAndRebuild(ctx context.Context, integrat
 	}
 
 	if hash != integration.Status.Digest {
-		action.L.Info("Monitor: Integration needs a rebuild")
-
+		action.L.Info("Integration %s digest has changed: resetting its status. Will check if it needs to be rebuilt and restarted.", integration.Name)
 		if isIntegrationKitResetRequired(integration, kit) {
 			integration.SetIntegrationKit(nil)
 		}
-
 		integration.Initialize()
 		integration.Status.Digest = hash
 


### PR DESCRIPTION
Change of a digest would reset an Integration, but a rebuild may not be required.

Closes #5219

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ctrl): message digest change
```
