### PR TITLE
chore: Use camel case for Pipe error handler ref

### DIFF
--- a/pkg/apis/camel/v1/integration_types_support.go
+++ b/pkg/apis/camel/v1/integration_types_support.go
@@ -116,6 +116,11 @@ func (in *IntegrationSpec) AddDependency(dependency string) {
 	in.Dependencies = append(in.Dependencies, dependency)
 }
 
+// AddConfigurationProperty adds a new configuration property.
+func (in *IntegrationSpec) AddConfigurationProperty(confValue string) {
+	in.AddConfiguration("property", confValue)
+}
+
 // GetConfigurationProperty returns a configuration property.
 func (in *IntegrationSpec) GetConfigurationProperty(property string) string {
 	for _, confSpec := range in.Configuration {

--- a/pkg/controller/pipe/integration.go
+++ b/pkg/controller/pipe/integration.go
@@ -224,10 +224,7 @@ func configureBinding(integration *v1.Integration, bindings ...*bindings.Binding
 				return err
 			}
 
-			integration.Spec.Configuration = append(integration.Spec.Configuration, v1.ConfigurationSpec{
-				Type:  "property",
-				Value: entry,
-			})
+			integration.Spec.AddConfigurationProperty(entry)
 		}
 
 	}

--- a/pkg/trait/error_handler.go
+++ b/pkg/trait/error_handler.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
-
 	"github.com/apache/camel-k/v2/pkg/util"
 )
 
@@ -86,8 +85,8 @@ func (t *errorHandlerTrait) addErrorHandlerDependencies(e *Environment, uri stri
 
 func (t *errorHandlerTrait) addGlobalErrorHandlerAsSource(e *Environment) error {
 	flowErrorHandler := map[string]interface{}{
-		"error-handler": map[string]string{
-			"ref-error-handler": t.ErrorHandlerRef,
+		"errorHandler": map[string]string{
+			"refErrorHandler": t.ErrorHandlerRef,
 		},
 	}
 	encodedFlowErrorHandler, err := yaml.Marshal([]map[string]interface{}{flowErrorHandler})


### PR DESCRIPTION
YAML DSL in Camel should use camel case instead of kebap case. PR also adds some unit tests

**Release Note**
```release-note
NONE
```
