### PR TITLE
chore(e2e): Separate common-it E2E tests, so they run more efficient

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -90,7 +90,7 @@ jobs:
           -p "${{ github.event.inputs.skip-problematic }}" \
           -q "${{ github.event.inputs.log-level }}" \
           -t "${{ github.event.inputs.test-filters }}"
-    - name: Smoke tests
+    - name: Common tests
       uses: ./.github/actions/e2e-common
       with:
         cluster-config-data: ${{ secrets.E2E_CLUSTER_CONFIG }}

--- a/e2e/advanced/catalog_builder_test.go
+++ b/e2e/advanced/catalog_builder_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -38,18 +39,18 @@ import (
 func TestCamelCatalogBuilder(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := fmt.Sprintf("camel-k-%s", ns)
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
-		g.Eventually(OperatorPod(t, ns)).ShouldNot(BeNil())
-		g.Eventually(Platform(t, ns)).ShouldNot(BeNil())
-		g.Eventually(PlatformConditionStatus(t, ns, v1.IntegrationPlatformConditionTypeCreated), TestTimeoutShort).
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
+		g.Eventually(OperatorPod(t, ctx, ns)).ShouldNot(BeNil())
+		g.Eventually(Platform(t, ctx, ns)).ShouldNot(BeNil())
+		g.Eventually(PlatformConditionStatus(t, ctx, ns, v1.IntegrationPlatformConditionTypeCreated), TestTimeoutShort).
 			Should(Equal(corev1.ConditionTrue))
 		catalogName := fmt.Sprintf("camel-catalog-%s", strings.ToLower(defaults.DefaultRuntimeVersion))
-		g.Eventually(CamelCatalog(t, ns, catalogName)).ShouldNot(BeNil())
-		g.Eventually(CamelCatalogPhase(t, ns, catalogName), TestTimeoutMedium).Should(Equal(v1.CamelCatalogPhaseReady))
+		g.Eventually(CamelCatalog(t, ctx, ns, catalogName)).ShouldNot(BeNil())
+		g.Eventually(CamelCatalogPhase(t, ctx, ns, catalogName), TestTimeoutMedium).Should(Equal(v1.CamelCatalogPhaseReady))
 
 		// Run an integration with a catalog not compatible
 		// The operator should create the catalog, but fail on reconciliation as it is not compatible
@@ -58,23 +59,21 @@ func TestCamelCatalogBuilder(t *testing.T) {
 			name := RandomizedSuffixName("java-1-15")
 			nonCompatibleCatalogName := "camel-catalog-1.15.0"
 			g.Expect(
-				KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
-					"-t", "camel.runtime-version=1.15.0",
-				).Execute()).To(Succeed())
+				KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "camel.runtime-version=1.15.0").Execute()).To(Succeed())
 
-			g.Eventually(CamelCatalog(t, ns, nonCompatibleCatalogName)).ShouldNot(BeNil())
-			g.Eventually(CamelCatalogPhase(t, ns, nonCompatibleCatalogName)).Should(Equal(v1.CamelCatalogPhaseError))
-			g.Eventually(CamelCatalogCondition(t, ns, nonCompatibleCatalogName, v1.CamelCatalogConditionReady)().Message).Should(ContainSubstring("Container image tool missing in catalog"))
+			g.Eventually(CamelCatalog(t, ctx, ns, nonCompatibleCatalogName)).ShouldNot(BeNil())
+			g.Eventually(CamelCatalogPhase(t, ctx, ns, nonCompatibleCatalogName)).Should(Equal(v1.CamelCatalogPhaseError))
+			g.Eventually(CamelCatalogCondition(t, ctx, ns, nonCompatibleCatalogName, v1.CamelCatalogConditionReady)().Message).Should(ContainSubstring("Container image tool missing in catalog"))
 
-			g.Eventually(IntegrationKit(t, ns, name)).ShouldNot(Equal(""))
-			kitName := IntegrationKit(t, ns, name)()
-			g.Eventually(KitPhase(t, ns, kitName)).Should(Equal(v1.IntegrationKitPhaseError))
-			g.Eventually(KitCondition(t, ns, kitName, v1.IntegrationKitConditionCatalogAvailable)().Reason).Should(Equal("Camel Catalog 1.15.0 error"))
-			g.Eventually(IntegrationPhase(t, ns, name)).Should(Equal(v1.IntegrationPhaseError))
-			g.Eventually(IntegrationCondition(t, ns, name, v1.IntegrationConditionKitAvailable)().Status).Should(Equal(corev1.ConditionFalse))
+			g.Eventually(IntegrationKit(t, ctx, ns, name)).ShouldNot(Equal(""))
+			kitName := IntegrationKit(t, ctx, ns, name)()
+			g.Eventually(KitPhase(t, ctx, ns, kitName)).Should(Equal(v1.IntegrationKitPhaseError))
+			g.Eventually(KitCondition(t, ctx, ns, kitName, v1.IntegrationKitConditionCatalogAvailable)().Reason).Should(Equal("Camel Catalog 1.15.0 error"))
+			g.Eventually(IntegrationPhase(t, ctx, ns, name)).Should(Equal(v1.IntegrationPhaseError))
+			g.Eventually(IntegrationCondition(t, ctx, ns, name, v1.IntegrationConditionKitAvailable)().Status).Should(Equal(corev1.ConditionFalse))
 
 			// Clean up
-			g.Eventually(DeleteIntegrations(t, ns)).Should(Equal(0))
+			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
 		})
 
 		// Run an integration with a compatible catalog
@@ -85,24 +84,22 @@ func TestCamelCatalogBuilder(t *testing.T) {
 			compatibleCatalogName := "camel-catalog-" + strings.ToLower(compatibleVersion)
 
 			// First of all we delete the catalog, if by any chance it was created previously
-			g.Expect(DeleteCamelCatalog(t, ns, compatibleCatalogName)()).Should(BeTrue())
-			g.Eventually(CamelCatalog(t, ns, compatibleCatalogName)).Should(BeNil())
+			g.Expect(DeleteCamelCatalog(t, ctx, ns, compatibleCatalogName)()).Should(BeTrue())
+			g.Eventually(CamelCatalog(t, ctx, ns, compatibleCatalogName)).Should(BeNil())
 
 			g.Expect(
-				KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
-					"-t", "camel.runtime-version="+compatibleVersion,
-				).Execute()).To(Succeed())
+				KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "camel.runtime-version="+compatibleVersion).Execute()).To(Succeed())
 
-			g.Eventually(CamelCatalog(t, ns, compatibleCatalogName)).ShouldNot(BeNil())
-			g.Eventually(CamelCatalogPhase(t, ns, compatibleCatalogName)).Should(Equal(v1.CamelCatalogPhaseReady))
-			g.Eventually(CamelCatalogCondition(t, ns, compatibleCatalogName, v1.CamelCatalogConditionReady)().Message).Should(Equal("Container image tool found in catalog"))
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).
+			g.Eventually(CamelCatalog(t, ctx, ns, compatibleCatalogName)).ShouldNot(BeNil())
+			g.Eventually(CamelCatalogPhase(t, ctx, ns, compatibleCatalogName)).Should(Equal(v1.CamelCatalogPhaseReady))
+			g.Eventually(CamelCatalogCondition(t, ctx, ns, compatibleCatalogName, v1.CamelCatalogConditionReady)().Message).Should(Equal("Container image tool found in catalog"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
 
 			// Clean up
-			g.Eventually(DeleteIntegrations(t, ns)).Should(Equal(0))
+			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
 		})
 
 		t.Run("Run catalog container exists", func(t *testing.T) {
@@ -111,32 +108,30 @@ func TestCamelCatalogBuilder(t *testing.T) {
 			compatibleCatalogName := "camel-catalog-" + strings.ToLower(compatibleVersion)
 
 			// First of all we delete the catalog, if by any chance it was created previously
-			g.Expect(DeleteCamelCatalog(t, ns, compatibleCatalogName)()).Should(BeTrue())
-			g.Eventually(CamelCatalog(t, ns, compatibleCatalogName)).Should(BeNil())
+			g.Expect(DeleteCamelCatalog(t, ctx, ns, compatibleCatalogName)()).Should(BeTrue())
+			g.Eventually(CamelCatalog(t, ctx, ns, compatibleCatalogName)).Should(BeNil())
 
 			g.Expect(
-				KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
-					"-t", "camel.runtime-version="+compatibleVersion,
-				).Execute()).To(Succeed())
+				KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "camel.runtime-version="+compatibleVersion).Execute()).To(Succeed())
 
-			g.Eventually(CamelCatalog(t, ns, compatibleCatalogName)).ShouldNot(BeNil())
-			g.Eventually(CamelCatalogPhase(t, ns, compatibleCatalogName)).Should(Equal(v1.CamelCatalogPhaseReady))
-			g.Eventually(CamelCatalogCondition(t, ns, compatibleCatalogName, v1.CamelCatalogConditionReady)().Message).Should(
+			g.Eventually(CamelCatalog(t, ctx, ns, compatibleCatalogName)).ShouldNot(BeNil())
+			g.Eventually(CamelCatalogPhase(t, ctx, ns, compatibleCatalogName)).Should(Equal(v1.CamelCatalogPhaseReady))
+			g.Eventually(CamelCatalogCondition(t, ctx, ns, compatibleCatalogName, v1.CamelCatalogConditionReady)().Message).Should(
 				Equal("Container image tool found in catalog"),
 			)
 
-			g.Eventually(IntegrationKit(t, ns, name)).ShouldNot(Equal(""))
-			kitName := IntegrationKit(t, ns, name)()
-			g.Eventually(KitPhase(t, ns, kitName)).Should(Equal(v1.IntegrationKitPhaseReady))
-			g.Eventually(IntegrationPodPhase(t, ns, name)).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationKit(t, ctx, ns, name)).ShouldNot(Equal(""))
+			kitName := IntegrationKit(t, ctx, ns, name)()
+			g.Eventually(KitPhase(t, ctx, ns, kitName)).Should(Equal(v1.IntegrationKitPhaseReady))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name)).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 			// Clean up
-			g.Eventually(DeleteIntegrations(t, ns)).Should(Equal(0))
+			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/advanced/dump_test.go
+++ b/e2e/advanced/dump_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"fmt"
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"testing"
@@ -37,9 +38,9 @@ import (
 func TestKamelCLIDump(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		t.Run("dump empty namespace", func(t *testing.T) {
-			dump := GetOutputString(Kamel(t, "dump", "-n", ns))
+			dump := GetOutputString(Kamel(t, ctx, "dump", "-n", ns))
 
 			g.Expect(dump).To(ContainSubstring("Found 0 integrations:"))
 			g.Expect(dump).To(ContainSubstring("Found 0 deployments:"))
@@ -47,16 +48,16 @@ func TestKamelCLIDump(t *testing.T) {
 
 		t.Run("dump non-empty namespace", func(t *testing.T) {
 			operatorID := fmt.Sprintf("camel-k-%s", ns)
-			g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-			g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-			g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
-			g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+			g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+			g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+			g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
+			g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, "yaml")).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "yaml")).Should(ContainSubstring("Magicstring!"))
 
-			dump := GetOutputString(Kamel(t, "dump", "-n", ns))
+			dump := GetOutputString(Kamel(t, ctx, "dump", "-n", ns))
 			g.Expect(dump).To(ContainSubstring("Found 1 platforms"))
 			g.Expect(dump).To(ContainSubstring("Found 1 integrations"))
 			g.Expect(dump).To(ContainSubstring("name: yaml"))

--- a/e2e/advanced/incremental_build_test.go
+++ b/e2e/advanced/incremental_build_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -38,33 +39,29 @@ import (
 func TestRunIncrementalBuildRoutine(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-incremental-build-routine"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		name := RandomizedSuffixName("java")
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-			"--name", name,
-		).Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-		integrationKitName := IntegrationKit(t, ns, name)()
-		g.Eventually(Kit(t, ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
-		g.Eventually(Kit(t, ns, integrationKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		integrationKitName := IntegrationKit(t, ctx, ns, name)()
+		g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
+		g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
 
 		t.Run("Reuse previous kit", func(t *testing.T) {
 			nameClone := "java-clone"
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", nameClone,
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameClone), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, nameClone, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, nameClone), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationCloneKitName := IntegrationKit(t, ns, nameClone)()
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", nameClone).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameClone), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, nameClone, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameClone), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationCloneKitName := IntegrationKit(t, ctx, ns, nameClone)()
 			g.Eventually(integrationCloneKitName).Should(Equal(integrationKitName))
 		})
 
@@ -72,193 +69,162 @@ func TestRunIncrementalBuildRoutine(t *testing.T) {
 			// Another integration that should be built on top of the previous IntegrationKit
 			// just add a new random dependency
 			nameIncremental := RandomizedSuffixName("java-incremental")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", nameIncremental,
-				"-d", "camel:zipfile",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameIncremental), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, nameIncremental, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, nameIncremental), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationIncrementalKitName := IntegrationKit(t, ns, nameIncremental)()
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", nameIncremental, "-d", "camel:zipfile").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameIncremental), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, nameIncremental, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameIncremental), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationIncrementalKitName := IntegrationKit(t, ctx, ns, nameIncremental)()
 			// the container comes in a format like
 			// 10.108.177.66/test-d7cad110-bb1d-4e79-8a0e-ebd44f6fe5d4/camel-k-kit-c8357r4k5tp6fn1idm60@sha256:d49716f0429ad8b23a1b8d20a357d64b1aa42a67c1a2a534ebd4c54cd598a18d
 			// we should be saving just to check the substring is contained
-			g.Eventually(Kit(t, ns, integrationIncrementalKitName)().Status.BaseImage).Should(ContainSubstring(integrationKitName))
-			g.Eventually(Kit(t, ns, integrationIncrementalKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
+			g.Eventually(Kit(t, ctx, ns, integrationIncrementalKitName)().Status.BaseImage).Should(ContainSubstring(integrationKitName))
+			g.Eventually(Kit(t, ctx, ns, integrationIncrementalKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }
 
 func TestRunIncrementalBuildPod(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-incremental-build-pod"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		name := RandomizedSuffixName("java")
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-			"--name", name,
-			"-t", "builder.strategy=pod",
-		).Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-		integrationKitName := IntegrationKit(t, ns, name)()
-		g.Eventually(Kit(t, ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
-		g.Eventually(Kit(t, ns, integrationKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
-		g.Eventually(BuilderPodsCount(t, ns)).Should(Equal(1))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "builder.strategy=pod").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		integrationKitName := IntegrationKit(t, ctx, ns, name)()
+		g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
+		g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
+		g.Eventually(BuilderPodsCount(t, ctx, ns)).Should(Equal(1))
 
 		t.Run("Reuse previous kit", func(t *testing.T) {
 			nameClone := RandomizedSuffixName("java-clone")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", nameClone,
-				"-t", "builder.strategy=pod",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameClone), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, nameClone, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, nameClone), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationCloneKitName := IntegrationKit(t, ns, nameClone)()
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", nameClone, "-t", "builder.strategy=pod").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameClone), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, nameClone, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameClone), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationCloneKitName := IntegrationKit(t, ctx, ns, nameClone)()
 			g.Eventually(integrationCloneKitName).Should(Equal(integrationKitName))
-			g.Eventually(BuilderPodsCount(t, ns)).Should(Equal(1))
+			g.Eventually(BuilderPodsCount(t, ctx, ns)).Should(Equal(1))
 		})
 
 		t.Run("Create incremental kit", func(t *testing.T) {
 			// Another integration that should be built on top of the previous IntegrationKit
 			// just add a new random dependency
 			nameIncremental := RandomizedSuffixName("java-incremental")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", nameIncremental,
-				"-d", "camel:zipfile",
-				"-t", "builder.strategy=pod",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameIncremental), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, nameIncremental, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, nameIncremental), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationIncrementalKitName := IntegrationKit(t, ns, nameIncremental)()
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", nameIncremental, "-d", "camel:zipfile", "-t", "builder.strategy=pod").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameIncremental), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, nameIncremental, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameIncremental), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationIncrementalKitName := IntegrationKit(t, ctx, ns, nameIncremental)()
 			// the container comes in a format like
 			// 10.108.177.66/test-d7cad110-bb1d-4e79-8a0e-ebd44f6fe5d4/camel-k-kit-c8357r4k5tp6fn1idm60@sha256:d49716f0429ad8b23a1b8d20a357d64b1aa42a67c1a2a534ebd4c54cd598a18d
 			// we should be saving just to check the substring is contained
-			g.Eventually(Kit(t, ns, integrationIncrementalKitName)().Status.BaseImage).Should(ContainSubstring(integrationKitName))
-			g.Eventually(Kit(t, ns, integrationIncrementalKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
-			g.Eventually(BuilderPodsCount(t, ns)).Should(Equal(2))
+			g.Eventually(Kit(t, ctx, ns, integrationIncrementalKitName)().Status.BaseImage).Should(ContainSubstring(integrationKitName))
+			g.Eventually(Kit(t, ctx, ns, integrationIncrementalKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
+			g.Eventually(BuilderPodsCount(t, ctx, ns)).Should(Equal(2))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }
 
 func TestRunIncrementalBuildOff(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-standard-build"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		name := RandomizedSuffixName("java")
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-			"--name", name,
-		).Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-		integrationKitName := IntegrationKit(t, ns, name)()
-		g.Eventually(Kit(t, ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		integrationKitName := IntegrationKit(t, ctx, ns, name)()
+		g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
 
 		t.Run("Don't reuse previous kit", func(t *testing.T) {
 			nameClone := RandomizedSuffixName("java-clone")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", nameClone,
-				"-t", "builder.incremental-image-build=false",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameClone), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, nameClone, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, nameClone), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationCloneKitName := IntegrationKit(t, ns, nameClone)()
-			g.Eventually(Kit(t, ns, integrationCloneKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", nameClone, "-t", "builder.incremental-image-build=false").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameClone), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, nameClone, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameClone), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationCloneKitName := IntegrationKit(t, ctx, ns, nameClone)()
+			g.Eventually(Kit(t, ctx, ns, integrationCloneKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
 		})
 
 		t.Run("Don't create incremental kit", func(t *testing.T) {
 			// Another integration that should be built on top of the previous IntegrationKit
 			// just add a new random dependency
 			nameIncremental := RandomizedSuffixName("java-incremental")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", nameIncremental,
-				"-d", "camel:zipfile",
-				"-t", "builder.incremental-image-build=false",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameIncremental), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, nameIncremental, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, nameIncremental), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationIncrementalKitName := IntegrationKit(t, ns, nameIncremental)()
-			g.Eventually(Kit(t, ns, integrationIncrementalKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", nameIncremental, "-d", "camel:zipfile", "-t", "builder.incremental-image-build=false").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameIncremental), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, nameIncremental, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameIncremental), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationIncrementalKitName := IntegrationKit(t, ctx, ns, nameIncremental)()
+			g.Eventually(Kit(t, ctx, ns, integrationIncrementalKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }
 
 func TestRunIncrementalBuildWithDifferentBaseImages(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-incremental-different-base"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		name := RandomizedSuffixName("java")
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-			"--name", name,
-		).Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-		integrationKitName := IntegrationKit(t, ns, name)()
-		g.Eventually(Kit(t, ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
-		g.Eventually(Kit(t, ns, integrationKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		integrationKitName := IntegrationKit(t, ctx, ns, name)()
+		g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.BaseImage).Should(Equal(defaults.BaseImage()))
+		g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
 
 		t.Run("Create incremental kit", func(t *testing.T) {
 			// Another integration that should be built on top of the previous IntegrationKit
 			// just add a new random dependency
 			nameIncremental := RandomizedSuffixName("java-incremental")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", nameIncremental,
-				"-d", "camel:zipfile",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameIncremental), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, nameIncremental, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, nameIncremental), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationIncrementalKitName := IntegrationKit(t, ns, nameIncremental)()
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", nameIncremental, "-d", "camel:zipfile").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameIncremental), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, nameIncremental, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameIncremental), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationIncrementalKitName := IntegrationKit(t, ctx, ns, nameIncremental)()
 			// the container comes in a format like
 			// 10.108.177.66/test-d7cad110-bb1d-4e79-8a0e-ebd44f6fe5d4/camel-k-kit-c8357r4k5tp6fn1idm60@sha256:d49716f0429ad8b23a1b8d20a357d64b1aa42a67c1a2a534ebd4c54cd598a18d
 			// we should be save just to check the substring is contained
-			g.Eventually(Kit(t, ns, integrationIncrementalKitName)().Status.BaseImage).Should(ContainSubstring(integrationKitName))
-			g.Eventually(Kit(t, ns, integrationIncrementalKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
+			g.Eventually(Kit(t, ctx, ns, integrationIncrementalKitName)().Status.BaseImage).Should(ContainSubstring(integrationKitName))
+			g.Eventually(Kit(t, ctx, ns, integrationIncrementalKitName)().Status.RootImage).Should(Equal(defaults.BaseImage()))
 		})
 
 		t.Run("Create new hierarchy kit", func(t *testing.T) {
 			// We should spin off a new hierarchy of builds
 			newBaseImage := "eclipse-temurin:17.0.8.1_1-jdk-ubi9-minimal"
 			name = RandomizedSuffixName("java-new")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-				"-d", "camel:mongodb",
-				"-t", fmt.Sprintf("builder.base-image=%s", newBaseImage),
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationKitName = IntegrationKit(t, ns, name)()
-			g.Eventually(Kit(t, ns, integrationKitName)().Status.BaseImage).Should(Equal(newBaseImage))
-			g.Eventually(Kit(t, ns, integrationKitName)().Status.RootImage).Should(Equal(newBaseImage))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-d", "camel:mongodb", "-t", fmt.Sprintf("builder.base-image=%s", newBaseImage)).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationKitName = IntegrationKit(t, ctx, ns, name)()
+			g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.BaseImage).Should(Equal(newBaseImage))
+			g.Eventually(Kit(t, ctx, ns, integrationKitName)().Status.RootImage).Should(Equal(newBaseImage))
 		})
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/advanced/main_test.go
+++ b/e2e/advanced/main_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package advanced
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -55,9 +54,9 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Test fast setup failed! - %s\n", message)
 	})
 
-	ctx := context.TODO()
 	var t *testing.T
 	g.Expect(TestClient(t)).ShouldNot(BeNil())
+	ctx := TestContext()
 	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
 	g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/advanced/main_test.go
+++ b/e2e/advanced/main_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -54,22 +55,23 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Test fast setup failed! - %s\n", message)
 	})
 
+	ctx := context.TODO()
 	var t *testing.T
 	g.Expect(TestClient(t)).ShouldNot(BeNil())
-	g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	g.Eventually(IntegrationLogs(t, ctx, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-	g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	g.Eventually(IntegrationLogs(t, ctx, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-	g.Expect(KamelRunWithID(t, operatorID, ns, "files/timer-source.groovy").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, "timer-source"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, "timer-source", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ns, "timer-source"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/timer-source.groovy").Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, "timer-source"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "timer-source", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	g.Eventually(IntegrationLogs(t, ctx, ns, "timer-source"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 	os.Exit(m.Run())
 }

--- a/e2e/advanced/main_test.go
+++ b/e2e/advanced/main_test.go
@@ -43,34 +43,32 @@ func TestMain(m *testing.M) {
 	}
 
 	fastSetup := GetEnvOrDefault("CAMEL_K_E2E_FAST_SETUP", "false")
-	if fastSetup != "true" {
-		os.Exit(m.Run())
+	if fastSetup == "true" {
+		operatorID := platform.DefaultPlatformName
+		ns := GetEnvOrDefault("CAMEL_K_GLOBAL_OPERATOR_NS", TestDefaultNamespace)
+
+		g := NewGomega(func(message string, callerSkip ...int) {
+			fmt.Printf("Test fast setup failed! - %s\n", message)
+		})
+
+		var t *testing.T
+		g.Expect(TestClient(t)).ShouldNot(BeNil())
+		ctx := TestContext()
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/timer-source.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "timer-source"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "timer-source", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "timer-source"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 	}
-
-	operatorID := platform.DefaultPlatformName
-	ns := GetEnvOrDefault("CAMEL_K_GLOBAL_OPERATOR_NS", TestDefaultNamespace)
-
-	g := NewGomega(func(message string, callerSkip ...int) {
-		fmt.Printf("Test fast setup failed! - %s\n", message)
-	})
-
-	var t *testing.T
-	g.Expect(TestClient(t)).ShouldNot(BeNil())
-	ctx := TestContext()
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ctx, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ctx, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/timer-source.groovy").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, "timer-source"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "timer-source", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ctx, ns, "timer-source"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 	os.Exit(m.Run())
 }

--- a/e2e/advanced/operator_id_filtering_test.go
+++ b/e2e/advanced/operator_id_filtering_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -37,91 +38,89 @@ import (
 func TestOperatorIDCamelCatalogReconciliation(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := fmt.Sprintf("camel-k-%s", ns)
-		g.Expect(KamelInstallWithID(t, operatorID, ns, "--global", "--force")).To(Succeed())
-		g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
-		g.Eventually(DefaultCamelCatalogPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.CamelCatalogPhaseReady))
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, "--global", "--force")).To(Succeed())
+		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(DefaultCamelCatalogPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.CamelCatalogPhaseReady))
 	})
 }
 
 func TestOperatorIDFiltering(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-		WithNewTestNamespace(t, func(g *WithT, nsop1 string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		WithNewTestNamespace(t, func(ctx context.Context, g *WithT, nsop1 string) {
 			operator1 := "operator-1"
-			g.Expect(CopyCamelCatalog(t, nsop1, operator1)).To(Succeed())
-			g.Expect(CopyIntegrationKits(t, nsop1, operator1)).To(Succeed())
-			g.Expect(KamelInstallWithIDAndKameletCatalog(t, operator1, nsop1, "--global", "--force")).To(Succeed())
-			g.Eventually(PlatformPhase(t, nsop1), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+			g.Expect(CopyCamelCatalog(t, ctx, nsop1, operator1)).To(Succeed())
+			g.Expect(CopyIntegrationKits(t, ctx, nsop1, operator1)).To(Succeed())
+			g.Expect(KamelInstallWithIDAndKameletCatalog(t, ctx, operator1, nsop1, "--global", "--force")).To(Succeed())
+			g.Eventually(PlatformPhase(t, ctx, nsop1), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
-			WithNewTestNamespace(t, func(g *WithT, nsop2 string) {
+			WithNewTestNamespace(t, func(ctx context.Context, g *WithT, nsop2 string) {
 				operator2 := "operator-2"
-				g.Expect(CopyCamelCatalog(t, nsop2, operator2)).To(Succeed())
-				g.Expect(CopyIntegrationKits(t, nsop2, operator2)).To(Succeed())
-				g.Expect(KamelInstallWithIDAndKameletCatalog(t, operator2, nsop2, "--global", "--force")).To(Succeed())
-				g.Eventually(PlatformPhase(t, nsop2), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+				g.Expect(CopyCamelCatalog(t, ctx, nsop2, operator2)).To(Succeed())
+				g.Expect(CopyIntegrationKits(t, ctx, nsop2, operator2)).To(Succeed())
+				g.Expect(KamelInstallWithIDAndKameletCatalog(t, ctx, operator2, nsop2, "--global", "--force")).To(Succeed())
+				g.Eventually(PlatformPhase(t, ctx, nsop2), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 				t.Run("Operators ignore non-scoped integrations", func(t *testing.T) {
-					g.Expect(KamelRunWithID(t, "operator-x", ns, "files/yaml.yaml", "--name", "untouched", "--force").Execute()).To(Succeed())
-					g.Consistently(IntegrationPhase(t, ns, "untouched"), 10*time.Second).Should(BeEmpty())
+					g.Expect(KamelRunWithID(t, ctx, "operator-x", ns, "files/yaml.yaml", "--name", "untouched", "--force").Execute()).To(Succeed())
+					g.Consistently(IntegrationPhase(t, ctx, ns, "untouched"), 10*time.Second).Should(BeEmpty())
 				})
 
 				t.Run("Operators run scoped integrations", func(t *testing.T) {
-					g.Expect(KamelRunWithID(t, "operator-x", ns, "files/yaml.yaml", "--name", "moving", "--force").Execute()).To(Succeed())
-					g.Expect(AssignIntegrationToOperator(t, ns, "moving", operator1)).To(Succeed())
-					g.Eventually(IntegrationPhase(t, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
-					g.Eventually(IntegrationPodPhase(t, ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-					g.Eventually(IntegrationLogs(t, ns, "moving"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+					g.Expect(KamelRunWithID(t, ctx, "operator-x", ns, "files/yaml.yaml", "--name", "moving", "--force").Execute()).To(Succeed())
+					g.Expect(AssignIntegrationToOperator(t, ctx, ns, "moving", operator1)).To(Succeed())
+					g.Eventually(IntegrationPhase(t, ctx, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
+					g.Eventually(IntegrationPodPhase(t, ctx, ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+					g.Eventually(IntegrationLogs(t, ctx, ns, "moving"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 				})
 
 				t.Run("Operators can handoff scoped integrations", func(t *testing.T) {
-					g.Expect(AssignIntegrationToOperator(t, ns, "moving", operator2)).To(Succeed())
-					g.Eventually(IntegrationPhase(t, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseBuildingKit))
-					g.Eventually(IntegrationPhase(t, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
-					g.Eventually(IntegrationPodPhase(t, ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-					g.Eventually(IntegrationLogs(t, ns, "moving"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+					g.Expect(AssignIntegrationToOperator(t, ctx, ns, "moving", operator2)).To(Succeed())
+					g.Eventually(IntegrationPhase(t, ctx, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseBuildingKit))
+					g.Eventually(IntegrationPhase(t, ctx, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
+					g.Eventually(IntegrationPodPhase(t, ctx, ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+					g.Eventually(IntegrationLogs(t, ctx, ns, "moving"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 				})
 
 				t.Run("Operators can be deactivated after completely handing off scoped integrations", func(t *testing.T) {
-					g.Expect(ScaleOperator(t, nsop1, 0)).To(Succeed())
-					g.Expect(Kamel(t, "rebuild", "-n", ns, "moving").Execute()).To(Succeed())
-					g.Eventually(IntegrationPhase(t, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
-					g.Eventually(IntegrationPodPhase(t, ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-					g.Eventually(IntegrationLogs(t, ns, "moving"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-					g.Expect(ScaleOperator(t, nsop1, 1)).To(Succeed())
+					g.Expect(ScaleOperator(t, ctx, nsop1, 0)).To(Succeed())
+					g.Expect(Kamel(t, ctx, "rebuild", "-n", ns, "moving").Execute()).To(Succeed())
+					g.Eventually(IntegrationPhase(t, ctx, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
+					g.Eventually(IntegrationPodPhase(t, ctx, ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+					g.Eventually(IntegrationLogs(t, ctx, ns, "moving"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+					g.Expect(ScaleOperator(t, ctx, nsop1, 1)).To(Succeed())
 				})
 
 				t.Run("Operators can run scoped integrations with fixed image", func(t *testing.T) {
-					image := IntegrationPodImage(t, ns, "moving")()
+					image := IntegrationPodImage(t, ctx, ns, "moving")()
 					g.Expect(image).NotTo(BeEmpty())
 					// Save resources by deleting "moving" integration
-					g.Expect(Kamel(t, "delete", "moving", "-n", ns).Execute()).To(Succeed())
+					g.Expect(Kamel(t, ctx, "delete", "moving", "-n", ns).Execute()).To(Succeed())
 
-					g.Expect(KamelRunWithID(t, "operator-x", ns, "files/yaml.yaml", "--name", "pre-built", "--force",
-						"-t", fmt.Sprintf("container.image=%s", image), "-t", "jvm.enabled=true").Execute()).To(Succeed())
-					g.Consistently(IntegrationPhase(t, ns, "pre-built"), 10*time.Second).Should(BeEmpty())
-					g.Expect(AssignIntegrationToOperator(t, ns, "pre-built", operator2)).To(Succeed())
-					g.Eventually(IntegrationPhase(t, ns, "pre-built"), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
-					g.Eventually(IntegrationPodPhase(t, ns, "pre-built"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-					g.Eventually(IntegrationLogs(t, ns, "pre-built"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-					g.Expect(Kamel(t, "delete", "pre-built", "-n", ns).Execute()).To(Succeed())
+					g.Expect(KamelRunWithID(t, ctx, "operator-x", ns, "files/yaml.yaml", "--name", "pre-built", "--force", "-t", fmt.Sprintf("container.image=%s", image), "-t", "jvm.enabled=true").Execute()).To(Succeed())
+					g.Consistently(IntegrationPhase(t, ctx, ns, "pre-built"), 10*time.Second).Should(BeEmpty())
+					g.Expect(AssignIntegrationToOperator(t, ctx, ns, "pre-built", operator2)).To(Succeed())
+					g.Eventually(IntegrationPhase(t, ctx, ns, "pre-built"), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
+					g.Eventually(IntegrationPodPhase(t, ctx, ns, "pre-built"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+					g.Eventually(IntegrationLogs(t, ctx, ns, "pre-built"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+					g.Expect(Kamel(t, ctx, "delete", "pre-built", "-n", ns).Execute()).To(Succeed())
 				})
 
 				t.Run("Operators can run scoped Pipes", func(t *testing.T) {
-					g.Expect(KamelBindWithID(t, "operator-x", ns, "timer-source?message=Hello", "log-sink",
-						"--name", "klb", "--force").Execute()).To(Succeed())
-					g.Consistently(Integration(t, ns, "klb"), 10*time.Second).Should(BeNil())
+					g.Expect(KamelBindWithID(t, ctx, "operator-x", ns, "timer-source?message=Hello", "log-sink", "--name", "klb", "--force").Execute()).To(Succeed())
+					g.Consistently(Integration(t, ctx, ns, "klb"), 10*time.Second).Should(BeNil())
 
-					g.Expect(AssignPipeToOperator(t, ns, "klb", operator1)).To(Succeed())
-					g.Eventually(Integration(t, ns, "klb"), TestTimeoutShort).ShouldNot(BeNil())
-					g.Eventually(IntegrationPhase(t, ns, "klb"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
-					g.Eventually(IntegrationPodPhase(t, ns, "klb"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+					g.Expect(AssignPipeToOperator(t, ctx, ns, "klb", operator1)).To(Succeed())
+					g.Eventually(Integration(t, ctx, ns, "klb"), TestTimeoutShort).ShouldNot(BeNil())
+					g.Eventually(IntegrationPhase(t, ctx, ns, "klb"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
+					g.Eventually(IntegrationPodPhase(t, ctx, ns, "klb"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 				})
 			})
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/advanced/platform_traits_test.go
+++ b/e2e/advanced/platform_traits_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"testing"
 
 	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
@@ -38,36 +39,34 @@ import (
 func TestTraitOnIntegrationPlatform(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-platform-trait-test"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
 		containerTestName := "testname"
 
-		g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
-		ip := Platform(t, ns)()
+		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		ip := Platform(t, ctx, ns)()
 		ip.Spec.Traits = v1.Traits{Logging: &trait.LoggingTrait{Level: "DEBUG"}, Container: &trait.ContainerTrait{Name: containerTestName}}
 
-		if err := TestClient(t).Update(TestContext, ip); err != nil {
+		if err := TestClient(t).Update(ctx, ip); err != nil {
 			t.Fatal("Can't create IntegrationPlatform", err)
 		}
-		g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		name := RandomizedSuffixName("java")
 		t.Run("Run integration with platform traits", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			g.Expect(IntegrationPod(t, ns, name)().Spec.Containers[0].Name).To(BeEquivalentTo(containerTestName))
+			g.Expect(IntegrationPod(t, ctx, ns, name)().Spec.Containers[0].Name).To(BeEquivalentTo(containerTestName))
 
 			found := false
-			for _, env := range IntegrationPod(t, ns, name)().Spec.Containers[0].Env {
+			for _, env := range IntegrationPod(t, ctx, ns, name)().Spec.Containers[0].Env {
 				if env.Name == "QUARKUS_LOG_LEVEL" {
 					g.Expect(env.Value).To(BeEquivalentTo("DEBUG"))
 					found = true
@@ -75,9 +74,9 @@ func TestTraitOnIntegrationPlatform(t *testing.T) {
 				}
 			}
 			g.Expect(found).To(BeTrue(), "Can't find QUARKUS_LOG_LEVEL ENV variable")
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("DEBUG"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("DEBUG"))
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 	})
 }

--- a/e2e/advanced/platform_traits_test.go
+++ b/e2e/advanced/platform_traits_test.go
@@ -48,12 +48,9 @@ func TestTraitOnIntegrationPlatform(t *testing.T) {
 		containerTestName := "testname"
 
 		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
-		ip := Platform(t, ctx, ns)()
-		ip.Spec.Traits = v1.Traits{Logging: &trait.LoggingTrait{Level: "DEBUG"}, Container: &trait.ContainerTrait{Name: containerTestName}}
-
-		if err := TestClient(t).Update(ctx, ip); err != nil {
-			t.Fatal("Can't create IntegrationPlatform", err)
-		}
+		g.Expect(UpdatePlatform(t, ctx, ns, operatorID, func(ip *v1.IntegrationPlatform) {
+			ip.Spec.Traits = v1.Traits{Logging: &trait.LoggingTrait{Level: "DEBUG"}, Container: &trait.ContainerTrait{Name: containerTestName}}
+		})).To(Succeed())
 		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		name := RandomizedSuffixName("java")

--- a/e2e/advanced/promote_test.go
+++ b/e2e/advanced/promote_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -39,141 +40,137 @@ func TestKamelCLIPromote(t *testing.T) {
 	one := int64(1)
 	two := int64(2)
 	// Dev environment namespace
-	WithNewTestNamespace(t, func(g *WithT, nsDev string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, nsDev string) {
 		operatorDevID := "camel-k-cli-promote-dev"
-		g.Expect(CopyCamelCatalog(t, nsDev, operatorDevID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, nsDev, operatorDevID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorDevID, nsDev)).To(Succeed())
-		g.Eventually(SelectedPlatformPhase(t, nsDev, operatorDevID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Expect(CopyCamelCatalog(t, ctx, nsDev, operatorDevID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, nsDev, operatorDevID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorDevID, nsDev)).To(Succeed())
+		g.Eventually(SelectedPlatformPhase(t, ctx, nsDev, operatorDevID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		// Dev content configmap
 		var cmData = make(map[string]string)
 		cmData["my-configmap-key"] = "I am development configmap!"
-		CreatePlainTextConfigmap(t, nsDev, "my-cm-promote", cmData)
+		CreatePlainTextConfigmap(t, ctx, nsDev, "my-cm-promote", cmData)
 		// Dev secret
 		var secData = make(map[string]string)
 		secData["my-secret-key"] = "very top secret development"
-		CreatePlainTextSecret(t, nsDev, "my-sec-promote", secData)
+		CreatePlainTextSecret(t, ctx, nsDev, "my-sec-promote", secData)
 
 		t.Run("plain integration dev", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorDevID, nsDev, "./files/promote-route.groovy",
-				"--config", "configmap:my-cm-promote",
-				"--config", "secret:my-sec-promote",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, nsDev, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationObservedGeneration(t, nsDev, "promote-route")).Should(Equal(&one))
+			g.Expect(KamelRunWithID(t, ctx, operatorDevID, nsDev, "./files/promote-route.groovy", "--config", "configmap:my-cm-promote", "--config", "secret:my-sec-promote").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, nsDev, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationObservedGeneration(t, ctx, nsDev, "promote-route")).Should(Equal(&one))
 			//g.Eventually(IntegrationConditionStatus(t, nsDev, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, nsDev, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am development configmap!"))
-			g.Eventually(IntegrationLogs(t, nsDev, "promote-route"), TestTimeoutShort).Should(ContainSubstring("very top secret development"))
+			g.Eventually(IntegrationLogs(t, ctx, nsDev, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am development configmap!"))
+			g.Eventually(IntegrationLogs(t, ctx, nsDev, "promote-route"), TestTimeoutShort).Should(ContainSubstring("very top secret development"))
 		})
 
 		t.Run("kamelet integration dev", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorDevID, nsDev, "my-own-timer-source")()).To(Succeed())
-			g.Expect(KamelRunWithID(t, operatorDevID, nsDev, "./files/timer-kamelet-usage.groovy").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, nsDev, "timer-kamelet-usage"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, nsDev, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
+			g.Expect(CreateTimerKamelet(t, ctx, operatorDevID, nsDev, "my-own-timer-source")()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorDevID, nsDev, "./files/timer-kamelet-usage.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, nsDev, "timer-kamelet-usage"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, nsDev, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
 		})
 
 		t.Run("binding dev", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorDevID, nsDev, "kb-timer-source")()).To(Succeed())
-			g.Expect(KamelBindWithID(t, operatorDevID, nsDev, "kb-timer-source", "log:info", "-p", "source.message=my-kamelet-binding-rocks").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, nsDev, "kb-timer-source-to-log"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, nsDev, "kb-timer-source-to-log"), TestTimeoutShort).Should(ContainSubstring("my-kamelet-binding-rocks"))
+			g.Expect(CreateTimerKamelet(t, ctx, operatorDevID, nsDev, "kb-timer-source")()).To(Succeed())
+			g.Expect(KamelBindWithID(t, ctx, operatorDevID, nsDev, "kb-timer-source", "log:info", "-p", "source.message=my-kamelet-binding-rocks").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, nsDev, "kb-timer-source-to-log"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, nsDev, "kb-timer-source-to-log"), TestTimeoutShort).Should(ContainSubstring("my-kamelet-binding-rocks"))
 		})
 
 		// Prod environment namespace
-		WithNewTestNamespace(t, func(g *WithT, nsProd string) {
+		WithNewTestNamespace(t, func(ctx context.Context, g *WithT, nsProd string) {
 			operatorProdID := "camel-k-cli-promote-prod"
-			g.Expect(CopyCamelCatalog(t, nsProd, operatorProdID)).To(Succeed())
-			g.Expect(CopyIntegrationKits(t, nsProd, operatorProdID)).To(Succeed())
-			g.Expect(KamelInstallWithID(t, operatorProdID, nsProd)).To(Succeed())
-			g.Eventually(PlatformPhase(t, nsProd), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+			g.Expect(CopyCamelCatalog(t, ctx, nsProd, operatorProdID)).To(Succeed())
+			g.Expect(CopyIntegrationKits(t, ctx, nsProd, operatorProdID)).To(Succeed())
+			g.Expect(KamelInstallWithID(t, ctx, operatorProdID, nsProd)).To(Succeed())
+			g.Eventually(PlatformPhase(t, ctx, nsProd), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 			t.Run("no configmap in destination", func(t *testing.T) {
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).NotTo(Succeed())
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).NotTo(Succeed())
 			})
 
 			// Prod content configmap
 			var cmData = make(map[string]string)
 			cmData["my-configmap-key"] = "I am production!"
-			CreatePlainTextConfigmap(t, nsProd, "my-cm-promote", cmData)
+			CreatePlainTextConfigmap(t, ctx, nsProd, "my-cm-promote", cmData)
 
 			t.Run("no secret in destination", func(t *testing.T) {
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).NotTo(Succeed())
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).NotTo(Succeed())
 			})
 
 			// Prod secret
 			var secData = make(map[string]string)
 			secData["my-secret-key"] = "very top secret production"
-			CreatePlainTextSecret(t, nsProd, "my-sec-promote", secData)
+			CreatePlainTextSecret(t, ctx, nsProd, "my-sec-promote", secData)
 
 			t.Run("plain integration promotion", func(t *testing.T) {
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).To(Succeed())
-				g.Eventually(IntegrationObservedGeneration(t, nsProd, "promote-route")).Should(Equal(&one))
-				g.Eventually(IntegrationPodPhase(t, nsProd, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, nsProd, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, nsProd, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am production!"))
-				g.Eventually(IntegrationLogs(t, nsProd, "promote-route"), TestTimeoutShort).Should(ContainSubstring("very top secret production"))
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).To(Succeed())
+				g.Eventually(IntegrationObservedGeneration(t, ctx, nsProd, "promote-route")).Should(Equal(&one))
+				g.Eventually(IntegrationPodPhase(t, ctx, nsProd, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, nsProd, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+				g.Eventually(IntegrationLogs(t, ctx, nsProd, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am production!"))
+				g.Eventually(IntegrationLogs(t, ctx, nsProd, "promote-route"), TestTimeoutShort).Should(ContainSubstring("very top secret production"))
 				// They must use the same image
-				g.Expect(IntegrationPodImage(t, nsProd, "promote-route")()).Should(Equal(IntegrationPodImage(t, nsDev, "promote-route")()))
+				g.Expect(IntegrationPodImage(t, ctx, nsProd, "promote-route")()).Should(Equal(IntegrationPodImage(t, ctx, nsDev, "promote-route")()))
 			})
 
 			t.Run("plain integration promotion update", func(t *testing.T) {
 				// We need to update the Integration CR in order the operator to restart it both in dev and prod envs
-				g.Expect(KamelRunWithID(t, operatorDevID, nsDev, "./files/promote-route-edited.groovy", "--name", "promote-route",
-					"--config", "configmap:my-cm-promote").Execute()).To(Succeed())
+				g.Expect(KamelRunWithID(t, ctx, operatorDevID, nsDev, "./files/promote-route-edited.groovy", "--name", "promote-route", "--config", "configmap:my-cm-promote").Execute()).To(Succeed())
 				// The generation has to be incremented
-				g.Eventually(IntegrationObservedGeneration(t, nsDev, "promote-route")).Should(Equal(&two))
-				g.Eventually(IntegrationPodPhase(t, nsDev, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, nsDev, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, nsDev, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am development configmap!"))
+				g.Eventually(IntegrationObservedGeneration(t, ctx, nsDev, "promote-route")).Should(Equal(&two))
+				g.Eventually(IntegrationPodPhase(t, ctx, nsDev, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, nsDev, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+				g.Eventually(IntegrationLogs(t, ctx, nsDev, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am development configmap!"))
 				// Update the configmap only in prod
 				var cmData = make(map[string]string)
 				cmData["my-configmap-key"] = "I am production, but I was updated!"
-				UpdatePlainTextConfigmap(t, nsProd, "my-cm-promote", cmData)
+				UpdatePlainTextConfigmap(t, ctx, nsProd, "my-cm-promote", cmData)
 				// Promote the edited Integration
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).To(Succeed())
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "promote-route", "--to", nsProd).Execute()).To(Succeed())
 				// The generation has to be incremented also in prod
-				g.Eventually(IntegrationObservedGeneration(t, nsDev, "promote-route")).Should(Equal(&two))
-				g.Eventually(IntegrationPodPhase(t, nsProd, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, nsProd, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, nsProd, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am production, but I was updated!"))
+				g.Eventually(IntegrationObservedGeneration(t, ctx, nsDev, "promote-route")).Should(Equal(&two))
+				g.Eventually(IntegrationPodPhase(t, ctx, nsProd, "promote-route"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, nsProd, "promote-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+				g.Eventually(IntegrationLogs(t, ctx, nsProd, "promote-route"), TestTimeoutShort).Should(ContainSubstring("I am production, but I was updated!"))
 				// They must use the same image
-				g.Expect(IntegrationPodImage(t, nsProd, "promote-route")()).Should(Equal(IntegrationPodImage(t, nsDev, "promote-route")()))
+				g.Expect(IntegrationPodImage(t, ctx, nsProd, "promote-route")()).Should(Equal(IntegrationPodImage(t, ctx, nsDev, "promote-route")()))
 			})
 
 			t.Run("no kamelet in destination", func(t *testing.T) {
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "timer-kamelet-usage", "--to", nsProd).Execute()).NotTo(Succeed())
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "timer-kamelet-usage", "--to", nsProd).Execute()).NotTo(Succeed())
 			})
 
 			t.Run("kamelet integration promotion", func(t *testing.T) {
-				g.Expect(CreateTimerKamelet(t, operatorProdID, nsProd, "my-own-timer-source")()).To(Succeed())
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "timer-kamelet-usage", "--to", nsProd).Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, nsProd, "timer-kamelet-usage"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationLogs(t, nsProd, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
+				g.Expect(CreateTimerKamelet(t, ctx, operatorProdID, nsProd, "my-own-timer-source")()).To(Succeed())
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "timer-kamelet-usage", "--to", nsProd).Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, nsProd, "timer-kamelet-usage"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationLogs(t, ctx, nsProd, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
 				// They must use the same image
-				g.Expect(IntegrationPodImage(t, nsProd, "timer-kamelet-usage")()).Should(Equal(IntegrationPodImage(t, nsDev, "timer-kamelet-usage")()))
+				g.Expect(IntegrationPodImage(t, ctx, nsProd, "timer-kamelet-usage")()).Should(Equal(IntegrationPodImage(t, ctx, nsDev, "timer-kamelet-usage")()))
 			})
 
 			t.Run("no kamelet for binding in destination", func(t *testing.T) {
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "kb-timer-source-to-log", "--to", nsProd).Execute()).NotTo(Succeed())
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "kb-timer-source-to-log", "--to", nsProd).Execute()).NotTo(Succeed())
 			})
 
 			t.Run("binding promotion", func(t *testing.T) {
-				g.Expect(CreateTimerKamelet(t, operatorProdID, nsProd, "kb-timer-source")()).To(Succeed())
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "kb-timer-source-to-log", "--to", nsProd).Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, nsProd, "kb-timer-source-to-log"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationLogs(t, nsProd, "kb-timer-source-to-log"), TestTimeoutShort).Should(ContainSubstring("my-kamelet-binding-rocks"))
+				g.Expect(CreateTimerKamelet(t, ctx, operatorProdID, nsProd, "kb-timer-source")()).To(Succeed())
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "kb-timer-source-to-log", "--to", nsProd).Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, nsProd, "kb-timer-source-to-log"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationLogs(t, ctx, nsProd, "kb-timer-source-to-log"), TestTimeoutShort).Should(ContainSubstring("my-kamelet-binding-rocks"))
 				// They must use the same image
-				g.Expect(IntegrationPodImage(t, nsProd, "kb-timer-source-to-log")()).Should(Equal(IntegrationPodImage(t, nsDev, "kb-timer-source-to-log")()))
+				g.Expect(IntegrationPodImage(t, ctx, nsProd, "kb-timer-source-to-log")()).Should(Equal(IntegrationPodImage(t, ctx, nsDev, "kb-timer-source-to-log")()))
 
 				//Binding update
-				g.Expect(KamelBindWithID(t, operatorDevID, nsDev, "kb-timer-source", "log:info", "-p", "source.message=my-kamelet-binding-rocks-again").Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, nsDev, "kb-timer-source-to-log"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationLogs(t, nsDev, "kb-timer-source-to-log"), TestTimeoutShort).Should(ContainSubstring("my-kamelet-binding-rocks-again"))
-				g.Expect(Kamel(t, "promote", "-n", nsDev, "kb-timer-source-to-log", "--to", nsProd).Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, nsProd, "kb-timer-source-to-log"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationLogs(t, nsProd, "kb-timer-source-to-log"), TestTimeoutShort).Should(ContainSubstring("my-kamelet-binding-rocks-again"))
+				g.Expect(KamelBindWithID(t, ctx, operatorDevID, nsDev, "kb-timer-source", "log:info", "-p", "source.message=my-kamelet-binding-rocks-again").Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, nsDev, "kb-timer-source-to-log"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationLogs(t, ctx, nsDev, "kb-timer-source-to-log"), TestTimeoutShort).Should(ContainSubstring("my-kamelet-binding-rocks-again"))
+				g.Expect(Kamel(t, ctx, "promote", "-n", nsDev, "kb-timer-source-to-log", "--to", nsProd).Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, nsProd, "kb-timer-source-to-log"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationLogs(t, ctx, nsProd, "kb-timer-source-to-log"), TestTimeoutShort).Should(ContainSubstring("my-kamelet-binding-rocks-again"))
 			})
 		})
 	})

--- a/e2e/advanced/reset_test.go
+++ b/e2e/advanced/reset_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -35,60 +36,60 @@ import (
 func TestKamelReset(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-cli-reset"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("Reset the whole platform", func(t *testing.T) {
 			name := RandomizedSuffixName("yaml1")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			g.Eventually(Kit(t, ns, IntegrationKit(t, ns, name)())).Should(Not(BeNil()))
-			g.Eventually(Integration(t, ns, name)).Should(Not(BeNil()))
+			g.Eventually(Kit(t, ctx, ns, IntegrationKit(t, ctx, ns, name)())).Should(Not(BeNil()))
+			g.Eventually(Integration(t, ctx, ns, name)).Should(Not(BeNil()))
 
-			g.Expect(Kamel(t, "reset", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "reset", "-n", ns).Execute()).To(Succeed())
 
-			g.Expect(Integration(t, ns, name)()).To(BeNil())
-			g.Expect(Kits(t, ns)()).To(HaveLen(0))
+			g.Expect(Integration(t, ctx, ns, name)()).To(BeNil())
+			g.Expect(Kits(t, ctx, ns)()).To(HaveLen(0))
 		})
 
 		t.Run("Reset skip-integrations", func(t *testing.T) {
 			name := RandomizedSuffixName("yaml2")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			g.Eventually(Kit(t, ns, IntegrationKit(t, ns, name)())).Should(Not(BeNil()))
-			g.Eventually(Integration(t, ns, name)).Should(Not(BeNil()))
+			g.Eventually(Kit(t, ctx, ns, IntegrationKit(t, ctx, ns, name)())).Should(Not(BeNil()))
+			g.Eventually(Integration(t, ctx, ns, name)).Should(Not(BeNil()))
 
-			g.Expect(Kamel(t, "reset", "-n", ns, "--skip-integrations").Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "reset", "-n", ns, "--skip-integrations").Execute()).To(Succeed())
 
-			g.Expect(Integration(t, ns, name)()).To(Not(BeNil()))
-			g.Expect(Kits(t, ns)()).To(HaveLen(0))
+			g.Expect(Integration(t, ctx, ns, name)()).To(Not(BeNil()))
+			g.Expect(Kits(t, ctx, ns)()).To(HaveLen(0))
 		})
 
 		t.Run("Reset skip-kits", func(t *testing.T) {
 			name := RandomizedSuffixName("yaml3")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			kitName := IntegrationKit(t, ns, name)()
-			g.Eventually(Kit(t, ns, kitName)).Should(Not(BeNil()))
-			g.Eventually(Integration(t, ns, name)).Should(Not(BeNil()))
+			kitName := IntegrationKit(t, ctx, ns, name)()
+			g.Eventually(Kit(t, ctx, ns, kitName)).Should(Not(BeNil()))
+			g.Eventually(Integration(t, ctx, ns, name)).Should(Not(BeNil()))
 
-			g.Expect(Kamel(t, "reset", "-n", ns, "--skip-kits").Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "reset", "-n", ns, "--skip-kits").Execute()).To(Succeed())
 
-			g.Expect(Integration(t, ns, name)()).To(BeNil())
-			g.Expect(Kit(t, ns, kitName)()).To(Not(BeNil()))
+			g.Expect(Integration(t, ctx, ns, name)()).To(BeNil())
+			g.Expect(Kit(t, ctx, ns, kitName)()).To(Not(BeNil()))
 		})
 		// Clean up
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/advanced/tekton_test.go
+++ b/e2e/advanced/tekton_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package advanced
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -35,14 +36,14 @@ import (
 func TestTektonLikeBehavior(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-		g.Expect(CreateOperatorServiceAccount(t, ns)).To(Succeed())
-		g.Expect(CreateOperatorRole(t, ns)).To(Succeed())
-		g.Expect(CreateOperatorRoleBinding(t, ns)).To(Succeed())
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		g.Expect(CreateOperatorServiceAccount(t, ctx, ns)).To(Succeed())
+		g.Expect(CreateOperatorRole(t, ctx, ns)).To(Succeed())
+		g.Expect(CreateOperatorRoleBinding(t, ctx, ns)).To(Succeed())
 
-		g.Eventually(OperatorPod(t, ns)).Should(BeNil())
-		g.Expect(CreateKamelPod(t, ns, "tekton-task", "install", "--skip-cluster-setup", "--force")).To(Succeed())
+		g.Eventually(OperatorPod(t, ctx, ns)).Should(BeNil())
+		g.Expect(CreateKamelPod(t, ctx, ns, "tekton-task", "install", "--skip-cluster-setup", "--force")).To(Succeed())
 
-		g.Eventually(OperatorPod(t, ns)).ShouldNot(BeNil())
+		g.Eventually(OperatorPod(t, ctx, ns)).ShouldNot(BeNil())
 	})
 }

--- a/e2e/builder/build_test.go
+++ b/e2e/builder/build_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package builder
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -42,14 +43,14 @@ type kitOptions struct {
 }
 
 func TestKitMaxBuildLimit(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-		createOperator(t, g, ns, "8m0s", "--global", "--force")
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		createOperator(t, ctx, g, ns, "8m0s", "--global", "--force")
 
-		pl := Platform(t, ns)()
+		pl := Platform(t, ctx, ns)()
 		// set maximum number of running builds and order strategy
 		pl.Spec.Build.MaxRunningBuilds = 2
 		pl.Spec.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategySequential
-		if err := TestClient(t).Update(TestContext, pl); err != nil {
+		if err := TestClient(t).Update(ctx, pl); err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
@@ -58,31 +59,31 @@ func TestKitMaxBuildLimit(t *testing.T) {
 		buildB := "integration-b"
 		buildC := "integration-c"
 
-		WithNewTestNamespace(t, func(g *WithT, ns1 string) {
-			WithNewTestNamespace(t, func(g *WithT, ns2 string) {
+		WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns1 string) {
+			WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns2 string) {
 				pl1 := v1.NewIntegrationPlatform(ns1, fmt.Sprintf("camel-k-%s", ns))
 				pl.Spec.DeepCopyInto(&pl1.Spec)
 				pl1.Spec.Build.Maven.Settings = v1.ValueSource{}
 				pl1.SetOperatorID(fmt.Sprintf("camel-k-%s", ns))
-				if err := TestClient(t).Create(TestContext, &pl1); err != nil {
+				if err := TestClient(t).Create(ctx, &pl1); err != nil {
 					t.Error(err)
 					t.FailNow()
 				}
 
-				g.Eventually(PlatformPhase(t, ns1), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+				g.Eventually(PlatformPhase(t, ctx, ns1), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 				pl2 := v1.NewIntegrationPlatform(ns2, fmt.Sprintf("camel-k-%s", ns))
 				pl.Spec.DeepCopyInto(&pl2.Spec)
 				pl2.Spec.Build.Maven.Settings = v1.ValueSource{}
 				pl2.SetOperatorID(fmt.Sprintf("camel-k-%s", ns))
-				if err := TestClient(t).Create(TestContext, &pl2); err != nil {
+				if err := TestClient(t).Create(ctx, &pl2); err != nil {
 					t.Error(err)
 					t.FailNow()
 				}
 
-				g.Eventually(PlatformPhase(t, ns2), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+				g.Eventually(PlatformPhase(t, ctx, ns2), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
-				doKitBuildInNamespace(t, g, buildA, ns, TestTimeoutShort, kitOptions{
+				doKitBuildInNamespace(t, ctx, g, buildA, ns, TestTimeoutShort, kitOptions{
 					operatorID: fmt.Sprintf("camel-k-%s", ns),
 					dependencies: []string{
 						"camel:timer", "camel:log",
@@ -92,7 +93,7 @@ func TestKitMaxBuildLimit(t *testing.T) {
 					},
 				}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
 
-				doKitBuildInNamespace(t, g, buildB, ns1, TestTimeoutShort, kitOptions{
+				doKitBuildInNamespace(t, ctx, g, buildB, ns1, TestTimeoutShort, kitOptions{
 					operatorID: fmt.Sprintf("camel-k-%s", ns),
 					dependencies: []string{
 						"camel:timer", "camel:log",
@@ -102,7 +103,7 @@ func TestKitMaxBuildLimit(t *testing.T) {
 					},
 				}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
 
-				doKitBuildInNamespace(t, g, buildC, ns2, TestTimeoutShort, kitOptions{
+				doKitBuildInNamespace(t, ctx, g, buildC, ns2, TestTimeoutShort, kitOptions{
 					operatorID: fmt.Sprintf("camel-k-%s", ns),
 					dependencies: []string{
 						"camel:timer", "camel:log",
@@ -117,41 +118,41 @@ func TestKitMaxBuildLimit(t *testing.T) {
 				}
 
 				limit := 0
-				for limit < 5 && BuildPhase(t, ns, buildA)() == v1.BuildPhaseRunning {
+				for limit < 5 && BuildPhase(t, ctx, ns, buildA)() == v1.BuildPhaseRunning {
 					// verify that number of running builds does not exceed max build limit
-					g.Consistently(BuildsRunning(BuildPhase(t, ns, buildA), BuildPhase(t, ns1, buildB), BuildPhase(t, ns2, buildC)), TestTimeoutShort, 10*time.Second).Should(Satisfy(notExceedsMaxBuildLimit))
+					g.Consistently(BuildsRunning(BuildPhase(t, ctx, ns, buildA), BuildPhase(t, ctx, ns1, buildB), BuildPhase(t, ctx, ns2, buildC)), TestTimeoutShort, 10*time.Second).Should(Satisfy(notExceedsMaxBuildLimit))
 					limit++
 				}
 
 				// make sure we have verified max build limit at least once
 				if limit == 0 {
-					t.Error(errors.New(fmt.Sprintf("Unexpected build phase '%s' for %s - not able to verify max builds limit", BuildPhase(t, ns, buildA)(), buildA)))
+					t.Error(errors.New(fmt.Sprintf("Unexpected build phase '%s' for %s - not able to verify max builds limit", BuildPhase(t, ctx, ns, buildA)(), buildA)))
 					t.FailNow()
 				}
 
 				// verify that all builds are successful
-				g.Eventually(BuildPhase(t, ns, buildA), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-				g.Eventually(KitPhase(t, ns, buildA), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+				g.Eventually(BuildPhase(t, ctx, ns, buildA), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+				g.Eventually(KitPhase(t, ctx, ns, buildA), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
 
-				g.Eventually(BuildPhase(t, ns1, buildB), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-				g.Eventually(KitPhase(t, ns1, buildB), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+				g.Eventually(BuildPhase(t, ctx, ns1, buildB), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+				g.Eventually(KitPhase(t, ctx, ns1, buildB), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
 
-				g.Eventually(BuildPhase(t, ns2, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-				g.Eventually(KitPhase(t, ns2, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+				g.Eventually(BuildPhase(t, ctx, ns2, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+				g.Eventually(KitPhase(t, ctx, ns2, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
 			})
 		})
 	})
 }
 
 func TestKitMaxBuildLimitFIFOStrategy(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-		createOperator(t, g, ns, "8m0s", "--global", "--force")
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		createOperator(t, ctx, g, ns, "8m0s", "--global", "--force")
 
-		pl := Platform(t, ns)()
+		pl := Platform(t, ctx, ns)()
 		// set maximum number of running builds and order strategy
 		pl.Spec.Build.MaxRunningBuilds = 2
 		pl.Spec.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategyFIFO
-		if err := TestClient(t).Update(TestContext, pl); err != nil {
+		if err := TestClient(t).Update(ctx, pl); err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
@@ -160,7 +161,7 @@ func TestKitMaxBuildLimitFIFOStrategy(t *testing.T) {
 		buildB := "integration-b"
 		buildC := "integration-c"
 
-		doKitBuildInNamespace(t, g, buildA, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildA, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:timer", "camel:log",
@@ -170,7 +171,7 @@ func TestKitMaxBuildLimitFIFOStrategy(t *testing.T) {
 			},
 		}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
 
-		doKitBuildInNamespace(t, g, buildB, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildB, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:timer", "camel:log",
@@ -180,7 +181,7 @@ func TestKitMaxBuildLimitFIFOStrategy(t *testing.T) {
 			},
 		}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
 
-		doKitBuildInNamespace(t, g, buildC, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildC, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:timer", "camel:log",
@@ -195,37 +196,37 @@ func TestKitMaxBuildLimitFIFOStrategy(t *testing.T) {
 		}
 
 		limit := 0
-		for limit < 5 && BuildPhase(t, ns, buildA)() == v1.BuildPhaseRunning {
+		for limit < 5 && BuildPhase(t, ctx, ns, buildA)() == v1.BuildPhaseRunning {
 			// verify that number of running builds does not exceed max build limit
-			g.Consistently(BuildsRunning(BuildPhase(t, ns, buildA), BuildPhase(t, ns, buildB), BuildPhase(t, ns, buildC)), TestTimeoutShort, 10*time.Second).Should(Satisfy(notExceedsMaxBuildLimit))
+			g.Consistently(BuildsRunning(BuildPhase(t, ctx, ns, buildA), BuildPhase(t, ctx, ns, buildB), BuildPhase(t, ctx, ns, buildC)), TestTimeoutShort, 10*time.Second).Should(Satisfy(notExceedsMaxBuildLimit))
 			limit++
 		}
 
 		// make sure we have verified max build limit at least once
 		if limit == 0 {
-			t.Error(errors.New(fmt.Sprintf("Unexpected build phase '%s' for %s - not able to verify max builds limit", BuildPhase(t, ns, buildA)(), buildA)))
+			t.Error(errors.New(fmt.Sprintf("Unexpected build phase '%s' for %s - not able to verify max builds limit", BuildPhase(t, ctx, ns, buildA)(), buildA)))
 			t.FailNow()
 		}
 
 		// verify that all builds are successful
-		g.Eventually(BuildPhase(t, ns, buildA), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-		g.Eventually(KitPhase(t, ns, buildA), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
-		g.Eventually(BuildPhase(t, ns, buildB), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-		g.Eventually(KitPhase(t, ns, buildB), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
-		g.Eventually(BuildPhase(t, ns, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-		g.Eventually(KitPhase(t, ns, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		g.Eventually(BuildPhase(t, ctx, ns, buildA), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		g.Eventually(KitPhase(t, ctx, ns, buildA), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		g.Eventually(BuildPhase(t, ctx, ns, buildB), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		g.Eventually(KitPhase(t, ctx, ns, buildB), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		g.Eventually(BuildPhase(t, ctx, ns, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		g.Eventually(KitPhase(t, ctx, ns, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
 	})
 }
 
 func TestKitMaxBuildLimitDependencyMatchingStrategy(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-		createOperator(t, g, ns, "8m0s", "--global", "--force")
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		createOperator(t, ctx, g, ns, "8m0s", "--global", "--force")
 
-		pl := Platform(t, ns)()
+		pl := Platform(t, ctx, ns)()
 		// set maximum number of running builds and order strategy
 		pl.Spec.Build.MaxRunningBuilds = 2
 		pl.Spec.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategyDependencies
-		if err := TestClient(t).Update(TestContext, pl); err != nil {
+		if err := TestClient(t).Update(ctx, pl); err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
@@ -234,7 +235,7 @@ func TestKitMaxBuildLimitDependencyMatchingStrategy(t *testing.T) {
 		buildB := "integration-b"
 		buildC := "integration-c"
 
-		doKitBuildInNamespace(t, g, buildA, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildA, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:timer", "camel:log",
@@ -244,7 +245,7 @@ func TestKitMaxBuildLimitDependencyMatchingStrategy(t *testing.T) {
 			},
 		}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
 
-		doKitBuildInNamespace(t, g, buildB, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildB, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:cron", "camel:log", "camel:joor",
@@ -254,7 +255,7 @@ func TestKitMaxBuildLimitDependencyMatchingStrategy(t *testing.T) {
 			},
 		}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
 
-		doKitBuildInNamespace(t, g, buildC, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildC, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:timer", "camel:log", "camel:joor", "camel:http",
@@ -269,37 +270,37 @@ func TestKitMaxBuildLimitDependencyMatchingStrategy(t *testing.T) {
 		}
 
 		limit := 0
-		for limit < 5 && BuildPhase(t, ns, buildA)() == v1.BuildPhaseRunning {
+		for limit < 5 && BuildPhase(t, ctx, ns, buildA)() == v1.BuildPhaseRunning {
 			// verify that number of running builds does not exceed max build limit
-			g.Consistently(BuildsRunning(BuildPhase(t, ns, buildA), BuildPhase(t, ns, buildB), BuildPhase(t, ns, buildC)), TestTimeoutShort, 10*time.Second).Should(Satisfy(notExceedsMaxBuildLimit))
+			g.Consistently(BuildsRunning(BuildPhase(t, ctx, ns, buildA), BuildPhase(t, ctx, ns, buildB), BuildPhase(t, ctx, ns, buildC)), TestTimeoutShort, 10*time.Second).Should(Satisfy(notExceedsMaxBuildLimit))
 			limit++
 		}
 
 		// make sure we have verified max build limit at least once
 		if limit == 0 {
-			t.Error(errors.New(fmt.Sprintf("Unexpected build phase '%s' for %s - not able to verify max builds limit", BuildPhase(t, ns, buildA)(), buildA)))
+			t.Error(errors.New(fmt.Sprintf("Unexpected build phase '%s' for %s - not able to verify max builds limit", BuildPhase(t, ctx, ns, buildA)(), buildA)))
 			t.FailNow()
 		}
 
 		// verify that all builds are successful
-		g.Eventually(BuildPhase(t, ns, buildA), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-		g.Eventually(KitPhase(t, ns, buildA), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
-		g.Eventually(BuildPhase(t, ns, buildB), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-		g.Eventually(KitPhase(t, ns, buildB), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
-		g.Eventually(BuildPhase(t, ns, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-		g.Eventually(KitPhase(t, ns, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		g.Eventually(BuildPhase(t, ctx, ns, buildA), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		g.Eventually(KitPhase(t, ctx, ns, buildA), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		g.Eventually(BuildPhase(t, ctx, ns, buildB), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		g.Eventually(KitPhase(t, ctx, ns, buildB), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		g.Eventually(BuildPhase(t, ctx, ns, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		g.Eventually(KitPhase(t, ctx, ns, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
 	})
 }
 
 func TestMaxBuildLimitWaitingBuilds(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-		createOperator(t, g, ns, "8m0s", "--global", "--force")
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		createOperator(t, ctx, g, ns, "8m0s", "--global", "--force")
 
-		pl := Platform(t, ns)()
+		pl := Platform(t, ctx, ns)()
 		// set maximum number of running builds and order strategy
 		pl.Spec.Build.MaxRunningBuilds = 1
 		pl.Spec.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategyFIFO
-		if err := TestClient(t).Update(TestContext, pl); err != nil {
+		if err := TestClient(t).Update(ctx, pl); err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
@@ -308,7 +309,7 @@ func TestMaxBuildLimitWaitingBuilds(t *testing.T) {
 		buildB := "integration-b"
 		buildC := "integration-c"
 
-		doKitBuildInNamespace(t, g, buildA, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildA, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:timer", "camel:log",
@@ -318,7 +319,7 @@ func TestMaxBuildLimitWaitingBuilds(t *testing.T) {
 			},
 		}, v1.BuildPhaseRunning, v1.IntegrationKitPhaseBuildRunning)
 
-		doKitBuildInNamespace(t, g, buildB, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildB, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:cron", "camel:log", "camel:joor",
@@ -328,7 +329,7 @@ func TestMaxBuildLimitWaitingBuilds(t *testing.T) {
 			},
 		}, v1.BuildPhaseScheduling, v1.IntegrationKitPhaseNone)
 
-		doKitBuildInNamespace(t, g, buildC, ns, TestTimeoutShort, kitOptions{
+		doKitBuildInNamespace(t, ctx, g, buildC, ns, TestTimeoutShort, kitOptions{
 			operatorID: fmt.Sprintf("camel-k-%s", ns),
 			dependencies: []string{
 				"camel:timer", "camel:log", "camel:joor", "camel:http",
@@ -339,24 +340,24 @@ func TestMaxBuildLimitWaitingBuilds(t *testing.T) {
 		}, v1.BuildPhaseScheduling, v1.IntegrationKitPhaseNone)
 
 		// verify that last build is waiting
-		g.Eventually(BuildConditions(t, ns, buildC), TestTimeoutMedium).ShouldNot(BeNil())
+		g.Eventually(BuildConditions(t, ctx, ns, buildC), TestTimeoutMedium).ShouldNot(BeNil())
 		g.Eventually(
-			BuildCondition(t, ns, buildC, v1.BuildConditionType(v1.BuildConditionScheduled))().Status,
+			BuildCondition(t, ctx, ns, buildC, v1.BuildConditionType(v1.BuildConditionScheduled))().Status,
 			TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
 		g.Eventually(
-			BuildCondition(t, ns, buildC, v1.BuildConditionType(v1.BuildConditionScheduled))().Reason,
+			BuildCondition(t, ctx, ns, buildC, v1.BuildConditionType(v1.BuildConditionScheduled))().Reason,
 			TestTimeoutShort).Should(Equal(v1.BuildConditionWaitingReason))
 
 		// verify that last build is scheduled
-		g.Eventually(BuildPhase(t, ns, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
-		g.Eventually(KitPhase(t, ns, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
+		g.Eventually(BuildPhase(t, ctx, ns, buildC), TestTimeoutLong).Should(Equal(v1.BuildPhaseSucceeded))
+		g.Eventually(KitPhase(t, ctx, ns, buildC), TestTimeoutLong).Should(Equal(v1.IntegrationKitPhaseReady))
 
-		g.Eventually(BuildConditions(t, ns, buildC), TestTimeoutLong).ShouldNot(BeNil())
+		g.Eventually(BuildConditions(t, ctx, ns, buildC), TestTimeoutLong).ShouldNot(BeNil())
 		g.Eventually(
-			BuildCondition(t, ns, buildC, v1.BuildConditionType(v1.BuildConditionScheduled))().Status,
+			BuildCondition(t, ctx, ns, buildC, v1.BuildConditionType(v1.BuildConditionScheduled))().Status,
 			TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 		g.Eventually(
-			BuildCondition(t, ns, buildC, v1.BuildConditionType(v1.BuildConditionScheduled))().Reason,
+			BuildCondition(t, ctx, ns, buildC, v1.BuildConditionType(v1.BuildConditionScheduled))().Reason,
 			TestTimeoutShort).Should(Equal(v1.BuildConditionReadyReason))
 	})
 }
@@ -392,22 +393,22 @@ func doKitFullBuild(t *testing.T, name string, buildTimeout string, testTimeout 
 	options kitOptions, buildPhase v1.BuildPhase, kitPhase v1.IntegrationKitPhase) {
 	t.Helper()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-		createOperator(t, g, ns, buildTimeout)
-		doKitBuildInNamespace(t, g, name, ns, testTimeout, options, buildPhase, kitPhase)
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		createOperator(t, ctx, g, ns, buildTimeout)
+		doKitBuildInNamespace(t, ctx, g, name, ns, testTimeout, options, buildPhase, kitPhase)
 	})
 }
 
-func createOperator(t *testing.T, g *WithT, ns string, buildTimeout string, installArgs ...string) {
+func createOperator(t *testing.T, ctx context.Context, g *WithT, ns string, buildTimeout string, installArgs ...string) {
 	args := []string{"--build-timeout", buildTimeout}
 	args = append(args, installArgs...)
 
 	operatorID := fmt.Sprintf("camel-k-%s", ns)
-	g.Expect(KamelInstallWithID(t, operatorID, ns, args...)).To(Succeed())
-	g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+	g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, args...)).To(Succeed())
+	g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 }
 
-func doKitBuildInNamespace(t *testing.T, g *WithT, name string, ns string, testTimeout time.Duration, options kitOptions, buildPhase v1.BuildPhase, kitPhase v1.IntegrationKitPhase) {
+func doKitBuildInNamespace(t *testing.T, ctx context.Context, g *WithT, name string, ns string, testTimeout time.Duration, options kitOptions, buildPhase v1.BuildPhase, kitPhase v1.IntegrationKitPhase) {
 
 	buildKitArgs := []string{"kit", "create", name, "-n", ns}
 	for _, dependency := range options.dependencies {
@@ -423,13 +424,13 @@ func doKitBuildInNamespace(t *testing.T, g *WithT, name string, ns string, testT
 		buildKitArgs = append(buildKitArgs, "--operator-id", fmt.Sprintf("camel-k-%s", ns))
 	}
 
-	g.Expect(Kamel(t, buildKitArgs...).Execute()).To(Succeed())
+	g.Expect(Kamel(t, ctx, buildKitArgs...).Execute()).To(Succeed())
 
-	g.Eventually(Build(t, ns, name), testTimeout).ShouldNot(BeNil())
+	g.Eventually(Build(t, ctx, ns, name), testTimeout).ShouldNot(BeNil())
 	if buildPhase != v1.BuildPhaseNone {
-		g.Eventually(BuildPhase(t, ns, name), testTimeout).Should(Equal(buildPhase))
+		g.Eventually(BuildPhase(t, ctx, ns, name), testTimeout).Should(Equal(buildPhase))
 	}
 	if kitPhase != v1.IntegrationKitPhaseNone {
-		g.Eventually(KitPhase(t, ns, name), testTimeout).Should(Equal(kitPhase))
+		g.Eventually(KitPhase(t, ctx, ns, name), testTimeout).Should(Equal(kitPhase))
 	}
 }

--- a/e2e/builder/registry_test.go
+++ b/e2e/builder/registry_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package builder
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -41,21 +42,16 @@ func TestRunWithDockerHubRegistry(t *testing.T) {
 		return
 	}
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-docker-hub"
-		g.Expect(KamelInstallWithID(t, operatorID, ns,
-			"--registry", "docker.io",
-			"--organization", user,
-			"--registry-auth-username", user,
-			"--registry-auth-password", pass,
-			"--cluster-type", "kubernetes")).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, "--registry", "docker.io", "--organization", user, "--registry-auth-username", user, "--registry-auth-password", pass, "--cluster-type", "kubernetes")).To(Succeed())
 
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/groovy.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "groovy"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ns, "groovy"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-		g.Eventually(IntegrationPodImage(t, ns, "groovy"), TestTimeoutShort).Should(HavePrefix("docker.io"))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/groovy.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "groovy"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "groovy"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		g.Eventually(IntegrationPodImage(t, ctx, ns, "groovy"), TestTimeoutShort).Should(HavePrefix("docker.io"))
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }
 
@@ -68,20 +64,15 @@ func TestRunWithGithubPackagesRegistry(t *testing.T) {
 		return
 	}
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-github-registry"
-		g.Expect(KamelInstallWithID(t, operatorID, ns,
-			"--registry", "docker.pkg.github.com",
-			"--organization", repo,
-			"--registry-auth-username", user,
-			"--registry-auth-password", pass,
-			"--cluster-type", "kubernetes")).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, "--registry", "docker.pkg.github.com", "--organization", repo, "--registry-auth-username", user, "--registry-auth-password", pass, "--cluster-type", "kubernetes")).To(Succeed())
 
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/groovy.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "groovy"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ns, "groovy"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-		g.Eventually(IntegrationPodImage(t, ns, "groovy"), TestTimeoutShort).Should(HavePrefix("docker.pkg.github.com"))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/groovy.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "groovy"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "groovy"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		g.Eventually(IntegrationPodImage(t, ctx, ns, "groovy"), TestTimeoutShort).Should(HavePrefix("docker.pkg.github.com"))
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/cli/bind_test.go
+++ b/e2e/common/cli/bind_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,33 +34,33 @@ import (
 )
 
 func TestKamelCLIBind(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		kameletName := "test-timer-source"
-		g.Expect(CreateTimerKamelet(t, operatorID, ns, kameletName)()).To(Succeed())
+		g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, kameletName)()).To(Succeed())
 
 		t.Run("bind timer to log", func(t *testing.T) {
-			g.Expect(KamelBindWithID(t, operatorID, ns, kameletName, "log:info", "-p", "source.message=helloTest").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "test-timer-source-to-log"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, "test-timer-source-to-log")).Should(ContainSubstring("Body: helloTest"))
-			g.Expect(KamelBindWithID(t, operatorID, ns, "test-timer-source", "log:info", "-p", "source.message=newText").Execute()).To(Succeed())
-			g.Eventually(IntegrationLogs(t, ns, "test-timer-source-to-log")).Should(ContainSubstring("Body: newText"))
+			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, kameletName, "log:info", "-p", "source.message=helloTest").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "test-timer-source-to-log"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "test-timer-source-to-log")).Should(ContainSubstring("Body: helloTest"))
+			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "test-timer-source", "log:info", "-p", "source.message=newText").Execute()).To(Succeed())
+			g.Eventually(IntegrationLogs(t, ctx, ns, "test-timer-source-to-log")).Should(ContainSubstring("Body: newText"))
 		})
 
 		t.Run("unsuccessful binding, no property", func(t *testing.T) {
-			g.Expect(KamelBindWithID(t, operatorID, ns, operatorNS+"/timer-source", "log:info").Execute()).NotTo(Succeed())
+			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, operatorNS+"/timer-source", "log:info").Execute()).NotTo(Succeed())
 		})
 
 		t.Run("bind uris", func(t *testing.T) {
-			g.Expect(KamelBindWithID(t, operatorID, ns, "timer:foo", "log:bar").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "timer-to-log"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, "timer-to-log")).Should(ContainSubstring("Body is null"))
+			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "timer:foo", "log:bar").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "timer-to-log"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "timer-to-log")).Should(ContainSubstring("Body is null"))
 		})
 
 		t.Run("bind with custom SA", func(t *testing.T) {
-			g.Expect(KamelBindWithID(t, operatorID, ns, "timer:foo", "log:bar", "--service-account", "my-service-account").Execute()).To(Succeed())
-			g.Eventually(IntegrationSpecSA(t, ns, "timer-to-log")).Should(Equal("my-service-account"))
+			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "timer:foo", "log:bar", "--service-account", "my-service-account").Execute()).To(Succeed())
+			g.Eventually(IntegrationSpecSA(t, ctx, ns, "timer-to-log")).Should(Equal("my-service-account"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/cli/delete_test.go
+++ b/e2e/common/cli/delete_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,47 +34,47 @@ import (
 )
 
 func TestKamelCLIDelete(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		t.Run("delete running integration", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Expect(Kamel(t, "delete", "yaml", "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, "yaml")).Should(BeNil())
-			g.Eventually(IntegrationPod(t, ns, "yaml"), TestTimeoutLong).Should(BeNil())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(Kamel(t, ctx, "delete", "yaml", "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, "yaml")).Should(BeNil())
+			g.Eventually(IntegrationPod(t, ctx, ns, "yaml"), TestTimeoutLong).Should(BeNil())
 		})
 
 		t.Run("delete building integration", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-			g.Expect(Kamel(t, "delete", "yaml", "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, "yaml")).Should(BeNil())
-			g.Eventually(IntegrationPod(t, ns, "yaml"), TestTimeoutLong).Should(BeNil())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "yaml", "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, "yaml")).Should(BeNil())
+			g.Eventually(IntegrationPod(t, ctx, ns, "yaml"), TestTimeoutLong).Should(BeNil())
 		})
 
 		t.Run("delete several integrations", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPodPhase(t, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Expect(Kamel(t, "delete", "yaml", "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, "yaml")).Should(BeNil())
-			g.Eventually(IntegrationPod(t, ns, "yaml"), TestTimeoutLong).Should(BeNil())
-			g.Expect(Kamel(t, "delete", "java", "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, "java")).Should(BeNil())
-			g.Eventually(IntegrationPod(t, ns, "java"), TestTimeoutLong).Should(BeNil())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(Kamel(t, ctx, "delete", "yaml", "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, "yaml")).Should(BeNil())
+			g.Eventually(IntegrationPod(t, ctx, ns, "yaml"), TestTimeoutLong).Should(BeNil())
+			g.Expect(Kamel(t, ctx, "delete", "java", "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, "java")).Should(BeNil())
+			g.Eventually(IntegrationPod(t, ctx, ns, "java"), TestTimeoutLong).Should(BeNil())
 		})
 
 		t.Run("delete all integrations", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPodPhase(t, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, "yaml")).Should(BeNil())
-			g.Eventually(IntegrationPod(t, ns, "yaml"), TestTimeoutLong).Should(BeNil())
-			g.Eventually(Integration(t, ns, "java")).Should(BeNil())
-			g.Eventually(IntegrationPod(t, ns, "java"), TestTimeoutLong).Should(BeNil())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, "yaml")).Should(BeNil())
+			g.Eventually(IntegrationPod(t, ctx, ns, "yaml"), TestTimeoutLong).Should(BeNil())
+			g.Eventually(Integration(t, ctx, ns, "java")).Should(BeNil())
+			g.Eventually(IntegrationPod(t, ctx, ns, "java"), TestTimeoutLong).Should(BeNil())
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/cli/describe_test.go
+++ b/e2e/common/cli/describe_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -36,13 +37,12 @@ import (
 )
 
 func TestKamelCliDescribe(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
 		t.Run("Test kamel describe integration", func(t *testing.T) {
-			integration := GetOutputString(Kamel(t, "describe", "integration", "yaml", "-n", ns))
+			integration := GetOutputString(Kamel(t, ctx, "describe", "integration", "yaml", "-n", ns))
 			r, _ := regexp.Compile("(?sm).*Name:\\s+yaml.*")
 			g.Expect(integration).To(MatchRegexp(r.String()))
 
@@ -54,9 +54,9 @@ func TestKamelCliDescribe(t *testing.T) {
 		})
 
 		t.Run("Test kamel describe integration kit", func(t *testing.T) {
-			kitName := Integration(t, ns, "yaml")().Status.IntegrationKit.Name
-			kitNamespace := Integration(t, ns, "yaml")().Status.IntegrationKit.Namespace
-			kit := GetOutputString(Kamel(t, "describe", "kit", kitName, "-n", kitNamespace))
+			kitName := Integration(t, ctx, ns, "yaml")().Status.IntegrationKit.Name
+			kitNamespace := Integration(t, ctx, ns, "yaml")().Status.IntegrationKit.Namespace
+			kit := GetOutputString(Kamel(t, ctx, "describe", "kit", kitName, "-n", kitNamespace))
 
 			r, _ := regexp.Compile("(?sm).*Namespace:\\s+" + kitNamespace + ".*")
 			g.Expect(kit).To(MatchRegexp(r.String()))
@@ -71,7 +71,7 @@ func TestKamelCliDescribe(t *testing.T) {
 		})
 
 		t.Run("Test kamel describe integration platform", func(t *testing.T) {
-			platform := GetOutputString(Kamel(t, "describe", "platform", operatorID, "-n", operatorNS))
+			platform := GetOutputString(Kamel(t, ctx, "describe", "platform", operatorID, "-n", operatorNS))
 			g.Expect(platform).To(ContainSubstring(fmt.Sprintf("Name:	%s", operatorID)))
 
 			r, _ := regexp.Compile("(?sm).*Namespace:\\s+" + operatorNS + ".*")
@@ -81,6 +81,6 @@ func TestKamelCliDescribe(t *testing.T) {
 			g.Expect(platform).To(MatchRegexp(r.String()))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/cli/dev_mode_test.go
+++ b/e2e/common/cli/dev_mode_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestRunDevMode(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		/*
 		 * TODO
 		 * The changing of the yaml file constant from "string" to "magic" is not being
@@ -50,7 +50,7 @@ func TestRunDevMode(t *testing.T) {
 		}
 
 		t.Run("run yaml dev mode", func(t *testing.T) {
-			ctx, cancel := context.WithCancel(TestContext)
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			piper, pipew := io.Pipe()
 			defer pipew.Close()
@@ -79,7 +79,7 @@ func TestRunDevMode(t *testing.T) {
 		})
 
 		t.Run("run yaml remote dev mode", func(t *testing.T) {
-			ctx, cancel := context.WithCancel(TestContext)
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			piper, pipew := io.Pipe()
 			defer pipew.Close()
@@ -114,15 +114,15 @@ func TestRunDevMode(t *testing.T) {
 			name := RandomizedSuffixName("yaml")
 
 			// First run (warm up)
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name)).Should(BeNil())
-			g.Eventually(IntegrationPod(t, ns, name), TestTimeoutMedium).Should(BeNil())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name)).Should(BeNil())
+			g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutMedium).Should(BeNil())
 
 			// Second run (rebuild)
-			ctx, cancel := context.WithCancel(TestContext)
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			piper, pipew := io.Pipe()
 			defer pipew.Close()
@@ -148,6 +148,6 @@ func TestRunDevMode(t *testing.T) {
 			g.Eventually(logScanner.IsFound("Magicstring!"), timeout).Should(BeTrue())
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/cli/duplicate_parameters_test.go
+++ b/e2e/common/cli/duplicate_parameters_test.go
@@ -35,7 +35,7 @@ import (
 func TestDuplicateParameters(t *testing.T) {
 	g := NewWithT(t)
 
-	ctx, cancel := context.WithCancel(TestContext)
+	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
 	// run kamel to output the traits/configuration structure in json format to check the processed values

--- a/e2e/common/cli/duplicate_parameters_test.go
+++ b/e2e/common/cli/duplicate_parameters_test.go
@@ -35,7 +35,7 @@ import (
 func TestDuplicateParameters(t *testing.T) {
 	g := NewWithT(t)
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(TestContext())
 	defer cancel()
 
 	// run kamel to output the traits/configuration structure in json format to check the processed values

--- a/e2e/common/cli/get_test.go
+++ b/e2e/common/cli/get_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -34,46 +35,46 @@ import (
 )
 
 func TestKamelCLIGet(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 
 		t.Run("get integration", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 			// regex is used for the compatibility of tests between OC and vanilla K8
 			// kamel get may have different output depending on the platform
-			g.Eventually(IntegrationKit(t, ns, "yaml")).ShouldNot(Equal(""))
-			kitName := IntegrationKit(t, ns, "yaml")()
-			kitNamespace := IntegrationKitNamespace(t, ns, "yaml")()
+			g.Eventually(IntegrationKit(t, ctx, ns, "yaml")).ShouldNot(Equal(""))
+			kitName := IntegrationKit(t, ctx, ns, "yaml")()
+			kitNamespace := IntegrationKitNamespace(t, ctx, ns, "yaml")()
 			regex := fmt.Sprintf("^NAME\tPHASE\tKIT\n\\s*yaml\tRunning\t(%s/%s|%s)", kitNamespace, kitName, kitName)
-			g.Expect(GetOutputString(Kamel(t, "get", "-n", ns))).To(MatchRegexp(regex))
+			g.Expect(GetOutputString(Kamel(t, ctx, "get", "-n", ns))).To(MatchRegexp(regex))
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("get several integrations", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPodPhase(t, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
-			g.Eventually(IntegrationKit(t, ns, "java")).ShouldNot(Equal(""))
-			g.Eventually(IntegrationKit(t, ns, "yaml")).ShouldNot(Equal(""))
-			kitName1 := IntegrationKit(t, ns, "java")()
-			kitName2 := IntegrationKit(t, ns, "yaml")()
-			kitNamespace1 := IntegrationKitNamespace(t, ns, "java")()
-			kitNamespace2 := IntegrationKitNamespace(t, ns, "yaml")()
+			g.Eventually(IntegrationKit(t, ctx, ns, "java")).ShouldNot(Equal(""))
+			g.Eventually(IntegrationKit(t, ctx, ns, "yaml")).ShouldNot(Equal(""))
+			kitName1 := IntegrationKit(t, ctx, ns, "java")()
+			kitName2 := IntegrationKit(t, ctx, ns, "yaml")()
+			kitNamespace1 := IntegrationKitNamespace(t, ctx, ns, "java")()
+			kitNamespace2 := IntegrationKitNamespace(t, ctx, ns, "yaml")()
 			regex := fmt.Sprintf("^NAME\tPHASE\tKIT\n\\s*java\tRunning\t"+
 				"(%s/%s|%s)\n\\s*yaml\tRunning\t(%s/%s|%s)\n", kitNamespace1, kitName1, kitName1, kitNamespace2, kitName2, kitName2)
-			g.Expect(GetOutputString(Kamel(t, "get", "-n", ns))).To(MatchRegexp(regex))
+			g.Expect(GetOutputString(Kamel(t, ctx, "get", "-n", ns))).To(MatchRegexp(regex))
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("get no integrations", func(t *testing.T) {
-			g.Expect(GetOutputString(Kamel(t, "get", "-n", ns))).NotTo(ContainSubstring("Running"))
-			g.Expect(GetOutputString(Kamel(t, "get", "-n", ns))).NotTo(ContainSubstring("Building Kit"))
+			g.Expect(GetOutputString(Kamel(t, ctx, "get", "-n", ns))).NotTo(ContainSubstring("Running"))
+			g.Expect(GetOutputString(Kamel(t, ctx, "get", "-n", ns))).NotTo(ContainSubstring("Building Kit"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/cli/help_test.go
+++ b/e2e/common/cli/help_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -31,10 +32,11 @@ import (
 )
 
 func TestKamelCLIHelp(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 
 	t.Run("default help message", func(t *testing.T) {
-		helpMsg := GetOutputString(Kamel(t, "help"))
+		helpMsg := GetOutputString(Kamel(t, ctx, "help"))
 		g.Expect(helpMsg).To(ContainSubstring("Apache Camel K is a lightweight integration platform, born on Kubernetes"))
 		g.Expect(helpMsg).To(ContainSubstring("Usage:"))
 		g.Expect(helpMsg).To(ContainSubstring("Available Commands:"))
@@ -42,14 +44,14 @@ func TestKamelCLIHelp(t *testing.T) {
 	})
 
 	t.Run("'get' command help (short flag)", func(t *testing.T) {
-		helpMsg := GetOutputString(Kamel(t, "get", "-h"))
+		helpMsg := GetOutputString(Kamel(t, ctx, "get", "-h"))
 		g.Expect(helpMsg).To(ContainSubstring("Get the status of integrations deployed on Kubernetes"))
 		g.Expect(helpMsg).To(ContainSubstring("Usage:"))
 		g.Expect(helpMsg).To(ContainSubstring("Flags:"))
 	})
 
 	t.Run("'bind' command help (long flag)", func(t *testing.T) {
-		helpMsg := GetOutputString(Kamel(t, "bind", "--help"))
+		helpMsg := GetOutputString(Kamel(t, ctx, "bind", "--help"))
 		g.Expect(helpMsg).To(ContainSubstring("Bind Kubernetes resources, such as Kamelets, in an integration flow."))
 		g.Expect(helpMsg).To(ContainSubstring("kamel bind [source] [sink] ... [flags]"))
 		g.Expect(helpMsg).To(ContainSubstring("Global Flags:"))

--- a/e2e/common/cli/help_test.go
+++ b/e2e/common/cli/help_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package cli
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -32,7 +31,7 @@ import (
 )
 
 func TestKamelCLIHelp(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 
 	t.Run("default help message", func(t *testing.T) {

--- a/e2e/common/cli/log_test.go
+++ b/e2e/common/cli/log_test.go
@@ -23,35 +23,37 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"strings"
 	"testing"
 
-	. "github.com/apache/camel-k/v2/e2e/support"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/apache/camel-k/v2/e2e/support"
 )
 
 func TestKamelCLILog(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		t.Run("check integration log", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml", "--name", "log-yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "log-yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml", "--name", "log-yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "log-yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 			// first line of the integration logs
-			firstLine := strings.Split(IntegrationLogs(t, ns, "log-yaml")(), "\n")[0]
-			podName := IntegrationPod(t, ns, "log-yaml")().Name
+			firstLine := strings.Split(IntegrationLogs(t, ctx, ns, "log-yaml")(), "\n")[0]
+			podName := IntegrationPod(t, ctx, ns, "log-yaml")().Name
 
-			logsCLI := GetOutputStringAsync(Kamel(t, "log", "log-yaml", "-n", ns))
+			logsCLI := GetOutputStringAsync(Kamel(t, ctx, "log", "log-yaml", "-n", ns))
 			g.Eventually(logsCLI).Should(ContainSubstring("Monitoring pod " + podName))
 			g.Eventually(logsCLI).Should(ContainSubstring(firstLine))
 
-			logs := strings.Split(IntegrationLogs(t, ns, "log-yaml")(), "\n")
+			logs := strings.Split(IntegrationLogs(t, ctx, ns, "log-yaml")(), "\n")
 			lastLine := logs[len(logs)-1]
 
-			logsCLI = GetOutputStringAsync(Kamel(t, "log", "log-yaml", "-n", ns, "--tail", "5"))
+			logsCLI = GetOutputStringAsync(Kamel(t, ctx, "log", "log-yaml", "-n", ns, "--tail", "5"))
 			g.Eventually(logsCLI).Should(ContainSubstring("Monitoring pod " + podName))
 			g.Eventually(logsCLI).Should(ContainSubstring(lastLine))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/cli/main_test.go
+++ b/e2e/common/cli/main_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -44,10 +43,10 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Test setup failed! - %s\n", message)
 	})
 
-	ctx := context.TODO()
 	var t *testing.T
 
 	g.Expect(TestClient(t)).ShouldNot(BeNil())
+	ctx := TestContext()
 
 	// Install global operator for tests in this package, all tests must use this operatorID
 	g.Expect(NewNamedTestNamespace(t, ctx, operatorNS, false)).ShouldNot(BeNil())

--- a/e2e/common/cli/main_test.go
+++ b/e2e/common/cli/main_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -43,20 +44,21 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Test setup failed! - %s\n", message)
 	})
 
+	ctx := context.TODO()
 	var t *testing.T
 
 	g.Expect(TestClient(t)).ShouldNot(BeNil())
 
 	// Install global operator for tests in this package, all tests must use this operatorID
-	g.Expect(NewNamedTestNamespace(t, operatorNS, false)).ShouldNot(BeNil())
-	g.Expect(CopyCamelCatalog(t, operatorNS, operatorID)).To(Succeed())
-	g.Expect(KamelInstallWithIDAndKameletCatalog(t, operatorID, operatorNS, "--global", "--force")).To(Succeed())
-	g.Eventually(SelectedPlatformPhase(t, operatorNS, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+	g.Expect(NewNamedTestNamespace(t, ctx, operatorNS, false)).ShouldNot(BeNil())
+	g.Expect(CopyCamelCatalog(t, ctx, operatorNS, operatorID)).To(Succeed())
+	g.Expect(KamelInstallWithIDAndKameletCatalog(t, ctx, operatorID, operatorNS, "--global", "--force")).To(Succeed())
+	g.Eventually(SelectedPlatformPhase(t, ctx, operatorNS, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 	exitCode := m.Run()
 
-	g.Expect(UninstallFromNamespace(t, operatorNS))
-	g.Expect(DeleteNamespace(t, operatorNS)).To(Succeed())
+	g.Expect(UninstallFromNamespace(t, ctx, operatorNS))
+	g.Expect(DeleteNamespace(t, ctx, operatorNS)).To(Succeed())
 
 	os.Exit(exitCode)
 }

--- a/e2e/common/cli/offline_commands_test.go
+++ b/e2e/common/cli/offline_commands_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -31,24 +32,27 @@ import (
 )
 
 func TestKamelVersionWorksOffline(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
-	g.Expect(Kamel(t, "version", "--kube-config", "non-existent-kubeconfig-file").Execute()).To(Succeed())
+	g.Expect(Kamel(t, ctx, "version", "--kube-config", "non-existent-kubeconfig-file").Execute()).To(Succeed())
 }
 
 func TestKamelHelpOptionWorksOffline(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 
-	traitCmd := Kamel(t, "run", "Xxx.java", "--help")
+	traitCmd := Kamel(t, ctx, "run", "Xxx.java", "--help")
 	traitCmd.SetOut(io.Discard)
 	g.Expect(traitCmd.Execute()).To(Succeed())
 }
 
 func TestKamelCompletionWorksOffline(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 
-	bashCmd := Kamel(t, "completion", "bash", "--kube-config", "non-existent-kubeconfig-file")
+	bashCmd := Kamel(t, ctx, "completion", "bash", "--kube-config", "non-existent-kubeconfig-file")
 	bashCmd.SetOut(io.Discard)
-	zshCmd := Kamel(t, "completion", "zsh", "--kube-config", "non-existent-kubeconfig-file")
+	zshCmd := Kamel(t, ctx, "completion", "zsh", "--kube-config", "non-existent-kubeconfig-file")
 	zshCmd.SetOut(io.Discard)
 	g.Expect(bashCmd.Execute()).To(Succeed())
 	g.Expect(zshCmd.Execute()).To(Succeed())

--- a/e2e/common/cli/offline_commands_test.go
+++ b/e2e/common/cli/offline_commands_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package cli
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -32,27 +31,24 @@ import (
 )
 
 func TestKamelVersionWorksOffline(t *testing.T) {
-	ctx := context.TODO()
 	g := NewWithT(t)
-	g.Expect(Kamel(t, ctx, "version", "--kube-config", "non-existent-kubeconfig-file").Execute()).To(Succeed())
+	g.Expect(Kamel(t, TestContext(), "version", "--kube-config", "non-existent-kubeconfig-file").Execute()).To(Succeed())
 }
 
 func TestKamelHelpOptionWorksOffline(t *testing.T) {
-	ctx := context.TODO()
 	g := NewWithT(t)
 
-	traitCmd := Kamel(t, ctx, "run", "Xxx.java", "--help")
+	traitCmd := Kamel(t, TestContext(), "run", "Xxx.java", "--help")
 	traitCmd.SetOut(io.Discard)
 	g.Expect(traitCmd.Execute()).To(Succeed())
 }
 
 func TestKamelCompletionWorksOffline(t *testing.T) {
-	ctx := context.TODO()
 	g := NewWithT(t)
 
-	bashCmd := Kamel(t, ctx, "completion", "bash", "--kube-config", "non-existent-kubeconfig-file")
+	bashCmd := Kamel(t, TestContext(), "completion", "bash", "--kube-config", "non-existent-kubeconfig-file")
 	bashCmd.SetOut(io.Discard)
-	zshCmd := Kamel(t, ctx, "completion", "zsh", "--kube-config", "non-existent-kubeconfig-file")
+	zshCmd := Kamel(t, TestContext(), "completion", "zsh", "--kube-config", "non-existent-kubeconfig-file")
 	zshCmd.SetOut(io.Discard)
 	g.Expect(bashCmd.Execute()).To(Succeed())
 	g.Expect(zshCmd.Execute()).To(Succeed())

--- a/e2e/common/cli/run_test.go
+++ b/e2e/common/cli/run_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -39,38 +40,38 @@ import (
 var sampleJar = "https://raw.githubusercontent.com/apache/camel-k/main/e2e/common/traits/files/jvm/sample-1.0.jar"
 
 func TestKamelCLIRun(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 
 		t.Run("Examples from GitHub", func(t *testing.T) {
 			t.Run("Java", func(t *testing.T) {
-				g.Expect(KamelRunWithID(t, operatorID, ns,
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns,
 					"github:apache/camel-k-examples/generic-examples/languages/Sample.java").Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, "sample"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, "sample", v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, "sample"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, "sample", v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, "sample"), TestTimeoutShort).Should(ContainSubstring("Hello Camel K!"))
-				g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+				g.Eventually(IntegrationLogs(t, ctx, ns, "sample"), TestTimeoutShort).Should(ContainSubstring("Hello Camel K!"))
+				g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 			})
 
 			t.Run("Java (RAW)", func(t *testing.T) {
-				g.Expect(KamelRunWithID(t, operatorID, ns,
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns,
 					"https://raw.githubusercontent.com/apache/camel-k-examples/main/generic-examples/languages/Sample.java").Execute()).
 					To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, "sample"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, "sample", v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, "sample"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, "sample", v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, "sample"), TestTimeoutShort).Should(ContainSubstring("Hello Camel K!"))
-				g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+				g.Eventually(IntegrationLogs(t, ctx, ns, "sample"), TestTimeoutShort).Should(ContainSubstring("Hello Camel K!"))
+				g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 			})
 
 			t.Run("Java (branch)", func(t *testing.T) {
-				g.Expect(KamelRunWithID(t, operatorID, ns,
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns,
 					"github:apache/camel-k-examples/generic-examples/languages/Sample.java?branch=main").Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, "sample"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, "sample", v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, "sample"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, "sample", v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, "sample"), TestTimeoutShort).Should(ContainSubstring("Hello Camel K!"))
-				g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+				g.Eventually(IntegrationLogs(t, ctx, ns, "sample"), TestTimeoutShort).Should(ContainSubstring("Hello Camel K!"))
+				g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 			})
 
 			// GIST does not like GITHUB_TOKEN apparently, we must temporarily remove it
@@ -79,26 +80,26 @@ func TestKamelCLIRun(t *testing.T) {
 
 			t.Run("Gist (ID)", func(t *testing.T) {
 				name := RandomizedSuffixName("github-gist-id")
-				g.Expect(KamelRunWithID(t, operatorID, ns, "--name", name,
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "--name", name,
 					"gist:e2c3f9a5fd0d9e79b21b04809786f17a").Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Tick!"))
-				g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Tick!"))
+				g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 			})
 
 			t.Run("Gist (URL)", func(t *testing.T) {
 				name := RandomizedSuffixName("github-gist-url")
-				g.Expect(KamelRunWithID(t, operatorID, ns, "--name", name,
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "--name", name,
 					"https://gist.github.com/lburgazzoli/e2c3f9a5fd0d9e79b21b04809786f17a").Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Tick!"))
-				g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Tick!"))
+				g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 			})
 
 			// Revert GITHUB TOKEN
@@ -106,80 +107,80 @@ func TestKamelCLIRun(t *testing.T) {
 			os.Unsetenv("GITHUB_TOKEN_TMP")
 
 			// Clean up
-			g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+			g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 		})
 
 		t.Run("Run and update", func(t *testing.T) {
 			name := RandomizedSuffixName("run")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/run.yaml", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/run.yaml", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magic default"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magic default"))
 
 			// Re-run the Integration with an updated configuration
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/run.yaml", "--name", name, "-p", "property=value").Execute()).
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/run.yaml", "--name", name, "-p", "property=value").Execute()).
 				To(Succeed())
 
 			// Check the Deployment has progressed successfully
-			g.Eventually(DeploymentCondition(t, ns, name, appsv1.DeploymentProgressing), TestTimeoutShort).
+			g.Eventually(DeploymentCondition(t, ctx, ns, name, appsv1.DeploymentProgressing), TestTimeoutShort).
 				Should(MatchFields(IgnoreExtras, Fields{
 					"Status": Equal(corev1.ConditionTrue),
 					"Reason": Equal("NewReplicaSetAvailable"),
 				}))
 
 			// Check the new configuration is taken into account
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutShort).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magic value"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magic value"))
 
 			// Clean up
-			g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+			g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 		})
 
 		t.Run("Run with glob patterns", func(t *testing.T) {
 			t.Run("YAML", func(t *testing.T) {
 				name := RandomizedSuffixName("run")
-				g.Expect(KamelRunWithID(t, operatorID, ns, "files/glob/run*", "--name", name).Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/glob/run*", "--name", name).Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello run 1 default"))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello run 2 default"))
-				g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello run 1 default"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello run 2 default"))
+				g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 			})
 
 			t.Run("Java", func(t *testing.T) {
 				name := RandomizedSuffixName("java")
-				g.Expect(KamelRunWithID(t, operatorID, ns, "files/glob/Java*", "--name", name).Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/glob/Java*", "--name", name).Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello java 1 default"))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello java 2 default"))
-				g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello java 1 default"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello java 2 default"))
+				g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 			})
 
 			t.Run("All", func(t *testing.T) {
 				name := RandomizedSuffixName("java")
-				g.Expect(KamelRunWithID(t, operatorID, ns, "files/glob/*", "--name", name).Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/glob/*", "--name", name).Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello run 1 default"))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello run 2 default"))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello java 1 default"))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello java 2 default"))
-				g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello run 1 default"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello run 2 default"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello java 1 default"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Hello java 2 default"))
+				g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 			})
 
 			// Clean up
-			g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+			g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 		})
 	})
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		/*
 		 * TODO
 		 * The dependency cannot be read by maven while building. See #3708
@@ -192,21 +193,21 @@ func TestKamelCLIRun(t *testing.T) {
 			}
 			// Requires a local integration platform in order to resolve the insecure registry
 			// Install platform (use the installer to get staging if present)
-			g.Expect(KamelInstallWithID(t, operatorID, ns, "--skip-operator-setup")).To(Succeed())
-			g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+			g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, "--skip-operator-setup")).To(Succeed())
+			g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "../traits/files/jvm/Classpath.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "../traits/files/jvm/Classpath.java",
 				"-d", sampleJar,
 			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "classpath"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "classpath", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "classpath"), TestTimeoutShort).Should(ContainSubstring("Hello World!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "classpath"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "classpath", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "classpath"), TestTimeoutShort).Should(ContainSubstring("Hello World!"))
 		})
 
-		g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+		g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 	})
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		/*
 		 * TODO
 		 * The dependency cannot be read by maven while building. See #3708
@@ -219,18 +220,18 @@ func TestKamelCLIRun(t *testing.T) {
 			}
 			// Requires a local integration platform in order to resolve the insecure registry
 			// Install platform (use the installer to get staging if present)
-			g.Expect(KamelInstallWithID(t, operatorID, ns, "--skip-operator-setup")).To(Succeed())
-			g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+			g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, "--skip-operator-setup")).To(Succeed())
+			g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "../traits/files/jvm/Classpath.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "../traits/files/jvm/Classpath.java",
 				"-d", sampleJar,
 				"-d", "https://raw.githubusercontent.com/apache/camel-k-examples/main/generic-examples/languages/Sample.java|targetPath=/tmp/foo",
 			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "classpath"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "classpath", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "classpath"), TestTimeoutShort).Should(ContainSubstring("Hello World!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "classpath"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "classpath", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "classpath"), TestTimeoutShort).Should(ContainSubstring("Hello World!"))
 		})
 
-		g.Eventually(DeleteIntegrations(t, ns), TestTimeoutLong).Should(Equal(0))
+		g.Eventually(DeleteIntegrations(t, ctx, ns), TestTimeoutLong).Should(Equal(0))
 	})
 }

--- a/e2e/common/cli/version_test.go
+++ b/e2e/common/cli/version_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package cli
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -33,11 +32,10 @@ import (
 )
 
 func TestKamelCLIVersion(t *testing.T) {
-	ctx := context.TODO()
 	g := NewWithT(t)
 
 	t.Run("check version correctness", func(t *testing.T) {
-		version := GetOutputString(Kamel(t, ctx, "version"))
+		version := GetOutputString(Kamel(t, TestContext(), "version"))
 		g.Expect(version).To(ContainSubstring(defaults.Version))
 	})
 }

--- a/e2e/common/cli/version_test.go
+++ b/e2e/common/cli/version_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -32,10 +33,11 @@ import (
 )
 
 func TestKamelCLIVersion(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 
 	t.Run("check version correctness", func(t *testing.T) {
-		version := GetOutputString(Kamel(t, "version"))
+		version := GetOutputString(Kamel(t, ctx, "version"))
 		g.Expect(version).To(ContainSubstring(defaults.Version))
 	})
 }

--- a/e2e/common/config/config_test.go
+++ b/e2e/common/config/config_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -37,108 +38,105 @@ import (
 func TestRunConfigExamples(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-config"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("Simple property", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/property-route.groovy", "-p", "my.message=test-property").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("test-property"))
-			g.Expect(Kamel(t, "delete", "property-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/property-route.groovy", "-p", "my.message=test-property").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("test-property"))
+			g.Expect(Kamel(t, ctx, "delete", "property-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Property file", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/property-file-route.groovy", "--property", "file:./files/my.properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "property-file-route"), TestTimeoutShort).Should(ContainSubstring("hello world"))
-			g.Expect(Kamel(t, "delete", "property-file-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/property-file-route.groovy", "--property", "file:./files/my.properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "property-file-route"), TestTimeoutShort).Should(ContainSubstring("hello world"))
+			g.Expect(Kamel(t, ctx, "delete", "property-file-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Property precedence", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/property-file-route.groovy", "-p", "my.key.2=universe", "-p", "file:./files/my.properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "property-file-route"), TestTimeoutShort).Should(ContainSubstring("hello universe"))
-			g.Expect(Kamel(t, "delete", "property-file-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/property-file-route.groovy", "-p", "my.key.2=universe", "-p", "file:./files/my.properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "property-file-route"), TestTimeoutShort).Should(ContainSubstring("hello universe"))
+			g.Expect(Kamel(t, ctx, "delete", "property-file-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Property from ConfigMap", func(t *testing.T) {
 			var cmData = make(map[string]string)
 			cmData["my.message"] = "my-configmap-property-value"
-			CreatePlainTextConfigmap(t, ns, "my-cm-test-property", cmData)
+			CreatePlainTextConfigmap(t, ctx, ns, "my-cm-test-property", cmData)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/property-route.groovy", "-p", "configmap:my-cm-test-property").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("my-configmap-property-value"))
-			g.Expect(Kamel(t, "delete", "property-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/property-route.groovy", "-p", "configmap:my-cm-test-property").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("my-configmap-property-value"))
+			g.Expect(Kamel(t, ctx, "delete", "property-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Property from ConfigMap as property file", func(t *testing.T) {
 			var cmData = make(map[string]string)
 			cmData["my.properties"] = "my.message=my-configmap-property-entry"
-			CreatePlainTextConfigmap(t, ns, "my-cm-test-properties", cmData)
+			CreatePlainTextConfigmap(t, ctx, ns, "my-cm-test-properties", cmData)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/property-route.groovy", "-p", "configmap:my-cm-test-properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("my-configmap-property-entry"))
-			g.Expect(Kamel(t, "delete", "property-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/property-route.groovy", "-p", "configmap:my-cm-test-properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("my-configmap-property-entry"))
+			g.Expect(Kamel(t, ctx, "delete", "property-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Property from Secret", func(t *testing.T) {
 			var secData = make(map[string]string)
 			secData["my.message"] = "my-secret-property-value"
-			CreatePlainTextSecret(t, ns, "my-sec-test-property", secData)
+			CreatePlainTextSecret(t, ctx, ns, "my-sec-test-property", secData)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/property-route.groovy", "-p", "secret:my-sec-test-property").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("my-secret-property-value"))
-			g.Expect(Kamel(t, "delete", "property-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/property-route.groovy", "-p", "secret:my-sec-test-property").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("my-secret-property-value"))
+			g.Expect(Kamel(t, ctx, "delete", "property-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Property from Secret as property file", func(t *testing.T) {
 			var secData = make(map[string]string)
 			secData["my.properties"] = "my.message=my-secret-property-entry"
-			CreatePlainTextSecret(t, ns, "my-sec-test-properties", secData)
+			CreatePlainTextSecret(t, ctx, ns, "my-sec-test-properties", secData)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/property-route.groovy", "-p", "secret:my-sec-test-properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "property-route"), TestTimeoutShort).Should(ContainSubstring("my-secret-property-entry"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/property-route.groovy", "--name", "property-route-secret", "-p", "secret:my-sec-test-properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "property-route-secret"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "property-route-secret", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "property-route-secret"), TestTimeoutShort).Should(ContainSubstring("my-secret-property-entry"))
 		})
 
 		t.Run("Property from Secret inlined", func(t *testing.T) {
 			var secData = make(map[string]string)
 			secData["my-message"] = "my-secret-external-value"
-			CreatePlainTextSecret(t, ns, "my-sec-inlined", secData)
+			CreatePlainTextSecret(t, ctx, ns, "my-sec-inlined", secData)
 
 			// TODO: remove jvm.options trait as soon as CAMEL-20054 gets fixed
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/property-secret-route.groovy",
-				"-t", "mount.configs=secret:my-sec-inlined",
-				"-t", "jvm.options=-Dcamel.k.mount-path.secrets=/etc/camel/conf.d/_secrets",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "property-secret-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "property-secret-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "property-secret-route"), TestTimeoutShort).Should(ContainSubstring("my-secret-external-value"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/property-secret-route.groovy", "-t", "mount.configs=secret:my-sec-inlined", "-t", "jvm.options=-Dcamel.k.mount-path.secrets=/etc/camel/conf.d/_secrets").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "property-secret-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "property-secret-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "property-secret-route"), TestTimeoutShort).Should(ContainSubstring("my-secret-external-value"))
 
 			// check integration schema does not contains unwanted default trait value.
-			g.Eventually(UnstructuredIntegration(t, ns, "property-secret-route")).ShouldNot(BeNil())
-			unstructuredIntegration := UnstructuredIntegration(t, ns, "property-secret-route")()
+			g.Eventually(UnstructuredIntegration(t, ctx, ns, "property-secret-route")).ShouldNot(BeNil())
+			unstructuredIntegration := UnstructuredIntegration(t, ctx, ns, "property-secret-route")()
 			mountTrait, _, _ := unstructured.NestedMap(unstructuredIntegration.Object, "spec", "traits", "mount")
 			g.Expect(mountTrait).ToNot(BeNil())
 			g.Expect(len(mountTrait)).To(Equal(1))
 			g.Expect(mountTrait["configs"]).ToNot(BeNil())
 
-			g.Expect(Kamel(t, "delete", "property-secret-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "property-secret-route", "-n", ns).Execute()).To(Succeed())
 
 		})
 
@@ -147,59 +145,59 @@ func TestRunConfigExamples(t *testing.T) {
 		// Store a configmap on the cluster
 		var cmData = make(map[string]string)
 		cmData["my-configmap-key"] = "my-configmap-content"
-		CreatePlainTextConfigmap(t, ns, "my-cm", cmData)
+		CreatePlainTextConfigmap(t, ctx, ns, "my-cm", cmData)
 
 		// Store a configmap with multiple values
 		var cmDataMulti = make(map[string]string)
 		cmDataMulti["my-configmap-key"] = "should-not-see-it"
 		cmDataMulti["my-configmap-key-2"] = "my-configmap-content-2"
-		CreatePlainTextConfigmap(t, ns, "my-cm-multi", cmDataMulti)
+		CreatePlainTextConfigmap(t, ctx, ns, "my-cm-multi", cmDataMulti)
 
 		t.Run("Config configmap", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/config-configmap-route.groovy", "--config", "configmap:my-cm").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "config-configmap-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "config-configmap-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "config-configmap-route"), TestTimeoutShort).Should(ContainSubstring(cmData["my-configmap-key"]))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/config-configmap-route.groovy", "--config", "configmap:my-cm").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "config-configmap-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "config-configmap-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "config-configmap-route"), TestTimeoutShort).Should(ContainSubstring(cmData["my-configmap-key"]))
 		})
 
 		t.Run("Resource configmap", func(t *testing.T) {
 			// We can reuse the configmap created previously
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/resource-configmap-route.groovy", "--resource", "configmap:my-cm").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "resource-configmap-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "resource-configmap-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "resource-configmap-route"), TestTimeoutShort).Should(ContainSubstring(cmData["my-configmap-key"]))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/resource-configmap-route.groovy", "--resource", "configmap:my-cm").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "resource-configmap-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "resource-configmap-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "resource-configmap-route"), TestTimeoutShort).Should(ContainSubstring(cmData["my-configmap-key"]))
 		})
 
 		t.Run("Resource configmap with destination", func(t *testing.T) {
 			// We can reuse the configmap created previously
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/resource-configmap-location-route.groovy", "--resource", "configmap:my-cm@/tmp/app").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "resource-configmap-location-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "resource-configmap-location-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "resource-configmap-location-route"), TestTimeoutShort).Should(ContainSubstring(cmData["my-configmap-key"]))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/resource-configmap-location-route.groovy", "--resource", "configmap:my-cm@/tmp/app").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "resource-configmap-location-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "resource-configmap-location-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "resource-configmap-location-route"), TestTimeoutShort).Should(ContainSubstring(cmData["my-configmap-key"]))
 		})
 
 		t.Run("Resource configmap with filtered key and destination", func(t *testing.T) {
 			// We'll use the configmap contaning 2 values filtering only 1 key
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/resource-configmap-key-location-route.groovy", "--resource", "configmap:my-cm-multi/my-configmap-key-2@/tmp/app/test.txt").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "resource-configmap-key-location-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "resource-configmap-key-location-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "resource-configmap-key-location-route"), TestTimeoutShort).ShouldNot(ContainSubstring(cmDataMulti["my-configmap-key"]))
-			g.Eventually(IntegrationLogs(t, ns, "resource-configmap-key-location-route"), TestTimeoutShort).Should(ContainSubstring(cmDataMulti["my-configmap-key-2"]))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/resource-configmap-key-location-route.groovy", "--resource", "configmap:my-cm-multi/my-configmap-key-2@/tmp/app/test.txt").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "resource-configmap-key-location-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "resource-configmap-key-location-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "resource-configmap-key-location-route"), TestTimeoutShort).ShouldNot(ContainSubstring(cmDataMulti["my-configmap-key"]))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "resource-configmap-key-location-route"), TestTimeoutShort).Should(ContainSubstring(cmDataMulti["my-configmap-key-2"]))
 		})
 
-		// Store a configmap as property file
-		var cmDataProps = make(map[string]string)
-		cmDataProps["my.properties"] = "my.key.1=hello\nmy.key.2=world"
-		CreatePlainTextConfigmap(t, ns, "my-cm-properties", cmDataProps)
-
 		t.Run("Config configmap as property file", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/config-configmap-properties-route.groovy", "--config", "configmap:my-cm-properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "config-configmap-properties-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "config-configmap-properties-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "config-configmap-properties-route"), TestTimeoutShort).Should(ContainSubstring("hello world"))
+			// Store a configmap as property file
+			var cmDataProps = make(map[string]string)
+			cmDataProps["my.properties"] = "my.key.1=hello\nmy.key.2=world"
+			CreatePlainTextConfigmap(t, ctx, ns, "my-cm-properties", cmDataProps)
+
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/config-configmap-properties-route.groovy", "--config", "configmap:my-cm-properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "config-configmap-properties-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "config-configmap-properties-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "config-configmap-properties-route"), TestTimeoutShort).Should(ContainSubstring("hello world"))
 		})
 
 		// Secret
@@ -207,127 +205,123 @@ func TestRunConfigExamples(t *testing.T) {
 		// Store a secret on the cluster
 		var secData = make(map[string]string)
 		secData["my-secret-key"] = "very top secret"
-		CreatePlainTextSecret(t, ns, "my-sec", secData)
+		CreatePlainTextSecret(t, ctx, ns, "my-sec", secData)
 
 		// Store a secret with multi values
 		var secDataMulti = make(map[string]string)
 		secDataMulti["my-secret-key"] = "very top secret"
 		secDataMulti["my-secret-key-2"] = "even more secret"
-		CreatePlainTextSecret(t, ns, "my-sec-multi", secDataMulti)
+		CreatePlainTextSecret(t, ctx, ns, "my-sec-multi", secDataMulti)
 
 		t.Run("Config secret", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/config-secret-route.groovy", "--config", "secret:my-sec").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "config-secret-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "config-secret-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "config-secret-route"), TestTimeoutShort).Should(ContainSubstring(secData["my-secret-key"]))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/config-secret-route.groovy", "--config", "secret:my-sec").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "config-secret-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "config-secret-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "config-secret-route"), TestTimeoutShort).Should(ContainSubstring(secData["my-secret-key"]))
 		})
 
 		t.Run("Resource secret", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/resource-secret-route.groovy", "--resource", "secret:my-sec").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "resource-secret-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "resource-secret-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "resource-secret-route"), TestTimeoutShort).Should(ContainSubstring(secData["my-secret-key"]))
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/resource-secret-route.groovy", "--resource", "secret:my-sec").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "resource-secret-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "resource-secret-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "resource-secret-route"), TestTimeoutShort).Should(ContainSubstring(secData["my-secret-key"]))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Secret with filtered key", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/config-secret-key-route.groovy", "--config", "secret:my-sec-multi/my-secret-key-2").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "config-secret-key-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "config-secret-key-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "config-secret-key-route"), TestTimeoutShort).ShouldNot(ContainSubstring(secDataMulti["my-secret-key"]))
-			g.Eventually(IntegrationLogs(t, ns, "config-secret-key-route"), TestTimeoutShort).Should(ContainSubstring(secDataMulti["my-secret-key-2"]))
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/config-secret-key-route.groovy", "--config", "secret:my-sec-multi/my-secret-key-2").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "config-secret-key-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "config-secret-key-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "config-secret-key-route"), TestTimeoutShort).ShouldNot(ContainSubstring(secDataMulti["my-secret-key"]))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "config-secret-key-route"), TestTimeoutShort).Should(ContainSubstring(secDataMulti["my-secret-key-2"]))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		// Build-Properties
 		t.Run("Build time property", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/build-property-route.groovy", "--build-property", "quarkus.application.name=my-super-application").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "build-property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "build-property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "build-property-route"), TestTimeoutShort).Should(ContainSubstring("my-super-application"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/build-property-route.groovy", "--build-property", "quarkus.application.name=my-super-application").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "build-property-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "build-property-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "build-property-route"), TestTimeoutShort).Should(ContainSubstring("my-super-application"))
 			// Don't delete - we need it for next test execution
 		})
 
 		// We need to check also that the property (which is available in the IntegrationKit) is correctly replaced and we don't reuse the same kit
 		t.Run("Build time property updated", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/build-property-route.groovy", "--name", "build-property-route-updated",
-				"--build-property", "quarkus.application.name=my-super-application-updated").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "build-property-route-updated"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "build-property-route-updated", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "build-property-route-updated"), TestTimeoutShort).Should(ContainSubstring("my-super-application-updated"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/build-property-route.groovy", "--name", "build-property-route-updated", "--build-property", "quarkus.application.name=my-super-application-updated").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "build-property-route-updated"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "build-property-route-updated", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "build-property-route-updated"), TestTimeoutShort).Should(ContainSubstring("my-super-application-updated"))
 			// Verify the integration kits are different
-			g.Eventually(IntegrationKit(t, ns, "build-property-route-updated")).ShouldNot(Equal(IntegrationKit(t, ns, "build-property-route")()))
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Eventually(IntegrationKit(t, ctx, ns, "build-property-route-updated")).ShouldNot(Equal(IntegrationKit(t, ctx, ns, "build-property-route")()))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		// Build-Properties file
 		t.Run("Build time property file", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "file:./files/quarkus.properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "build-property-file-route"), TestTimeoutShort).Should(ContainSubstring("my-super-application"))
-			g.Expect(Kamel(t, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "file:./files/quarkus.properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "build-property-file-route"), TestTimeoutShort).Should(ContainSubstring("my-super-application"))
+			g.Expect(Kamel(t, ctx, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Build time property file with precedence", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "quarkus.application.name=my-overridden-application", "--build-property", "file:./files/quarkus.properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "build-property-file-route"), TestTimeoutMedium).Should(ContainSubstring("my-overridden-application"))
-			g.Expect(Kamel(t, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/build-property-file-route.groovy", "--name", "build-property-file-route-precedence", "--build-property", "quarkus.application.name=my-overridden-application", "--build-property", "file:./files/quarkus.properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "build-property-file-route-precedence"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "build-property-file-route-precedence", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "build-property-file-route-precedence"), TestTimeoutShort).Should(ContainSubstring("my-overridden-application"))
+			g.Expect(Kamel(t, ctx, "delete", "build-property-file-route-precedence", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Build time property from ConfigMap", func(t *testing.T) {
 			var cmData = make(map[string]string)
 			cmData["quarkus.application.name"] = "my-cool-application"
-			CreatePlainTextConfigmap(t, ns, "my-cm-test-build-property", cmData)
+			CreatePlainTextConfigmap(t, ctx, ns, "my-cm-test-build-property", cmData)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "configmap:my-cm-test-build-property").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "build-property-file-route"), TestTimeoutLong).Should(ContainSubstring("my-cool-application"))
-			g.Expect(Kamel(t, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "configmap:my-cm-test-build-property").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "build-property-file-route"), TestTimeoutShort).Should(ContainSubstring("my-cool-application"))
+			g.Expect(Kamel(t, ctx, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Build time property from ConfigMap as property file", func(t *testing.T) {
 			var cmData = make(map[string]string)
 			cmData["my.properties"] = "quarkus.application.name=my-super-cool-application"
-			CreatePlainTextConfigmap(t, ns, "my-cm-test-build-properties", cmData)
+			CreatePlainTextConfigmap(t, ctx, ns, "my-cm-test-build-properties", cmData)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "configmap:my-cm-test-build-properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "build-property-file-route"), TestTimeoutShort).Should(ContainSubstring("my-super-cool-application"))
-			g.Expect(Kamel(t, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
-
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/build-property-file-route.groovy", "--name", "build-property-file-route-cm", "--build-property", "configmap:my-cm-test-build-properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "build-property-file-route-cm"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "build-property-file-route-cm", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "build-property-file-route-cm"), TestTimeoutShort).Should(ContainSubstring("my-super-cool-application"))
+			g.Expect(Kamel(t, ctx, "delete", "build-property-file-route-cm", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Build time property from Secret", func(t *testing.T) {
 			var secData = make(map[string]string)
 			secData["quarkus.application.name"] = "my-great-application"
-			CreatePlainTextSecret(t, ns, "my-sec-test-build-property", secData)
+			CreatePlainTextSecret(t, ctx, ns, "my-sec-test-build-property", secData)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "secret:my-sec-test-build-property").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "build-property-file-route"), TestTimeoutShort).Should(ContainSubstring("my-great-application"))
-			g.Expect(Kamel(t, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
-
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "secret:my-sec-test-build-property").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "build-property-file-route"), TestTimeoutShort).Should(ContainSubstring("my-great-application"))
+			g.Expect(Kamel(t, ctx, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Build time property from Secret as property file", func(t *testing.T) {
 			var secData = make(map[string]string)
 			secData["my.properties"] = "quarkus.application.name=my-awsome-application"
-			CreatePlainTextSecret(t, ns, "my-sec-test-build-properties", secData)
+			CreatePlainTextSecret(t, ctx, ns, "my-sec-test-build-properties", secData)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "./files/build-property-file-route.groovy", "--build-property", "secret:my-sec-test-build-properties").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "build-property-file-route"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "build-property-file-route", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "build-property-file-route"), TestTimeoutShort).Should(ContainSubstring("my-awsome-application"))
-			g.Expect(Kamel(t, "delete", "build-property-file-route", "-n", ns).Execute()).To(Succeed())
-
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "./files/build-property-file-route.groovy", "--name", "build-property-file-route-secret", "--build-property", "secret:my-sec-test-build-properties").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "build-property-file-route-secret"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "build-property-file-route-secret", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "build-property-file-route-secret"), TestTimeoutShort).Should(ContainSubstring("my-awsome-application"))
+			g.Expect(Kamel(t, ctx, "delete", "build-property-file-route-secret", "-n", ns).Execute()).To(Succeed())
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/config/kamelet_config_test.go
+++ b/e2e/common/config/kamelet_config_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -38,102 +39,102 @@ import (
 func TestKameletImplicitConfigDefaultUserProperty(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-config-kamelet-user-property"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run test default config using properties", func(t *testing.T) {
 
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "iconfig01-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "iconfig01-timer-source")()).To(Succeed())
 
 			name := RandomizedSuffixName("iconfig-test-timer-source-int01")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/TimerKameletIntegrationConfiguration01.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/TimerKameletIntegrationConfiguration01.java",
 				"-p", "camel.kamelet.iconfig01-timer-source.message='Default message 01'",
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("Default message 01"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("Default message 01"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteKamelet(t, ns, "iconfig01-timer-source")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteKamelet(t, ctx, ns, "iconfig01-timer-source")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test default config using mounted secret", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "iconfig03-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "iconfig03-timer-source")()).To(Succeed())
 
 			name := RandomizedSuffixName("iconfig-test-timer-source-int3")
 			secretName := "my-iconfig-int3-secret"
 
 			var secData = make(map[string]string)
 			secData["camel.kamelet.iconfig03-timer-source.message"] = "very top mounted secret message"
-			g.Expect(CreatePlainTextSecret(t, ns, secretName, secData)).To(Succeed())
-			g.Eventually(SecretByName(t, ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
+			g.Expect(CreatePlainTextSecret(t, ctx, ns, secretName, secData)).To(Succeed())
+			g.Eventually(SecretByName(t, ctx, ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/TimerKameletIntegrationConfiguration03.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/TimerKameletIntegrationConfiguration03.java",
 				"-t", "mount.configs=secret:"+secretName,
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("very top mounted secret message"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("very top mounted secret message"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteSecret(t, ns, secretName)).To(Succeed())
-			g.Eventually(SecretByName(t, ns, secretName), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteKamelet(t, ns, "iconfig03-timer-source")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteSecret(t, ctx, ns, secretName)).To(Succeed())
+			g.Eventually(SecretByName(t, ctx, ns, secretName), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteKamelet(t, ctx, ns, "iconfig03-timer-source")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test default config using mounted configmap", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "iconfig04-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "iconfig04-timer-source")()).To(Succeed())
 
 			name := RandomizedSuffixName("iconfig-test-timer-source-int4")
 			cmName := "my-iconfig-int4-configmap"
 
 			var cmData = make(map[string]string)
 			cmData["camel.kamelet.iconfig04-timer-source.message"] = "very top mounted configmap message"
-			g.Expect(CreatePlainTextConfigmap(t, ns, cmName, cmData)).To(Succeed())
+			g.Expect(CreatePlainTextConfigmap(t, ctx, ns, cmName, cmData)).To(Succeed())
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/TimerKameletIntegrationConfiguration04.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/TimerKameletIntegrationConfiguration04.java",
 				"-t", "mount.configs=configmap:"+cmName,
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("very top mounted configmap message"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("very top mounted configmap message"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteConfigmap(t, ns, cmName)).To(Succeed())
-			g.Expect(DeleteKamelet(t, ns, "iconfig04-timer-source")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteConfigmap(t, ctx, ns, cmName)).To(Succeed())
+			g.Expect(DeleteKamelet(t, ctx, ns, "iconfig04-timer-source")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test named config using properties", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "iconfig05-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "iconfig05-timer-source")()).To(Succeed())
 
 			name := RandomizedSuffixName("iconfig-test-timer-source-int5")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration05.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration05.java",
 				"-p", "camel.kamelet.iconfig05-timer-source.message='Default message 05'",
 				"-p", "camel.kamelet.iconfig05-timer-source.mynamedconfig.message='My Named Config message'",
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("My Named Config message"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("My Named Config message"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteKamelet(t, ns, "iconfig05-timer-source")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteKamelet(t, ctx, ns, "iconfig05-timer-source")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test named config using labeled secret", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "iconfig06-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "iconfig06-timer-source")()).To(Succeed())
 
 			name := RandomizedSuffixName("iconfig-test-timer-source-int6")
 			secretName := "my-iconfig-int6-secret"
@@ -143,78 +144,78 @@ func TestKameletImplicitConfigDefaultUserProperty(t *testing.T) {
 			var labels = make(map[string]string)
 			labels["camel.apache.org/kamelet"] = "iconfig06-timer-source"
 			labels["camel.apache.org/kamelet.configuration"] = "mynamedconfig"
-			g.Expect(CreatePlainTextSecretWithLabels(t, ns, secretName, secData, labels)).To(Succeed())
-			g.Eventually(SecretByName(t, ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
+			g.Expect(CreatePlainTextSecretWithLabels(t, ctx, ns, secretName, secData, labels)).To(Succeed())
+			g.Eventually(SecretByName(t, ctx, ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration06.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration06.java",
 				"-p", "camel.kamelet.iconfig06-timer-source.message='Default message 06'",
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("very top named secret message"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("very top named secret message"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteSecret(t, ns, secretName)).To(Succeed())
-			g.Eventually(SecretByName(t, ns, secretName), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteKamelet(t, ns, "iconfig06-timer-source")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteSecret(t, ctx, ns, secretName)).To(Succeed())
+			g.Eventually(SecretByName(t, ctx, ns, secretName), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteKamelet(t, ctx, ns, "iconfig06-timer-source")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test named config using mounted secret", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "iconfig07-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "iconfig07-timer-source")()).To(Succeed())
 
 			name := RandomizedSuffixName("iconfig-test-timer-source-int7")
 			secretName := "my-iconfig-int7-secret"
 
 			var secData = make(map[string]string)
 			secData["camel.kamelet.iconfig07-timer-source.mynamedconfig.message"] = "very top named mounted secret message"
-			g.Expect(CreatePlainTextSecret(t, ns, secretName, secData)).To(Succeed())
-			g.Eventually(SecretByName(t, ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
+			g.Expect(CreatePlainTextSecret(t, ctx, ns, secretName, secData)).To(Succeed())
+			g.Eventually(SecretByName(t, ctx, ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration07.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration07.java",
 				"-p", "camel.kamelet.iconfig07-timer-source.message='Default message 07'",
 				"-t", "mount.configs=secret:"+secretName,
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("very top named mounted secret message"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("very top named mounted secret message"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteSecret(t, ns, secretName)).To(Succeed())
-			g.Eventually(SecretByName(t, ns, secretName), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteKamelet(t, ns, "iconfig07-timer-source")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteSecret(t, ctx, ns, secretName)).To(Succeed())
+			g.Eventually(SecretByName(t, ctx, ns, secretName), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteKamelet(t, ctx, ns, "iconfig07-timer-source")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test named config using mounted configmap", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "iconfig08-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "iconfig08-timer-source")()).To(Succeed())
 
 			name := RandomizedSuffixName("iconfig-test-timer-source-int8")
 			cmName := "my-iconfig-int8-configmap"
 
 			var cmData = make(map[string]string)
 			cmData["camel.kamelet.iconfig08-timer-source.mynamedconfig.message"] = "very top named mounted configmap message"
-			g.Expect(CreatePlainTextConfigmap(t, ns, cmName, cmData)).To(Succeed())
+			g.Expect(CreatePlainTextConfigmap(t, ctx, ns, cmName, cmData)).To(Succeed())
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration08.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/TimerKameletIntegrationNamedConfiguration08.java",
 				"-p", "camel.kamelet.iconfig08-timer-source.message='Default message 08'",
 				"-t", "mount.configs=configmap:"+cmName,
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("very top named mounted configmap message"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("very top named mounted configmap message"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteConfigmap(t, ns, cmName)).To(Succeed())
-			g.Expect(DeleteKamelet(t, ns, "iconfig08-timer-source")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteConfigmap(t, ctx, ns, cmName)).To(Succeed())
+			g.Expect(DeleteKamelet(t, ctx, ns, "iconfig08-timer-source")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test default config using labeled secret", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "iconfig09-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "iconfig09-timer-source")()).To(Succeed())
 
 			name := RandomizedSuffixName("iconfig-test-timer-source-int9")
 			secretName := "my-iconfig-int9-secret"
@@ -223,70 +224,70 @@ func TestKameletImplicitConfigDefaultUserProperty(t *testing.T) {
 			secData["camel.kamelet.iconfig09-timer-source.message"] = "very top labeled secret message"
 			var labels = make(map[string]string)
 			labels["camel.apache.org/kamelet"] = "iconfig09-timer-source"
-			g.Expect(CreatePlainTextSecretWithLabels(t, ns, secretName, secData, labels)).To(Succeed())
-			g.Eventually(SecretByName(t, ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
+			g.Expect(CreatePlainTextSecretWithLabels(t, ctx, ns, secretName, secData, labels)).To(Succeed())
+			g.Eventually(SecretByName(t, ctx, ns, secretName), TestTimeoutLong).Should(Not(BeNil()))
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/TimerKameletIntegrationConfiguration09.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/TimerKameletIntegrationConfiguration09.java",
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("very top labeled secret message"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("very top labeled secret message"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteSecret(t, ns, secretName)).To(Succeed())
-			g.Eventually(SecretByName(t, ns, secretName), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteKamelet(t, ns, "iconfig09-timer-source")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteSecret(t, ctx, ns, secretName)).To(Succeed())
+			g.Eventually(SecretByName(t, ctx, ns, secretName), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteKamelet(t, ctx, ns, "iconfig09-timer-source")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test default config inlined properties", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "config01-timer-source")()).To(Succeed())
-			g.Expect(CreateLogKamelet(t, operatorID, ns, "config01-log-sink")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "config01-timer-source")()).To(Succeed())
+			g.Expect(CreateLogKamelet(t, ctx, operatorID, ns, "config01-log-sink")()).To(Succeed())
 
 			name := RandomizedSuffixName("config-test-timer-source-int1")
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/timer-kamelet-integration-inlined-configuration-01.yaml",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/timer-kamelet-integration-inlined-configuration-01.yaml",
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("important message"))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("integrationLogger"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("important message"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("integrationLogger"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteKamelet(t, ns, "config01-timer-source")).To(Succeed())
-			g.Expect(DeleteKamelet(t, ns, "config01-log-sink")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteKamelet(t, ctx, ns, "config01-timer-source")).To(Succeed())
+			g.Expect(DeleteKamelet(t, ctx, ns, "config01-log-sink")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test default config parameters properties", func(t *testing.T) {
 
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "config02-timer-source")()).To(Succeed())
-			g.Expect(CreateLogKamelet(t, operatorID, ns, "config02-log-sink")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "config02-timer-source")()).To(Succeed())
+			g.Expect(CreateLogKamelet(t, ctx, operatorID, ns, "config02-log-sink")()).To(Succeed())
 
 			name := RandomizedSuffixName("config-test-timer-source-int2")
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/timer-kamelet-integration-parameters-configuration-02.yaml",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/timer-kamelet-integration-parameters-configuration-02.yaml",
 				"-p", "my-message='My parameter message 02'",
 				"-p", "my-logger='myIntegrationLogger02'",
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("My parameter message 02"))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("myIntegrationLogger02"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("My parameter message 02"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("myIntegrationLogger02"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteKamelet(t, ns, "config02-timer-source")).To(Succeed())
-			g.Expect(DeleteKamelet(t, ns, "config02-log-sink")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteKamelet(t, ctx, ns, "config02-timer-source")).To(Succeed())
+			g.Expect(DeleteKamelet(t, ctx, ns, "config02-log-sink")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test default config secret properties", func(t *testing.T) {
 
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "config03-timer-source")()).To(Succeed())
-			g.Expect(CreateLogKamelet(t, operatorID, ns, "config03-log-sink")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "config03-timer-source")()).To(Succeed())
+			g.Expect(CreateLogKamelet(t, ctx, operatorID, ns, "config03-log-sink")()).To(Succeed())
 
 			name := RandomizedSuffixName("config-test-timer-source-int3")
 			secretName := "my-config-int3-secret"
@@ -294,28 +295,28 @@ func TestKameletImplicitConfigDefaultUserProperty(t *testing.T) {
 			var secData = make(map[string]string)
 			secData["my-message"] = "My secret message 03"
 			secData["my-logger"] = "mySecretIntegrationLogger03"
-			g.Expect(CreatePlainTextSecret(t, ns, secretName, secData)).To(Succeed())
+			g.Expect(CreatePlainTextSecret(t, ctx, ns, secretName, secData)).To(Succeed())
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/timer-kamelet-integration-parameters-configuration-03.yaml",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/timer-kamelet-integration-parameters-configuration-03.yaml",
 				"-t", "mount.configs=secret:"+secretName,
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("My secret message 03"))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("mySecretIntegrationLogger03"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("My secret message 03"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("mySecretIntegrationLogger03"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteSecret(t, ns, secretName)).To(Succeed())
-			g.Expect(DeleteKamelet(t, ns, "config03-timer-source")).To(Succeed())
-			g.Expect(DeleteKamelet(t, ns, "config03-log-sink")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteSecret(t, ctx, ns, secretName)).To(Succeed())
+			g.Expect(DeleteKamelet(t, ctx, ns, "config03-timer-source")).To(Succeed())
+			g.Expect(DeleteKamelet(t, ctx, ns, "config03-log-sink")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("run test default config configmap properties", func(t *testing.T) {
 
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "config04-timer-source")()).To(Succeed())
-			g.Expect(CreateLogKamelet(t, operatorID, ns, "config04-log-sink")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "config04-timer-source")()).To(Succeed())
+			g.Expect(CreateLogKamelet(t, ctx, operatorID, ns, "config04-log-sink")()).To(Succeed())
 
 			name := RandomizedSuffixName("config-test-timer-source-int4")
 			cmName := "my-config-int4-configmap"
@@ -323,22 +324,22 @@ func TestKameletImplicitConfigDefaultUserProperty(t *testing.T) {
 			var cmData = make(map[string]string)
 			cmData["my-message"] = "My configmap message 04"
 			cmData["my-logger"] = "myConfigmapIntegrationLogger04"
-			g.Expect(CreatePlainTextConfigmap(t, ns, cmName, cmData)).To(Succeed())
+			g.Expect(CreatePlainTextConfigmap(t, ctx, ns, cmName, cmData)).To(Succeed())
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/timer-kamelet-integration-parameters-configuration-04.yaml",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/timer-kamelet-integration-parameters-configuration-04.yaml",
 				"-t", "mount.configs=configmap:"+cmName,
 				"--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("My configmap message 04"))
-			g.Eventually(IntegrationLogs(t, ns, name)).Should(ContainSubstring("myConfigmapIntegrationLogger04"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("My configmap message 04"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("myConfigmapIntegrationLogger04"))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
-			g.Expect(DeleteConfigmap(t, ns, cmName)).To(Succeed())
-			g.Expect(DeleteKamelet(t, ns, "config04-timer-source")).To(Succeed())
-			g.Expect(DeleteKamelet(t, ns, "config04-log-sink")).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(DeleteConfigmap(t, ctx, ns, cmName)).To(Succeed())
+			g.Expect(DeleteKamelet(t, ctx, ns, "config04-timer-source")).To(Succeed())
+			g.Expect(DeleteKamelet(t, ctx, ns, "config04-log-sink")).To(Succeed())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 	})

--- a/e2e/common/languages/groovy_test.go
+++ b/e2e/common/languages/groovy_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package languages
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,21 +37,21 @@ import (
 func TestRunSimpleGroovyExamples(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-runtimes-groovy"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run groovy", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/groovy.groovy").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "groovy"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "groovy", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "groovy"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/groovy.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "groovy"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "groovy", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "groovy"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/languages/java_test.go
+++ b/e2e/common/languages/java_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package languages
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,21 +37,21 @@ import (
 func TestRunSimpleJavaExamples(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-runtimes-java"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run java", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/languages/js_test.go
+++ b/e2e/common/languages/js_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package languages
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,21 +37,21 @@ import (
 func TestRunSimpleJavaScriptExamples(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-runtimes-js"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run js", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/js.js").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "js"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "js", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "js"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/js.js").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "js"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "js", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "js"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/languages/kotlin_test.go
+++ b/e2e/common/languages/kotlin_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package languages
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,21 +37,21 @@ import (
 func TestRunSimpleKotlinExamples(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-runtimes-kotlin"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run kotlin", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/kotlin.kts").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "kotlin"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "kotlin", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "kotlin"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/kotlin.kts").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "kotlin"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "kotlin", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "kotlin"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/languages/polyglot_test.go
+++ b/e2e/common/languages/polyglot_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package languages
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,22 +37,22 @@ import (
 func TestRunPolyglotExamples(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-runtimes-polyglot"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run polyglot", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "--name", "polyglot", "files/js-polyglot.js", "files/yaml-polyglot.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "polyglot"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "polyglot", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "polyglot"), TestTimeoutShort).Should(ContainSubstring("Magicpolyglot-yaml"))
-			g.Eventually(IntegrationLogs(t, ns, "polyglot"), TestTimeoutShort).Should(ContainSubstring("Magicpolyglot-js"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "--name", "polyglot", "files/js-polyglot.js", "files/yaml-polyglot.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "polyglot"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "polyglot", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "polyglot"), TestTimeoutShort).Should(ContainSubstring("Magicpolyglot-yaml"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "polyglot"), TestTimeoutShort).Should(ContainSubstring("Magicpolyglot-js"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/languages/xml_test.go
+++ b/e2e/common/languages/xml_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package languages
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,21 +37,21 @@ import (
 func TestRunSimpleXmlExamples(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-runtimes-xml"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run xml", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/xml.xml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "xml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "xml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "xml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/xml.xml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "xml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "xml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "xml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/languages/yaml_test.go
+++ b/e2e/common/languages/yaml_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package languages
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,21 +37,21 @@ import (
 func TestRunSimpleYamlExamples(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-runtimes-yaml"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run yaml", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/main_test.go
+++ b/e2e/common/main_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -48,18 +49,19 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Test setup failed! - %s\n", message)
 	})
 
+	ctx := context.TODO()
 	var t *testing.T
 
 	g.Expect(TestClient(t)).ShouldNot(BeNil())
-	g.Expect(KamelRunWithID(t, operatorID, ns, "languages/files/Java.java").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "languages/files/Java.java").Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	g.Eventually(IntegrationLogs(t, ctx, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-	g.Expect(KamelRunWithID(t, operatorID, ns, "languages/files/yaml.yaml").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "languages/files/yaml.yaml").Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	g.Eventually(IntegrationLogs(t, ctx, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 	os.Exit(m.Run())
 }

--- a/e2e/common/main_test.go
+++ b/e2e/common/main_test.go
@@ -41,26 +41,29 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
-	operatorID := platform.DefaultPlatformName
-	ns := GetEnvOrDefault("CAMEL_K_GLOBAL_OPERATOR_NS", TestDefaultNamespace)
+	fastSetup := GetEnvOrDefault("CAMEL_K_E2E_FAST_SETUP", "false")
+	if fastSetup == "true" {
+		operatorID := platform.DefaultPlatformName
+		ns := GetEnvOrDefault("CAMEL_K_GLOBAL_OPERATOR_NS", TestDefaultNamespace)
 
-	g := NewGomega(func(message string, callerSkip ...int) {
-		fmt.Printf("Test setup failed! - %s\n", message)
-	})
+		g := NewGomega(func(message string, callerSkip ...int) {
+			fmt.Printf("Test setup failed! - %s\n", message)
+		})
 
-	var t *testing.T
+		var t *testing.T
 
-	g.Expect(TestClient(t)).ShouldNot(BeNil())
-	ctx := TestContext()
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "languages/files/Java.java").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ctx, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		g.Expect(TestClient(t)).ShouldNot(BeNil())
+		ctx := TestContext()
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "languages/files/Java.java").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "java"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "languages/files/yaml.yaml").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ctx, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "languages/files/yaml.yaml").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+	}
 
 	os.Exit(m.Run())
 }

--- a/e2e/common/main_test.go
+++ b/e2e/common/main_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package common
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -49,10 +48,10 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Test setup failed! - %s\n", message)
 	})
 
-	ctx := context.TODO()
 	var t *testing.T
 
 	g.Expect(TestClient(t)).ShouldNot(BeNil())
+	ctx := TestContext()
 	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "languages/files/Java.java").Execute()).To(Succeed())
 	g.Eventually(IntegrationPodPhase(t, ctx, ns, "java"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "java", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))

--- a/e2e/common/misc/client_test.go
+++ b/e2e/common/misc/client_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,32 +42,31 @@ import (
 func TestClientFunctionalities(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		cfg, err := config.GetConfig()
 		require.NoError(t, err)
 		camel, err := versioned.NewForConfig(cfg)
 		require.NoError(t, err)
 
-		lst, err := camel.CamelV1().Integrations(ns).List(TestContext, metav1.ListOptions{})
+		lst, err := camel.CamelV1().Integrations(ns).List(ctx, metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Empty(t, lst.Items)
 
-		integration, err := camel.CamelV1().Integrations(ns).Create(TestContext, &v1.Integration{
+		integration, err := camel.CamelV1().Integrations(ns).Create(ctx, &v1.Integration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dummy",
 			},
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		lst, err = camel.CamelV1().Integrations(ns).List(TestContext, metav1.ListOptions{})
+		lst, err = camel.CamelV1().Integrations(ns).List(ctx, metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.NotEmpty(t, lst.Items)
 		assert.Equal(t, lst.Items[0].Name, integration.Name)
 
-		err = camel.CamelV1().Integrations(ns).Delete(TestContext, "dummy", metav1.DeleteOptions{})
+		err = camel.CamelV1().Integrations(ns).Delete(ctx, "dummy", metav1.DeleteOptions{})
 		require.NoError(t, err)
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/misc/cron_test.go
+++ b/e2e/common/misc/cron_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,49 +37,49 @@ import (
 func TestRunCronExample(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-cron"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("cron", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/cron.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationCronJob(t, ns, "cron"), TestTimeoutLong).ShouldNot(BeNil())
-			g.Eventually(IntegrationConditionStatus(t, ns, "cron", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "cron"), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/cron.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron"), TestTimeoutLong).ShouldNot(BeNil())
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "cron"), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
 		})
 
 		t.Run("cron-yaml", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/cron-yaml.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationCronJob(t, ns, "cron-yaml"), TestTimeoutLong).ShouldNot(BeNil())
-			g.Eventually(IntegrationConditionStatus(t, ns, "cron-yaml", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "cron-yaml"), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/cron-yaml.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-yaml"), TestTimeoutLong).ShouldNot(BeNil())
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-yaml", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-yaml"), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
 		})
 
 		t.Run("cron-timer", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/cron-timer.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationCronJob(t, ns, "cron-timer"), TestTimeoutLong).ShouldNot(BeNil())
-			g.Eventually(IntegrationConditionStatus(t, ns, "cron-timer", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "cron-timer"), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/cron-timer.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-timer"), TestTimeoutLong).ShouldNot(BeNil())
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-timer", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-timer"), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
 		})
 
 		t.Run("cron-fallback", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/cron-fallback.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "cron-fallback"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "cron-fallback", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "cron-fallback"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/cron-fallback.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-fallback"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-fallback", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-fallback"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 		})
 
 		t.Run("cron-quartz", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/cron-quartz.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "cron-quartz"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, "cron-quartz", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, "cron-quartz"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/cron-quartz.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-quartz"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-quartz", v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-quartz"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/misc/integration_fail_test.go
+++ b/e2e/common/misc/integration_fail_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -37,158 +38,157 @@ import (
 func TestBadRouteIntegration(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-bad-route"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run bad java route", func(t *testing.T) {
 			name := RandomizedSuffixName("bad-route")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/BadRoute.java", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPhase(t, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/BadRoute.java", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionFalse))
 
 			// Make sure the Integration can be scaled
-			g.Expect(ScaleIntegration(t, ns, name, 2)).To(Succeed())
+			g.Expect(ScaleIntegration(t, ctx, ns, name, 2)).To(Succeed())
 			// Check the scale cascades into the Deployment scale
-			g.Eventually(IntegrationPods(t, ns, name), TestTimeoutShort).Should(HaveLen(2))
+			g.Eventually(IntegrationPods(t, ctx, ns, name), TestTimeoutShort).Should(HaveLen(2))
 			// Check it also cascades into the Integration scale subresource Status field
-			g.Eventually(IntegrationStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 2)))
 			// Check the Integration stays in error phase
-			g.Eventually(IntegrationPhase(t, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
 
 			// Kit valid
-			kitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
-			g.Eventually(KitPhase(t, integrationKitNamespace, kitName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
+			kitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
+			g.Eventually(KitPhase(t, ctx, integrationKitNamespace, kitName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
 		})
 
 		t.Run("run missing dependency java route", func(t *testing.T) {
 			name := RandomizedSuffixName("java-route")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name,
 				"-d", "mvn:com.example:nonexistent:1.0").Execute()).To(Succeed())
 			// Integration in error
-			g.Eventually(IntegrationPhase(t, ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseError))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionKitAvailable), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
-			g.Eventually(IntegrationCondition(t, ns, name, v1.IntegrationConditionKitAvailable), TestTimeoutShort).Should(
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseError))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionKitAvailable), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
+			g.Eventually(IntegrationCondition(t, ctx, ns, name, v1.IntegrationConditionKitAvailable), TestTimeoutShort).Should(
 				WithTransform(IntegrationConditionReason, Equal(v1.IntegrationConditionKitAvailableReason)))
-			g.Eventually(IntegrationCondition(t, ns, name, v1.IntegrationConditionKitAvailable), TestTimeoutShort).Should(
+			g.Eventually(IntegrationCondition(t, ctx, ns, name, v1.IntegrationConditionKitAvailable), TestTimeoutShort).Should(
 				WithTransform(IntegrationConditionMessage, ContainSubstring("is in state \"Error\"")))
 			// Kit in error
-			kitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
-			g.Eventually(KitPhase(t, integrationKitNamespace, kitName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseError))
+			kitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
+			g.Eventually(KitPhase(t, ctx, integrationKitNamespace, kitName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseError))
 			//Build in error with 5 attempts
-			build := Build(t, integrationKitNamespace, kitName)()
+			build := Build(t, ctx, integrationKitNamespace, kitName)()
 			g.Eventually(build.Status.Phase, TestTimeoutShort).Should(Equal(v1.BuildPhaseError))
 			g.Eventually(build.Status.Failure.Recovery.Attempt, TestTimeoutShort).Should(Equal(5))
 
 			// Fixing the route should reconcile the Integration
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPhase(t, ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseRunning))
 			// New Kit success
-			kitRecoveryName := IntegrationKit(t, ns, name)()
-			integrationKitRecoveryNamespace := IntegrationKitNamespace(t, ns, name)()
-			g.Eventually(KitPhase(t, integrationKitRecoveryNamespace, kitRecoveryName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
+			kitRecoveryName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitRecoveryNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
+			g.Eventually(KitPhase(t, ctx, integrationKitRecoveryNamespace, kitRecoveryName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
 			g.Expect(kitRecoveryName).NotTo(Equal(kitName))
 			// New Build success
-			buildRecovery := Build(t, integrationKitRecoveryNamespace, kitRecoveryName)()
+			buildRecovery := Build(t, ctx, integrationKitRecoveryNamespace, kitRecoveryName)()
 			g.Eventually(buildRecovery.Status.Phase, TestTimeoutShort).Should(Equal(v1.BuildPhaseSucceeded))
 
 		})
 
 		t.Run("run invalid dependency java route", func(t *testing.T) {
 			name := RandomizedSuffixName("invalid-dependency")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
-				"-d", "camel:non-existent").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-d", "camel:non-existent").Execute()).To(Succeed())
 			// Integration in error with Initialization Failed condition
-			g.Eventually(IntegrationPhase(t, ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseError))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseError))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionFalse))
-			g.Eventually(IntegrationCondition(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(And(
+			g.Eventually(IntegrationCondition(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(And(
 				WithTransform(IntegrationConditionReason, Equal(v1.IntegrationConditionInitializationFailedReason)),
 				WithTransform(IntegrationConditionMessage, HavePrefix("error during trait customization")),
 			))
 			// Kit shouldn't be created
-			g.Consistently(IntegrationKit(t, ns, name), 10*time.Second).Should(BeEmpty())
+			g.Consistently(IntegrationKit(t, ctx, ns, name), 10*time.Second).Should(BeEmpty())
 
 			// Fixing the route should reconcile the Integration in Initialization Failed condition to Running
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 			// New Kit success
-			kitRecoveryName := IntegrationKit(t, ns, name)()
-			integrationKitRecoveryNamespace := IntegrationKitNamespace(t, ns, name)()
-			g.Eventually(KitPhase(t, integrationKitRecoveryNamespace, kitRecoveryName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
+			kitRecoveryName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitRecoveryNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
+			g.Eventually(KitPhase(t, ctx, integrationKitRecoveryNamespace, kitRecoveryName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
 			// New Build success
-			buildRecovery := Build(t, integrationKitRecoveryNamespace, kitRecoveryName)()
+			buildRecovery := Build(t, ctx, integrationKitRecoveryNamespace, kitRecoveryName)()
 			g.Eventually(buildRecovery.Status.Phase, TestTimeoutShort).Should(Equal(v1.BuildPhaseSucceeded))
 		})
 
 		t.Run("run unresolvable component java route", func(t *testing.T) {
 			name := RandomizedSuffixName("unresolvable-route")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Unresolvable.java", "--name", name).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Unresolvable.java", "--name", name).Execute()).To(Succeed())
 			// Integration in error with Initialization Failed condition
-			g.Eventually(IntegrationPhase(t, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionFalse))
-			g.Eventually(IntegrationCondition(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(And(
+			g.Eventually(IntegrationCondition(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(And(
 				WithTransform(IntegrationConditionReason, Equal(v1.IntegrationConditionInitializationFailedReason)),
 				WithTransform(IntegrationConditionMessage, HavePrefix("error during trait customization")),
 			))
 			// Kit shouldn't be created
-			g.Consistently(IntegrationKit(t, ns, name), 10*time.Second).Should(BeEmpty())
+			g.Consistently(IntegrationKit(t, ctx, ns, name), 10*time.Second).Should(BeEmpty())
 
 			// Fixing the route should reconcile the Integration in Initialization Failed condition to Running
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 			// New Kit success
-			kitRecoveryName := IntegrationKit(t, ns, name)()
-			integrationKitRecoveryNamespace := IntegrationKitNamespace(t, ns, name)()
-			g.Eventually(KitPhase(t, integrationKitRecoveryNamespace, kitRecoveryName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
+			kitRecoveryName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitRecoveryNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
+			g.Eventually(KitPhase(t, ctx, integrationKitRecoveryNamespace, kitRecoveryName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
 			// New Build success
-			buildRecovery := Build(t, integrationKitRecoveryNamespace, kitRecoveryName)()
+			buildRecovery := Build(t, ctx, integrationKitRecoveryNamespace, kitRecoveryName)()
 			g.Eventually(buildRecovery.Status.Phase, TestTimeoutShort).Should(Equal(v1.BuildPhaseSucceeded))
 		})
 
 		t.Run("run invalid java route", func(t *testing.T) {
 			name := RandomizedSuffixName("invalid-java-route")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/InvalidJava.java", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPhase(t, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/InvalidJava.java", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseError))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionFalse))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Compilation error"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Compilation error"))
 
 			// Kit valid
-			kitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
-			g.Eventually(KitPhase(t, integrationKitNamespace, kitName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
+			kitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
+			g.Eventually(KitPhase(t, ctx, integrationKitNamespace, kitName), TestTimeoutShort).Should(Equal(v1.IntegrationKitPhaseReady))
 
 			// Fixing the route should reconcile the Integration in Initialization Failed condition to Running
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 			// Kit should not have changed
-			kitRecoveryName := IntegrationKit(t, ns, name)()
+			kitRecoveryName := IntegrationKit(t, ctx, ns, name)()
 			g.Expect(kitRecoveryName).To(Equal(kitName))
 
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/misc/integration_trait_update_test.go
+++ b/e2e/common/misc/integration_trait_update_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,27 +37,27 @@ import (
 func TestTraitUpdates(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-trait-update"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("run and update trait", func(t *testing.T) {
 			name := RandomizedSuffixName("yaml-route")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 			var numberOfPods = func(pods *int32) bool {
 				return *pods >= 1 && *pods <= 2
 			}
 			// Adding a property will change the camel trait
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml", "--name", name, "-p", "hello=world").Execute()).To(Succeed())
-			g.Consistently(IntegrationPodsNumbers(t, ns, name), TestTimeoutShort, 1*time.Second).Should(Satisfy(numberOfPods))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml", "--name", name, "-p", "hello=world").Execute()).To(Succeed())
+			g.Consistently(IntegrationPodsNumbers(t, ctx, ns, name), TestTimeoutShort, 1*time.Second).Should(Satisfy(numberOfPods))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/misc/maven_repository_test.go
+++ b/e2e/common/misc/maven_repository_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,29 +37,25 @@ import (
 func TestRunExtraRepository(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-extra-repository"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		name := RandomizedSuffixName("java")
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-			"--maven-repository", "https://maven.repository.redhat.com/ga@id=redhat",
-			"--dependency", "mvn:org.jolokia:jolokia-core:1.7.1.redhat-00001",
-			"--name", name,
-		).Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--maven-repository", "https://maven.repository.redhat.com/ga@id=redhat", "--dependency", "mvn:org.jolokia:jolokia-core:1.7.1.redhat-00001", "--name", name).Execute()).To(Succeed())
 
-		g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-		g.Eventually(Integration(t, ns, name)).Should(WithTransform(IntegrationSpec, And(
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		g.Eventually(Integration(t, ctx, ns, name)).Should(WithTransform(IntegrationSpec, And(
 			HaveExistingField("Repositories"),
 			HaveField("Repositories", ContainElements("https://maven.repository.redhat.com/ga@id=redhat")),
 		)))
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/misc/pipe_test.go
+++ b/e2e/common/misc/pipe_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -37,75 +38,66 @@ import (
 func TestPipe(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-pipe"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		// Error Handler testing
 		t.Run("test error handler", func(t *testing.T) {
-			g.Expect(createErrorProducerKamelet(t, operatorID, ns, "my-own-error-producer-source")()).To(Succeed())
-			g.Expect(CreateLogKamelet(t, operatorID, ns, "my-own-log-sink")()).To(Succeed())
+			g.Expect(createErrorProducerKamelet(t, ctx, operatorID, ns, "my-own-error-producer-source")()).To(Succeed())
+			g.Expect(CreateLogKamelet(t, ctx, operatorID, ns, "my-own-log-sink")()).To(Succeed())
 
 			t.Run("throw error test", func(t *testing.T) {
-				g.Expect(KamelBindWithID(t, operatorID, ns,
-					"my-own-error-producer-source",
-					"my-own-log-sink",
+				g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "my-own-error-producer-source", "my-own-log-sink",
 					"--error-handler", "sink:my-own-log-sink",
 					"-p", "source.message=throw Error",
 					"-p", "sink.loggerName=integrationLogger",
 					"-p", "error-handler.loggerName=kameletErrorHandler",
 					// Needed in the test to make sure to do the right string comparison later
 					"-t", "logging.color=false",
-					"--name", "throw-error-binding",
-				).Execute()).To(Succeed())
+					"--name", "throw-error-binding").Execute()).To(Succeed())
 
-				g.Eventually(IntegrationPodPhase(t, ns, "throw-error-binding"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationLogs(t, ns, "throw-error-binding"), TestTimeoutShort).Should(ContainSubstring("[kameletErrorHandler] (Camel (camel-1) thread #1 - timer://tick)"))
-				g.Eventually(IntegrationLogs(t, ns, "throw-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("[integrationLogger] (Camel (camel-1) thread #1 - timer://tick)"))
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, "throw-error-binding"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationLogs(t, ctx, ns, "throw-error-binding"), TestTimeoutShort).Should(ContainSubstring("[kameletErrorHandler] (Camel (camel-1) thread #1 - timer://tick)"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, "throw-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("[integrationLogger] (Camel (camel-1) thread #1 - timer://tick)"))
 
 			})
 
 			t.Run("don't throw error test", func(t *testing.T) {
-				g.Expect(KamelBindWithID(t, operatorID, ns,
-					"my-own-error-producer-source",
-					"my-own-log-sink",
+				g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "my-own-error-producer-source", "my-own-log-sink",
 					"--error-handler", "sink:my-own-log-sink",
 					"-p", "source.message=true",
 					"-p", "sink.loggerName=integrationLogger",
 					"-p", "error-handler.loggerName=kameletErrorHandler",
 					// Needed in the test to make sure to do the right string comparison later
 					"-t", "logging.color=false",
-					"--name", "no-error-binding",
-				).Execute()).To(Succeed())
+					"--name", "no-error-binding").Execute()).To(Succeed())
 
-				g.Eventually(IntegrationPodPhase(t, ns, "no-error-binding"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationLogs(t, ns, "no-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("[kameletErrorHandler] (Camel (camel-1) thread #1 - timer://tick)"))
-				g.Eventually(IntegrationLogs(t, ns, "no-error-binding"), TestTimeoutShort).Should(ContainSubstring("[integrationLogger] (Camel (camel-1) thread #1 - timer://tick)"))
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, "no-error-binding"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationLogs(t, ctx, ns, "no-error-binding"), TestTimeoutShort).ShouldNot(ContainSubstring("[kameletErrorHandler] (Camel (camel-1) thread #1 - timer://tick)"))
+				g.Eventually(IntegrationLogs(t, ctx, ns, "no-error-binding"), TestTimeoutShort).Should(ContainSubstring("[integrationLogger] (Camel (camel-1) thread #1 - timer://tick)"))
 
 			})
 		})
 
 		//Pipe with traits testing
 		t.Run("test Pipe with trait", func(t *testing.T) {
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "my-own-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "my-own-timer-source")()).To(Succeed())
 			// Log sink kamelet exists from previous test
 
-			g.Expect(KamelBindWithID(t, operatorID, ns,
-				"my-own-timer-source",
-				"my-own-log-sink",
+			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "my-own-timer-source", "my-own-log-sink",
 				"-p", "source.message=hello from test",
 				"-p", "sink.loggerName=integrationLogger",
 				"--annotation", "trait.camel.apache.org/camel.properties=[\"camel.prop1=a\",\"camel.prop2=b\"]",
-				"--name", "kb-with-traits",
-			).Execute()).To(Succeed())
+				"--name", "kb-with-traits").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, "kb-with-traits"), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, "kb-with-traits"), TestTimeoutShort).Should(ContainSubstring("hello from test"))
-			g.Eventually(IntegrationLogs(t, ns, "kb-with-traits"), TestTimeoutShort).Should(ContainSubstring("integrationLogger"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "kb-with-traits"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "kb-with-traits"), TestTimeoutShort).Should(ContainSubstring("hello from test"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "kb-with-traits"), TestTimeoutShort).Should(ContainSubstring("integrationLogger"))
 		})
 
 		// Pipe with wrong spec
@@ -113,22 +105,22 @@ func TestPipe(t *testing.T) {
 			name := RandomizedSuffixName("bad-klb")
 			kb := v1.NewPipe(ns, name)
 			kb.Spec = v1.PipeSpec{}
-			_, err := kubernetes.ReplaceResource(TestContext, TestClient(t), &kb)
+			_, err := kubernetes.ReplaceResource(ctx, TestClient(t), &kb)
 			g.Eventually(err).Should(BeNil())
-			g.Eventually(PipePhase(t, ns, name), TestTimeoutShort).Should(Equal(v1.PipePhaseError))
-			g.Eventually(PipeConditionStatus(t, ns, name, v1.PipeConditionReady), TestTimeoutShort).ShouldNot(Equal(corev1.ConditionTrue))
-			g.Eventually(PipeCondition(t, ns, name, v1.PipeIntegrationConditionError), TestTimeoutShort).Should(
+			g.Eventually(PipePhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(v1.PipePhaseError))
+			g.Eventually(PipeConditionStatus(t, ctx, ns, name, v1.PipeConditionReady), TestTimeoutShort).ShouldNot(Equal(corev1.ConditionTrue))
+			g.Eventually(PipeCondition(t, ctx, ns, name, v1.PipeIntegrationConditionError), TestTimeoutShort).Should(
 				WithTransform(PipeConditionMessage, And(
 					ContainSubstring("could not determine source URI"),
 					ContainSubstring("no ref or URI specified in endpoint"),
 				)))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }
 
-func createErrorProducerKamelet(t *testing.T, operatorID string, ns string, name string) func() error {
+func createErrorProducerKamelet(t *testing.T, ctx context.Context, operatorID string, ns string, name string) func() error {
 	props := map[string]v1.JSONSchemaProp{
 		"message": {
 			Type: "string",
@@ -156,5 +148,5 @@ func createErrorProducerKamelet(t *testing.T, operatorID string, ns string, name
 		},
 	}
 
-	return CreateKamelet(t, operatorID, ns, name, flow, props, nil)
+	return CreateKamelet(t, operatorID, ctx, ns, name, flow, props, nil)
 }

--- a/e2e/common/misc/registry_maven_wagon_test.go
+++ b/e2e/common/misc/registry_maven_wagon_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -47,13 +48,13 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 		return
 	}
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-registry-maven-repo"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("image registry is a maven repository", func(t *testing.T) {
 			// Create integration that should decrypt an encrypted message to "foobar" and log it
@@ -63,59 +64,55 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 			pom, err := filepath.Abs("files/registry/sample-decryption-1.0.pom")
 			require.NoError(t, err)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/registry/FoobarDecryption.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/registry/FoobarDecryption.java",
 				"--name", name,
 				"-d", fmt.Sprintf("file://%s", jar),
-				"-d", fmt.Sprintf("file://%s", pom),
-			).Execute()).To(Succeed())
+				"-d", fmt.Sprintf("file://%s", pom)).Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("foobar"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("foobar"))
 		})
 
 		t.Run("local files are mounted in the integration container at the default path", func(t *testing.T) {
 			name := RandomizedSuffixName("laughing-route-default-path")
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/registry/LaughingRoute.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/registry/LaughingRoute.java",
 				"--name", name,
 				"-p", "location=/deployments/?filename=laugh.txt",
-				"-d", "file://files/registry/laugh.txt",
-			).Execute()).To(Succeed())
+				"-d", "file://files/registry/laugh.txt").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("haha"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("haha"))
 		})
 
 		t.Run("local files are mounted in the integration container at a custom path", func(t *testing.T) {
 			name := RandomizedSuffixName("laughing-route-custom-path")
 			customPath := "this/is/a/custom/path/"
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/registry/LaughingRoute.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/registry/LaughingRoute.java",
 				"--name", name,
 				"-p", fmt.Sprintf("location=%s", customPath),
-				"-d", fmt.Sprintf("file://files/registry/laugh.txt?targetPath=%slaugh.txt", customPath),
-			).Execute()).To(Succeed())
+				"-d", fmt.Sprintf("file://files/registry/laugh.txt?targetPath=%slaugh.txt", customPath)).Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("haha"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("haha"))
 		})
 
 		t.Run("local directory is mounted in the integration container", func(t *testing.T) {
 			name := RandomizedSuffixName("laughing-route-directory")
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/registry/LaughingRoute.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/registry/LaughingRoute.java",
 				"--name", name,
 				"-p", "location=files/registry/",
-				"-d", fmt.Sprintf("file://files/registry/laughs/?targetPath=files/registry/"),
-			).Execute()).To(Succeed())
+				"-d", fmt.Sprintf("file://files/registry/laughs/?targetPath=files/registry/")).Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("haha"))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("hehe"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("haha"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("hehe"))
 		})
 
 		t.Run("pom file is extracted from JAR", func(t *testing.T) {
@@ -124,29 +121,28 @@ func TestImageRegistryIsAMavenRepository(t *testing.T) {
 			jar, err := filepath.Abs("files/registry/sample-decryption-1.0.jar")
 			require.NoError(t, err)
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/registry/FoobarDecryption.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/registry/FoobarDecryption.java",
 				"--name", name,
-				"-d", fmt.Sprintf("file://%s", jar),
-			).Execute()).To(Succeed())
+				"-d", fmt.Sprintf("file://%s", jar)).Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("foobar"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("foobar"))
 		})
 
 		t.Run("dependency can be used at build time", func(t *testing.T) {
 			// Create integration that should run a Xslt transformation whose template needs to be present at build time
 			name := RandomizedSuffixName("xslt")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/registry/classpath/Xslt.java", "--name", name,
-				"-d", "file://files/registry/classpath/cheese.xsl?targetPath=xslt/cheese.xsl&classpath=true",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/registry/classpath/Xslt.java",
+				"--name", name,
+				"-d", "file://files/registry/classpath/cheese.xsl?targetPath=xslt/cheese.xsl&classpath=true").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("<cheese><item>A</item></cheese>"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("<cheese><item>A</item></cheese>"))
 		})
 
 		// Clean up
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/misc/scale_binding_test.go
+++ b/e2e/common/misc/scale_binding_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -42,13 +43,13 @@ import (
 func TestPipeScale(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-pipe-scale"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithIDAndKameletCatalog(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithIDAndKameletCatalog(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		ocp, err := openshift.IsOpenShift(TestClient(t))
 		require.NoError(t, err)
@@ -58,26 +59,26 @@ func TestPipeScale(t *testing.T) {
 		}
 
 		name := RandomizedSuffixName("timer2log")
-		g.Expect(KamelBindWithID(t, operatorID, ns, "timer-source?message=HelloPipe", "log-sink", "--name", name).Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		g.Eventually(PipeConditionStatus(t, ns, name, v1.PipeConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("HelloPipe"))
+		g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "timer-source?message=HelloPipe", "log-sink", "--name", name).Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(PipeConditionStatus(t, ctx, ns, name, v1.PipeConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("HelloPipe"))
 
 		t.Run("Update Pipe scale spec", func(t *testing.T) {
-			g.Expect(ScalePipe(t, ns, name, 3)).To(Succeed())
+			g.Expect(ScalePipe(t, ctx, ns, name, 3)).To(Succeed())
 			// Check the scale cascades into the Deployment scale
-			g.Eventually(IntegrationPods(t, ns, name), TestTimeoutShort).Should(HaveLen(3))
+			g.Eventually(IntegrationPods(t, ctx, ns, name), TestTimeoutShort).Should(HaveLen(3))
 			// Check it also cascades into the Integration scale subresource Status field
-			g.Eventually(IntegrationStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 3)))
 			// Check it also cascades into the Pipe scale subresource Status field
-			g.Eventually(PipeStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(PipeStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 3)))
 			// Check the readiness condition becomes truthy back
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 			// Finally check the readiness condition becomes truthy back onPipe
-			g.Eventually(PipeConditionStatus(t, ns, name, v1.PipeConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(PipeConditionStatus(t, ctx, ns, name, v1.PipeConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 		})
 
 		t.Run("ScalePipe with polymorphic client", func(t *testing.T) {
@@ -86,21 +87,21 @@ func TestPipeScale(t *testing.T) {
 
 			// Patch the integration scale subresource
 			patch := "{\"spec\":{\"replicas\":2}}"
-			_, err = scaleClient.Scales(ns).Patch(TestContext, v1.SchemeGroupVersion.WithResource("Pipes"), name, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
+			_, err = scaleClient.Scales(ns).Patch(ctx, v1.SchemeGroupVersion.WithResource("Pipes"), name, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
 			g.Expect(err).To(BeNil())
 
 			// Check the readiness condition is still truthy as down-scaling
-			g.Expect(PipeConditionStatus(t, ns, name, v1.PipeConditionReady)()).To(Equal(corev1.ConditionTrue))
+			g.Expect(PipeConditionStatus(t, ctx, ns, name, v1.PipeConditionReady)()).To(Equal(corev1.ConditionTrue))
 			// Check the Integration scale subresource Spec field
-			g.Eventually(IntegrationSpecReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationSpecReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 2)))
 			// Then check it cascades into the Deployment scale
-			g.Eventually(IntegrationPods(t, ns, name), TestTimeoutShort).Should(HaveLen(2))
+			g.Eventually(IntegrationPods(t, ctx, ns, name), TestTimeoutShort).Should(HaveLen(2))
 			// Check it cascades into the Integration scale subresource Status field
-			g.Eventually(IntegrationStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 2)))
 			// Finally check it cascades into the Pipe scale subresource Status field
-			g.Eventually(PipeStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(PipeStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 2)))
 		})
 
@@ -109,33 +110,33 @@ func TestPipeScale(t *testing.T) {
 			g.Expect(err).To(BeNil())
 
 			// Getter
-			PipeScale, err := camel.CamelV1().Pipes(ns).GetScale(TestContext, name, metav1.GetOptions{})
+			PipeScale, err := camel.CamelV1().Pipes(ns).GetScale(ctx, name, metav1.GetOptions{})
 			g.Expect(err).To(BeNil())
 			g.Expect(PipeScale.Spec.Replicas).To(BeNumerically("==", 2))
 			g.Expect(PipeScale.Status.Replicas).To(BeNumerically("==", 2))
 
 			// Setter
 			PipeScale.Spec.Replicas = 1
-			_, err = camel.CamelV1().Pipes(ns).UpdateScale(TestContext, name, PipeScale, metav1.UpdateOptions{})
+			_, err = camel.CamelV1().Pipes(ns).UpdateScale(ctx, name, PipeScale, metav1.UpdateOptions{})
 			g.Expect(err).To(BeNil())
 
 			// Check the readiness condition is still truthy as down-scaling inPipe
-			g.Expect(PipeConditionStatus(t, ns, name, v1.PipeConditionReady)()).To(Equal(corev1.ConditionTrue))
+			g.Expect(PipeConditionStatus(t, ctx, ns, name, v1.PipeConditionReady)()).To(Equal(corev1.ConditionTrue))
 			// Check the Pipe scale subresource Spec field
-			g.Eventually(PipeSpecReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(PipeSpecReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 1)))
 			// Check the readiness condition is still truthy as down-scaling
-			g.Expect(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady)()).To(Equal(corev1.ConditionTrue))
+			g.Expect(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady)()).To(Equal(corev1.ConditionTrue))
 			// Check the Integration scale subresource Spec field
-			g.Eventually(IntegrationSpecReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationSpecReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 1)))
 			// Then check it cascades into the Deployment scale
-			g.Eventually(IntegrationPods(t, ns, name), TestTimeoutShort).Should(HaveLen(1))
+			g.Eventually(IntegrationPods(t, ctx, ns, name), TestTimeoutShort).Should(HaveLen(1))
 			// Finally check it cascades into the Integration scale subresource Status field
-			g.Eventually(IntegrationStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 1)))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/misc/scale_integration_test.go
+++ b/e2e/common/misc/scale_integration_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package misc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -41,31 +42,31 @@ import (
 func TestIntegrationScale(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-integration-scale"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		name := RandomizedSuffixName("java")
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-		g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 		t.Run("Update integration scale spec", func(t *testing.T) {
-			g.Expect(ScaleIntegration(t, ns, name, 3)).To(Succeed())
+			g.Expect(ScaleIntegration(t, ctx, ns, name, 3)).To(Succeed())
 			// Check the readiness condition becomes falsy
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
 			// Check the scale cascades into the Deployment scale
-			g.Eventually(IntegrationPods(t, ns, name), TestTimeoutShort).Should(HaveLen(3))
+			g.Eventually(IntegrationPods(t, ctx, ns, name), TestTimeoutShort).Should(HaveLen(3))
 			// Check it also cascades into the Integration scale subresource Status field
-			g.Eventually(IntegrationStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 3)))
 			// Finally check the readiness condition becomes truthy back
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 		})
 
 		t.Run("Scale integration with polymorphic client", func(t *testing.T) {
@@ -74,18 +75,18 @@ func TestIntegrationScale(t *testing.T) {
 
 			// Patch the integration scale subresource
 			patch := "{\"spec\":{\"replicas\":2}}"
-			_, err = scaleClient.Scales(ns).Patch(TestContext, v1.SchemeGroupVersion.WithResource("integrations"), name, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
+			_, err = scaleClient.Scales(ns).Patch(ctx, v1.SchemeGroupVersion.WithResource("integrations"), name, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
 			g.Expect(err).To(BeNil())
 
 			// Check the readiness condition is still truthy as down-scaling
-			g.Expect(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady)()).To(Equal(corev1.ConditionTrue))
+			g.Expect(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady)()).To(Equal(corev1.ConditionTrue))
 			// Check the Integration scale subresource Spec field
-			g.Eventually(IntegrationSpecReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationSpecReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 2)))
 			// Then check it cascades into the Deployment scale
-			g.Eventually(IntegrationPods(t, ns, name), TestTimeoutShort).Should(HaveLen(2))
+			g.Eventually(IntegrationPods(t, ctx, ns, name), TestTimeoutShort).Should(HaveLen(2))
 			// Finally check it cascades into the Integration scale subresource Status field
-			g.Eventually(IntegrationStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 2)))
 		})
 
@@ -94,46 +95,46 @@ func TestIntegrationScale(t *testing.T) {
 			g.Expect(err).To(BeNil())
 
 			// Getter
-			integrationScale, err := camel.CamelV1().Integrations(ns).GetScale(TestContext, name, metav1.GetOptions{})
+			integrationScale, err := camel.CamelV1().Integrations(ns).GetScale(ctx, name, metav1.GetOptions{})
 			g.Expect(err).To(BeNil())
 			g.Expect(integrationScale.Spec.Replicas).To(BeNumerically("==", 2))
 			g.Expect(integrationScale.Status.Replicas).To(BeNumerically("==", 2))
 
 			// Setter
 			integrationScale.Spec.Replicas = 1
-			integrationScale, err = camel.CamelV1().Integrations(ns).UpdateScale(TestContext, name, integrationScale, metav1.UpdateOptions{})
+			integrationScale, err = camel.CamelV1().Integrations(ns).UpdateScale(ctx, name, integrationScale, metav1.UpdateOptions{})
 			g.Expect(err).To(BeNil())
 
 			// Check the readiness condition is still truthy as down-scaling
-			g.Expect(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady)()).To(Equal(corev1.ConditionTrue))
+			g.Expect(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady)()).To(Equal(corev1.ConditionTrue))
 			// Check the Integration scale subresource Spec field
-			g.Eventually(IntegrationSpecReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationSpecReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 1)))
 			// Then check it cascades into the Deployment scale
-			g.Eventually(IntegrationPods(t, ns, name), TestTimeoutShort).Should(HaveLen(1))
+			g.Eventually(IntegrationPods(t, ctx, ns, name), TestTimeoutShort).Should(HaveLen(1))
 			// Finally check it cascades into the Integration scale subresource Status field
-			g.Eventually(IntegrationStatusReplicas(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, name), TestTimeoutShort).
 				Should(gstruct.PointTo(BeNumerically("==", 1)))
 		})
 
 		t.Run("Scale integration with external image", func(t *testing.T) {
-			image := IntegrationPodImage(t, ns, name)()
+			image := IntegrationPodImage(t, ctx, ns, name)()
 			g.Expect(image).NotTo(BeEmpty())
 			// Save resources by deleting the integration
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", "pre-built", "-t", fmt.Sprintf("container.image=%s", image)).Execute()).To(Succeed())
-			g.Eventually(IntegrationPhase(t, ns, "pre-built"), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
-			g.Eventually(IntegrationPodPhase(t, ns, "pre-built"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Expect(ScaleIntegration(t, ns, "pre-built", 0)).To(Succeed())
-			g.Eventually(IntegrationPod(t, ns, "pre-built"), TestTimeoutMedium).Should(BeNil())
-			g.Expect(ScaleIntegration(t, ns, "pre-built", 1)).To(Succeed())
-			g.Eventually(IntegrationPhase(t, ns, "pre-built"), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
-			g.Eventually(IntegrationPodPhase(t, ns, "pre-built"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", "pre-built", "-t", fmt.Sprintf("container.image=%s", image)).Execute()).To(Succeed())
+			g.Eventually(IntegrationPhase(t, ctx, ns, "pre-built"), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "pre-built"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(ScaleIntegration(t, ctx, ns, "pre-built", 0)).To(Succeed())
+			g.Eventually(IntegrationPod(t, ctx, ns, "pre-built"), TestTimeoutMedium).Should(BeNil())
+			g.Expect(ScaleIntegration(t, ctx, ns, "pre-built", 1)).To(Succeed())
+			g.Eventually(IntegrationPhase(t, ctx, ns, "pre-built"), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "pre-built"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
-			g.Expect(Kamel(t, "delete", "pre-built", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "pre-built", "-n", ns).Execute()).To(Succeed())
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/traits/builder_test.go
+++ b/e2e/common/traits/builder_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -38,99 +39,96 @@ import (
 func TestBuilderTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-builder"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("Run build strategy routine", func(t *testing.T) {
 			name := RandomizedSuffixName("java")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-				"-t", "builder.order-strategy=sequential",
-				"-t", "builder.strategy=routine").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "builder.order-strategy=sequential", "-t", "builder.strategy=routine").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			integrationKitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
+			integrationKitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
 			builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyRoutine))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategySequential))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyRoutine))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategySequential))
 			// Default resource CPU Check
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal(""))
 
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName), TestTimeoutShort).Should(BeNil())
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName), TestTimeoutShort).Should(BeNil())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Run build order strategy dependencies", func(t *testing.T) {
 			name := RandomizedSuffixName("java-dependencies-strategy")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java",
 				"--name", name,
 				// This is required in order to avoid reusing a Kit already existing (which is the default behavior)
 				"--build-property", "strategy=dependencies",
 				"-t", "builder.order-strategy=dependencies").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			integrationKitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
+			integrationKitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
 			builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyRoutine))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategyDependencies))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyRoutine))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategyDependencies))
 			// Default resource CPU Check
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName), TestTimeoutShort).Should(BeNil())
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName), TestTimeoutShort).Should(BeNil())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Run build order strategy fifo", func(t *testing.T) {
 			name := RandomizedSuffixName("java-fifo-strategy")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java",
 				"--name", name,
 				// This is required in order to avoid reusing a Kit already existing (which is the default behavior)
 				"--build-property", "strategy=fifo",
 				"-t", "builder.order-strategy=fifo").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			integrationKitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
+			integrationKitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
 			builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyRoutine))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategyFIFO))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyRoutine))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategyFIFO))
 			// Default resource CPU Check
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal(""))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal(""))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal(""))
 
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName), TestTimeoutShort).Should(BeNil())
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName), TestTimeoutShort).Should(BeNil())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Run build resources configuration", func(t *testing.T) {
 			name := RandomizedSuffixName("java-resource-config")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java",
 				"--name", name,
 				// This is required in order to avoid reusing a Kit already existing (which is the default behavior)
 				"--build-property", "resources=new-build",
@@ -141,147 +139,132 @@ func TestBuilderTrait(t *testing.T) {
 				"-t", "builder.strategy=pod",
 			).Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			integrationKitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
+			integrationKitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
 			builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
 
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyPod))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategySequential))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal("500m"))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal("1000m"))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal("2Gi"))
-			g.Eventually(BuildConfig(t, integrationKitNamespace, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal("3Gi"))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().Strategy, TestTimeoutShort).Should(Equal(v1.BuildStrategyPod))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().OrderStrategy, TestTimeoutShort).Should(Equal(v1.BuildOrderStrategySequential))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().RequestCPU, TestTimeoutShort).Should(Equal("500m"))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().LimitCPU, TestTimeoutShort).Should(Equal("1000m"))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().RequestMemory, TestTimeoutShort).Should(Equal("2Gi"))
+			g.Eventually(BuildConfig(t, ctx, integrationKitNamespace, integrationKitName)().LimitMemory, TestTimeoutShort).Should(Equal("3Gi"))
 
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName), TestTimeoutShort).ShouldNot(BeNil())
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName), TestTimeoutShort).ShouldNot(BeNil())
 			// Let's assert we set the resources on the builder container
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Name, TestTimeoutShort).Should(Equal("builder"))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Resources.Requests.Cpu().String(), TestTimeoutShort).Should(Equal("500m"))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Resources.Limits.Cpu().String(), TestTimeoutShort).Should(Equal("1"))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Resources.Requests.Memory().String(), TestTimeoutShort).Should(Equal("2Gi"))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Resources.Limits.Memory().String(), TestTimeoutShort).Should(Equal("3Gi"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Name, TestTimeoutShort).Should(Equal("builder"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Resources.Requests.Cpu().String(), TestTimeoutShort).Should(Equal("500m"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Resources.Limits.Cpu().String(), TestTimeoutShort).Should(Equal("1"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Resources.Requests.Memory().String(), TestTimeoutShort).Should(Equal("2Gi"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Resources.Limits.Memory().String(), TestTimeoutShort).Should(Equal("3Gi"))
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Run custom pipeline task", func(t *testing.T) {
 			name := RandomizedSuffixName("java-pipeline")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-				"-t", "builder.tasks=custom1;alpine;tree",
-				"-t", "builder.tasks=custom2;alpine;cat maven/pom.xml",
-				"-t", "builder.strategy=pod",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "builder.tasks=custom1;alpine;tree", "-t", "builder.tasks=custom2;alpine;cat maven/pom.xml", "-t", "builder.strategy=pod").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			integrationKitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
+			integrationKitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
 			builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName), TestTimeoutShort).ShouldNot(BeNil())
-			g.Eventually(len(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers), TestTimeoutShort).Should(Equal(4))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Name, TestTimeoutShort).Should(Equal("builder"))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[1].Name, TestTimeoutShort).Should(Equal("custom1"))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[2].Name, TestTimeoutShort).Should(Equal("custom2"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName), TestTimeoutShort).ShouldNot(BeNil())
+			g.Eventually(len(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers), TestTimeoutShort).Should(Equal(4))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Name, TestTimeoutShort).Should(Equal("builder"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[1].Name, TestTimeoutShort).Should(Equal("custom1"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[2].Name, TestTimeoutShort).Should(Equal("custom2"))
 
 			// Check containers conditions
-			g.Eventually(Build(t, integrationKitNamespace, integrationKitName), TestTimeoutShort).ShouldNot(BeNil())
+			g.Eventually(Build(t, ctx, integrationKitNamespace, integrationKitName), TestTimeoutShort).ShouldNot(BeNil())
 			g.Eventually(
-				Build(t, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom1 succeeded")).Status,
+				Build(t, ctx, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom1 succeeded")).Status,
 				TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 			g.Eventually(
-				Build(t, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom1 succeeded")).Message,
+				Build(t, ctx, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom1 succeeded")).Message,
 				TestTimeoutShort).Should(ContainSubstring("generated-bytecode.jar"))
-			g.Eventually(Build(t, integrationKitNamespace, integrationKitName), TestTimeoutShort).ShouldNot(BeNil())
+			g.Eventually(Build(t, ctx, integrationKitNamespace, integrationKitName), TestTimeoutShort).ShouldNot(BeNil())
 			g.Eventually(
-				Build(t, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom2 succeeded")).Status,
+				Build(t, ctx, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom2 succeeded")).Status,
 				TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 			g.Eventually(
-				Build(t, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom2 succeeded")).Message,
+				Build(t, ctx, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom2 succeeded")).Message,
 				TestTimeoutShort).Should(ContainSubstring("</project>"))
 
 			// Check logs
-			g.Eventually(Logs(t, integrationKitNamespace, builderKitName, corev1.PodLogOptions{Container: "custom1"})).Should(ContainSubstring(`generated-bytecode.jar`))
-			g.Eventually(Logs(t, integrationKitNamespace, builderKitName, corev1.PodLogOptions{Container: "custom2"})).Should(ContainSubstring(`<artifactId>camel-k-runtime-bom</artifactId>`))
+			g.Eventually(Logs(t, ctx, integrationKitNamespace, builderKitName, corev1.PodLogOptions{Container: "custom1"})).Should(ContainSubstring(`generated-bytecode.jar`))
+			g.Eventually(Logs(t, ctx, integrationKitNamespace, builderKitName, corev1.PodLogOptions{Container: "custom2"})).Should(ContainSubstring(`<artifactId>camel-k-runtime-bom</artifactId>`))
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Run custom pipeline task error", func(t *testing.T) {
 			name := RandomizedSuffixName("java-error")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-				"-t", "builder.tasks=custom1;alpine;cat missingfile.txt",
-				"-t", "builder.strategy=pod",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "builder.tasks=custom1;alpine;cat missingfile.txt", "-t", "builder.strategy=pod").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPhase(t, ns, name)).Should(Equal(v1.IntegrationPhaseBuildingKit))
-			integrationKitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
+			g.Eventually(IntegrationPhase(t, ctx, ns, name)).Should(Equal(v1.IntegrationPhaseBuildingKit))
+			integrationKitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
 			// Check containers conditions
-			g.Eventually(Build(t, integrationKitNamespace, integrationKitName), TestTimeoutLong).ShouldNot(BeNil())
-			g.Eventually(BuildConditions(t, integrationKitNamespace, integrationKitName), TestTimeoutLong).ShouldNot(BeNil())
-			g.Eventually(BuildCondition(t, integrationKitNamespace, integrationKitName, v1.BuildConditionType("Container custom1 succeeded")), TestTimeoutMedium).ShouldNot(BeNil())
+			g.Eventually(Build(t, ctx, integrationKitNamespace, integrationKitName), TestTimeoutLong).ShouldNot(BeNil())
+			g.Eventually(BuildConditions(t, ctx, integrationKitNamespace, integrationKitName), TestTimeoutLong).ShouldNot(BeNil())
+			g.Eventually(BuildCondition(t, ctx, integrationKitNamespace, integrationKitName, v1.BuildConditionType("Container custom1 succeeded")), TestTimeoutMedium).ShouldNot(BeNil())
 			g.Eventually(
-				BuildCondition(t, integrationKitNamespace, integrationKitName, v1.BuildConditionType("Container custom1 succeeded"))().Status,
+				BuildCondition(t, ctx, integrationKitNamespace, integrationKitName, v1.BuildConditionType("Container custom1 succeeded"))().Status,
 				TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
 			g.Eventually(
-				BuildCondition(t, integrationKitNamespace, integrationKitName, v1.BuildConditionType("Container custom1 succeeded"))().Message,
+				BuildCondition(t, ctx, integrationKitNamespace, integrationKitName, v1.BuildConditionType("Container custom1 succeeded"))().Message,
 				TestTimeoutShort).Should(ContainSubstring("No such file or directory"))
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Run maven profile", func(t *testing.T) {
 			name := RandomizedSuffixName("java-maven-profile")
 
 			mavenProfile1Cm := newMavenProfileConfigMap(ns, "maven-profile-owasp", "owasp-profile")
-			g.Expect(TestClient(t).Create(TestContext, mavenProfile1Cm)).To(Succeed())
+			g.Expect(TestClient(t).Create(ctx, mavenProfile1Cm)).To(Succeed())
 			mavenProfile2Cm := newMavenProfileConfigMap(ns, "maven-profile-dependency", "dependency-profile")
-			g.Expect(TestClient(t).Create(TestContext, mavenProfile2Cm)).To(Succeed())
+			g.Expect(TestClient(t).Create(ctx, mavenProfile2Cm)).To(Succeed())
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-				"-t", "builder.maven-profiles=configmap:maven-profile-owasp/owasp-profile",
-				"-t", "builder.maven-profiles=configmap:maven-profile-dependency/dependency-profile",
-				"-t", "builder.tasks=custom1;alpine;cat maven/pom.xml",
-				"-t", "builder.strategy=pod",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "builder.maven-profiles=configmap:maven-profile-owasp/owasp-profile", "-t", "builder.maven-profiles=configmap:maven-profile-dependency/dependency-profile", "-t", "builder.tasks=custom1;alpine;cat maven/pom.xml", "-t", "builder.strategy=pod").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			integrationKitName := IntegrationKit(t, ns, name)()
-			integrationKitNamespace := IntegrationKitNamespace(t, ns, name)()
+			integrationKitName := IntegrationKit(t, ctx, ns, name)()
+			integrationKitNamespace := IntegrationKitNamespace(t, ctx, ns, name)()
 			builderKitName := fmt.Sprintf("camel-k-%s-builder", integrationKitName)
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName), TestTimeoutShort).ShouldNot(BeNil())
-			g.Eventually(len(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers), TestTimeoutShort).Should(Equal(3))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Name, TestTimeoutShort).Should(Equal("builder"))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[1].Name, TestTimeoutShort).Should(Equal("custom1"))
-			g.Eventually(BuilderPod(t, integrationKitNamespace, builderKitName)().Spec.InitContainers[2].Name, TestTimeoutShort).Should(Equal("package"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName), TestTimeoutShort).ShouldNot(BeNil())
+			g.Eventually(len(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers), TestTimeoutShort).Should(Equal(3))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[0].Name, TestTimeoutShort).Should(Equal("builder"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[1].Name, TestTimeoutShort).Should(Equal("custom1"))
+			g.Eventually(BuilderPod(t, ctx, integrationKitNamespace, builderKitName)().Spec.InitContainers[2].Name, TestTimeoutShort).Should(Equal("package"))
 
 			// Check containers conditions
-			g.Eventually(Build(t, integrationKitNamespace, integrationKitName), TestTimeoutShort).ShouldNot(BeNil())
+			g.Eventually(Build(t, ctx, integrationKitNamespace, integrationKitName), TestTimeoutShort).ShouldNot(BeNil())
 			g.Eventually(
-				Build(t, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom1 succeeded")).Status,
+				Build(t, ctx, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom1 succeeded")).Status,
 				TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 			g.Eventually(
-				Build(t, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom1 succeeded")).Message,
+				Build(t, ctx, integrationKitNamespace, integrationKitName)().Status.GetCondition(v1.BuildConditionType("Container custom1 succeeded")).Message,
 				TestTimeoutShort).Should(ContainSubstring("</project>"))
 
 			// Check logs
-			g.Eventually(Logs(t, integrationKitNamespace, builderKitName, corev1.PodLogOptions{Container: "custom1"})).Should(ContainSubstring(`<id>owasp-profile</id>`))
-			g.Eventually(Logs(t, integrationKitNamespace, builderKitName, corev1.PodLogOptions{Container: "custom1"})).Should(ContainSubstring(`<id>dependency-profile</id>`))
+			g.Eventually(Logs(t, ctx, integrationKitNamespace, builderKitName, corev1.PodLogOptions{Container: "custom1"})).Should(ContainSubstring(`<id>owasp-profile</id>`))
+			g.Eventually(Logs(t, ctx, integrationKitNamespace, builderKitName, corev1.PodLogOptions{Container: "custom1"})).Should(ContainSubstring(`<id>dependency-profile</id>`))
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-			g.Expect(TestClient(t).Delete(TestContext, mavenProfile1Cm)).To(Succeed())
-			g.Expect(TestClient(t).Delete(TestContext, mavenProfile2Cm)).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(TestClient(t).Delete(ctx, mavenProfile1Cm)).To(Succeed())
+			g.Expect(TestClient(t).Delete(ctx, mavenProfile2Cm)).To(Succeed())
 		})
 	})
 }

--- a/e2e/common/traits/camel_test.go
+++ b/e2e/common/traits/camel_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,43 +37,38 @@ import (
 func TestCamelTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-camel"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("properties changes should not rebuild", func(t *testing.T) {
 
-			g.Expect(Kamel(t, "reset", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "reset", "-n", ns).Execute()).To(Succeed())
 
 			name := RandomizedSuffixName("java")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
 
 			// checking the integration status
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			integrationKit := IntegrationKit(t, ns, name)()
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			integrationKit := IntegrationKit(t, ctx, ns, name)()
 
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-				"-p", "a=1",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutShort).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			g.Eventually(IntegrationKit(t, ns, name)).Should(Equal(integrationKit))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-p", "a=1").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationKit(t, ctx, ns, name)).Should(Equal(integrationKit))
 
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
-			g.Eventually(Integration(t, ns, name), TestTimeoutLong).Should(BeNil())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Eventually(Integration(t, ctx, ns, name), TestTimeoutLong).Should(BeNil())
 		})
 
 		// Clean-up
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/traits/container_test.go
+++ b/e2e/common/traits/container_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -37,35 +38,28 @@ import (
 func TestContainerTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-container"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("Container image pull policy and resources configuration", func(t *testing.T) {
 			name := RandomizedSuffixName("java1")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"-t", "container.image-pull-policy=Always",
-				"-t", "container.request-cpu=0.005",
-				"-t", "container.request-memory=100Mi",
-				"-t", "container.limit-cpu=200m",
-				"-t", "container.limit-memory=500Mi",
-				"--name", name,
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			g.Eventually(IntegrationPodHas(t, ns, name, func(pod *corev1.Pod) bool {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "-t", "container.image-pull-policy=Always", "-t", "container.request-cpu=0.005", "-t", "container.request-memory=100Mi", "-t", "container.limit-cpu=200m", "-t", "container.limit-memory=500Mi", "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodHas(t, ctx, ns, name, func(pod *corev1.Pod) bool {
 				if len(pod.Spec.Containers) != 1 {
 					return false
 				}
 				imagePullPolicy := pod.Spec.Containers[0].ImagePullPolicy
 				return imagePullPolicy == "Always"
 			}), TestTimeoutShort).Should(BeTrue())
-			g.Eventually(IntegrationPodHas(t, ns, name, func(pod *corev1.Pod) bool {
+			g.Eventually(IntegrationPodHas(t, ctx, ns, name, func(pod *corev1.Pod) bool {
 				if len(pod.Spec.Containers) != 1 {
 					return false
 				}
@@ -73,7 +67,7 @@ func TestContainerTrait(t *testing.T) {
 				requestsCpu := pod.Spec.Containers[0].Resources.Requests.Cpu()
 				return limitsCpu != nil && limitsCpu.String() == "200m" && requestsCpu != nil && requestsCpu.String() == "5m"
 			}), TestTimeoutShort).Should(BeTrue())
-			g.Eventually(IntegrationPodHas(t, ns, name, func(pod *corev1.Pod) bool {
+			g.Eventually(IntegrationPodHas(t, ctx, ns, name, func(pod *corev1.Pod) bool {
 				if len(pod.Spec.Containers) != 1 {
 					return false
 				}
@@ -87,14 +81,11 @@ func TestContainerTrait(t *testing.T) {
 		t.Run("Container name", func(t *testing.T) {
 			name := RandomizedSuffixName("java2")
 			containerName := "my-container-name"
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"-t", "container.name="+containerName,
-				"--name", name,
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			g.Eventually(IntegrationPodHas(t, ns, name, func(pod *corev1.Pod) bool {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "-t", "container.name="+containerName, "--name", name).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodHas(t, ctx, ns, name, func(pod *corev1.Pod) bool {
 				if len(pod.Spec.Containers) != 1 {
 					return false
 				}
@@ -103,8 +94,8 @@ func TestContainerTrait(t *testing.T) {
 			}), TestTimeoutShort).Should(BeTrue())
 
 			// check integration schema does not contains unwanted default trait value.
-			g.Eventually(UnstructuredIntegration(t, ns, name)).ShouldNot(BeNil())
-			unstructuredIntegration := UnstructuredIntegration(t, ns, name)()
+			g.Eventually(UnstructuredIntegration(t, ctx, ns, name)).ShouldNot(BeNil())
+			unstructuredIntegration := UnstructuredIntegration(t, ctx, ns, name)()
 			containerTrait, _, _ := unstructured.NestedMap(unstructuredIntegration.Object, "spec", "traits", "container")
 			g.Expect(containerTrait).ToNot(BeNil())
 			g.Expect(len(containerTrait)).To(Equal(1))
@@ -113,6 +104,6 @@ func TestContainerTrait(t *testing.T) {
 		})
 
 		// Clean-up
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/traits/error_handler_test.go
+++ b/e2e/common/traits/error_handler_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -36,27 +37,21 @@ import (
 func TestErrorHandlerTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-errorhandler"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("Run errored integration with error handler", func(t *testing.T) {
 			name := RandomizedSuffixName("error-handler")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/ErroredRoute.java",
-				"--name", name,
-				"-t", "error-handler.enabled=true",
-				"-t", "error-handler.ref=defaultErrorHandler",
-				"-p", "camel.beans.defaultErrorHandler=#class:org.apache.camel.builder.DeadLetterChannelBuilder",
-				"-p", "camel.beans.defaultErrorHandler.deadLetterUri=log:my-special-error-handler-in-place?level=ERROR&showCaughtException=false&showBody=false&showBodyType=false&showExchangePattern=false",
-			).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).ShouldNot(ContainSubstring("InvalidPayloadException"))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("my-special-error-handler-in-place"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/ErroredRoute.java", "--name", name, "-t", "error-handler.enabled=true", "-t", "error-handler.ref=defaultErrorHandler", "-p", "camel.beans.defaultErrorHandler=#class:org.apache.camel.builder.DeadLetterChannelBuilder", "-p", "camel.beans.defaultErrorHandler.deadLetterUri=log:my-special-error-handler-in-place?level=ERROR&showCaughtException=false&showBody=false&showBodyType=false&showExchangePattern=false").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).ShouldNot(ContainSubstring("InvalidPayloadException"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("my-special-error-handler-in-place"))
 		})
 	})
 }

--- a/e2e/common/traits/jolokia_test.go
+++ b/e2e/common/traits/jolokia_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -38,35 +39,30 @@ import (
 func TestJolokiaTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-jolokia"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("Run Java with Jolokia", func(t *testing.T) {
 			name := RandomizedSuffixName("java")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java",
-				"--name", name,
-				"-t", "jolokia.enabled=true",
-				"-t", "jolokia.use-ssl-client-authentication=false",
-				"-t", "jolokia.protocol=http",
-				"-t", "jolokia.extended-client-check=false").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "jolokia.enabled=true", "-t", "jolokia.use-ssl-client-authentication=false", "-t", "jolokia.protocol=http", "-t", "jolokia.extended-client-check=false").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-			pod := IntegrationPod(t, ns, name)
+			pod := IntegrationPod(t, ctx, ns, name)
 			response, err := TestClient(t).CoreV1().RESTClient().Get().
-				AbsPath(fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/proxy/jolokia/", ns, pod().Name)).DoRaw(TestContext)
+				AbsPath(fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/proxy/jolokia/", ns, pod().Name)).DoRaw(ctx)
 			g.Expect(err).To(BeNil())
 			g.Expect(response).To(ContainSubstring(`"status":200`))
 
 			// check integration schema does not contains unwanted default trait value.
-			g.Eventually(UnstructuredIntegration(t, ns, name)).ShouldNot(BeNil())
-			unstructuredIntegration := UnstructuredIntegration(t, ns, name)()
+			g.Eventually(UnstructuredIntegration(t, ctx, ns, name)).ShouldNot(BeNil())
+			unstructuredIntegration := UnstructuredIntegration(t, ctx, ns, name)()
 			jolokiaTrait, _, _ := unstructured.NestedMap(unstructuredIntegration.Object, "spec", "traits", "jolokia")
 			g.Expect(jolokiaTrait).ToNot(BeNil())
 			g.Expect(len(jolokiaTrait)).To(Equal(4))
@@ -77,6 +73,6 @@ func TestJolokiaTrait(t *testing.T) {
 
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/traits/master_test.go
+++ b/e2e/common/traits/master_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -38,47 +39,36 @@ import (
 func TestMasterTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-master"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("master works", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Master.java").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "master"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, "master"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Master.java").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "master"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "master"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("only one integration with master runs", func(t *testing.T) {
 			nameFirst := RandomizedSuffixName("first")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Master.java",
-				"--name", nameFirst,
-				"--label", "leader-group=same",
-				"-t", "master.label-key=leader-group",
-				"-t", "master.label-value=same",
-				"-t", "owner.target-labels=leader-group").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameFirst), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, nameFirst), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Master.java", "--name", nameFirst, "--label", "leader-group=same", "-t", "master.label-key=leader-group", "-t", "master.label-value=same", "-t", "owner.target-labels=leader-group").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameFirst), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameFirst), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 			// Start a second integration with the same lock (it should not start the route)
 			nameSecond := RandomizedSuffixName("second")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Master.java",
-				"--name", nameSecond,
-				"--label", "leader-group=same",
-				"-t", "master.label-key=leader-group",
-				"-t", "master.label-value=same",
-				"-t", "master.resource-name=first-lock",
-				"-t", "owner.target-labels=leader-group").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, nameSecond), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, nameSecond), TestTimeoutShort).Should(ContainSubstring("started in"))
-			g.Eventually(IntegrationLogs(t, ns, nameSecond), 30*time.Second).ShouldNot(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Master.java", "--name", nameSecond, "--label", "leader-group=same", "-t", "master.label-key=leader-group", "-t", "master.label-value=same", "-t", "master.resource-name=first-lock", "-t", "owner.target-labels=leader-group").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, nameSecond), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameSecond), TestTimeoutShort).Should(ContainSubstring("started in"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, nameSecond), 30*time.Second).ShouldNot(ContainSubstring("Magicstring!"))
 
 			// check integration schema does not contains unwanted default trait value.
-			g.Eventually(UnstructuredIntegration(t, ns, nameFirst)).ShouldNot(BeNil())
-			unstructuredIntegration := UnstructuredIntegration(t, ns, nameFirst)()
+			g.Eventually(UnstructuredIntegration(t, ctx, ns, nameFirst)).ShouldNot(BeNil())
+			unstructuredIntegration := UnstructuredIntegration(t, ctx, ns, nameFirst)()
 			builderTrait, _, _ := unstructured.NestedMap(unstructuredIntegration.Object, "spec", "traits", "addons", "master")
 			g.Expect(builderTrait).ToNot(BeNil())
 			g.Expect(len(builderTrait)).To(Equal(2))
@@ -86,6 +76,6 @@ func TestMasterTrait(t *testing.T) {
 			g.Expect(builderTrait["labelValue"]).To(Equal("same"))
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/traits/pull_secret_test.go
+++ b/e2e/common/traits/pull_secret_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -38,47 +39,44 @@ import (
 func TestPullSecretTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-pull-secret"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		ocp, err := openshift.IsOpenShift(TestClient(t))
 		g.Expect(err).To(BeNil())
 
 		t.Run("Image pull secret is set on pod", func(t *testing.T) {
 			name := RandomizedSuffixName("java1")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
-				"-t", "pull-secret.enabled=true",
-				"-t", "pull-secret.secret-name=dummy-secret").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "pull-secret.enabled=true", "-t", "pull-secret.secret-name=dummy-secret").Execute()).To(Succeed())
 			// pod may not run because the pull secret is dummy
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
 
-			pod := IntegrationPod(t, ns, name)()
+			pod := IntegrationPod(t, ctx, ns, name)()
 			g.Expect(pod.Spec.ImagePullSecrets).NotTo(BeEmpty())
 			g.Expect(pod.Spec.ImagePullSecrets[0].Name).To(Equal("dummy-secret"))
 		})
 
 		t.Run("Explicitly disable image pull secret", func(t *testing.T) {
 			name := RandomizedSuffixName("java2")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
-				"-t", "pull-secret.enabled=false").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "pull-secret.enabled=false").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 			// check integration schema does not contains unwanted default trait value.
-			g.Eventually(UnstructuredIntegration(t, ns, name)).ShouldNot(BeNil())
-			unstructuredIntegration := UnstructuredIntegration(t, ns, name)()
+			g.Eventually(UnstructuredIntegration(t, ctx, ns, name)).ShouldNot(BeNil())
+			unstructuredIntegration := UnstructuredIntegration(t, ctx, ns, name)()
 			pullSecretTrait, _, _ := unstructured.NestedMap(unstructuredIntegration.Object, "spec", "traits", "pull-secret")
 			g.Expect(pullSecretTrait).ToNot(BeNil())
 			g.Expect(len(pullSecretTrait)).To(Equal(1))
 			g.Expect(pullSecretTrait["enabled"]).To(Equal(false))
 
-			pod := IntegrationPod(t, ns, name)()
+			pod := IntegrationPod(t, ctx, ns, name)()
 			if ocp {
 				// OpenShift `default` service account has imagePullSecrets so it's always set
 				g.Expect(pod.Spec.ImagePullSecrets).NotTo(BeEmpty())
@@ -91,18 +89,18 @@ func TestPullSecretTrait(t *testing.T) {
 			// OpenShift always has an internal registry so image pull secret is set by default
 			t.Run("Image pull secret is automatically set by default", func(t *testing.T) {
 				name := RandomizedSuffixName("java3")
-				g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name).Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
-				pod := IntegrationPod(t, ns, name)()
+				pod := IntegrationPod(t, ctx, ns, name)()
 				g.Expect(pod.Spec.ImagePullSecrets).NotTo(BeEmpty())
 				g.Expect(pod.Spec.ImagePullSecrets[0].Name).To(HavePrefix("default-dockercfg-"))
 			})
 		}
 
 		// Clean-up
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/traits/service_binding_test.go
+++ b/e2e/common/traits/service_binding_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -38,13 +39,13 @@ import (
 func TestServiceBindingTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-service-binding"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("Integration Service Binding", func(t *testing.T) {
 			// Create our mock service config
@@ -69,17 +70,14 @@ func TestServiceBindingTrait(t *testing.T) {
 				},
 			}
 			serviceRef := fmt.Sprintf("%s:%s/%s", service.TypeMeta.Kind, ns, service.ObjectMeta.Name)
-			g.Expect(TestClient(t).Create(TestContext, service)).To(Succeed())
+			g.Expect(TestClient(t).Create(ctx, service)).To(Succeed())
 			// Create integration and bind it to our service
 			name := RandomizedSuffixName("service-binding")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/ServiceBinding.java",
-				"--name", name,
-				"--connect", serviceRef,
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/ServiceBinding.java", "--name", name, "--connect", serviceRef).Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring(fmt.Sprintf("%s:%s", host, port)))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring(fmt.Sprintf("%s:%s", host, port)))
 		})
 
 		t.Run("Binding Service Binding", func(t *testing.T) {
@@ -102,16 +100,14 @@ func TestServiceBindingTrait(t *testing.T) {
 				},
 			}
 			serviceRef := fmt.Sprintf("%s:%s/%s", service.TypeMeta.Kind, ns, service.ObjectMeta.Name)
-			g.Expect(TestClient(t).Create(TestContext, service)).To(Succeed())
-			g.Expect(CreateTimerKamelet(t, operatorID, ns, "my-timer-source")()).To(Succeed())
-			g.Expect(KamelBindWithID(t, operatorID, ns, "my-timer-source", "log:info",
-				"-p", "source.message=Hello+world",
-				"--connect", serviceRef).Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "my-timer-source-to-log"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, "my-timer-source-to-log")).Should(ContainSubstring("Body: Hello+world"))
+			g.Expect(TestClient(t).Create(ctx, service)).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, "my-timer-source")()).To(Succeed())
+			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "my-timer-source", "log:info", "-p", "source.message=Hello+world", "--connect", serviceRef).Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "my-timer-source-to-log"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "my-timer-source-to-log")).Should(ContainSubstring("Body: Hello+world"))
 		})
 
 		// Clean up
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/common/traits/service_test.go
+++ b/e2e/common/traits/service_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package traits
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -37,95 +38,87 @@ import (
 func TestServiceTrait(t *testing.T) {
 	t.Parallel()
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-traits-service"
-		g.Expect(CopyCamelCatalog(t, ns, operatorID)).To(Succeed())
-		g.Expect(CopyIntegrationKits(t, ns, operatorID)).To(Succeed())
-		g.Expect(KamelInstallWithID(t, operatorID, ns)).To(Succeed())
+		g.Expect(CopyCamelCatalog(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(CopyIntegrationKits(t, ctx, ns, operatorID)).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns)).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("NodePort service", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/PlatformHttpServer.java",
-				"-t", "service.enabled=true",
-				"-t", "service.node-port=true").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java", "-t", "service.enabled=true", "-t", "service.node-port=true").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
 			//
 			// Service names can vary with the ExternalName Service
 			// sometimes being created first and being given the root name
 			//
-			g.Eventually(ServicesByType(t, ns, corev1.ServiceTypeNodePort), TestTimeoutLong).ShouldNot(BeEmpty())
+			g.Eventually(ServicesByType(t, ctx, ns, corev1.ServiceTypeNodePort), TestTimeoutLong).ShouldNot(BeEmpty())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("Default service (ClusterIP)", func(t *testing.T) {
 			// Service trait is enabled by default
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/PlatformHttpServer.java").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
 			//
 			// Service names can vary with the ExternalName Service
 			// sometimes being created first and being given the root name
 			//
-			g.Eventually(ServicesByType(t, ns, corev1.ServiceTypeClusterIP), TestTimeoutLong).ShouldNot(BeEmpty())
+			g.Eventually(ServicesByType(t, ctx, ns, corev1.ServiceTypeClusterIP), TestTimeoutLong).ShouldNot(BeEmpty())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("NodePort service from Type", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/PlatformHttpServer.java",
-				"-t", "service.enabled=true",
-				"-t", "service.type=NodePort").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java", "-t", "service.enabled=true", "-t", "service.type=NodePort").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
 			//
 			// Service names can vary with the ExternalName Service
 			// sometimes being created first and being given the root name
 			//
-			g.Eventually(ServicesByType(t, ns, corev1.ServiceTypeNodePort), TestTimeoutLong).ShouldNot(BeEmpty())
+			g.Eventually(ServicesByType(t, ctx, ns, corev1.ServiceTypeNodePort), TestTimeoutLong).ShouldNot(BeEmpty())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("ClusterIP service from Type", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/PlatformHttpServer.java",
-				"-t", "service.enabled=true",
-				"-t", "service.type=ClusterIP").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java", "-t", "service.enabled=true", "-t", "service.type=ClusterIP").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
 			//
 			// Service names can vary with the ExternalName Service
 			// sometimes being created first and being given the root name
 			//
-			g.Eventually(ServicesByType(t, ns, corev1.ServiceTypeClusterIP), TestTimeoutLong).ShouldNot(BeEmpty())
+			g.Eventually(ServicesByType(t, ctx, ns, corev1.ServiceTypeClusterIP), TestTimeoutLong).ShouldNot(BeEmpty())
 
 			// check integration schema does not contains unwanted default trait value.
-			g.Eventually(UnstructuredIntegration(t, ns, "platform-http-server")).ShouldNot(BeNil())
-			unstructuredIntegration := UnstructuredIntegration(t, ns, "platform-http-server")()
+			g.Eventually(UnstructuredIntegration(t, ctx, ns, "platform-http-server")).ShouldNot(BeNil())
+			unstructuredIntegration := UnstructuredIntegration(t, ctx, ns, "platform-http-server")()
 			serviceTrait, _, _ := unstructured.NestedMap(unstructuredIntegration.Object, "spec", "traits", "service")
 			g.Expect(serviceTrait).ToNot(BeNil())
 			g.Expect(len(serviceTrait)).To(Equal(2))
 			g.Expect(serviceTrait["enabled"]).To(Equal(true))
 			g.Expect(serviceTrait["type"]).To(Equal("ClusterIP"))
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("LoadBalancer service from Type", func(t *testing.T) {
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/PlatformHttpServer.java",
-				"-t", "service.enabled=true",
-				"-t", "service.type=LoadBalancer").Execute()).To(Succeed())
-			g.Eventually(IntegrationPodPhase(t, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java", "-t", "service.enabled=true", "-t", "service.type=LoadBalancer").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "platform-http-server"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 
 			//
 			// Service names can vary with the ExternalName Service
 			// sometimes being created first and being given the root name
 			//
-			g.Eventually(ServicesByType(t, ns, corev1.ServiceTypeLoadBalancer), TestTimeoutLong).ShouldNot(BeEmpty())
+			g.Eventually(ServicesByType(t, ctx, ns, corev1.ServiceTypeLoadBalancer), TestTimeoutLong).ShouldNot(BeEmpty())
 
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 	})
 }

--- a/e2e/install/cli/global_kamelet_test.go
+++ b/e2e/install/cli/global_kamelet_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -32,42 +33,42 @@ import (
 )
 
 func TestRunGlobalKamelet(t *testing.T) {
-	WithGlobalOperatorNamespace(t, func(g *WithT, operatorNamespace string) {
+	WithGlobalOperatorNamespace(t, func(ctx context.Context, g *WithT, operatorNamespace string) {
 		operatorID := "camel-k-global-kamelet"
-		g.Expect(KamelInstallWithID(t, operatorID, operatorNamespace, "--global", "--force")).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, operatorNamespace, "--global", "--force")).To(Succeed())
 
 		t.Run("Global operator + namespaced kamelet test", func(t *testing.T) {
 
 			// NS2: namespace without operator
-			WithNewTestNamespace(t, func(g *WithT, ns2 string) {
-				g.Expect(CreateTimerKamelet(t, operatorID, ns2, "my-own-timer-source")()).To(Succeed())
+			WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns2 string) {
+				g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns2, "my-own-timer-source")()).To(Succeed())
 
-				g.Expect(KamelInstallWithID(t, operatorID, ns2, "--skip-operator-setup", "--olm=false")).To(Succeed())
+				g.Expect(KamelInstallWithID(t, ctx, operatorID, ns2, "--skip-operator-setup", "--olm=false")).To(Succeed())
 
-				g.Expect(KamelRunWithID(t, operatorID, ns2, "files/timer-kamelet-usage.groovy").Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns2, "timer-kamelet-usage"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationLogs(t, ns2, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
-				g.Expect(Kamel(t, "delete", "--all", "-n", ns2).Execute()).To(Succeed())
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns2, "files/timer-kamelet-usage.groovy").Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, ns2, "timer-kamelet-usage"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationLogs(t, ctx, ns2, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
+				g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns2).Execute()).To(Succeed())
 			})
 		})
 
 		t.Run("Global operator + global kamelet test", func(t *testing.T) {
 
-			g.Expect(CreateTimerKamelet(t, operatorID, operatorNamespace, "my-own-timer-source")()).To(Succeed())
+			g.Expect(CreateTimerKamelet(t, ctx, operatorID, operatorNamespace, "my-own-timer-source")()).To(Succeed())
 
 			// NS3: namespace without operator
-			WithNewTestNamespace(t, func(g *WithT, ns3 string) {
-				g.Expect(KamelInstallWithID(t, operatorID, ns3, "--skip-operator-setup", "--olm=false")).To(Succeed())
+			WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns3 string) {
+				g.Expect(KamelInstallWithID(t, ctx, operatorID, ns3, "--skip-operator-setup", "--olm=false")).To(Succeed())
 
-				g.Expect(KamelRunWithID(t, operatorID, ns3, "files/timer-kamelet-usage.groovy").Execute()).To(Succeed())
-				g.Eventually(IntegrationPodPhase(t, ns3, "timer-kamelet-usage"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationLogs(t, ns3, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
-				g.Expect(Kamel(t, "delete", "--all", "-n", ns3).Execute()).To(Succeed())
-				g.Expect(TestClient(t).Delete(TestContext, Kamelet(t, "my-own-timer-source", operatorNamespace)())).To(Succeed())
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns3, "files/timer-kamelet-usage.groovy").Execute()).To(Succeed())
+				g.Eventually(IntegrationPodPhase(t, ctx, ns3, "timer-kamelet-usage"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationLogs(t, ctx, ns3, "timer-kamelet-usage"), TestTimeoutShort).Should(ContainSubstring("Hello world"))
+				g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns3).Execute()).To(Succeed())
+				g.Expect(TestClient(t).Delete(ctx, Kamelet(t, ctx, "my-own-timer-source", operatorNamespace)())).To(Succeed())
 			})
 		})
 
-		g.Expect(Kamel(t, "uninstall", "-n", operatorNamespace, "--skip-crd", "--skip-cluster-roles=false", "--skip-cluster-role-bindings=false").Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "uninstall", "-n", operatorNamespace, "--skip-crd", "--skip-cluster-roles=false", "--skip-cluster-role-bindings=false").Execute()).To(Succeed())
 	})
 
 }

--- a/e2e/install/kustomize/operator_test.go
+++ b/e2e/install/kustomize/operator_test.go
@@ -41,7 +41,7 @@ func TestOperatorBasic(t *testing.T) {
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
 
-	ctx := context.TODO()
+	ctx := TestContext()
 
 	// Ensure no CRDs are already installed
 	g := NewWithT(t)
@@ -87,7 +87,7 @@ func TestOperatorKustomizeAlternativeImage(t *testing.T) {
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
 
-	ctx := context.TODO()
+	ctx := TestContext()
 
 	// Ensure no CRDs are already installed
 	g := NewWithT(t)
@@ -121,7 +121,7 @@ func TestOperatorKustomizeGlobal(t *testing.T) {
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
 
-	ctx := context.TODO()
+	ctx := TestContext()
 
 	// Ensure no CRDs are already installed
 	g := NewWithT(t)

--- a/e2e/install/kustomize/setup_test.go
+++ b/e2e/install/kustomize/setup_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package kustomize
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -34,18 +35,19 @@ import (
 )
 
 func TestSetupKustomizeBasic(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
 
 	// Ensure no CRDs are already installed
-	g.Expect(UninstallAll(t)).To(Succeed())
+	g.Expect(UninstallAll(t, ctx)).To(Succeed())
 	g.Eventually(CRDs(t)).Should(HaveLen(0))
 
 	// Return the cluster to previous state
-	defer Cleanup(t)
+	defer Cleanup(t, ctx)
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		namespaceArg := fmt.Sprintf("NAMESPACE=%s", ns)
 		ExpectExecSucceed(t, g, Make(t, "setup-cluster", namespaceArg))
 		g.Eventually(CRDs(t)).Should(HaveLen(GetExpectedCRDs(defaults.Version)))
@@ -54,14 +56,14 @@ func TestSetupKustomizeBasic(t *testing.T) {
 
 		kpRoles := ExpectedKubePromoteRoles
 		opRoles := kpRoles + ExpectedOSPromoteRoles
-		g.Eventually(Role(t, ns)).Should(Or(HaveLen(kpRoles), HaveLen(opRoles)))
+		g.Eventually(Role(t, ctx, ns)).Should(Or(HaveLen(kpRoles), HaveLen(opRoles)))
 
 		kcRoles := ExpectedKubeClusterRoles
 		ocRoles := kcRoles + ExpectedOSClusterRoles
-		g.Eventually(ClusterRole(t)).Should(Or(HaveLen(kcRoles), HaveLen(ocRoles)))
+		g.Eventually(ClusterRole(t, ctx)).Should(Or(HaveLen(kcRoles), HaveLen(ocRoles)))
 
 		// Tidy up to ensure next test works
-		g.Expect(Kamel(t, "uninstall", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "uninstall", "-n", ns).Execute()).To(Succeed())
 	})
 
 }
@@ -70,25 +72,27 @@ func TestSetupKustomizeGlobal(t *testing.T) {
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
 
+	ctx := context.TODO()
+
 	// Ensure no CRDs are already installed
 	g := NewWithT(t)
-	g.Expect(UninstallAll(t)).To(Succeed())
+	g.Expect(UninstallAll(t, ctx)).To(Succeed())
 	g.Eventually(CRDs(t)).Should(HaveLen(0))
 
 	// Return the cluster to previous state
-	defer Cleanup(t)
+	defer Cleanup(t, ctx)
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		namespaceArg := fmt.Sprintf("NAMESPACE=%s", ns)
 		ExpectExecSucceed(t, g, Make(t, "setup-cluster", namespaceArg))
 		g.Eventually(CRDs(t)).Should(HaveLen(GetExpectedCRDs(defaults.Version)))
 
 		ExpectExecSucceed(t, g, Make(t, "setup", "GLOBAL=true", namespaceArg))
 
-		g.Eventually(Role(t, ns)).Should(HaveLen(0))
+		g.Eventually(Role(t, ctx, ns)).Should(HaveLen(0))
 
 		kcpRoles := ExpectedKubeClusterRoles + ExpectedKubePromoteRoles
 		ocpRoles := kcpRoles + ExpectedOSClusterRoles + ExpectedOSPromoteRoles
-		g.Eventually(ClusterRole(t)).Should(Or(HaveLen(kcpRoles), HaveLen(ocpRoles)))
+		g.Eventually(ClusterRole(t, ctx)).Should(Or(HaveLen(kcpRoles), HaveLen(ocpRoles)))
 	})
 }

--- a/e2e/install/kustomize/setup_test.go
+++ b/e2e/install/kustomize/setup_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestSetupKustomizeBasic(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
@@ -72,7 +72,7 @@ func TestSetupKustomizeGlobal(t *testing.T) {
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
 
-	ctx := context.TODO()
+	ctx := TestContext()
 
 	// Ensure no CRDs are already installed
 	g := NewWithT(t)

--- a/e2e/install/kustomize/uninstall_test.go
+++ b/e2e/install/kustomize/uninstall_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package kustomize
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -36,26 +37,27 @@ import (
 )
 
 func TestKustomizeUninstallBasic(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
 
 	// Ensure no CRDs are already installed
-	g.Expect(UninstallAll(t)).To(Succeed())
+	g.Expect(UninstallAll(t, ctx)).To(Succeed())
 	g.Eventually(CRDs(t)).Should(HaveLen(0))
 
 	// Return the cluster to previous state
-	defer Cleanup(t)
+	defer Cleanup(t, ctx)
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		namespaceArg := fmt.Sprintf("NAMESPACE=%s", ns)
 		ExpectExecSucceed(t, g, Make(t, "setup-cluster", namespaceArg))
 		ExpectExecSucceed(t, g, Make(t, "setup", namespaceArg))
 		ExpectExecSucceed(t, g, Make(t, "platform", namespaceArg))
 		// Skip default kamelets installation for faster test runs
 		ExpectExecSucceed(t, g, Make(t, "operator", namespaceArg, "INSTALL_DEFAULT_KAMELETS=false"))
-		g.Eventually(OperatorPod(t, ns)).ShouldNot(BeNil())
-		g.Eventually(OperatorPodPhase(t, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+		g.Eventually(OperatorPod(t, ctx, ns)).ShouldNot(BeNil())
+		g.Eventually(OperatorPodPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 
 		// Do uninstall
 		ExpectExecSucceed(t, g, Make(t, "uninstall", namespaceArg))
@@ -63,12 +65,12 @@ func TestKustomizeUninstallBasic(t *testing.T) {
 		// Refresh the test client to account for the newly installed CRDs
 		RefreshClient(t)
 
-		g.Eventually(OperatorPod(t, ns)).Should(BeNil())
-		g.Eventually(Platform(t, ns)).Should(BeNil())
+		g.Eventually(OperatorPod(t, ctx, ns)).Should(BeNil())
+		g.Eventually(Platform(t, ctx, ns)).Should(BeNil())
 		// The operator can dynamically create a for its builders
 		// so, in case there is a build strategy "pod", expect this to have 1 role
-		g.Eventually(Role(t, ns)).Should(BeNil())
-		g.Eventually(ClusterRole(t)).Should(BeNil())
+		g.Eventually(Role(t, ctx, ns)).Should(BeNil())
+		g.Eventually(ClusterRole(t, ctx)).Should(BeNil())
 		// CRDs should be still there
 		g.Eventually(CRDs(t)).Should(HaveLen(GetExpectedCRDs(defaults.Version)))
 
@@ -81,26 +83,27 @@ func TestKustomizeUninstallBasic(t *testing.T) {
 }
 
 func TestUninstallGlobal(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
 
 	// Ensure no CRDs are already installed
-	g.Expect(UninstallAll(t)).To(Succeed())
+	g.Expect(UninstallAll(t, ctx)).To(Succeed())
 	g.Eventually(CRDs(t)).Should(HaveLen(0))
 
 	// Return the cluster to previous state
-	defer Cleanup(t)
+	defer Cleanup(t, ctx)
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		namespaceArg := fmt.Sprintf("NAMESPACE=%s", ns)
 		ExpectExecSucceed(t, g, Make(t, "setup-cluster", namespaceArg))
 		ExpectExecSucceed(t, g, Make(t, "setup", namespaceArg, "GLOBAL=true"))
 		ExpectExecSucceed(t, g, Make(t, "platform", namespaceArg))
 		// Skip default kamelets installation for faster test runs
 		ExpectExecSucceed(t, g, Make(t, "operator", namespaceArg, "GLOBAL=true", "INSTALL_DEFAULT_KAMELETS=false"))
-		g.Eventually(OperatorPod(t, ns)).ShouldNot(BeNil())
-		g.Eventually(OperatorPodPhase(t, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+		g.Eventually(OperatorPod(t, ctx, ns)).ShouldNot(BeNil())
+		g.Eventually(OperatorPodPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 
 		// Do uninstall
 		ExpectExecSucceed(t, g, Make(t, "uninstall", namespaceArg))
@@ -108,10 +111,10 @@ func TestUninstallGlobal(t *testing.T) {
 		// Refresh the test client to account for the newly installed CRDs
 		RefreshClient(t)
 
-		g.Eventually(OperatorPod(t, ns)).Should(BeNil())
-		g.Eventually(Platform(t, ns)).Should(BeNil())
-		g.Eventually(Role(t, ns)).Should(BeNil())
-		g.Eventually(ClusterRole(t)).Should(BeNil())
+		g.Eventually(OperatorPod(t, ctx, ns)).Should(BeNil())
+		g.Eventually(Platform(t, ctx, ns)).Should(BeNil())
+		g.Eventually(Role(t, ctx, ns)).Should(BeNil())
+		g.Eventually(ClusterRole(t, ctx)).Should(BeNil())
 		// CRDs should be still there
 		g.Eventually(CRDs(t)).Should(HaveLen(GetExpectedCRDs(defaults.Version)))
 

--- a/e2e/install/kustomize/uninstall_test.go
+++ b/e2e/install/kustomize/uninstall_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestKustomizeUninstallBasic(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)
@@ -83,7 +83,7 @@ func TestKustomizeUninstallBasic(t *testing.T) {
 }
 
 func TestUninstallGlobal(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 	makeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	os.Setenv("CAMEL_K_TEST_MAKE_DIR", makeDir)

--- a/e2e/install/upgrade/helm_upgrade_test.go
+++ b/e2e/install/upgrade/helm_upgrade_test.go
@@ -41,7 +41,7 @@ import (
 
 // WARNING: this test is not OLM specific but needs certain setting we provide in OLM installation scenario
 func TestHelmOperatorUpgrade(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 
 	KAMEL_INSTALL_REGISTRY := os.Getenv("KAMEL_INSTALL_REGISTRY")

--- a/e2e/install/upgrade/olm_upgrade_test.go
+++ b/e2e/install/upgrade/olm_upgrade_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package upgrade
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -65,9 +66,8 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 		t.Logf("Testing cross-OLM channel upgrade %s -> %s", prevUpdateChannel, newUpdateChannel)
 	}
 
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
-
-		g.Expect(CreateOrUpdateCatalogSource(t, ns, catalogSourceName, prevIIB)).To(Succeed())
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		g.Expect(CreateOrUpdateCatalogSource(t, ctx, ns, catalogSourceName, prevIIB)).To(Succeed())
 		ocp, err := openshift.IsOpenShift(TestClient(t))
 		require.NoError(t, err)
 
@@ -75,18 +75,18 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 			// Wait for pull secret to be created in namespace
 			// e.g. test-camel-k-source-dockercfg-zlltn
 			secretPrefix := fmt.Sprintf("%s-dockercfg-", catalogSourceName)
-			g.Eventually(SecretByName(t, ns, secretPrefix), TestTimeoutLong).Should(Not(BeNil()))
+			g.Eventually(SecretByName(t, ctx, ns, secretPrefix), TestTimeoutLong).Should(Not(BeNil()))
 		}
 
-		g.Eventually(CatalogSourcePodRunning(t, ns, catalogSourceName), TestTimeoutMedium).Should(BeNil())
-		g.Eventually(CatalogSourcePhase(t, ns, catalogSourceName), TestTimeoutMedium).Should(Equal("READY"))
+		g.Eventually(CatalogSourcePodRunning(t, ctx, ns, catalogSourceName), TestTimeoutMedium).Should(BeNil())
+		g.Eventually(CatalogSourcePhase(t, ctx, ns, catalogSourceName), TestTimeoutMedium).Should(Equal("READY"))
 
 		// Set KAMEL_BIN only for this test - don't override the ENV variable for all tests
 		g.Expect(os.Setenv("KAMEL_BIN", kamel)).To(Succeed())
 
 		if len(CRDs(t)()) > 0 {
 			// Clean up old installation - maybe leftover from another test
-			if err := UninstallAll(t); err != nil && !kerrors.IsNotFound(err) {
+			if err := UninstallAll(t, ctx); err != nil && !kerrors.IsNotFound(err) {
 				t.Error(err)
 				t.FailNow()
 			}
@@ -106,13 +106,13 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 			args = append(args, "--olm-channel", prevUpdateChannel)
 		}
 
-		g.Expect(Kamel(t, args...).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, args...).Execute()).To(Succeed())
 
 		// Find the only one Camel K CSV
 		noAdditionalConditions := func(csv olm.ClusterServiceVersion) bool {
 			return true
 		}
-		g.Eventually(ClusterServiceVersionPhase(t, noAdditionalConditions, ns), TestTimeoutMedium).
+		g.Eventually(ClusterServiceVersionPhase(t, ctx, noAdditionalConditions, ns), TestTimeoutMedium).
 			Should(Equal(olm.CSVPhaseSucceeded))
 
 		// Refresh the test client to account for the newly installed CRDs
@@ -126,75 +126,75 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 		var prevIPVersionPrefix string
 		var newIPVersionMajorMinorPatch string
 
-		prevCSVVersion = ClusterServiceVersion(t, noAdditionalConditions, ns)().Spec.Version
+		prevCSVVersion = ClusterServiceVersion(t, ctx, noAdditionalConditions, ns)().Spec.Version
 		prevIPVersionPrefix = fmt.Sprintf("%d.%d", prevCSVVersion.Version.Major, prevCSVVersion.Version.Minor)
 		t.Logf("Using Previous CSV Version: %s", prevCSVVersion.Version.String())
 
 		// Check the operator pod is running
-		g.Eventually(OperatorPodPhase(t, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+		g.Eventually(OperatorPodPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 
 		// Check the IntegrationPlatform has been reconciled
-		g.Eventually(PlatformVersion(t, ns)).Should(ContainSubstring(prevIPVersionPrefix))
+		g.Eventually(PlatformVersion(t, ctx, ns)).Should(ContainSubstring(prevIPVersionPrefix))
 
 		name := "yaml"
-		g.Expect(Kamel(t, "run", "-n", ns, "files/yaml.yaml").Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "run", "-n", ns, "files/yaml.yaml").Execute()).To(Succeed())
 		kbindName := "timer-to-log"
-		g.Expect(KamelBind(t, ns, "timer-source?message=Hello", "log-sink", "--name", kbindName).Execute()).To(Succeed())
+		g.Expect(KamelBind(t, ctx, ns, "timer-source?message=Hello", "log-sink", "--name", kbindName).Execute()).To(Succeed())
 
 		// Check the Integration runs correctly
-		g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutLong).
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutLong).
 			Should(Equal(corev1.ConditionTrue))
 		if prevCSVVersion.Version.String() >= "2" { // since 2.0 Pipe, previously KameletBinding
-			g.Eventually(PipeConditionStatus(t, ns, kbindName, v1.PipeConditionReady), TestTimeoutShort).
+			g.Eventually(PipeConditionStatus(t, ctx, ns, kbindName, v1.PipeConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
 		}
-		g.Eventually(IntegrationPodPhase(t, ns, kbindName), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, kbindName, v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, kbindName), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, kbindName, v1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(corev1.ConditionTrue))
 
 		// Check the Integration version matches that of the current operator
-		g.Expect(IntegrationVersion(t, ns, name)()).To(ContainSubstring(prevIPVersionPrefix))
-		g.Expect(IntegrationVersion(t, ns, kbindName)()).To(ContainSubstring(prevIPVersionPrefix))
+		g.Expect(IntegrationVersion(t, ctx, ns, name)()).To(ContainSubstring(prevIPVersionPrefix))
+		g.Expect(IntegrationVersion(t, ctx, ns, kbindName)()).To(ContainSubstring(prevIPVersionPrefix))
 
 		t.Run("OLM upgrade", func(t *testing.T) {
 			// Trigger Camel K operator upgrade by updating the CatalogSource with the new index image
-			g.Expect(CreateOrUpdateCatalogSource(t, ns, catalogSourceName, newIIB)).To(Succeed())
+			g.Expect(CreateOrUpdateCatalogSource(t, ctx, ns, catalogSourceName, newIIB)).To(Succeed())
 
 			if crossChannelUpgrade {
 				t.Log("Patching Camel K OLM subscription channel.")
-				subscription, err := GetSubscription(t, ns)
+				subscription, err := GetSubscription(t, ctx, ns)
 				g.Expect(err).To(BeNil())
 				g.Expect(subscription).NotTo(BeNil())
 
 				// Patch the Subscription to avoid conflicts with concurrent updates performed by OLM
 				patch := fmt.Sprintf("{\"spec\":{\"channel\":%q}}", newUpdateChannel)
 				g.Expect(
-					TestClient(t).Patch(TestContext, subscription, ctrl.RawPatch(types.MergePatchType, []byte(patch))),
+					TestClient(t).Patch(ctx, subscription, ctrl.RawPatch(types.MergePatchType, []byte(patch))),
 				).To(Succeed())
 				// Assert the response back from the API server
 				g.Expect(subscription.Spec.Channel).To(Equal(newUpdateChannel))
 			}
 
 			// The new CSV is installed
-			g.Eventually(ClusterServiceVersionPhase(t, func(csv olm.ClusterServiceVersion) bool {
+			g.Eventually(ClusterServiceVersionPhase(t, ctx, func(csv olm.ClusterServiceVersion) bool {
 				return csv.Spec.Version.Version.String() != prevCSVVersion.Version.String()
 			}, ns), TestTimeoutMedium).Should(Equal(olm.CSVPhaseSucceeded))
 
 			// The old CSV is gone
-			g.Eventually(ClusterServiceVersion(t, func(csv olm.ClusterServiceVersion) bool {
+			g.Eventually(ClusterServiceVersion(t, ctx, func(csv olm.ClusterServiceVersion) bool {
 				return csv.Spec.Version.Version.String() == prevCSVVersion.Version.String()
 			}, ns), TestTimeoutMedium).Should(BeNil())
 
-			newCSVVersion = ClusterServiceVersion(t, noAdditionalConditions, ns)().Spec.Version
+			newCSVVersion = ClusterServiceVersion(t, ctx, noAdditionalConditions, ns)().Spec.Version
 			newIPVersionMajorMinorPatch = fmt.Sprintf("%d.%d.%d", newCSVVersion.Version.Major, newCSVVersion.Version.Minor, newCSVVersion.Version.Patch)
 
 			g.Expect(prevCSVVersion.Version.String()).NotTo(Equal(newCSVVersion.Version.String()))
 
-			g.Eventually(OperatorPodPhase(t, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-			g.Eventually(OperatorImage(t, ns), TestTimeoutShort).Should(Equal(defaults.OperatorImage()))
+			g.Eventually(OperatorPodPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+			g.Eventually(OperatorImage(t, ctx, ns), TestTimeoutShort).Should(Equal(defaults.OperatorImage()))
 
 			// Check the IntegrationPlatform has been reconciled
-			g.Eventually(PlatformVersion(t, ns)).Should(ContainSubstring(newIPVersionMajorMinorPatch))
+			g.Eventually(PlatformVersion(t, ctx, ns)).Should(ContainSubstring(newIPVersionMajorMinorPatch))
 		})
 
 		t.Run("Integration upgrade", func(t *testing.T) {
@@ -202,60 +202,60 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 			g.Expect(os.Setenv("KAMEL_BIN", "")).To(Succeed())
 
 			// Check the Integration hasn't been upgraded
-			g.Consistently(IntegrationVersion(t, ns, name), 5*time.Second, 1*time.Second).
+			g.Consistently(IntegrationVersion(t, ctx, ns, name), 5*time.Second, 1*time.Second).
 				Should(ContainSubstring(prevIPVersionPrefix))
 
 			// Rebuild the Integration
-			g.Expect(Kamel(t, "rebuild", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "rebuild", "--all", "-n", ns).Execute()).To(Succeed())
 			if prevCSVVersion.Version.String() >= "2" {
-				g.Eventually(PipeConditionStatus(t, ns, kbindName, v1.PipeConditionReady), TestTimeoutMedium).
+				g.Eventually(PipeConditionStatus(t, ctx, ns, kbindName, v1.PipeConditionReady), TestTimeoutMedium).
 					Should(Equal(corev1.ConditionTrue))
 			}
 
 			// Check the Integration runs correctly
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutMedium).
 				Should(Equal(corev1.ConditionTrue))
 
 			// Check the Integration version has been upgraded
-			g.Eventually(IntegrationVersion(t, ns, name)).Should(ContainSubstring(newIPVersionMajorMinorPatch))
-			g.Eventually(IntegrationVersion(t, ns, kbindName)).Should(ContainSubstring(newIPVersionMajorMinorPatch))
+			g.Eventually(IntegrationVersion(t, ctx, ns, name)).Should(ContainSubstring(newIPVersionMajorMinorPatch))
+			g.Eventually(IntegrationVersion(t, ctx, ns, kbindName)).Should(ContainSubstring(newIPVersionMajorMinorPatch))
 
 			// Check the previous kit is not garbage collected (skip Build - present in case of respin)
 			prevCSVVersionMajorMinorPatch := fmt.Sprintf("%d.%d.%d",
 				prevCSVVersion.Version.Major, prevCSVVersion.Version.Minor, prevCSVVersion.Version.Patch)
-			g.Eventually(Kits(t, ns, KitWithVersion(prevCSVVersionMajorMinorPatch))).Should(HaveLen(2))
+			g.Eventually(Kits(t, ctx, ns, KitWithVersion(prevCSVVersionMajorMinorPatch))).Should(HaveLen(2))
 			// Check a new kit is created with the current version
-			g.Eventually(Kits(t, ns, KitWithVersionPrefix(newIPVersionMajorMinorPatch))).Should(HaveLen(2))
+			g.Eventually(Kits(t, ctx, ns, KitWithVersionPrefix(newIPVersionMajorMinorPatch))).Should(HaveLen(2))
 			// Check the new kit is ready
-			g.Eventually(Kits(t, ns, KitWithVersionPrefix(newIPVersionMajorMinorPatch), KitWithPhase(v1.IntegrationKitPhaseReady)),
+			g.Eventually(Kits(t, ctx, ns, KitWithVersionPrefix(newIPVersionMajorMinorPatch), KitWithPhase(v1.IntegrationKitPhaseReady)),
 				TestTimeoutMedium).Should(HaveLen(2))
 
-			kit := Kits(t, ns, KitWithVersionPrefix(newIPVersionMajorMinorPatch), KitWithLabels(map[string]string{"camel.apache.org/created.by.name": name}))()[0]
-			kitKbind := Kits(t, ns, KitWithVersionPrefix(newIPVersionMajorMinorPatch), KitWithLabels(map[string]string{"camel.apache.org/created.by.name": kbindName}))()[0]
+			kit := Kits(t, ctx, ns, KitWithVersionPrefix(newIPVersionMajorMinorPatch), KitWithLabels(map[string]string{"camel.apache.org/created.by.name": name}))()[0]
+			kitKbind := Kits(t, ctx, ns, KitWithVersionPrefix(newIPVersionMajorMinorPatch), KitWithLabels(map[string]string{"camel.apache.org/created.by.name": kbindName}))()[0]
 
 			// Check the Integration uses the new kit
-			g.Eventually(IntegrationKit(t, ns, name), TestTimeoutMedium).Should(Equal(kit.Name))
-			g.Eventually(IntegrationKit(t, ns, kbindName), TestTimeoutMedium).Should(Equal(kitKbind.Name))
+			g.Eventually(IntegrationKit(t, ctx, ns, name), TestTimeoutMedium).Should(Equal(kit.Name))
+			g.Eventually(IntegrationKit(t, ctx, ns, kbindName), TestTimeoutMedium).Should(Equal(kitKbind.Name))
 			// Check the Integration Pod uses the new image
-			g.Eventually(IntegrationPodImage(t, ns, name)).Should(Equal(kit.Status.Image))
-			g.Eventually(IntegrationPodImage(t, ns, kbindName)).Should(Equal(kitKbind.Status.Image))
+			g.Eventually(IntegrationPodImage(t, ctx, ns, name)).Should(Equal(kit.Status.Image))
+			g.Eventually(IntegrationPodImage(t, ctx, ns, kbindName)).Should(Equal(kitKbind.Status.Image))
 
 			// Check the Integration runs correctly
-			g.Eventually(IntegrationPodPhase(t, ns, name)).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPodPhase(t, ns, kbindName)).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutLong).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name)).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, kbindName)).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutLong).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationConditionStatus(t, ns, kbindName, v1.IntegrationConditionReady), TestTimeoutLong).
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, kbindName, v1.IntegrationConditionReady), TestTimeoutLong).
 				Should(Equal(corev1.ConditionTrue))
 
 			// Clean up
-			g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 			// Delete Integration Platform as it does not get removed with uninstall and might cause next tests to fail
-			DeletePlatform(t, ns)()
-			g.Expect(Kamel(t, "uninstall", "-n", ns).Execute()).To(Succeed())
+			DeletePlatform(t, ctx, ns)()
+			g.Expect(Kamel(t, ctx, "uninstall", "-n", ns).Execute()).To(Succeed())
 			// Clean up cluster-wide resources that are not removed by OLM
-			g.Expect(Kamel(t, "uninstall", "--all", "-n", ns, "--olm=false").Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "uninstall", "--all", "-n", ns, "--olm=false").Execute()).To(Succeed())
 		})
 	})
 }

--- a/e2e/knative/kamelet_test.go
+++ b/e2e/knative/kamelet_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package knative
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -39,7 +38,7 @@ import (
 
 // Test that a Pipe can be changed and the changes are propagated to the Integration
 func TestKameletChange(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 	timerPipe := "timer-binding"
 

--- a/e2e/knative/kamelet_test.go
+++ b/e2e/knative/kamelet_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package knative
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -38,58 +39,45 @@ import (
 
 // Test that a Pipe can be changed and the changes are propagated to the Integration
 func TestKameletChange(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 	timerPipe := "timer-binding"
 
 	knChannel := "test-kamelet-messages"
 	knChannelConf := fmt.Sprintf("%s:InMemoryChannel:%s", messaging.SchemeGroupVersion.String(), knChannel)
 	timerSource := "my-timer-source"
-	g.Expect(CreateTimerKamelet(t, operatorID, ns, timerSource)()).To(Succeed())
-	g.Expect(CreateKnativeChannel(t, ns, knChannel)()).To(Succeed())
+	g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, timerSource)()).To(Succeed())
+	g.Expect(CreateKnativeChannel(t, ctx, ns, knChannel)()).To(Succeed())
 	// Consumer route that will read from the KNative channel
-	g.Expect(KamelRunWithID(t, operatorID, ns, "files/test-kamelet-display.groovy", "-w").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, "test-kamelet-display")).Should(Equal(corev1.PodRunning))
+	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/test-kamelet-display.groovy", "-w").Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, "test-kamelet-display")).Should(Equal(corev1.PodRunning))
 
 	// Create the Pipe
-	g.Expect(KamelBindWithID(t, operatorID, ns,
-		timerSource,
-		knChannelConf,
-		"-p", "source.message=HelloKNative!",
-		"--annotation", "trait.camel.apache.org/health.enabled=true",
-		"--annotation", "trait.camel.apache.org/health.readiness-initial-delay=10",
-		"--name", timerPipe,
-	).Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, timerPipe)).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, timerPipe, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	g.Expect(KamelBindWithID(t, ctx, operatorID, ns, timerSource, knChannelConf, "-p", "source.message=HelloKNative!", "--annotation", "trait.camel.apache.org/health.enabled=true", "--annotation", "trait.camel.apache.org/health.readiness-initial-delay=10", "--name", timerPipe).Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, timerPipe)).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, timerPipe, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 	// Consume the message
-	g.Eventually(IntegrationLogs(t, ns, "test-kamelet-display"), TestTimeoutShort).Should(ContainSubstring("HelloKNative!"))
+	g.Eventually(IntegrationLogs(t, ctx, ns, "test-kamelet-display"), TestTimeoutShort).Should(ContainSubstring("HelloKNative!"))
 
-	g.Eventually(PipeCondition(t, ns, timerPipe, v1.PipeConditionReady), TestTimeoutMedium).Should(And(
+	g.Eventually(PipeCondition(t, ctx, ns, timerPipe, v1.PipeConditionReady), TestTimeoutMedium).Should(And(
 		WithTransform(PipeConditionStatusExtract, Equal(corev1.ConditionTrue)),
 		WithTransform(PipeConditionReason, Equal(v1.IntegrationConditionDeploymentReadyReason)),
 		WithTransform(PipeConditionMessage, Equal(fmt.Sprintf("1/1 ready replicas"))),
 	))
 
 	// Update the Pipe
-	g.Expect(KamelBindWithID(t, operatorID, ns,
-		timerSource,
-		knChannelConf,
-		"-p", "source.message=message is Hi",
-		"--annotation", "trait.camel.apache.org/health.enabled=true",
-		"--annotation", "trait.camel.apache.org/health.readiness-initial-delay=10",
-		"--name", timerPipe,
-	).Execute()).To(Succeed())
+	g.Expect(KamelBindWithID(t, ctx, operatorID, ns, timerSource, knChannelConf, "-p", "source.message=message is Hi", "--annotation", "trait.camel.apache.org/health.enabled=true", "--annotation", "trait.camel.apache.org/health.readiness-initial-delay=10", "--name", timerPipe).Execute()).To(Succeed())
 
-	g.Eventually(IntegrationPodPhase(t, ns, timerPipe), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, timerPipe, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ns, "test-kamelet-display"), TestTimeoutShort).Should(ContainSubstring("message is Hi"))
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, timerPipe), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, timerPipe, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+	g.Eventually(IntegrationLogs(t, ctx, ns, "test-kamelet-display"), TestTimeoutShort).Should(ContainSubstring("message is Hi"))
 
-	g.Eventually(PipeCondition(t, ns, timerPipe, v1.PipeConditionReady), TestTimeoutMedium).
+	g.Eventually(PipeCondition(t, ctx, ns, timerPipe, v1.PipeConditionReady), TestTimeoutMedium).
 		Should(And(
 			WithTransform(PipeConditionStatusExtract, Equal(corev1.ConditionTrue)),
 			WithTransform(PipeConditionReason, Equal(v1.IntegrationConditionDeploymentReadyReason)),
 			WithTransform(PipeConditionMessage, Equal("1/1 ready replicas")),
 		))
 
-	g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+	g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 }

--- a/e2e/knative/knative_test.go
+++ b/e2e/knative/knative_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestKnative(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 
 	knChannelMessages := "messages"

--- a/e2e/knative/knative_test.go
+++ b/e2e/knative/knative_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package knative
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -36,120 +37,120 @@ import (
 )
 
 func TestKnative(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 
 	knChannelMessages := "messages"
 	knChannelWords := "words"
-	g.Expect(CreateKnativeChannel(t, ns, knChannelMessages)()).To(Succeed())
-	g.Expect(CreateKnativeChannel(t, ns, knChannelWords)()).To(Succeed())
+	g.Expect(CreateKnativeChannel(t, ctx, ns, knChannelMessages)()).To(Succeed())
+	g.Expect(CreateKnativeChannel(t, ctx, ns, knChannelWords)()).To(Succeed())
 
 	t.Run("Service combo", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knative2.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, "knative2", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knative3.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "knative3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, "knative3", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knative1.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "knative1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, "knative1", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative2.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative2", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative3.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative3", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative1.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative1", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
 		// Correct logs
-		g.Eventually(IntegrationLogs(t, ns, "knative1"), TestTimeoutMedium).Should(ContainSubstring("Received from 2: Hello from knative2"))
-		g.Eventually(IntegrationLogs(t, ns, "knative1"), TestTimeoutMedium).Should(ContainSubstring("Received from 3: Hello from knative3"))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knative1"), TestTimeoutMedium).Should(ContainSubstring("Received from 2: Hello from knative2"))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knative1"), TestTimeoutMedium).Should(ContainSubstring("Received from 3: Hello from knative3"))
 		// Incorrect logs
-		g.Consistently(IntegrationLogs(t, ns, "knative1"), 10*time.Second).ShouldNot(ContainSubstring("Received from 2: Hello from knative3"))
-		g.Consistently(IntegrationLogs(t, ns, "knative1"), 10*time.Second).ShouldNot(ContainSubstring("Received from 3: Hello from knative2"))
+		g.Consistently(IntegrationLogs(t, ctx, ns, "knative1"), 10*time.Second).ShouldNot(ContainSubstring("Received from 2: Hello from knative3"))
+		g.Consistently(IntegrationLogs(t, ctx, ns, "knative1"), 10*time.Second).ShouldNot(ContainSubstring("Received from 3: Hello from knative2"))
 		// Clean up
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 
 	t.Run("Channel combo v1beta1", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativech2.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativech1.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "knativech2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ns, "knativech1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ns, "knativech2"), TestTimeoutMedium).Should(ContainSubstring("Received: Hello from knativech1"))
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativech2.groovy").Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativech1.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativech2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativech1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativech2"), TestTimeoutMedium).Should(ContainSubstring("Received: Hello from knativech1"))
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 
 	t.Run("Channel combo get to post", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativegetpost2.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativegetpost1.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "knativegetpost2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ns, "knativegetpost1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ns, "knativegetpost2"), TestTimeoutMedium).Should(ContainSubstring(`Received ""`))
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativegetpost2.groovy").Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativegetpost1.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativegetpost2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativegetpost1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativegetpost2"), TestTimeoutMedium).Should(ContainSubstring(`Received ""`))
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 
 	t.Run("Multi channel chain", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativemultihop3.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativemultihop2.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativemultihop1.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "knativemultihop3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ns, "knativemultihop2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ns, "knativemultihop1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From messages: message`))
-		g.Eventually(IntegrationLogs(t, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: word`))
-		g.Eventually(IntegrationLogs(t, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: transformed message`))
-		g.Eventually(IntegrationLogs(t, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: word`))
-		g.Eventually(IntegrationLogs(t, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From words: message`))
-		g.Eventually(IntegrationLogs(t, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: transformed message`))
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop3.groovy").Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop2.groovy").Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop1.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From messages: message`))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: word`))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: transformed message`))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: word`))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From words: message`))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: transformed message`))
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 
 	t.Run("Flow", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/flow.yaml").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "flow"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ns, "flow", camelv1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(v1.ConditionTrue))
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/flow.yaml").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "flow"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "flow", camelv1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(v1.ConditionTrue))
 
 		t.Run("Scale to zero", func(t *testing.T) {
-			g.Eventually(IntegrationPod(t, ns, "flow"), TestTimeoutLong).Should(BeNil())
+			g.Eventually(IntegrationPod(t, ctx, ns, "flow"), TestTimeoutLong).Should(BeNil())
 		})
 
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 
 	t.Run("Knative-service disabled", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/http_out.groovy", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(Service(t, ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
-		g.Consistently(KnativeService(t, ns, "http-out"), TestTimeoutShort).Should(BeNil())
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/http_out.groovy", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(Service(t, ctx, ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
+		g.Consistently(KnativeService(t, ctx, ns, "http-out"), TestTimeoutShort).Should(BeNil())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 
 	t.Run("Knative-service priority", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/http_out.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(KnativeService(t, ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/http_out.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(KnativeService(t, ctx, ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 
 	t.Run("Knative-service annotation", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knative2.groovy",
-			"-t", "knative-service.annotations.'haproxy.router.openshift.io/balance'=roundrobin").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(KnativeService(t, ns, "knative2"), TestTimeoutShort).ShouldNot(BeNil())
-		ks := KnativeService(t, ns, "knative2")()
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative2.groovy", "-t", "knative-service.annotations.'haproxy.router.openshift.io/balance'=roundrobin").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(KnativeService(t, ctx, ns, "knative2"), TestTimeoutShort).ShouldNot(BeNil())
+		ks := KnativeService(t, ctx, ns, "knative2")()
 		annotations := ks.ObjectMeta.Annotations
 		g.Expect(annotations["haproxy.router.openshift.io/balance"]).To(Equal("roundrobin"))
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }
 
 func TestRunBroker(t *testing.T) {
-	WithNewTestNamespaceWithKnativeBroker(t, func(g *WithT, ns string) {
+	WithNewTestNamespaceWithKnativeBroker(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := fmt.Sprintf("camel-k-%s", ns)
-		g.Expect(KamelInstallWithID(t, operatorID, ns, "--trait-profile", "knative")).To(Succeed())
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, "--trait-profile", "knative")).To(Succeed())
 
-		g.Eventually(SelectedPlatformPhase(t, ns, operatorID), TestTimeoutMedium).Should(Equal(camelv1.IntegrationPlatformPhaseReady))
+		g.Eventually(SelectedPlatformPhase(t, ctx, ns, operatorID), TestTimeoutMedium).Should(Equal(camelv1.IntegrationPlatformPhaseReady))
 
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativeevt1.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, operatorID, ns, "files/knativeevt2.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ns, "knativeevt1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ns, "knativeevt2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ns, "knativeevt2"), TestTimeoutMedium).Should(ContainSubstring("Received 1: Hello 1"))
-		g.Eventually(IntegrationLogs(t, ns, "knativeevt2"), TestTimeoutMedium).Should(ContainSubstring("Received 2: Hello 2"))
-		g.Eventually(IntegrationLogs(t, ns, "knativeevt2")).ShouldNot(ContainSubstring("Received 1: Hello 2"))
-		g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativeevt1.groovy").Execute()).To(Succeed())
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativeevt2.groovy").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativeevt1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativeevt2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativeevt2"), TestTimeoutMedium).Should(ContainSubstring("Received 1: Hello 1"))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativeevt2"), TestTimeoutMedium).Should(ContainSubstring("Received 2: Hello 2"))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "knativeevt2")).ShouldNot(ContainSubstring("Received 1: Hello 2"))
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 	})
 }

--- a/e2e/knative/openapi_test.go
+++ b/e2e/knative/openapi_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package knative
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
@@ -33,7 +32,7 @@ import (
 )
 
 func TestOpenAPIService(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 
 	openapiContent, err := ioutil.ReadFile("./files/petstore-api.yaml")

--- a/e2e/knative/pod_test.go
+++ b/e2e/knative/pod_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package knative
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -34,16 +35,16 @@ import (
 )
 
 func TestPodTraitWithKnative(t *testing.T) {
+	ctx := context.TODO()
 	g := NewWithT(t)
 
-	g.Expect(KamelRunWithID(t, operatorID, ns, "files/podtest-knative2.groovy",
-		"--pod-template", "files/template-knative.yaml").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, "podtest-knative2"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, "podtest-knative2", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
-	g.Expect(KamelRunWithID(t, operatorID, ns, "files/podtest-knative1.groovy").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ns, "podtest-knative1"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ns, "podtest-knative1", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ns, "podtest-knative1"), TestTimeoutShort).Should(ContainSubstring("hello from the template"))
+	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/podtest-knative2.groovy", "--pod-template", "files/template-knative.yaml").Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, "podtest-knative2"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "podtest-knative2", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/podtest-knative1.groovy").Execute()).To(Succeed())
+	g.Eventually(IntegrationPodPhase(t, ctx, ns, "podtest-knative1"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+	g.Eventually(IntegrationConditionStatus(t, ctx, ns, "podtest-knative1", v1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
+	g.Eventually(IntegrationLogs(t, ctx, ns, "podtest-knative1"), TestTimeoutShort).Should(ContainSubstring("hello from the template"))
 
-	g.Expect(Kamel(t, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+	g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 }

--- a/e2e/knative/pod_test.go
+++ b/e2e/knative/pod_test.go
@@ -23,7 +23,6 @@ limitations under the License.
 package knative
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -35,7 +34,7 @@ import (
 )
 
 func TestPodTraitWithKnative(t *testing.T) {
-	ctx := context.TODO()
+	ctx := TestContext()
 	g := NewWithT(t)
 
 	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/podtest-knative2.groovy", "--pod-template", "files/template-knative.yaml").Execute()).To(Succeed())

--- a/e2e/native/native_binding_test.go
+++ b/e2e/native/native_binding_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package native
 
 import (
+	"context"
 	. "github.com/apache/camel-k/v2/e2e/support"
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	. "github.com/onsi/gomega"
@@ -31,44 +32,34 @@ import (
 )
 
 func TestNativeBinding(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-native-binding"
-		g.Expect(KamelInstallWithIDAndKameletCatalog(t, operatorID, ns,
-			"--build-timeout", "90m0s",
-			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=6g",
-		)).To(Succeed())
-		g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Expect(KamelInstallWithIDAndKameletCatalog(t, ctx, operatorID, ns, "--build-timeout", "90m0s", "--maven-cli-option", "-Dquarkus.native.native-image-xmx=6g")).To(Succeed())
+		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 		message := "Magicstring!"
 		t.Run("binding with native build", func(t *testing.T) {
 			bindingName := "native-binding"
-			g.Expect(KamelBindWithID(t, operatorID, ns,
-				"timer-source",
-				"log-sink",
-				"-p", "source.message="+message,
-				"--annotation", "trait.camel.apache.org/quarkus.build-mode=native",
-				"--annotation", "trait.camel.apache.org/builder.tasks-limit-memory=quarkus-native:6.5Gi",
-				"--name", bindingName,
-			).Execute()).To(Succeed())
+			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "timer-source", "log-sink", "-p", "source.message="+message, "--annotation", "trait.camel.apache.org/quarkus.build-mode=native", "--annotation", "trait.camel.apache.org/builder.tasks-limit-memory=quarkus-native:6.5Gi", "--name", bindingName).Execute()).To(Succeed())
 
 			// ====================================
 			// !!! THE MOST TIME-CONSUMING PART !!!
 			// ====================================
-			g.Eventually(Kits(t, ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady)),
+			g.Eventually(Kits(t, ctx, ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady)),
 				TestTimeoutVeryLong).Should(HaveLen(1))
 
-			nativeKit := Kits(t, ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady))()[0]
-			g.Eventually(IntegrationKit(t, ns, bindingName), TestTimeoutShort).Should(Equal(nativeKit.Name))
+			nativeKit := Kits(t, ctx, ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady))()[0]
+			g.Eventually(IntegrationKit(t, ctx, ns, bindingName), TestTimeoutShort).Should(Equal(nativeKit.Name))
 
-			g.Eventually(IntegrationPodPhase(t, ns, bindingName), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ns, bindingName), TestTimeoutShort).Should(ContainSubstring(message))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, bindingName), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, bindingName), TestTimeoutShort).Should(ContainSubstring(message))
 
-			g.Eventually(IntegrationPod(t, ns, bindingName), TestTimeoutShort).
+			g.Eventually(IntegrationPod(t, ctx, ns, bindingName), TestTimeoutShort).
 				Should(WithTransform(getContainerCommand(),
 					MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
 
 			// Clean up
-			g.Expect(Kamel(t, "delete", bindingName, "-n", ns).Execute()).To(Succeed())
-			g.Expect(DeleteKits(t, ns)).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", bindingName, "-n", ns).Execute()).To(Succeed())
+			g.Expect(DeleteKits(t, ctx, ns)).To(Succeed())
 		})
 	})
 }

--- a/e2e/native/native_test.go
+++ b/e2e/native/native_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package native
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -35,130 +36,114 @@ import (
 )
 
 func TestNativeIntegrations(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-quarkus-native"
-		g.Expect(KamelInstallWithID(t, operatorID, ns,
-			"--build-timeout", "90m0s",
-			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=6g",
-		)).To(Succeed())
-		g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, "--build-timeout", "90m0s", "--maven-cli-option", "-Dquarkus.native.native-image-xmx=6g")).To(Succeed())
+		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		t.Run("unsupported integration source language", func(t *testing.T) {
 			name := RandomizedSuffixName("unsupported-js")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/JavaScript.js", "--name", name,
-				"-t", "quarkus.build-mode=native",
-				"-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/JavaScript.js", "--name", name, "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPhase(t, ns, name)).Should(Equal(v1.IntegrationPhaseError))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionKitAvailable)).
+			g.Eventually(IntegrationPhase(t, ctx, ns, name)).Should(Equal(v1.IntegrationPhaseError))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionKitAvailable)).
 				Should(Equal(corev1.ConditionFalse))
 
 			// check integration schema does not contains unwanted default trait value.
-			g.Eventually(UnstructuredIntegration(t, ns, name)).ShouldNot(BeNil())
-			unstructuredIntegration := UnstructuredIntegration(t, ns, name)()
+			g.Eventually(UnstructuredIntegration(t, ctx, ns, name)).ShouldNot(BeNil())
+			unstructuredIntegration := UnstructuredIntegration(t, ctx, ns, name)()
 			quarkusTrait, _, _ := unstructured.NestedMap(unstructuredIntegration.Object, "spec", "traits", "quarkus")
 			g.Expect(quarkusTrait).ToNot(BeNil())
 			g.Expect(len(quarkusTrait)).To(Equal(1))
 			g.Expect(quarkusTrait["buildMode"]).ToNot(BeNil())
 
 			// Clean up
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("xml native support", func(t *testing.T) {
 			name := RandomizedSuffixName("xml-native")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Xml.xml", "--name", name,
-				"-t", "quarkus.build-mode=native",
-				"-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Xml.xml", "--name", name, "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 				Should(WithTransform(getContainerCommand(), MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
 
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("XML Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("XML Magicstring!"))
 
 			// Clean up
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("automatic rollout deployment from jvm to native kit", func(t *testing.T) {
 			// Let's make sure we start from a clean state
-			g.Expect(DeleteKits(t, ns)).To(Succeed())
+			g.Expect(DeleteKits(t, ctx, ns)).To(Succeed())
 			name := RandomizedSuffixName("yaml-native")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml.yaml", "--name", name,
-				"-t", "quarkus.build-mode=jvm",
-				"-t", "quarkus.build-mode=native",
-				"-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml.yaml", "--name", name, "-t", "quarkus.build-mode=jvm", "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi").Execute()).To(Succeed())
 
 			// Check that two Kits are created with distinct layout
-			g.Eventually(Kits(t, ns, withFastJarLayout)).Should(HaveLen(1))
-			g.Eventually(Kits(t, ns, withNativeLayout)).Should(HaveLen(1))
+			g.Eventually(Kits(t, ctx, ns, withFastJarLayout)).Should(HaveLen(1))
+			g.Eventually(Kits(t, ctx, ns, withNativeLayout)).Should(HaveLen(1))
 
 			// Check the fast-jar Kit is ready
-			g.Eventually(Kits(t, ns, withFastJarLayout, KitWithPhase(v1.IntegrationKitPhaseReady)),
+			g.Eventually(Kits(t, ctx, ns, withFastJarLayout, KitWithPhase(v1.IntegrationKitPhaseReady)),
 				TestTimeoutLong).Should(HaveLen(1))
 
-			fastJarKit := Kits(t, ns, withFastJarLayout, KitWithPhase(v1.IntegrationKitPhaseReady))()[0]
+			fastJarKit := Kits(t, ctx, ns, withFastJarLayout, KitWithPhase(v1.IntegrationKitPhaseReady))()[0]
 			// Check the Integration uses the fast-jar Kit
-			g.Eventually(IntegrationKit(t, ns, name), TestTimeoutShort).Should(Equal(fastJarKit.Name))
+			g.Eventually(IntegrationKit(t, ctx, ns, name), TestTimeoutShort).Should(Equal(fastJarKit.Name))
 			// Check the Integration Pod uses the fast-jar Kit
-			g.Eventually(IntegrationPodImage(t, ns, name)).Should(Equal(fastJarKit.Status.Image))
+			g.Eventually(IntegrationPodImage(t, ctx, ns, name)).Should(Equal(fastJarKit.Status.Image))
 
 			// Check the Integration is ready
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 				Should(WithTransform(getContainerCommand(), ContainSubstring("java")))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
 
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutMedium).Should(ContainSubstring("Magicstring!"))
 
 			// ====================================
 			// !!! THE MOST TIME-CONSUMING PART !!!
 			// ====================================
 			// Check the native Kit is ready
-			g.Eventually(Kits(t, ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady)),
+			g.Eventually(Kits(t, ctx, ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady)),
 				TestTimeoutVeryLong).Should(HaveLen(1))
 
-			nativeKit := Kits(t, ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady))()[0]
+			nativeKit := Kits(t, ctx, ns, withNativeLayout, KitWithPhase(v1.IntegrationKitPhaseReady))()[0]
 			// Check the Integration uses the native Kit
-			g.Eventually(IntegrationKit(t, ns, name), TestTimeoutShort).Should(Equal(nativeKit.Name))
+			g.Eventually(IntegrationKit(t, ctx, ns, name), TestTimeoutShort).Should(Equal(nativeKit.Name))
 			// Check the Integration Pod uses the native Kit
-			g.Eventually(IntegrationPodImage(t, ns, name)).Should(Equal(nativeKit.Status.Image))
+			g.Eventually(IntegrationPodImage(t, ctx, ns, name)).Should(Equal(nativeKit.Status.Image))
 
 			// Check the Integration is still ready
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 				Should(WithTransform(getContainerCommand(), MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
 
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 
 			t.Run("yaml native should not rebuild", func(t *testing.T) {
 				name := RandomizedSuffixName("yaml-native-2")
-				g.Expect(KamelRunWithID(t, operatorID, ns, "files/yaml2.yaml", "--name", name,
-					"-t", "quarkus.build-mode=native",
-					"-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi",
-				).Execute()).To(Succeed())
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/yaml2.yaml", "--name", name, "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:6.5Gi").Execute()).To(Succeed())
 
 				// This one should run quickly as it suppose to reuse an IntegrationKit
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutShort).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 					Should(WithTransform(getContainerCommand(), MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!2"))
-				g.Eventually(IntegrationKit(t, ns, "yaml-native-2")).Should(Equal(IntegrationKit(t, ns, "yaml-native")()))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Magicstring!2"))
+				g.Eventually(IntegrationKit(t, ctx, ns, "yaml-native-2")).Should(Equal(IntegrationKit(t, ctx, ns, "yaml-native")()))
 			})
 
 			// Clean up
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
 		})
 
 	})

--- a/e2e/native/native_with_sources_test.go
+++ b/e2e/native/native_with_sources_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package native
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -33,13 +34,10 @@ import (
 )
 
 func TestNativeHighMemoryIntegrations(t *testing.T) {
-	WithNewTestNamespace(t, func(g *WithT, ns string) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-quarkus-high-memory-native"
-		g.Expect(KamelInstallWithID(t, operatorID, ns,
-			"--build-timeout", "90m0s",
-			"--maven-cli-option", "-Dquarkus.native.native-image-xmx=9g",
-		)).To(Succeed())
-		g.Eventually(PlatformPhase(t, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
+		g.Expect(KamelInstallWithID(t, ctx, operatorID, ns, "--build-timeout", "90m0s", "--maven-cli-option", "-Dquarkus.native.native-image-xmx=9g")).To(Succeed())
+		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 
 		javaNativeName := RandomizedSuffixName("java-native")
 		javaNativeCloneName := RandomizedSuffixName("java-native-clone")
@@ -47,91 +45,76 @@ func TestNativeHighMemoryIntegrations(t *testing.T) {
 
 		t.Run("java native support", func(t *testing.T) {
 			name := javaNativeName
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
-				"-t", "quarkus.build-mode=native",
-				"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 				Should(WithTransform(getContainerCommand(), MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magicstring!"))
 
 			t.Run("java native same should not rebuild", func(t *testing.T) {
 				name := javaNativeCloneName
-				g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java.java", "--name", name,
-					"-t", "quarkus.build-mode=native",
-					"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
-				).Execute()).To(Succeed())
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java.java", "--name", name, "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi").Execute()).To(Succeed())
 
 				// This one should run quickly as it suppose to reuse an IntegrationKit
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutShort).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 					Should(WithTransform(getContainerCommand(), MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magicstring!"))
-				g.Eventually(IntegrationKit(t, ns, javaNativeCloneName)).Should(Equal(IntegrationKit(t, ns, javaNativeName)()))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magicstring!"))
+				g.Eventually(IntegrationKit(t, ctx, ns, javaNativeCloneName)).Should(Equal(IntegrationKit(t, ctx, ns, javaNativeName)()))
 			})
 
 			t.Run("java native should rebuild", func(t *testing.T) {
 				name := javaNative2Name
-				g.Expect(KamelRunWithID(t, operatorID, ns, "files/Java2.java", "--name", name,
-					"-t", "quarkus.build-mode=native",
-					"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
-				).Execute()).To(Succeed())
+				g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Java2.java", "--name", name, "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi").Execute()).To(Succeed())
 
-				g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
-				g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+				g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
+				g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 					Should(WithTransform(getContainerCommand(), MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
-				g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+				g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 					Should(Equal(corev1.ConditionTrue))
-				g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magic2string!"))
-				g.Eventually(IntegrationKit(t, ns, javaNative2Name)).ShouldNot(Equal(IntegrationKit(t, ns, javaNativeName)()))
+				g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Java Magic2string!"))
+				g.Eventually(IntegrationKit(t, ctx, ns, javaNative2Name)).ShouldNot(Equal(IntegrationKit(t, ctx, ns, javaNativeName)()))
 			})
 
 			// Clean up
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("groovy native support", func(t *testing.T) {
 			name := RandomizedSuffixName("groovy-native")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Groovy.groovy", "--name", name,
-				"-t", "quarkus.build-mode=native",
-				"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Groovy.groovy", "--name", name, "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 				Should(WithTransform(getContainerCommand(), MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
 
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Groovy Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Groovy Magicstring!"))
 
 			// Clean up
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
 		})
 
 		t.Run("kotlin native support", func(t *testing.T) {
 			name := RandomizedSuffixName("kotlin-native")
-			g.Expect(KamelRunWithID(t, operatorID, ns, "files/Kotlin.kts", "--name", name,
-				"-t", "quarkus.build-mode=native",
-				"-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi",
-			).Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/Kotlin.kts", "--name", name, "-t", "quarkus.build-mode=native", "-t", "builder.tasks-limit-memory=quarkus-native:9.5Gi").Execute()).To(Succeed())
 
-			g.Eventually(IntegrationPodPhase(t, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationPod(t, ns, name), TestTimeoutShort).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutVeryLong).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationPod(t, ctx, ns, name), TestTimeoutShort).
 				Should(WithTransform(getContainerCommand(), MatchRegexp(".*camel-k-integration-\\d+\\.\\d+\\.\\d+[-A-Za-z]*-runner.*")))
-			g.Eventually(IntegrationConditionStatus(t, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).
 				Should(Equal(corev1.ConditionTrue))
 
-			g.Eventually(IntegrationLogs(t, ns, name), TestTimeoutShort).Should(ContainSubstring("Kotlin Magicstring!"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Kotlin Magicstring!"))
 
 			// Clean up
-			g.Expect(Kamel(t, "delete", name, "-n", ns).Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "delete", name, "-n", ns).Execute()).To(Succeed())
 		})
 	})
 }

--- a/e2e/support/csv.go
+++ b/e2e/support/csv.go
@@ -23,6 +23,7 @@ limitations under the License.
 package support
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -41,10 +42,10 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/log"
 )
 
-func ClusterServiceVersion(t *testing.T, conditions func(olm.ClusterServiceVersion) bool, ns string) func() *olm.ClusterServiceVersion {
+func ClusterServiceVersion(t *testing.T, ctx context.Context, conditions func(olm.ClusterServiceVersion) bool, ns string) func() *olm.ClusterServiceVersion {
 	return func() *olm.ClusterServiceVersion {
 		lst := olm.ClusterServiceVersionList{}
-		if err := TestClient(t).List(TestContext, &lst, ctrl.InNamespace(ns)); err != nil {
+		if err := TestClient(t).List(ctx, &lst, ctrl.InNamespace(ns)); err != nil {
 			panic(err)
 		}
 		for _, s := range lst.Items {
@@ -56,16 +57,16 @@ func ClusterServiceVersion(t *testing.T, conditions func(olm.ClusterServiceVersi
 	}
 }
 
-func ClusterServiceVersionPhase(t *testing.T, conditions func(olm.ClusterServiceVersion) bool, ns string) func() olm.ClusterServiceVersionPhase {
+func ClusterServiceVersionPhase(t *testing.T, ctx context.Context, conditions func(olm.ClusterServiceVersion) bool, ns string) func() olm.ClusterServiceVersionPhase {
 	return func() olm.ClusterServiceVersionPhase {
-		if csv := ClusterServiceVersion(t, conditions, ns)(); csv != nil && unsafe.Sizeof(csv.Status) > 0 {
+		if csv := ClusterServiceVersion(t, ctx, conditions, ns)(); csv != nil && unsafe.Sizeof(csv.Status) > 0 {
 			return csv.Status.Phase
 		}
 		return ""
 	}
 }
 
-func CreateOrUpdateCatalogSource(t *testing.T, ns, name, image string) error {
+func CreateOrUpdateCatalogSource(t *testing.T, ctx context.Context, ns, name, image string) error {
 	catalogSource := &olm.CatalogSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -73,7 +74,7 @@ func CreateOrUpdateCatalogSource(t *testing.T, ns, name, image string) error {
 		},
 	}
 
-	_, err := ctrlutil.CreateOrUpdate(TestContext, TestClient(t), catalogSource, func() error {
+	_, err := ctrlutil.CreateOrUpdate(ctx, TestClient(t), catalogSource, func() error {
 		catalogSource.Spec = olm.CatalogSourceSpec{
 			Image:       image,
 			SourceType:  "grpc",
@@ -86,7 +87,7 @@ func CreateOrUpdateCatalogSource(t *testing.T, ns, name, image string) error {
 	return err
 }
 
-func CatalogSource(t *testing.T, ns, name string) func() *olm.CatalogSource {
+func CatalogSource(t *testing.T, ctx context.Context, ns, name string) func() *olm.CatalogSource {
 	return func() *olm.CatalogSource {
 		cs := &olm.CatalogSource{
 			TypeMeta: metav1.TypeMeta{
@@ -98,7 +99,7 @@ func CatalogSource(t *testing.T, ns, name string) func() *olm.CatalogSource {
 				Name:      name,
 			},
 		}
-		if err := TestClient(t).Get(TestContext, ctrl.ObjectKeyFromObject(cs), cs); err != nil && k8serrors.IsNotFound(err) {
+		if err := TestClient(t).Get(ctx, ctrl.ObjectKeyFromObject(cs), cs); err != nil && k8serrors.IsNotFound(err) {
 			return nil
 		} else if err != nil {
 			log.Errorf(err, "Error while retrieving CatalogSource %s", name)
@@ -108,18 +109,18 @@ func CatalogSource(t *testing.T, ns, name string) func() *olm.CatalogSource {
 	}
 }
 
-func CatalogSourcePhase(t *testing.T, ns, name string) func() string {
+func CatalogSourcePhase(t *testing.T, ctx context.Context, ns, name string) func() string {
 	return func() string {
-		if source := CatalogSource(t, ns, name)(); source != nil && source.Status.GRPCConnectionState != nil {
-			return CatalogSource(t, ns, name)().Status.GRPCConnectionState.LastObservedState
+		if source := CatalogSource(t, ctx, ns, name)(); source != nil && source.Status.GRPCConnectionState != nil {
+			return CatalogSource(t, ctx, ns, name)().Status.GRPCConnectionState.LastObservedState
 		}
 		return ""
 	}
 }
 
-func CatalogSourcePod(t *testing.T, ns, csName string) func() *corev1.Pod {
+func CatalogSourcePod(t *testing.T, ctx context.Context, ns, csName string) func() *corev1.Pod {
 	return func() *corev1.Pod {
-		podList, err := TestClient(t).CoreV1().Pods(ns).List(TestContext, metav1.ListOptions{})
+		podList, err := TestClient(t).CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 		if err != nil && k8serrors.IsNotFound(err) {
 			return nil
 		} else if err != nil {
@@ -140,8 +141,8 @@ func CatalogSourcePod(t *testing.T, ns, csName string) func() *corev1.Pod {
 	}
 }
 
-func CatalogSourcePodRunning(t *testing.T, ns, csName string) error {
-	podFunc := CatalogSourcePod(t, ns, csName)
+func CatalogSourcePodRunning(t *testing.T, ctx context.Context, ns, csName string) error {
+	podFunc := CatalogSourcePod(t, ctx, ns, csName)
 
 	for i := 1; i < 5; i++ {
 		csPod := podFunc()
@@ -151,7 +152,7 @@ func CatalogSourcePodRunning(t *testing.T, ns, csName string) error {
 
 		if i == 2 {
 			fmt.Println("Catalog Source Pod still not ready so delete & allow it to be redeployed ...")
-			if err := TestClient(t).Delete(TestContext, csPod); err != nil {
+			if err := TestClient(t).Delete(ctx, csPod); err != nil {
 				return err
 			}
 		}
@@ -163,9 +164,9 @@ func CatalogSourcePodRunning(t *testing.T, ns, csName string) error {
 	return fmt.Errorf("Catalog Source Pod failed to reach a 'running' state")
 }
 
-func GetSubscription(t *testing.T, ns string) (*olm.Subscription, error) {
+func GetSubscription(t *testing.T, ctx context.Context, ns string) (*olm.Subscription, error) {
 	lst := olm.SubscriptionList{}
-	if err := TestClient(t).List(TestContext, &lst, ctrl.InNamespace(ns)); err != nil {
+	if err := TestClient(t).List(ctx, &lst, ctrl.InNamespace(ns)); err != nil {
 		return nil, err
 	}
 	for _, s := range lst.Items {

--- a/e2e/support/test_nexus_hooks.go
+++ b/e2e/support/test_nexus_hooks.go
@@ -23,6 +23,7 @@ limitations under the License.
 package support
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -53,7 +54,7 @@ func init() {
 						Name:      nexusService,
 					}
 
-					if err := TestClient(nil).Get(TestContext, key, &svc); err != nil {
+					if err := TestClient(nil).Get(context.TODO(), key, &svc); err != nil {
 						svcExists = false
 					}
 					svcChecked = true

--- a/e2e/support/test_nexus_hooks.go
+++ b/e2e/support/test_nexus_hooks.go
@@ -23,7 +23,6 @@ limitations under the License.
 package support
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -54,7 +53,7 @@ func init() {
 						Name:      nexusService,
 					}
 
-					if err := TestClient(nil).Get(context.TODO(), key, &svc); err != nil {
+					if err := TestClient(nil).Get(TestContext(), key, &svc); err != nil {
 						svcExists = false
 					}
 					svcChecked = true

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -136,6 +136,7 @@ var TestTimeoutVeryLong = 60 * time.Minute
 
 var NoOlmOperatorImage string
 
+var testContext = context.TODO()
 var testClient client.Client
 var clientMutex = sync.Mutex{}
 
@@ -153,6 +154,10 @@ func failTest(t *testing.T, err error) {
 	} else {
 		panic(err)
 	}
+}
+
+func TestContext() context.Context {
+	return testContext
 }
 
 func TestClient(t *testing.T) client.Client {
@@ -180,6 +185,7 @@ func RefreshClient(t *testing.T) client.Client {
 	if err != nil {
 		failTest(t, err)
 	}
+	testContext = context.TODO()
 	return testClient
 }
 
@@ -2781,21 +2787,19 @@ func Pods(t *testing.T, ctx context.Context, ns string) func() []corev1.Pod {
 }
 
 func WithNewTestNamespace(t *testing.T, doRun func(context.Context, *gomega.WithT, string)) {
-	ctx := context.TODO()
-	ns := NewTestNamespace(t, ctx, false)
-	defer deleteTestNamespace(t, ctx, ns)
+	ns := NewTestNamespace(t, testContext, false)
+	defer deleteTestNamespace(t, testContext, ns)
 	defer userCleanup(t)
 
-	invokeUserTestCode(t, ctx, ns.GetName(), doRun)
+	invokeUserTestCode(t, testContext, ns.GetName(), doRun)
 }
 
 func WithGlobalOperatorNamespace(t *testing.T, test func(context.Context, *gomega.WithT, string)) {
-	ctx := context.TODO()
 	ocp, err := openshift.IsOpenShift(TestClient(t))
 	require.NoError(t, err)
 	if ocp {
 		// global operators are always installed in the openshift-operators namespace
-		invokeUserTestCode(t, ctx, "openshift-operators", test)
+		invokeUserTestCode(t, testContext, "openshift-operators", test)
 	} else {
 		// create new namespace for the global operator
 		WithNewTestNamespace(t, test)
@@ -2803,13 +2807,12 @@ func WithGlobalOperatorNamespace(t *testing.T, test func(context.Context, *gomeg
 }
 
 func WithNewTestNamespaceWithKnativeBroker(t *testing.T, doRun func(context.Context, *gomega.WithT, string)) {
-	ctx := context.TODO()
-	ns := NewTestNamespace(t, ctx, true)
-	defer deleteTestNamespace(t, ctx, ns)
-	defer deleteKnativeBroker(t, ctx, ns)
+	ns := NewTestNamespace(t, testContext, true)
+	defer deleteTestNamespace(t, testContext, ns)
+	defer deleteKnativeBroker(t, testContext, ns)
 	defer userCleanup(t)
 
-	invokeUserTestCode(t, ctx, ns.GetName(), doRun)
+	invokeUserTestCode(t, testContext, ns.GetName(), doRun)
 }
 
 func userCleanup(t *testing.T) {

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -308,6 +308,16 @@ func kamelInstallWithContext(t *testing.T, ctx context.Context, operatorID strin
 		}
 	}
 
+	runtimeVersion := os.Getenv("CAMEL_K_TEST_RUNTIME_VERSION")
+	if runtimeVersion != "" {
+		fmt.Printf("Setting runtime version to %s\n", runtimeVersion)
+		installArgs = append(installArgs, "--runtime-version", runtimeVersion)
+	}
+	baseImage := os.Getenv("CAMEL_K_TEST_BASE_IMAGE")
+	if baseImage != "" {
+		fmt.Printf("Setting base image to %s\n", baseImage)
+		installArgs = append(installArgs, "--base-image", baseImage)
+	}
 	opImage := os.Getenv("CAMEL_K_TEST_OPERATOR_IMAGE")
 	if opImage != "" {
 		fmt.Printf("Setting operator image to %s\n", opImage)

--- a/e2e/support/test_util.go
+++ b/e2e/support/test_util.go
@@ -23,6 +23,7 @@ limitations under the License.
 package support
 
 import (
+	"context"
 	"github.com/apache/camel-k/v2/pkg/util/log"
 	"os"
 	"os/exec"
@@ -101,24 +102,24 @@ func ExpectExecError(t *testing.T, g *WithT, command *exec.Cmd) {
 }
 
 // Cleanup Clean up the cluster ready for the next set of tests
-func Cleanup(t *testing.T) {
+func Cleanup(t *testing.T, ctx context.Context) {
 	// Remove the locally installed operator
-	if err := UninstallAll(t); err != nil {
+	if err := UninstallAll(t, ctx); err != nil {
 		log.Error(err, "Failed to uninstall Camel K")
 	}
 
 	// Ensure the CRDs & ClusterRoles are reinstalled if not already
-	if err := Kamel(t, "install", "--olm=false", "--cluster-setup").Execute(); err != nil {
+	if err := Kamel(t, ctx, "install", "--olm=false", "--cluster-setup").Execute(); err != nil {
 		log.Error(err, "Failed to perform Camel K cluster setup")
 	}
 }
 
 // UninstallAll Removes all items
-func UninstallAll(t *testing.T) error {
-	return Kamel(t, "uninstall", "--olm=false", "--all").Execute()
+func UninstallAll(t *testing.T, ctx context.Context) error {
+	return Kamel(t, ctx, "uninstall", "--olm=false", "--all").Execute()
 }
 
 // UninstallFromNamespace Removes operator from given namespace
-func UninstallFromNamespace(t *testing.T, ns string) error {
-	return Kamel(t, "uninstall", "--olm=false", "-n", ns).Execute()
+func UninstallFromNamespace(t *testing.T, ctx context.Context, ns string) error {
+	return Kamel(t, ctx, "uninstall", "--olm=false", "-n", ns).Execute()
 }

--- a/script/Makefile
+++ b/script/Makefile
@@ -362,7 +362,7 @@ endif
 
 build-compile-integration-tests:
 	@echo "####### Compiling integration tests..."
-	export CAMEL_K_E2E_JUST_COMPILE="true" ;\
+	export CAMEL_K_E2E_JUST_COMPILE="true"; \
 	go test -run nope -tags="integration" ./e2e/...
 
 clean:


### PR DESCRIPTION
- Do not run fast setup locally
- Improve Integration logs waiting for container created
- Use UpdatePlatform func as it is more stable
- Add option to set base image and runtime version in E2E tests
- Refactor new context instantiation injecting context to each test