### PR TITLE
[Backport 2.3.x]: fix(cli): openshift cli install rbac path

### DIFF
--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -464,7 +464,7 @@ func installClusterRoleBinding(ctx context.Context, c client.Client, collection 
 func installOpenShiftRoles(ctx context.Context, c client.Client, namespace string, customizer ResourceCustomizer, collection *kubernetes.Collection, force bool, global bool) error {
 	if global {
 		return ResourcesOrCollect(ctx, c, namespace, collection, force, customizer,
-			"/config/openshift/descoped/operator-cluster-role-openshift.yaml",
+			"/config/rbac/openshift/descoped/operator-cluster-role-openshift.yaml",
 			"/config/rbac/openshift/descoped/operator-cluster-role-binding-openshift.yaml",
 		)
 	} else {


### PR DESCRIPTION
Backport from https://github.com/apache/camel-k/pull/5316




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(cli): openshift cli install global operator rbac path
```
