### PR TITLE
[Backport 2.3.x] fix(trait): compute cm after catalog

### DIFF
--- a/e2e/common/misc/pipe_with_image_test.go
+++ b/e2e/common/misc/pipe_with_image_test.go
@@ -61,7 +61,7 @@ func TestPipeWithImage(t *testing.T) {
 			)))
 			g.Eventually(IntegrationStatusImage(t, ctx, ns, bindingID)).
 				Should(Equal(expectedImage))
-			g.Eventually(IntegrationPodPhase(t, ctx, ns, bindingID), TestTimeoutLong).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, bindingID), TestTimeoutShort).
 				Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationPodImage(t, ctx, ns, bindingID)).
 				Should(Equal(expectedImage))
@@ -79,7 +79,7 @@ func TestPipeWithImage(t *testing.T) {
 			)))
 			g.Eventually(IntegrationStatusImage(t, ctx, ns, bindingID)).
 				Should(Equal(expectedImage))
-			g.Eventually(IntegrationPodPhase(t, ctx, ns, bindingID), TestTimeoutLong).
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, bindingID), TestTimeoutShort).
 				Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationPodImage(t, ctx, ns, bindingID)).
 				Should(Equal(expectedImage))

--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -79,11 +79,6 @@ func (t *camelTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 }
 
 func (t *camelTrait) Apply(e *Environment) error {
-	if e.IntegrationKitInPhase(v1.IntegrationKitPhaseReady) && e.IntegrationInRunningPhases() {
-		// Get all resources
-		maps := t.computeConfigMaps(e)
-		e.Resources.AddAll(maps)
-	}
 	if e.IntegrationKit != nil && e.IntegrationKit.IsSynthetic() {
 		// This is required as during init phase, the trait set by default these values
 		// which are widely used in the platform for different purposese.
@@ -107,7 +102,11 @@ func (t *camelTrait) Apply(e *Environment) error {
 		e.IntegrationKit.Status.RuntimeVersion = e.CamelCatalog.Runtime.Version
 		e.IntegrationKit.Status.RuntimeProvider = e.CamelCatalog.Runtime.Provider
 	}
-
+	if e.IntegrationKitInPhase(v1.IntegrationKitPhaseReady) && e.IntegrationInRunningPhases() {
+		// Get all resources
+		maps := t.computeConfigMaps(e)
+		e.Resources.AddAll(maps)
+	}
 	return nil
 }
 

--- a/pkg/trait/mount.go
+++ b/pkg/trait/mount.go
@@ -113,8 +113,10 @@ func (t *mountTrait) Apply(e *Environment) error {
 	}
 
 	if visited {
-		// Volumes declared in the Integration resources
-		e.configureVolumesAndMounts(volumes, &container.VolumeMounts)
+		// Volumes declared in the Integration resources (we skip for synthetic kits)
+		if e.IntegrationKit == nil || !e.IntegrationKit.IsSynthetic() {
+			e.configureVolumesAndMounts(volumes, &container.VolumeMounts)
+		}
 		// Volumes declared in the trait config/resource options
 		err := t.configureVolumesAndMounts(volumes, &container.VolumeMounts)
 		if err != nil {


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): compute cm after catalog
```
