### PR TITLE
feat(trait): allow usage of semver for camel.runtime-version 

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -6377,6 +6377,8 @@ string
 
 
 The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
+to the best matching Catalog existing on the cluster.
 
 |`properties` +
 []string

--- a/docs/modules/traits/pages/camel.adoc
+++ b/docs/modules/traits/pages/camel.adoc
@@ -30,6 +30,8 @@ The following configuration options are available:
 | camel.runtime-version
 | string
 | The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
+to the best matching Catalog existing on the cluster.
 
 | camel.properties
 | []string

--- a/helm/camel-k/crds/crd-integration-kit.yaml
+++ b/helm/camel-k/crds/crd-integration-kit.yaml
@@ -355,7 +355,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   quarkus:

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -671,7 +671,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:
@@ -2573,7 +2576,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:

--- a/helm/camel-k/crds/crd-integration-profile.yaml
+++ b/helm/camel-k/crds/crd-integration-profile.yaml
@@ -547,7 +547,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:
@@ -2332,7 +2335,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -6566,7 +6566,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -6851,7 +6851,10 @@ spec:
                           runtimeVersion:
                             description: The camel-k-runtime version to use for the
                               integration. It overrides the default version set in
-                              the Integration Platform.
+                              the Integration Platform. You can use a fixed version
+                              (for example "3.2.3") or a semantic version (for example
+                              "3.x") which will try to resolve to the best matching
+                              Catalog existing on the cluster.
                             type: string
                         type: object
                       container:

--- a/helm/camel-k/crds/crd-pipe.yaml
+++ b/helm/camel-k/crds/crd-pipe.yaml
@@ -6849,7 +6849,10 @@ spec:
                           runtimeVersion:
                             description: The camel-k-runtime version to use for the
                               integration. It overrides the default version set in
-                              the Integration Platform.
+                              the Integration Platform. You can use a fixed version
+                              (for example "3.2.3") or a semantic version (for example
+                              "3.x") which will try to resolve to the best matching
+                              Catalog existing on the cluster.
                             type: string
                         type: object
                       container:

--- a/pkg/apis/camel/v1/trait/camel.go
+++ b/pkg/apis/camel/v1/trait/camel.go
@@ -23,6 +23,8 @@ package trait
 type CamelTrait struct {
 	PlatformBaseTrait `property:",squash" json:",inline"`
 	// The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+	// You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
+	// to the best matching Catalog existing on the cluster.
 	RuntimeVersion string `property:"runtime-version" json:"runtimeVersion,omitempty"`
 	// A list of properties to be provided to the Integration runtime
 	Properties []string `property:"properties" json:"properties,omitempty"`

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationkits.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationkits.yaml
@@ -355,7 +355,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   quarkus:

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -671,7 +671,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:
@@ -2573,7 +2576,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -547,7 +547,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:
@@ -2332,7 +2335,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -6566,7 +6566,10 @@ spec:
                       runtimeVersion:
                         description: The camel-k-runtime version to use for the integration.
                           It overrides the default version set in the Integration
-                          Platform.
+                          Platform. You can use a fixed version (for example "3.2.3")
+                          or a semantic version (for example "3.x") which will try
+                          to resolve to the best matching Catalog existing on the
+                          cluster.
                         type: string
                     type: object
                   container:

--- a/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
@@ -6851,7 +6851,10 @@ spec:
                           runtimeVersion:
                             description: The camel-k-runtime version to use for the
                               integration. It overrides the default version set in
-                              the Integration Platform.
+                              the Integration Platform. You can use a fixed version
+                              (for example "3.2.3") or a semantic version (for example
+                              "3.x") which will try to resolve to the best matching
+                              Catalog existing on the cluster.
                             type: string
                         type: object
                       container:

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -6849,7 +6849,10 @@ spec:
                           runtimeVersion:
                             description: The camel-k-runtime version to use for the
                               integration. It overrides the default version set in
-                              the Integration Platform.
+                              the Integration Platform. You can use a fixed version
+                              (for example "3.2.3") or a semantic version (for example
+                              "3.x") which will try to resolve to the best matching
+                              Catalog existing on the cluster.
                             type: string
                         type: object
                       container:

--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -86,7 +86,7 @@ func (t *camelTrait) Apply(e *Environment) error {
 		}
 	}
 
-	e.RuntimeVersion = t.RuntimeVersion
+	e.RuntimeVersion = e.CamelCatalog.Runtime.Version
 
 	if e.Integration != nil {
 		e.Integration.Status.RuntimeVersion = e.CamelCatalog.Runtime.Version

--- a/pkg/trait/camel_test.go
+++ b/pkg/trait/camel_test.go
@@ -230,3 +230,19 @@ func TestCamelMatches(t *testing.T) {
 	t2.RuntimeVersion = "3.2.1"
 	assert.False(t, t1.Matches(&t2))
 }
+
+func TestCamelCatalogSemver(t *testing.T) {
+	trait, environment := createNominalCamelTest(true)
+	trait.RuntimeVersion = "2.x"
+	environment.CamelCatalog.CamelCatalogSpec.Runtime.Version = "2.16.0"
+
+	configured, condition, err := trait.Configure(environment)
+	require.NoError(t, err)
+	assert.Nil(t, condition)
+	assert.True(t, configured)
+
+	err = trait.Apply(environment)
+	require.NoError(t, err)
+	// 2.x will translate with 2.16.0 as it is already existing
+	assert.Equal(t, environment.CamelCatalog.CamelCatalogSpec.Runtime.Version, environment.RuntimeVersion)
+}


### PR DESCRIPTION
<!-- Description -->

With this PR we fix a minor problem that was impeding us to make use of the semantic version jolly. Once this is merged we'll be able to run:
```
kamel run test.yaml -t camel.runtime-version=2.x
```
which will resolve to the best match of the existing CamelCatalogs. For example, given:
```
NAME                   RUNTIME PROVIDER   RUNTIME VERSION   RUNTIME CAMEL VERSION   PHASE
camel-catalog-2.16.0   quarkus            2.16.0            3.20.1                  Ready
camel-catalog-3.8.1    quarkus            3.8.1             4.4.1                   Ready
```
It will pick up version 2.1.6.0

Closes https://github.com/apache/camel-k/issues/4739
<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(trait): allow usage of semver for camel.runtime-version 
```
