### PR TITLE
fix(#5292): Simplify run cmd for archs other than amd64

### DIFF
--- a/pkg/builder/jib.go
+++ b/pkg/builder/jib.go
@@ -111,10 +111,16 @@ func (t *jibTask) Do(ctx context.Context) v1.BuildStatus {
 	mavenArgs = append(mavenArgs, jib.JibMavenToImageParam+t.task.Image)
 	mavenArgs = append(mavenArgs, jib.JibMavenFromImageParam+baseImage)
 	mavenArgs = append(mavenArgs, jib.JibMavenBaseImageCache+mavenDir+"/jib")
+
+	// Build the integration for the arch configured in the IntegrationPlatform.
+	// This can explicitly be configured with the `-t builder.platforms` trait.
+	// Building the integration for multiarch is deferred until the next major version (e.g. 3.x)
+
 	if t.task.Configuration.ImagePlatforms != nil {
 		platforms := strings.Join(t.task.Configuration.ImagePlatforms, ",")
 		mavenArgs = append(mavenArgs, jib.JibMavenFromPlatforms+platforms)
 	}
+
 	if t.task.Registry.Insecure {
 		mavenArgs = append(mavenArgs, jib.JibMavenInsecureRegistries+"true")
 	}

--- a/pkg/platform/defaults.go
+++ b/pkg/platform/defaults.go
@@ -357,9 +357,17 @@ func setPlatformDefaults(p *v1.IntegrationPlatform, verbose bool) error {
 	}
 	setStatusAdditionalInfo(p)
 
+	buildConfig := &p.Status.Build.BuildConfiguration
+	if buildConfig.ImagePlatforms == nil {
+		if runtime.GOARCH == "arm64" {
+			buildConfig.ImagePlatforms = []string{"linux/arm64"}
+		}
+	}
+
 	if verbose {
 		log.Log.Infof("RuntimeVersion set to %s", p.Status.Build.RuntimeVersion)
 		log.Log.Infof("BaseImage set to %s", p.Status.Build.BaseImage)
+		log.Log.Infof("ImagePlatforms set to %s", buildConfig.ImagePlatforms)
 		log.Log.Infof("LocalRepository set to %s", p.Status.Build.Maven.LocalRepository)
 		log.Log.Infof("Timeout set to %s", p.Status.Build.GetTimeout())
 	}


### PR DESCRIPTION
This adds `-Djib.from.platforms=linux/arm64` when there is no explicit `-t builder.platforms` trait. 
Unlike previous attempts, this change should not interfere with the upgrade functionality.

On arm64, try this ...

```
make images

kamel install
kamel run --dev ./e2e/advanced/files/Java.java
```
