### PR TITLE
Adding eventing core types on RBAC

### DIFF
--- a/helm/camel-k/templates/operator-cluster-roles.yaml
+++ b/helm/camel-k/templates/operator-cluster-roles.yaml
@@ -294,6 +294,7 @@ rules:
   - eventing.knative.dev
   resources:
   - triggers
+  - brokers
   verbs:
   - create
   - delete
@@ -305,6 +306,8 @@ rules:
   - messaging.knative.dev
   resources:
   - subscriptions
+  - channels
+  - inmemorychannels
   verbs:
   - create
   - delete

--- a/helm/camel-k/templates/operator-role.yaml
+++ b/helm/camel-k/templates/operator-role.yaml
@@ -231,6 +231,7 @@ rules:
   - eventing.knative.dev
   resources:
   - triggers
+  - brokers
   verbs:
   - create
   - delete
@@ -242,6 +243,8 @@ rules:
   - messaging.knative.dev
   resources:
   - subscriptions
+  - channels
+  - inmemorychannels
   verbs:
   - create
   - delete


### PR DESCRIPTION
<!-- Description -->

Adding missing types on helm chart for
* eventing
* messaging
APIs of knative

the non-helm manifests have those (kept same order)

-->

**Release Note**
```release-note
NONE
```
