### PR TITLE
fix(trait): don't report runtime version...

### DIFF
--- a/addons/keda/keda.go
+++ b/addons/keda/keda.go
@@ -120,10 +120,12 @@ func (t *kedaTrait) Configure(e *trait.Environment) (bool, *trait.TraitCondition
 	if e.Integration == nil || !pointer.BoolDeref(t.Enabled, false) {
 		return false, nil, nil
 	}
+	if e.CamelCatalog == nil {
+		return false, trait.NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	if !e.IntegrationInPhase(camelv1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}
-
 	if t.Auto == nil || *t.Auto {
 		if err := t.populateTriggersFromKamelets(e); err != nil {
 			return false, nil, err

--- a/addons/master/master.go
+++ b/addons/master/master.go
@@ -92,6 +92,9 @@ func (t *masterTrait) Configure(e *trait.Environment) (bool, *trait.TraitConditi
 	if !pointer.BoolDeref(t.Enabled, true) {
 		return false, trait.NewIntegrationConditionUserDisabled(masterComponent), nil
 	}
+	if e.CamelCatalog == nil {
+		return false, trait.NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization, v1.IntegrationPhaseBuildingKit) && !e.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}

--- a/addons/resume/resume.go
+++ b/addons/resume/resume.go
@@ -79,6 +79,9 @@ func (r *resumeTrait) Configure(environment *trait.Environment) (bool, *trait.Tr
 	if !pointer.BoolDeref(r.Enabled, false) {
 		return false, nil, nil
 	}
+	if environment.CamelCatalog == nil {
+		return false, trait.NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	if !environment.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !environment.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}

--- a/addons/telemetry/telemetry.go
+++ b/addons/telemetry/telemetry.go
@@ -93,7 +93,9 @@ func (t *telemetryTrait) Configure(e *trait.Environment) (bool, *trait.TraitCond
 	if e.Integration == nil || !pointer.BoolDeref(t.Enabled, false) {
 		return false, nil, nil
 	}
-
+	if e.CamelCatalog == nil {
+		return false, trait.NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	var condition *trait.TraitCondition
 	if pointer.BoolDeref(t.Auto, true) {
 		if t.Endpoint == "" {

--- a/addons/tracing/tracing.go
+++ b/addons/tracing/tracing.go
@@ -90,6 +90,9 @@ func (t *tracingTrait) Configure(e *trait.Environment) (bool, *trait.TraitCondit
 	if e.Integration == nil || !pointer.BoolDeref(t.Enabled, false) {
 		return false, nil, nil
 	}
+	if e.CamelCatalog == nil {
+		return false, trait.NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 
 	if pointer.BoolDeref(t.Auto, true) {
 		if t.Endpoint == "" {
@@ -125,30 +128,23 @@ func (t *tracingTrait) Configure(e *trait.Environment) (bool, *trait.TraitCondit
 func (t *tracingTrait) Apply(e *trait.Environment) error {
 	util.StringSliceUniqueAdd(&e.Integration.Status.Capabilities, v1.CapabilityTracing)
 
-	if e.CamelCatalog != nil {
-		provider := e.CamelCatalog.CamelCatalogSpec.Runtime.Provider
-		properties := tracingProperties[provider]
+	provider := e.CamelCatalog.CamelCatalogSpec.Runtime.Provider
+	properties := tracingProperties[provider]
 
-		if appPropEnabled := properties[propEnabled]; appPropEnabled != "" {
-			e.ApplicationProperties[appPropEnabled] = "true"
-		}
-
-		if appPropEndpoint := properties[propEndpoint]; appPropEndpoint != "" && t.Endpoint != "" {
-			e.ApplicationProperties[appPropEndpoint] = t.Endpoint
-		}
-
-		if appPropServiceName := properties[propServiceName]; appPropServiceName != "" && t.ServiceName != "" {
-			e.ApplicationProperties[appPropServiceName] = t.ServiceName
-		}
-
-		if appPropSamplerType := properties[propSamplerType]; appPropSamplerType != "" && t.SamplerType != nil {
-			e.ApplicationProperties[appPropSamplerType] = *t.SamplerType
-		}
-
-		if appPropSamplerParam := properties[propSamplerParam]; appPropSamplerParam != "" && t.SamplerParam != nil {
-			e.ApplicationProperties[appPropSamplerParam] = *t.SamplerParam
-		}
-
+	if appPropEnabled := properties[propEnabled]; appPropEnabled != "" {
+		e.ApplicationProperties[appPropEnabled] = "true"
+	}
+	if appPropEndpoint := properties[propEndpoint]; appPropEndpoint != "" && t.Endpoint != "" {
+		e.ApplicationProperties[appPropEndpoint] = t.Endpoint
+	}
+	if appPropServiceName := properties[propServiceName]; appPropServiceName != "" && t.ServiceName != "" {
+		e.ApplicationProperties[appPropServiceName] = t.ServiceName
+	}
+	if appPropSamplerType := properties[propSamplerType]; appPropSamplerType != "" && t.SamplerType != nil {
+		e.ApplicationProperties[appPropSamplerType] = *t.SamplerType
+	}
+	if appPropSamplerParam := properties[propSamplerParam]; appPropSamplerParam != "" && t.SamplerParam != nil {
+		e.ApplicationProperties[appPropSamplerParam] = *t.SamplerParam
 	}
 
 	return nil

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -90,7 +90,9 @@ func (t *builderTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 	if e.IntegrationKit == nil {
 		return false, nil, nil
 	}
-
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	condition := t.adaptDeprecatedFields()
 	if e.Platform.Status.Build.PublishStrategy == v1.IntegrationPlatformBuildPublishStrategySpectrum {
 		condition = newOrAppend(condition, "Spectrum publishing strategy is deprecated and may be removed in future releases. Make sure to use any supported publishing strategy instead.")

--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -63,11 +63,8 @@ func (t *camelTrait) Matches(trait Trait) bool {
 }
 
 func (t *camelTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
-	if e.IntegrationKit != nil && e.IntegrationKit.IsExternal() {
-		return false, newIntegrationConditionPlatformDisabledWithMessage("Camel", "integration kit was not created via Camel K operator"), nil
-	}
 	if e.Integration != nil && e.Integration.IsSynthetic() {
-		return false, newIntegrationConditionPlatformDisabledWithMessage("Camel", "syntetic integration"), nil
+		return false, NewIntegrationConditionPlatformDisabledWithMessage("Camel", "synthetic integration"), nil
 	}
 
 	if t.RuntimeVersion == "" {
@@ -82,13 +79,26 @@ func (t *camelTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 }
 
 func (t *camelTrait) Apply(e *Environment) error {
+	if e.IntegrationKitInPhase(v1.IntegrationKitPhaseReady) && e.IntegrationInRunningPhases() {
+		// Get all resources
+		maps := t.computeConfigMaps(e)
+		e.Resources.AddAll(maps)
+	}
+	if e.IntegrationKit != nil && e.IntegrationKit.IsSynthetic() {
+		// This is required as during init phase, the trait set by default these values
+		// which are widely used in the platform for different purposese.
+		if e.Integration != nil {
+			e.Integration.Status.RuntimeVersion = ""
+			e.Integration.Status.RuntimeProvider = ""
+		}
+		return nil
+	}
 	if e.CamelCatalog == nil {
 		if err := t.loadOrCreateCatalog(e, t.RuntimeVersion); err != nil {
 			return err
 		}
 	}
 	e.RuntimeVersion = e.CamelCatalog.Runtime.Version
-
 	if e.Integration != nil {
 		e.Integration.Status.RuntimeVersion = e.CamelCatalog.Runtime.Version
 		e.Integration.Status.RuntimeProvider = e.CamelCatalog.Runtime.Provider
@@ -96,12 +106,6 @@ func (t *camelTrait) Apply(e *Environment) error {
 	if e.IntegrationKit != nil {
 		e.IntegrationKit.Status.RuntimeVersion = e.CamelCatalog.Runtime.Version
 		e.IntegrationKit.Status.RuntimeProvider = e.CamelCatalog.Runtime.Provider
-	}
-
-	if e.IntegrationKitInPhase(v1.IntegrationKitPhaseReady) && e.IntegrationInRunningPhases() {
-		// Get all resources
-		maps := t.computeConfigMaps(e)
-		e.Resources.AddAll(maps)
 	}
 
 	return nil

--- a/pkg/trait/camel_test.go
+++ b/pkg/trait/camel_test.go
@@ -246,3 +246,32 @@ func TestCamelCatalogSemver(t *testing.T) {
 	// 2.x will translate with 2.16.0 as it is already existing
 	assert.Equal(t, environment.CamelCatalog.CamelCatalogSpec.Runtime.Version, environment.RuntimeVersion)
 }
+
+func TestCamelTraitExternalKit(t *testing.T) {
+	trait, environment := createNominalCamelTest(true)
+	environment.Integration.Status = v1.IntegrationStatus{}
+	environment.IntegrationKit.Labels[v1.IntegrationKitTypeLabel] = v1.IntegrationKitTypeExternal
+
+	configured, condition, err := trait.Configure(environment)
+	require.NoError(t, err)
+	assert.Equal(t, "explicitly disabled by the platform: integration kit was not created via Camel K operator", condition.message)
+	assert.False(t, configured)
+
+	assert.Equal(t, v1.RuntimeProvider(""), environment.Integration.Status.RuntimeProvider)
+	assert.Equal(t, "", environment.Integration.Status.RuntimeVersion)
+}
+
+func TestCamelTraitSyntheticIntegration(t *testing.T) {
+	trait, environment := createNominalCamelTest(true)
+	environment.Integration.Status = v1.IntegrationStatus{}
+	environment.Integration.Annotations = make(map[string]string)
+	environment.Integration.Annotations[v1.IntegrationSyntheticLabel] = "true"
+
+	configured, condition, err := trait.Configure(environment)
+	require.NoError(t, err)
+	assert.Equal(t, "explicitly disabled by the platform: syntetic integration", condition.message)
+	assert.False(t, configured)
+
+	assert.Equal(t, v1.RuntimeProvider(""), environment.Integration.Status.RuntimeProvider)
+	assert.Equal(t, "", environment.Integration.Status.RuntimeVersion)
+}

--- a/pkg/trait/container.go
+++ b/pkg/trait/container.go
@@ -168,7 +168,6 @@ func (t *containerTrait) configureImageIntegrationKit(e *Environment) error {
 			kit.SetOperatorID(operatorID)
 		}
 
-		t.L.Infof("image %s", kit.Spec.Image)
 		e.Resources.Add(kit)
 		e.Integration.SetIntegrationKit(kit)
 	}

--- a/pkg/trait/cron.go
+++ b/pkg/trait/cron.go
@@ -83,6 +83,9 @@ func (t *cronTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}
+	if e.CamelCatalog == nil {
+		return false, newIntegrationConditionPlatformDisabledWithMessage("Cron", "no camel catalog available for this Integration"), nil
+	}
 
 	if _, ok := e.CamelCatalog.Runtime.Capabilities[v1.CapabilityCron]; !ok {
 		return false, NewIntegrationCondition(

--- a/pkg/trait/cron.go
+++ b/pkg/trait/cron.go
@@ -84,9 +84,8 @@ func (t *cronTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 		return false, nil, nil
 	}
 	if e.CamelCatalog == nil {
-		return false, newIntegrationConditionPlatformDisabledWithMessage("Cron", "no camel catalog available for this Integration"), nil
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
 	}
-
 	if _, ok := e.CamelCatalog.Runtime.Capabilities[v1.CapabilityCron]; !ok {
 		return false, NewIntegrationCondition(
 			"Cron",
@@ -96,7 +95,6 @@ func (t *cronTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 			"the runtime provider %s does not declare 'cron' capability",
 		), nil
 	}
-
 	if pointer.BoolDeref(t.Auto, true) {
 		globalCron, err := t.getGlobalCron(e)
 		if err != nil {
@@ -309,6 +307,9 @@ func (c *cronInfo) withSchedule(schedule string) *cronInfo {
 }
 
 func (t *cronTrait) getGlobalCron(e *Environment) (*cronInfo, error) {
+	if e.CamelCatalog == nil {
+		return nil, nil
+	}
 	fromURIs, err := t.getSourcesFromURIs(e)
 	if err != nil {
 		return nil, err

--- a/pkg/trait/dependencies.go
+++ b/pkg/trait/dependencies.go
@@ -42,7 +42,9 @@ func (t *dependenciesTrait) Configure(e *Environment) (bool, *TraitCondition, er
 	if e.Integration == nil {
 		return false, nil, nil
 	}
-
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	return e.IntegrationInPhase(v1.IntegrationPhaseInitialization), nil, nil
 }
 

--- a/pkg/trait/dependencies_test.go
+++ b/pkg/trait/dependencies_test.go
@@ -28,9 +28,13 @@ import (
 )
 
 func TestDependenciesTraitApplicability(t *testing.T) {
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
+
 	e := &Environment{
-		Catalog:     NewEnvironmentTestCatalog(),
-		Integration: &v1.Integration{},
+		CamelCatalog: catalog,
+		Catalog:      NewEnvironmentTestCatalog(),
+		Integration:  &v1.Integration{},
 	}
 
 	trait := newDependenciesTrait()

--- a/pkg/trait/error_handler.go
+++ b/pkg/trait/error_handler.go
@@ -44,11 +44,13 @@ func (t *errorHandlerTrait) Configure(e *Environment) (bool, *TraitCondition, er
 	if e.Integration == nil {
 		return false, nil, nil
 	}
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}
-
 	if t.ErrorHandlerRef == "" {
 		t.ErrorHandlerRef = e.Integration.Spec.GetConfigurationProperty(v1.ErrorHandlerRefName)
 	}

--- a/pkg/trait/error_handler_test.go
+++ b/pkg/trait/error_handler_test.go
@@ -29,9 +29,12 @@ import (
 )
 
 func TestErrorHandlerConfigureFromIntegrationProperty(t *testing.T) {
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
 	e := &Environment{
-		Catalog:     NewEnvironmentTestCatalog(),
-		Integration: &v1.Integration{},
+		CamelCatalog: catalog,
+		Catalog:      NewEnvironmentTestCatalog(),
+		Integration:  &v1.Integration{},
 	}
 	e.Integration.Spec.AddConfigurationProperty(fmt.Sprintf("%v = %s", v1.ErrorHandlerRefName, "defaultErrorHandler"))
 
@@ -56,9 +59,12 @@ func TestErrorHandlerConfigureFromIntegrationProperty(t *testing.T) {
 }
 
 func TestErrorHandlerApplySource(t *testing.T) {
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
 	e := &Environment{
-		Catalog:     NewEnvironmentTestCatalog(),
-		Integration: &v1.Integration{},
+		CamelCatalog: catalog,
+		Catalog:      NewEnvironmentTestCatalog(),
+		Integration:  &v1.Integration{},
 	}
 	e.Integration.Spec.AddConfiguration("property", fmt.Sprintf("%v = %s", v1.ErrorHandlerRefName, "defaultErrorHandler"))
 	e.Integration.Status.Phase = v1.IntegrationPhaseInitialization

--- a/pkg/trait/health.go
+++ b/pkg/trait/health.go
@@ -53,6 +53,9 @@ func newHealthTrait() Trait {
 }
 
 func (t *healthTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	if e.Integration == nil ||
 		!e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
 		return false, nil, nil

--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -66,16 +66,16 @@ func (t *jvmTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 	// The JVM trait must be disabled in case the current IntegrationKit corresponds to a native build
 	if qt := e.Catalog.GetTrait(quarkusTraitID); qt != nil {
 		if quarkus, ok := qt.(*quarkusTrait); ok && quarkus.isNativeIntegration(e) {
-			return false, newIntegrationConditionPlatformDisabledWithMessage("JVM", "quarkus native build"), nil
+			return false, NewIntegrationConditionPlatformDisabledWithMessage("JVM", "quarkus native build"), nil
 		}
 	}
 
 	if e.IntegrationKit != nil && e.IntegrationKit.IsSynthetic() {
-		return false, newIntegrationConditionPlatformDisabledWithMessage("JVM", "integration kit was not created via Camel K operator"), nil
+		return false, NewIntegrationConditionPlatformDisabledWithMessage("JVM", "integration kit was not created via Camel K operator"), nil
 	}
 
 	if e.CamelCatalog == nil {
-		return false, newIntegrationConditionPlatformDisabledWithMessage("JVM", "no camel catalog available for this Integration"), nil
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
 	}
 	return true, nil, nil
 }

--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -74,6 +74,9 @@ func (t *jvmTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 		return false, newIntegrationConditionPlatformDisabledWithMessage("JVM", "integration kit was not created via Camel K operator"), nil
 	}
 
+	if e.CamelCatalog == nil {
+		return false, newIntegrationConditionPlatformDisabledWithMessage("JVM", "no camel catalog available for this Integration"), nil
+	}
 	return true, nil, nil
 }
 

--- a/pkg/trait/kamelets.go
+++ b/pkg/trait/kamelets.go
@@ -79,6 +79,9 @@ func (t *kameletsTrait) Configure(e *Environment) (bool, *TraitCondition, error)
 	if !pointer.BoolDeref(t.Enabled, true) {
 		return false, NewIntegrationConditionUserDisabled("Kamelets"), nil
 	}
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -73,6 +73,9 @@ func (t *knativeTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 	if !pointer.BoolDeref(t.Enabled, true) {
 		return false, NewIntegrationConditionUserDisabled("Knative"), nil
 	}
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -144,8 +144,8 @@ func (t *knativeServiceTrait) Apply(e *Environment) error {
 }
 
 func (t *knativeServiceTrait) SelectControllerStrategy(e *Environment) (*ControllerStrategy, error) {
-	if !pointer.BoolDeref(t.Enabled, true) {
-		// explicitly disabled
+	if !pointer.BoolDeref(t.Enabled, true) || e.CamelCatalog == nil {
+		// explicitly disabled or sourceless Integration (missing catalog)
 		return nil, nil
 	}
 

--- a/pkg/trait/logging.go
+++ b/pkg/trait/logging.go
@@ -52,9 +52,11 @@ func (l loggingTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 	if e.Integration == nil {
 		return false, nil, nil
 	}
-
 	if !pointer.BoolDeref(l.Enabled, true) {
 		return false, NewIntegrationConditionUserDisabled("Logging"), nil
+	}
+	if e.CamelCatalog == nil {
+		return false, newIntegrationConditionPlatformDisabledWithMessage("Logging", "no camel catalog available for this Integration"), nil
 	}
 
 	return e.IntegrationInRunningPhases(), nil, nil

--- a/pkg/trait/logging.go
+++ b/pkg/trait/logging.go
@@ -56,7 +56,7 @@ func (l loggingTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 		return false, NewIntegrationConditionUserDisabled("Logging"), nil
 	}
 	if e.CamelCatalog == nil {
-		return false, newIntegrationConditionPlatformDisabledWithMessage("Logging", "no camel catalog available for this Integration"), nil
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
 	}
 
 	return e.IntegrationInRunningPhases(), nil, nil

--- a/pkg/trait/openapi.go
+++ b/pkg/trait/openapi.go
@@ -59,7 +59,9 @@ func (t *openAPITrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization) {
 		return false, nil, nil
 	}
-
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	// check if the runtime provides 'rest' capabilities
 	if _, ok := e.CamelCatalog.Runtime.Capabilities[v1.CapabilityRest]; !ok {
 		return false, nil, fmt.Errorf("the runtime provider %s does not declare 'rest' capability", e.CamelCatalog.Runtime.Provider)

--- a/pkg/trait/quarkus.go
+++ b/pkg/trait/quarkus.go
@@ -140,6 +140,9 @@ func (t *quarkusTrait) Matches(trait Trait) bool {
 }
 
 func (t *quarkusTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	condition := t.adaptDeprecatedFields()
 
 	return e.IntegrationInPhase(v1.IntegrationPhaseBuildingKit) ||

--- a/pkg/trait/service.go
+++ b/pkg/trait/service.go
@@ -56,13 +56,15 @@ func (t *serviceTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 			"explicitly disabled",
 		), nil
 	}
-
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	// in case the knative-service and service trait are enabled, the knative-service has priority
 	// then this service is disabled
 	if e.GetTrait(knativeServiceTraitID) != nil {
 		knativeServiceTrait, _ := e.GetTrait(knativeServiceTraitID).(*knativeServiceTrait)
 		if pointer.BoolDeref(knativeServiceTrait.Enabled, true) {
-			return false, newIntegrationConditionPlatformDisabledWithMessage("Service", "knative-service trait has priority over this trait"), nil
+			return false, NewIntegrationConditionPlatformDisabledWithMessage("Service", "knative-service trait has priority over this trait"), nil
 		}
 	}
 

--- a/pkg/trait/service_binding.go
+++ b/pkg/trait/service_binding.go
@@ -70,6 +70,9 @@ func (t *serviceBindingTrait) Configure(e *Environment) (bool, *TraitCondition, 
 	if !pointer.BoolDeref(t.Enabled, true) {
 		return false, NewIntegrationConditionUserDisabled("ServiceBinding"), nil
 	}
+	if e.CamelCatalog == nil {
+		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+	}
 	if len(t.Services) == 0 {
 		return false, nil, nil
 	}

--- a/pkg/trait/trait_condition_types.go
+++ b/pkg/trait/trait_condition_types.go
@@ -56,8 +56,23 @@ func NewIntegrationConditionUserDisabled(traitID string) *TraitCondition {
 	return NewIntegrationCondition(traitID, v1.IntegrationConditionTraitInfo, corev1.ConditionTrue, traitConfigurationReason, userDisabledMessage)
 }
 
-func newIntegrationConditionPlatformDisabledWithMessage(traitID string, message string) *TraitCondition {
+func NewIntegrationConditionUserEnabledWithMessage(traitID string, message string) *TraitCondition {
+	return NewIntegrationCondition(traitID, v1.IntegrationConditionTraitInfo, corev1.ConditionTrue, traitConfigurationReason, fmt.Sprintf("%s: %s", userEnabledMessage, message))
+}
+
+func NewIntegrationConditionPlatformDisabledWithMessage(traitID string, message string) *TraitCondition {
 	return NewIntegrationCondition(traitID, v1.IntegrationConditionTraitInfo, corev1.ConditionTrue, traitConfigurationReason, fmt.Sprintf("%s: %s", platformDisabledMessage, message))
+}
+
+// This one is reused among different traits in order to avoid polluting the conditions with the same message.
+func NewIntegrationConditionPlatformDisabledCatalogMissing() *TraitCondition {
+	return NewIntegrationCondition(
+		"Generic",
+		v1.IntegrationConditionTraitInfo,
+		corev1.ConditionTrue,
+		traitConfigurationReason,
+		"no camel catalog available for this Integration. Several traits have not been executed for this reason. Check applied trait condition to know more.",
+	)
 }
 
 func (tc *TraitCondition) integrationCondition() (v1.IntegrationConditionType, corev1.ConditionStatus, string, string) {


### PR DESCRIPTION
... for external kit or syntetic Integrations.

As a side effect, we had to introduce a further check to avoid leveraging a Camel catalog which was taken as default.

```
$ k get it
NAME               PHASE     RUNTIME PROVIDER   RUNTIME VERSION   KIT                    REPLICAS
my-camel-main-v1   Running                                        kit-my-camel-main-v1   1
```

Closes #5309

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): don't report runtime version when non managed Integrations
```
