### PR TITLE
fix(cli): openshift cli install rbac path

### DIFF
--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -464,7 +464,7 @@ func installClusterRoleBinding(ctx context.Context, c client.Client, collection 
 func installOpenShiftRoles(ctx context.Context, c client.Client, namespace string, customizer ResourceCustomizer, collection *kubernetes.Collection, force bool, global bool) error {
 	if global {
 		return ResourcesOrCollect(ctx, c, namespace, collection, force, customizer,
-			"/config/openshift/descoped/operator-cluster-role-openshift.yaml",
+			"/config/rbac/openshift/descoped/operator-cluster-role-openshift.yaml",
 			"/config/rbac/openshift/descoped/operator-cluster-role-binding-openshift.yaml",
 		)
 	} else {


### PR DESCRIPTION
The CLI install in openshift on global operator fails because it can't find the file. 

**Release Note**
```release-note
fix(cli): openshift cli install global operator rbac path
```
