### PR TITLE
chore: re-enable file permissions test on darwin

### DIFF
--- a/pkg/cmd/source/util_test.go
+++ b/pkg/cmd/source/util_test.go
@@ -1,6 +1,3 @@
-//go:build !darwin
-// +build !darwin
-
 /*
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Greetings,

the `TestPermissionDenied` was disabled on Darwin because it was accessing `/root` which does not exist on Mac. Well, MacOS is not UNIX I guess.

A "good first issue" ticket was created:

https://github.com/apache/camel-k/issues/2563

I wanted to take a stab on this, however, unfortunately it looks like `TestPermissionDenied` was already fixed. It now creates a proper temporary file and drops permissions via `Chomod`. The only thing that was left to be done was to remove the build tags.

And this is exactly what this PR does. Tested on the latest MacOS on Macbook Pro M1, I believe Intel should be the same story.

Have a good one. Cheers.