### PR TITLE
Add Kamelet v1alpha1 sample

### DIFF
--- a/pkg/resources/config/samples/bases/camel_v1alpha1_kamelet.yaml
+++ b/pkg/resources/config/samples/bases/camel_v1alpha1_kamelet.yaml
@@ -15,22 +15,21 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-#
-# * patches/integration-platform-patch.yaml
-# customizes the integration platform custom resource
-# Edit the patch manually to add required configuration
-#
-resources:
-- bases/camel_v1_integrationplatform.yaml
-- bases/camel_v1_integrationprofile.yaml
-- bases/camel_v1_integration.yaml
-- bases/camel_v1_integrationkit.yaml
-- bases/camel_v1_camelcatalog.yaml
-- bases/camel_v1_build.yaml
-- bases/camel_v1_kamelet.yaml
-- bases/camel_v1_pipe.yaml
-- bases/camel_v1alpha1_kamelet.yaml
-- bases/camel_v1alpha1_kameletbinding.yaml
-
-patchesStrategicMerge:
-- patch-integration-platform.yaml
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: timer-to-log-example
+spec:
+  source:
+    ref:
+      apiVersion: camel.apache.org/v1alpha1
+      kind: Kamelet
+      name: timer-source
+    properties:
+      period: 2000
+      message: Hello world
+  sink:
+    ref:
+      apiVersion: camel.apache.org/v1alpha1
+      kind: Kamelet
+      name: log-sink


### PR DESCRIPTION
<!-- Description -->

When generating the operator bundle metadata, there is a missing sample for v1alpha1 Kamelet.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
