### PR TITLE
[DO NOT MERGE] Check with -race option

### DIFF
--- a/.github/actions/e2e-common/exec-tests.sh
+++ b/.github/actions/e2e-common/exec-tests.sh
@@ -145,9 +145,9 @@ exit_code=0
 if [ "${SMOKE_TEST_ONLY}" == "true" ]; then
   DO_TEST_PREBUILD=false GOTESTFMT="-json 2>&1 | gotestfmt" make test-smoke || exit_code=1
 elif [ "${CUSTOM_INSTALL_TEST}" == "true" ]; then
-  DO_TEST_PREBUILD=false GOTESTFMT="-json 2>&1 | gotestfmt" make test-advanced || exit_code=1
+  DO_TEST_PREBUILD=false GOTESTFMT="-race -json 2>&1 | gotestfmt" make test-advanced || exit_code=1
 else
-  DO_TEST_PREBUILD=false GOTESTFMT="-json 2>&1 | gotestfmt" make test-common || exit_code=1
+  DO_TEST_PREBUILD=false GOTESTFMT="-race -json 2>&1 | gotestfmt" make test-common || exit_code=1
 fi
 set +e
 


### PR DESCRIPTION
Ref #5315

Remove "fatal error: concurrent map read and map write" from calling apis.AddToScheme more than once.
The 1st commit adds -race to check the race condition is no longer there. It needs to be removed before merge
The 2nd commit changes the call to conditional execution to avoid adding the same schemes more than one. That does not explains why we are creating the Client more than once in the tests.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
