### PR TITLE
fix(install): No duplicate envvars on operator pod container

### DIFF
--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -145,7 +145,9 @@ func OperatorOrCollect(ctx context.Context, cmd *cobra.Command, c client.Client,
 						fmt.Fprintln(cmd.ErrOrStderr(), "Warning: could not parse environment variables!")
 					}
 					for i := 0; i < len(d.Spec.Template.Spec.Containers); i++ {
-						d.Spec.Template.Spec.Containers[i].Env = append(d.Spec.Template.Spec.Containers[i].Env, envVars...)
+						for _, envVar := range envVars {
+							envvar.SetVar(&d.Spec.Template.Spec.Containers[i].Env, envVar)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Backport of https://github.com/apache/camel-k/pull/5350




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(install): No duplicate envvars on operator pod container
```
