### PR TITLE
fix(#5402): Evaluate Knative profile based on Serving/Eventing installed

### DIFF
--- a/pkg/controller/integration/platform_setup.go
+++ b/pkg/controller/integration/platform_setup.go
@@ -97,7 +97,7 @@ func determineBestTraitProfile(c client.Client, integration *v1.Integration, p *
 		// Use platform spec profile if set
 		return p.Spec.Profile, nil
 	}
-	if ok, err := knative.IsServingInstalled(c); err != nil {
+	if ok, err := knative.IsInstalled(c); err != nil {
 		return "", err
 	} else if ok {
 		return v1.TraitProfileKnative, nil

--- a/pkg/controller/kameletbinding/integration.go
+++ b/pkg/controller/kameletbinding/integration.go
@@ -248,7 +248,7 @@ func determineTraitProfile(ctx context.Context, c client.Client, binding *v1alph
 			return pl.Spec.Profile, nil
 		}
 	}
-	if ok, err := knative.IsServingInstalled(c); err != nil {
+	if ok, err := knative.IsInstalled(c); err != nil {
 		return "", err
 	} else if ok {
 		return v1.TraitProfileKnative, nil

--- a/pkg/controller/pipe/integration.go
+++ b/pkg/controller/pipe/integration.go
@@ -248,7 +248,7 @@ func determineTraitProfile(ctx context.Context, c client.Client, binding *v1.Pip
 			return pl.Spec.Profile, nil
 		}
 	}
-	if ok, err := knative.IsServingInstalled(c); err != nil {
+	if ok, err := knative.IsInstalled(c); err != nil {
 		return "", err
 	} else if ok {
 		return v1.TraitProfileKnative, nil

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -331,7 +331,9 @@ func (t *knativeTrait) configureEvents(e *Environment, env *knativeapi.CamelEnvi
 				serviceName = "default"
 			}
 			servicePath := fmt.Sprintf("/events/%s", eventType)
-			t.createTrigger(e, ref, eventType, servicePath)
+			if triggerErr := t.createTrigger(e, ref, eventType, servicePath); triggerErr != nil {
+				return triggerErr
+			}
 
 			if !env.ContainsService(serviceName, knativeapi.CamelEndpointKindSource, knativeapi.CamelServiceTypeEvent, ref.APIVersion, ref.Kind) {
 				svc := knativeapi.CamelServiceDefinition{
@@ -475,7 +477,7 @@ func (t *knativeTrait) configureSinkBinding(e *Environment, env *knativeapi.Came
 	return err
 }
 
-func (t *knativeTrait) createTrigger(e *Environment, ref *corev1.ObjectReference, eventType string, path string) {
+func (t *knativeTrait) createTrigger(e *Environment, ref *corev1.ObjectReference, eventType string, path string) error {
 	// TODO extend to additional filters too, to filter them at source and not at destination
 	found := e.Resources.HasKnativeTrigger(func(trigger *eventing.Trigger) bool {
 		return trigger.Spec.Broker == ref.Name &&
@@ -486,9 +488,32 @@ func (t *knativeTrait) createTrigger(e *Environment, ref *corev1.ObjectReference
 		if ref.Namespace == "" {
 			ref.Namespace = e.Integration.Namespace
 		}
-		trigger := knativeutil.CreateTrigger(*ref, e.Integration.Name, eventType, path)
+
+		controllerStrategy, err := e.DetermineControllerStrategy()
+		if err != nil {
+			return err
+		}
+
+		var trigger *eventing.Trigger
+		switch controllerStrategy {
+		case ControllerStrategyKnativeService:
+			trigger, err = knativeutil.CreateKnativeServiceTrigger(*ref, e.Integration.Name, eventType, path)
+			if err != nil {
+				return err
+			}
+		case ControllerStrategyDeployment:
+			trigger, err = knativeutil.CreateServiceTrigger(*ref, e.Integration.Name, eventType, path)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("failed to create Knative trigger: unsupported controller strategy %s", controllerStrategy)
+		}
+
 		e.Resources.Add(trigger)
 	}
+
+	return nil
 }
 
 func (t *knativeTrait) ifServiceMissingDo(

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -30,6 +30,7 @@ import (
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/metadata"
+	"github.com/apache/camel-k/v2/pkg/util/knative"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 )
 
@@ -146,6 +147,11 @@ func (t *knativeServiceTrait) Apply(e *Environment) error {
 func (t *knativeServiceTrait) SelectControllerStrategy(e *Environment) (*ControllerStrategy, error) {
 	if !pointer.BoolDeref(t.Enabled, true) || e.CamelCatalog == nil {
 		// explicitly disabled or sourceless Integration (missing catalog)
+		return nil, nil
+	}
+
+	// Knative serving is required
+	if ok, _ := knative.IsServingInstalled(e.Client); !ok {
 		return nil, nil
 	}
 

--- a/pkg/trait/knative_service_test.go
+++ b/pkg/trait/knative_service_test.go
@@ -414,6 +414,81 @@ func TestKnativeServiceNotApplicable(t *testing.T) {
 	}))
 }
 
+func TestKnativeServiceNoServingAvailable(t *testing.T) {
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
+
+	client, _ := test.NewFakeClient()
+	fakeClient := client.(*test.FakeClient) //nolint
+	fakeClient.DisableKnativeServing()
+
+	traitCatalog := NewCatalog(nil)
+
+	environment := Environment{
+		CamelCatalog: catalog,
+		Catalog:      traitCatalog,
+		Client:       client,
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      KnativeServiceTestName,
+				Namespace: KnativeServiceTestNamespace,
+			},
+			Status: v1.IntegrationStatus{
+				Phase: v1.IntegrationPhaseDeploying,
+			},
+			Spec: v1.IntegrationSpec{
+				Profile: v1.TraitProfileKnative,
+				Sources: []v1.SourceSpec{
+					{
+						DataSpec: v1.DataSpec{
+							Name:    "routes.js",
+							Content: `from("platform-http:test").log("hello")`,
+						},
+						Language: v1.LanguageJavaScript,
+					},
+				},
+			},
+		},
+		IntegrationKit: &v1.IntegrationKit{
+			Status: v1.IntegrationKitStatus{
+				Phase: v1.IntegrationKitPhaseReady,
+			},
+		},
+		Platform: &v1.IntegrationPlatform{
+			Spec: v1.IntegrationPlatformSpec{
+				Cluster: v1.IntegrationPlatformClusterOpenShift,
+				Build: v1.IntegrationPlatformBuildSpec{
+					PublishStrategy: v1.IntegrationPlatformBuildPublishStrategyS2I,
+					Registry:        v1.RegistrySpec{Address: "registry"},
+					RuntimeVersion:  catalog.Runtime.Version,
+				},
+			},
+			Status: v1.IntegrationPlatformStatus{
+				Phase: v1.IntegrationPlatformPhaseReady,
+			},
+		},
+		EnvVars:        make([]corev1.EnvVar, 0),
+		ExecutedTraits: make([]Trait, 0),
+		Resources:      kubernetes.NewCollection(),
+	}
+	environment.Platform.ResyncStatusFullConfig()
+
+	// don't care about conditions in this unit test
+	_, err = traitCatalog.apply(&environment)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, environment.ExecutedTraits)
+	assert.Nil(t, environment.GetTrait("knative-service"))
+
+	assert.Nil(t, environment.Resources.GetKnativeService(func(service *serving.Service) bool {
+		return service.Name == KnativeServiceTestName
+	}))
+
+	assert.NotNil(t, environment.Resources.GetDeployment(func(deployment *appsv1.Deployment) bool {
+		return deployment.Name == KnativeServiceTestName
+	}))
+}
+
 func TestKnativeServiceWithRollout(t *testing.T) {
 	environment := createKnativeServiceTestEnvironment(t, &traitv1.KnativeServiceTrait{RolloutDuration: "60s"})
 	assert.NotEmpty(t, environment.ExecutedTraits)


### PR DESCRIPTION
Fixes #5402

- Use Knative profile when Serving or Eventing is installed on cluster
- Make sure to enable Knative trait when Serving or Eventing is installed
- Enable knative-service trait only when Knative Serving is installed
- Garbage collect Serving and Eventing resources in gc trait only when Serving/Eventing is installed on the cluster
- Do not use Serving service in Knative trigger when not installed on cluster
- Use arbitrary Service as a subscriber in Knative trigger when Serving is not available

**Release Note**
```release-note
fix(#5402): Evaluate Knative profile based on Serving/Eventing installed
```
