### PR TITLE
fix(ci): use ubuntu which now have 16 GB memory

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -65,7 +65,7 @@ concurrency:
 jobs:
   higher-memory:
     if: contains(github.event.pull_request.labels.*.name, 'trigger native test')
-    runs-on: macos-12
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -90,7 +90,8 @@ jobs:
 
   lower-memory:
     if: contains(github.event.pull_request.labels.*.name, 'trigger native test')
-    runs-on: macos-12
+    runs-on: ubuntu-latest
+
 
     steps:
     - name: Checkout code

--- a/.github/workflows/nightly-native-test.yml
+++ b/.github/workflows/nightly-native-test.yml
@@ -34,7 +34,7 @@ jobs:
         ref-branch: [main]
 
     if: github.repository == 'apache/camel-k'
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
     - name: "Checkout code"
       uses: actions/checkout@v4


### PR DESCRIPTION
Closes #4885

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ci): use ubuntu which now have 16 GB memory
```
