### PR TITLE
[#5252] release-nightly does not build/push multiarch manifest

### DIFF
--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -110,7 +110,6 @@ runs:
       shell: bash
       run: |
         make VERSION=${{ env.VERSION }} IMAGE_NAME=${{ env.IMAGE_NAME }} images-nightly
-        make IMAGE_ARCH=arm64 VERSION=${{ env.VERSION }} IMAGE_NAME=${{ env.IMAGE_NAME }} images-nightly
         make VERSION=${{ env.VERSION }} IMAGE_NAME=${{ env.IMAGE_NAME }} release-nightly
 
     - name: Generate SBOM

--- a/docs/modules/ROOT/pages/contributing/developers.adoc
+++ b/docs/modules/ROOT/pages/contributing/developers.adoc
@@ -96,11 +96,11 @@ After a successful build, if you're connected to a Docker daemon, you can build 
 make images
 ----
 
-The above command produces a `camel-k` image with the name `docker.io/apache/camel-k`. Sometimes you might need to produce `camel-k` images that need to be pushed to the custom repository e.g. `docker.io/myrepo/camel-k`, to do that you can pass a parameter `STAGING_IMAGE_NAME` to `make` as shown below:
+The above command produces a `camel-k` image with the name `docker.io/apache/camel-k`. Sometimes you might need to produce `camel-k` images that need to be pushed to the custom repository e.g. `docker.io/myrepo/camel-k`, to do that you can pass a parameter `STAGING_IMAGE` to `make` as shown below:
 
 [source]
 ----
-make STAGING_IMAGE_NAME='docker.io/myrepo/camel-k' images-push-staging
+make STAGING_IMAGE='docker.io/myrepo/camel-k' images-push-staging
 ----
 
 [[testing]]

--- a/script/Makefile
+++ b/script/Makefile
@@ -78,7 +78,7 @@ INDEX_DIR := index
 OPM := opm
 
 # Used to push pre-release artifacts
-STAGING_IMAGE_NAME := docker.io/camelk/camel-k
+STAGING_IMAGE := docker.io/camelk/camel-k
 STAGING_RUNTIME_REPO :=
 
 # Kamelets options
@@ -456,17 +456,29 @@ images-all:
 	make IMAGE_ARCH=arm64 images
 	make IMAGE_ARCH=amd64 images
 
-images-push-staging:
-	docker tag $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-amd64 $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)-amd64
-	docker tag $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-amd64 $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)
-	docker push $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)-amd64
-	docker push $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)
+images-push:
+	docker push $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-amd64
+	docker push $(CUSTOM_IMAGE):$(CUSTOM_VERSION)
 	@if docker inspect $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64 &> /dev/null; then \
 		echo "Image $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64 exists, building the multiarch manifest"; \
-		docker tag $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64 $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)-arm64; \
-		docker push $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)-arm64; \
-		docker manifest create $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION) --amend $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)-amd64 --amend $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION)-arm64; \
-		docker manifest push --purge $(STAGING_IMAGE_NAME):$(CUSTOM_VERSION); \
+		docker push $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64; \
+		docker manifest create $(CUSTOM_IMAGE):$(CUSTOM_VERSION) --amend $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-amd64 --amend $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64; \
+		docker manifest push --purge $(CUSTOM_IMAGE):$(CUSTOM_VERSION); \
+	else \
+		echo "Image $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64 does not exist"; \
+	fi
+
+images-push-staging:
+	docker tag $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-amd64 $(STAGING_IMAGE):$(CUSTOM_VERSION)-amd64
+	docker tag $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-amd64 $(STAGING_IMAGE):$(CUSTOM_VERSION)
+	docker push $(STAGING_IMAGE):$(CUSTOM_VERSION)-amd64
+	docker push $(STAGING_IMAGE):$(CUSTOM_VERSION)
+	@if docker inspect $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64 &> /dev/null; then \
+		echo "Image $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64 exists, building the multiarch manifest"; \
+		docker tag $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64 $(STAGING_IMAGE):$(CUSTOM_VERSION)-arm64; \
+		docker push $(STAGING_IMAGE):$(CUSTOM_VERSION)-arm64; \
+		docker manifest create $(STAGING_IMAGE):$(CUSTOM_VERSION) --amend $(STAGING_IMAGE):$(CUSTOM_VERSION)-amd64 --amend $(STAGING_IMAGE):$(CUSTOM_VERSION)-arm64; \
+		docker manifest push --purge $(STAGING_IMAGE):$(CUSTOM_VERSION); \
 	else \
 		echo "Image $(CUSTOM_IMAGE):$(CUSTOM_VERSION)-arm64 does not exist"; \
 	fi
@@ -508,7 +520,7 @@ sbomgen:
 	cyclonedx-gomod mod -licenses -json -output sbom.json
 
 # Build images
-images-nightly: clean codegen set-version build-resources images
+images-nightly: clean codegen set-version build-resources images-all
 
 # Release artifacts
 release-nightly: cross-compile images-push


### PR DESCRIPTION
To build all image variants, call

```
make images-all
```

Support push for `CUSTOM_IMAGE` (i.e. not just `STAGING_IMAGE`)