### PR TITLE
Only enable knative trait when there is a knative endpoint

### DIFF
--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -123,6 +123,11 @@ func (t *knativeTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 			}
 			t.EventSinks = items
 		}
+		hasKnativeEndpoint := len(t.ChannelSources) > 0 || len(t.ChannelSinks) > 0 || len(t.EndpointSources) > 0 || len(t.EndpointSinks) > 0 || len(t.EventSources) > 0 || len(t.EventSinks) > 0
+		t.Enabled = &hasKnativeEndpoint
+		if !hasKnativeEndpoint {
+			return false, nil, nil
+		}
 		if t.FilterSourceChannels == nil {
 			// Filtering is no longer used by default
 			t.FilterSourceChannels = pointer.Bool(false)

--- a/pkg/trait/knative_service_test.go
+++ b/pkg/trait/knative_service_test.go
@@ -122,7 +122,7 @@ func TestKnativeService(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, environment.ExecutedTraits)
-	assert.NotNil(t, environment.GetTrait("knative"))
+	assert.NotNil(t, environment.GetTrait("knative-service"))
 	assert.Equal(t, 4, environment.Resources.Size())
 
 	s := environment.Resources.GetKnativeService(func(service *serving.Service) bool {
@@ -335,7 +335,7 @@ func TestKnativeServiceWithRest(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, environment.ExecutedTraits)
-	assert.NotNil(t, environment.GetTrait("knative"))
+	assert.NotNil(t, environment.GetTrait("knative-service"))
 
 	assert.NotNil(t, environment.Resources.GetKnativeService(func(service *serving.Service) bool {
 		return service.Name == KnativeServiceTestName
@@ -403,7 +403,7 @@ func TestKnativeServiceNotApplicable(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, environment.ExecutedTraits)
-	assert.NotNil(t, environment.GetTrait("knative"))
+	assert.Nil(t, environment.GetTrait("knative-service"))
 
 	assert.Nil(t, environment.Resources.GetKnativeService(func(service *serving.Service) bool {
 		return service.Name == KnativeServiceTestName


### PR DESCRIPTION
https://github.com/apache/camel-k/issues/5145

Remove the SortChannelFakeClient function since it's not used.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Only enable knative trait when there is a knative endpoint
```
