### PR TITLE
chore(e2e): Use new test namespace in Knative E2E tests

### DIFF
--- a/e2e/knative/default.go
+++ b/e2e/knative/default.go
@@ -25,5 +25,4 @@ import (
 	"github.com/apache/camel-k/v2/pkg/platform"
 )
 
-var ns = support.GetEnvOrDefault("CAMEL_K_TEST_NAMESPACE", support.TestDefaultNamespace)
 var operatorID = support.GetEnvOrDefault("CAMEL_K_OPERATOR_ID", platform.DefaultPlatformName)

--- a/e2e/knative/gc_test.go
+++ b/e2e/knative/gc_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package knative
 
 import (
+	"context"
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	corev1 "k8s.io/api/core/v1"
 	"testing"
@@ -32,34 +33,33 @@ import (
 )
 
 func TestGarbageCollectResources(t *testing.T) {
-	ctx := TestContext()
-	g := NewWithT(t)
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		integration := "platform-http-server"
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, integration), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, integration, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 
-	integration := "platform-http-server"
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, integration), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, integration, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(KnativeService(t, ctx, ns, integration), TestTimeoutMedium).Should(BeNil())
+		g.Eventually(ServiceType(t, ctx, ns, integration), TestTimeoutMedium).Should(Equal(corev1.ServiceTypeClusterIP))
 
-	g.Eventually(KnativeService(t, ctx, ns, integration), TestTimeoutMedium).Should(BeNil())
-	g.Eventually(ServiceType(t, ctx, ns, integration), TestTimeoutMedium).Should(Equal(corev1.ServiceTypeClusterIP))
+		// Update integration and enable knative service trait - existing arbitrary service should be garbage collected
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java").Execute()).To(Succeed())
 
-	// Update integration and enable knative service trait - existing arbitrary service should be garbage collected
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java").Execute()).To(Succeed())
+		g.Eventually(KnativeService(t, ctx, ns, integration), TestTimeoutShort).ShouldNot(BeNil())
+		g.Eventually(ServiceType(t, ctx, ns, integration), TestTimeoutShort).Should(Equal(corev1.ServiceTypeExternalName))
 
-	g.Eventually(KnativeService(t, ctx, ns, integration), TestTimeoutShort).ShouldNot(BeNil())
-	g.Eventually(ServiceType(t, ctx, ns, integration), TestTimeoutShort).Should(Equal(corev1.ServiceTypeExternalName))
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, integration), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, integration, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, integration), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, integration, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		// Disable knative service trait again - this time knative service should be garbage collected
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
 
-	// Disable knative service trait again - this time knative service should be garbage collected
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/PlatformHttpServer.java", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
+		g.Eventually(KnativeService(t, ctx, ns, integration), TestTimeoutMedium).Should(BeNil())
+		g.Eventually(ServiceType(t, ctx, ns, integration), TestTimeoutMedium).Should(Equal(corev1.ServiceTypeClusterIP))
 
-	g.Eventually(KnativeService(t, ctx, ns, integration), TestTimeoutMedium).Should(BeNil())
-	g.Eventually(ServiceType(t, ctx, ns, integration), TestTimeoutMedium).Should(Equal(corev1.ServiceTypeClusterIP))
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, integration), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, integration, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, integration), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, integration, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-
-	g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+	})
 }

--- a/e2e/knative/kamelet_test.go
+++ b/e2e/knative/kamelet_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package knative
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -38,45 +39,45 @@ import (
 
 // Test that a Pipe can be changed and the changes are propagated to the Integration
 func TestKameletChange(t *testing.T) {
-	ctx := TestContext()
-	g := NewWithT(t)
-	timerPipe := "timer-binding"
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		timerPipe := "timer-binding"
 
-	knChannel := "test-kamelet-messages"
-	knChannelConf := fmt.Sprintf("%s:InMemoryChannel:%s", messaging.SchemeGroupVersion.String(), knChannel)
-	timerSource := "my-timer-source"
-	g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, timerSource)()).To(Succeed())
-	g.Expect(CreateKnativeChannel(t, ctx, ns, knChannel)()).To(Succeed())
-	// Consumer route that will read from the KNative channel
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/test-kamelet-display.groovy", "-w").Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, "test-kamelet-display")).Should(Equal(corev1.PodRunning))
+		knChannel := "test-kamelet-messages"
+		knChannelConf := fmt.Sprintf("%s:InMemoryChannel:%s", messaging.SchemeGroupVersion.String(), knChannel)
+		timerSource := "my-timer-source"
+		g.Expect(CreateTimerKamelet(t, ctx, operatorID, ns, timerSource)()).To(Succeed())
+		g.Expect(CreateKnativeChannel(t, ctx, ns, knChannel)()).To(Succeed())
+		// Consumer route that will read from the KNative channel
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/test-kamelet-display.groovy", "-w").Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, "test-kamelet-display")).Should(Equal(corev1.PodRunning))
 
-	// Create the Pipe
-	g.Expect(KamelBindWithID(t, ctx, operatorID, ns, timerSource, knChannelConf, "-p", "source.message=HelloKNative!", "--annotation", "trait.camel.apache.org/health.enabled=true", "--annotation", "trait.camel.apache.org/health.readiness-initial-delay=10", "--name", timerPipe).Execute()).To(Succeed())
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, timerPipe)).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, timerPipe, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	// Consume the message
-	g.Eventually(IntegrationLogs(t, ctx, ns, "test-kamelet-display"), TestTimeoutShort).Should(ContainSubstring("HelloKNative!"))
+		// Create the Pipe
+		g.Expect(KamelBindWithID(t, ctx, operatorID, ns, timerSource, knChannelConf, "-p", "source.message=HelloKNative!", "--annotation", "trait.camel.apache.org/health.enabled=true", "--annotation", "trait.camel.apache.org/health.readiness-initial-delay=10", "--name", timerPipe).Execute()).To(Succeed())
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, timerPipe)).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, timerPipe, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		// Consume the message
+		g.Eventually(IntegrationLogs(t, ctx, ns, "test-kamelet-display"), TestTimeoutShort).Should(ContainSubstring("HelloKNative!"))
 
-	g.Eventually(PipeCondition(t, ctx, ns, timerPipe, v1.PipeConditionReady), TestTimeoutMedium).Should(And(
-		WithTransform(PipeConditionStatusExtract, Equal(corev1.ConditionTrue)),
-		WithTransform(PipeConditionReason, Equal(v1.IntegrationConditionDeploymentReadyReason)),
-		WithTransform(PipeConditionMessage, Equal(fmt.Sprintf("1/1 ready replicas"))),
-	))
-
-	// Update the Pipe
-	g.Expect(KamelBindWithID(t, ctx, operatorID, ns, timerSource, knChannelConf, "-p", "source.message=message is Hi", "--annotation", "trait.camel.apache.org/health.enabled=true", "--annotation", "trait.camel.apache.org/health.readiness-initial-delay=10", "--name", timerPipe).Execute()).To(Succeed())
-
-	g.Eventually(IntegrationPodPhase(t, ctx, ns, timerPipe), TestTimeoutLong).Should(Equal(corev1.PodRunning))
-	g.Eventually(IntegrationConditionStatus(t, ctx, ns, timerPipe, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-	g.Eventually(IntegrationLogs(t, ctx, ns, "test-kamelet-display"), TestTimeoutShort).Should(ContainSubstring("message is Hi"))
-
-	g.Eventually(PipeCondition(t, ctx, ns, timerPipe, v1.PipeConditionReady), TestTimeoutMedium).
-		Should(And(
+		g.Eventually(PipeCondition(t, ctx, ns, timerPipe, v1.PipeConditionReady), TestTimeoutMedium).Should(And(
 			WithTransform(PipeConditionStatusExtract, Equal(corev1.ConditionTrue)),
 			WithTransform(PipeConditionReason, Equal(v1.IntegrationConditionDeploymentReadyReason)),
-			WithTransform(PipeConditionMessage, Equal("1/1 ready replicas")),
+			WithTransform(PipeConditionMessage, Equal(fmt.Sprintf("1/1 ready replicas"))),
 		))
 
-	g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		// Update the Pipe
+		g.Expect(KamelBindWithID(t, ctx, operatorID, ns, timerSource, knChannelConf, "-p", "source.message=message is Hi", "--annotation", "trait.camel.apache.org/health.enabled=true", "--annotation", "trait.camel.apache.org/health.readiness-initial-delay=10", "--name", timerPipe).Execute()).To(Succeed())
+
+		g.Eventually(IntegrationPodPhase(t, ctx, ns, timerPipe), TestTimeoutLong).Should(Equal(corev1.PodRunning))
+		g.Eventually(IntegrationConditionStatus(t, ctx, ns, timerPipe, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "test-kamelet-display"), TestTimeoutShort).Should(ContainSubstring("message is Hi"))
+
+		g.Eventually(PipeCondition(t, ctx, ns, timerPipe, v1.PipeConditionReady), TestTimeoutMedium).
+			Should(And(
+				WithTransform(PipeConditionStatusExtract, Equal(corev1.ConditionTrue)),
+				WithTransform(PipeConditionReason, Equal(v1.IntegrationConditionDeploymentReadyReason)),
+				WithTransform(PipeConditionMessage, Equal("1/1 ready replicas")),
+			))
+
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+	})
 }

--- a/e2e/knative/knative_test.go
+++ b/e2e/knative/knative_test.go
@@ -37,103 +37,102 @@ import (
 )
 
 func TestKnative(t *testing.T) {
-	ctx := TestContext()
-	g := NewWithT(t)
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		knChannelMessages := "messages"
+		knChannelWords := "words"
+		g.Expect(CreateKnativeChannel(t, ctx, ns, knChannelMessages)()).To(Succeed())
+		g.Expect(CreateKnativeChannel(t, ctx, ns, knChannelWords)()).To(Succeed())
 
-	knChannelMessages := "messages"
-	knChannelWords := "words"
-	g.Expect(CreateKnativeChannel(t, ctx, ns, knChannelMessages)()).To(Succeed())
-	g.Expect(CreateKnativeChannel(t, ctx, ns, knChannelWords)()).To(Succeed())
-
-	t.Run("Service combo", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative2.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative2", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative3.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative3", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative1.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative1", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
-		// Correct logs
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knative1"), TestTimeoutMedium).Should(ContainSubstring("Received from 2: Hello from knative2"))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knative1"), TestTimeoutMedium).Should(ContainSubstring("Received from 3: Hello from knative3"))
-		// Incorrect logs
-		g.Consistently(IntegrationLogs(t, ctx, ns, "knative1"), 10*time.Second).ShouldNot(ContainSubstring("Received from 2: Hello from knative3"))
-		g.Consistently(IntegrationLogs(t, ctx, ns, "knative1"), 10*time.Second).ShouldNot(ContainSubstring("Received from 3: Hello from knative2"))
-		// Clean up
-		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-	})
-
-	t.Run("Channel combo v1beta1", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativech2.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativech1.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativech2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativech1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knativech2"), TestTimeoutMedium).Should(ContainSubstring("Received: Hello from knativech1"))
-		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-	})
-
-	t.Run("Channel combo get to post", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativegetpost2.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativegetpost1.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativegetpost2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativegetpost1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knativegetpost2"), TestTimeoutMedium).Should(ContainSubstring(`Received ""`))
-		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-	})
-
-	t.Run("Multi channel chain", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop3.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop2.groovy").Execute()).To(Succeed())
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop1.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From messages: message`))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: word`))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: transformed message`))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: word`))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From words: message`))
-		g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: transformed message`))
-		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-	})
-
-	t.Run("Flow", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/flow.yaml").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "flow"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(IntegrationConditionStatus(t, ctx, ns, "flow", camelv1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(v1.ConditionTrue))
-
-		t.Run("Scale to zero", func(t *testing.T) {
-			g.Eventually(IntegrationPod(t, ctx, ns, "flow"), TestTimeoutLong).Should(BeNil())
+		t.Run("Service combo", func(t *testing.T) {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative2.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative2", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative3.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative3", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative1.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knative1", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+			// Correct logs
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knative1"), TestTimeoutMedium).Should(ContainSubstring("Received from 2: Hello from knative2"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knative1"), TestTimeoutMedium).Should(ContainSubstring("Received from 3: Hello from knative3"))
+			// Incorrect logs
+			g.Consistently(IntegrationLogs(t, ctx, ns, "knative1"), 10*time.Second).ShouldNot(ContainSubstring("Received from 2: Hello from knative3"))
+			g.Consistently(IntegrationLogs(t, ctx, ns, "knative1"), 10*time.Second).ShouldNot(ContainSubstring("Received from 3: Hello from knative2"))
+			// Clean up
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
 		})
 
-		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-	})
+		t.Run("Channel combo v1beta1", func(t *testing.T) {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativech2.groovy").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativech1.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativech2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativech1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knativech2"), TestTimeoutMedium).Should(ContainSubstring("Received: Hello from knativech1"))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
 
-	t.Run("Knative-service disabled", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/http_out.groovy", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(Service(t, ctx, ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
-		g.Consistently(KnativeService(t, ctx, ns, "http-out"), TestTimeoutShort).Should(BeNil())
-		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-	})
+		t.Run("Channel combo get to post", func(t *testing.T) {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativegetpost2.groovy").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativegetpost1.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativegetpost2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativegetpost1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knativegetpost2"), TestTimeoutMedium).Should(ContainSubstring(`Received ""`))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
 
-	t.Run("Knative-service priority", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/http_out.groovy").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(KnativeService(t, ctx, ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
-		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
-	})
+		t.Run("Multi channel chain", func(t *testing.T) {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop3.groovy").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop2.groovy").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knativemultihop1.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop3"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativemultihop1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From messages: message`))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: word`))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), TestTimeoutMedium).Should(ContainSubstring(`From words: transformed message`))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: word`))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From words: message`))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "knativemultihop3"), 10*time.Second).ShouldNot(ContainSubstring(`From messages: transformed message`))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
 
-	t.Run("Knative-service annotation", func(t *testing.T) {
-		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative2.groovy", "-t", "knative-service.annotations.'haproxy.router.openshift.io/balance'=roundrobin").Execute()).To(Succeed())
-		g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
-		g.Eventually(KnativeService(t, ctx, ns, "knative2"), TestTimeoutShort).ShouldNot(BeNil())
-		ks := KnativeService(t, ctx, ns, "knative2")()
-		annotations := ks.ObjectMeta.Annotations
-		g.Expect(annotations["haproxy.router.openshift.io/balance"]).To(Equal("roundrobin"))
-		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		t.Run("Flow", func(t *testing.T) {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/flow.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "flow"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "flow", camelv1.IntegrationConditionReady), TestTimeoutLong).Should(Equal(v1.ConditionTrue))
+
+			t.Run("Scale to zero", func(t *testing.T) {
+				g.Eventually(IntegrationPod(t, ctx, ns, "flow"), TestTimeoutLong).Should(BeNil())
+			})
+
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("Knative-service disabled", func(t *testing.T) {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/http_out.groovy", "-t", "knative-service.enabled=false").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(Service(t, ctx, ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
+			g.Consistently(KnativeService(t, ctx, ns, "http-out"), TestTimeoutShort).Should(BeNil())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("Knative-service priority", func(t *testing.T) {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/http_out.groovy").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "http-out"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(KnativeService(t, ctx, ns, "http-out"), TestTimeoutShort).ShouldNot(BeNil())
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
+
+		t.Run("Knative-service annotation", func(t *testing.T) {
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/knative2.groovy", "-t", "knative-service.annotations.'haproxy.router.openshift.io/balance'=roundrobin").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knative2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(KnativeService(t, ctx, ns, "knative2"), TestTimeoutShort).ShouldNot(BeNil())
+			ks := KnativeService(t, ctx, ns, "knative2")()
+			annotations := ks.ObjectMeta.Annotations
+			g.Expect(annotations["haproxy.router.openshift.io/balance"]).To(Equal("roundrobin"))
+			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		})
 	})
 }
 

--- a/e2e/knative/openapi_test.go
+++ b/e2e/knative/openapi_test.go
@@ -23,6 +23,7 @@ limitations under the License.
 package knative
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
@@ -32,26 +33,25 @@ import (
 )
 
 func TestOpenAPIService(t *testing.T) {
-	ctx := TestContext()
-	g := NewWithT(t)
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		openapiContent, err := ioutil.ReadFile("./files/petstore-api.yaml")
+		require.NoError(t, err)
+		var cmDataProps = make(map[string]string)
+		cmDataProps["petstore-api.yaml"] = string(openapiContent)
+		CreatePlainTextConfigmap(t, ctx, ns, "my-openapi-knative", cmDataProps)
 
-	openapiContent, err := ioutil.ReadFile("./files/petstore-api.yaml")
-	require.NoError(t, err)
-	var cmDataProps = make(map[string]string)
-	cmDataProps["petstore-api.yaml"] = string(openapiContent)
-	CreatePlainTextConfigmap(t, ctx, ns, "my-openapi-knative", cmDataProps)
+		g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "--name", "petstore", "--open-api", "configmap:my-openapi-knative", "files/petstore.groovy").Execute()).To(Succeed())
 
-	g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "--name", "petstore", "--open-api", "configmap:my-openapi-knative", "files/petstore.groovy").Execute()).To(Succeed())
+		g.Eventually(KnativeService(t, ctx, ns, "petstore"), TestTimeoutLong).
+			Should(Not(BeNil()))
 
-	g.Eventually(KnativeService(t, ctx, ns, "petstore"), TestTimeoutLong).
-		Should(Not(BeNil()))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "petstore"), TestTimeoutMedium).
+			Should(ContainSubstring("Started listPets (rest://get:/v1:/pets)"))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "petstore"), TestTimeoutMedium).
+			Should(ContainSubstring("Started createPets (rest://post:/v1:/pets)"))
+		g.Eventually(IntegrationLogs(t, ctx, ns, "petstore"), TestTimeoutMedium).
+			Should(ContainSubstring("Started showPetById (rest://get:/v1:/pets/%7BpetId%7D)"))
 
-	g.Eventually(IntegrationLogs(t, ctx, ns, "petstore"), TestTimeoutMedium).
-		Should(ContainSubstring("Started listPets (rest://get:/v1:/pets)"))
-	g.Eventually(IntegrationLogs(t, ctx, ns, "petstore"), TestTimeoutMedium).
-		Should(ContainSubstring("Started createPets (rest://post:/v1:/pets)"))
-	g.Eventually(IntegrationLogs(t, ctx, ns, "petstore"), TestTimeoutMedium).
-		Should(ContainSubstring("Started showPetById (rest://get:/v1:/pets/%7BpetId%7D)"))
-
-	g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+	})
 }


### PR DESCRIPTION
- Enables better error analysis due to automatic dump of resources on test failure

**Release Note**
```release-note
NONE
```
