### PR TITLE
fix(#5242): Disable noErrorHandler setting for Camel 4.4.0

### DIFF
--- a/pkg/apis/camel/v1/integration_types_support.go
+++ b/pkg/apis/camel/v1/integration_types_support.go
@@ -116,6 +116,11 @@ func (in *IntegrationSpec) AddDependency(dependency string) {
 	in.Dependencies = append(in.Dependencies, dependency)
 }
 
+// AddConfigurationProperty adds a new configuration property.
+func (in *IntegrationSpec) AddConfigurationProperty(confValue string) {
+	in.AddConfiguration("property", confValue)
+}
+
 // GetConfigurationProperty returns a configuration property.
 func (in *IntegrationSpec) GetConfigurationProperty(property string) string {
 	for _, confSpec := range in.Configuration {

--- a/pkg/controller/pipe/integration.go
+++ b/pkg/controller/pipe/integration.go
@@ -224,10 +224,7 @@ func configureBinding(integration *v1.Integration, bindings ...*bindings.Binding
 				return err
 			}
 
-			integration.Spec.Configuration = append(integration.Spec.Configuration, v1.ConfigurationSpec{
-				Type:  "property",
-				Value: entry,
-			})
+			integration.Spec.AddConfigurationProperty(entry)
 		}
 
 	}


### PR DESCRIPTION
- Runtime version 3.8.0+ requires this setting so pipe error handler works as expected
- noErrorHandler is set for Kamelets by default since Camel 4.4.0

**Release Note**
```release-note
fix(#5242): Disable noErrorHandler setting for Camel 4.4.0 to make pipe error handler work
```
