### PR TITLE
[Backport 2.3.x] fix(trait): controller strategy default service port name

### DIFF
--- a/pkg/trait/container.go
+++ b/pkg/trait/container.go
@@ -43,11 +43,10 @@ import (
 )
 
 const (
-	defaultContainerName     = "integration"
-	defaultContainerPort     = 8080
-	defaultContainerPortName = "http"
-	defaultServicePort       = 80
-	containerTraitID         = "container"
+	defaultContainerName = "integration"
+	defaultContainerPort = 8080
+	defaultServicePort   = 80
+	containerTraitID     = "container"
 )
 
 type containerTrait struct {
@@ -261,15 +260,14 @@ func (t *containerTrait) configureContainer(e *Environment) error {
 func (t *containerTrait) configureService(e *Environment, container *corev1.Container, isKnative bool) {
 	name := t.PortName
 	if name == "" {
-		name = defaultContainerPortName
+		name = e.determineDefaultContainerPortName()
 	}
 	containerPort := corev1.ContainerPort{
+		Name:          name,
 		ContainerPort: int32(t.Port),
 		Protocol:      corev1.ProtocolTCP,
 	}
 	if !isKnative {
-		// Knative does not want name=http
-		containerPort.Name = name
 		// The service is managed by Knative, so, we only take care of this when it's managed by us
 		service := e.Resources.GetServiceForIntegration(e.Integration)
 		if service != nil {

--- a/pkg/trait/container_probes_test.go
+++ b/pkg/trait/container_probes_test.go
@@ -207,10 +207,10 @@ func TestProbesOnKnativeService(t *testing.T) {
 	container := env.GetIntegrationContainer()
 
 	assert.Equal(t, "", container.LivenessProbe.HTTPGet.Host)
-	assert.Equal(t, int32(0), container.LivenessProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, int32(defaultContainerPort), container.LivenessProbe.HTTPGet.Port.IntVal)
 	assert.Equal(t, defaultLivenessProbePath, container.LivenessProbe.HTTPGet.Path)
 	assert.Equal(t, "", container.ReadinessProbe.HTTPGet.Host)
-	assert.Equal(t, int32(0), container.ReadinessProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, int32(defaultContainerPort), container.ReadinessProbe.HTTPGet.Port.IntVal)
 	assert.Equal(t, defaultReadinessProbePath, container.ReadinessProbe.HTTPGet.Path)
 	assert.Equal(t, int32(1234), container.LivenessProbe.TimeoutSeconds)
 }

--- a/pkg/trait/container_test.go
+++ b/pkg/trait/container_test.go
@@ -653,5 +653,5 @@ func TestKnativeServiceContainerPorts(t *testing.T) {
 	container := environment.GetIntegrationContainer()
 	assert.Len(t, container.Ports, 1)
 	assert.Equal(t, int32(8081), container.Ports[0].ContainerPort)
-	assert.Equal(t, "", container.Ports[0].Name)
+	assert.Equal(t, defaultKnativeContainerPortName, container.Ports[0].Name)
 }

--- a/pkg/trait/health.go
+++ b/pkg/trait/health.go
@@ -87,17 +87,14 @@ func (t *healthTrait) Apply(e *Environment) error {
 	if container == nil {
 		return fmt.Errorf("unable to find integration container: %s", e.Integration.Name)
 	}
+
 	var port *intstr.IntOrString
-	// Use the default named HTTP container port if it exists.
-	// For Knative, the Serving webhook is responsible for setting the user-land port,
-	// and associating the probes with the corresponding port.
-	if containerPort := e.getIntegrationContainerPort(); containerPort != nil && containerPort.Name == defaultContainerPortName {
-		p := intstr.FromString(defaultContainerPortName)
-		port = &p
-	} else if e.GetTrait(knativeServiceTraitID) == nil {
-		p := intstr.FromInt(defaultContainerPort)
-		port = &p
+	containerPort := e.getIntegrationContainerPort()
+	if containerPort == nil {
+		containerPort = e.createContainerPort()
 	}
+	p := intstr.FromInt(int(containerPort.ContainerPort))
+	port = &p
 
 	if e.CamelCatalog.Runtime.Capabilities["health"].Metadata != nil {
 		t.setCatalogConfiguration(container, port, e.CamelCatalog.Runtime.Capabilities["health"].Metadata)

--- a/pkg/trait/route.go
+++ b/pkg/trait/route.go
@@ -80,11 +80,14 @@ func (t *routeTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 }
 
 func (t *routeTrait) Apply(e *Environment) error {
-	servicePortName := defaultContainerPortName
+	servicePortName := ""
 	if dt := e.Catalog.GetTrait(containerTraitID); dt != nil {
 		if ct, ok := dt.(*containerTrait); ok {
 			servicePortName = ct.ServicePortName
 		}
+	}
+	if servicePortName == "" {
+		servicePortName = e.determineDefaultContainerPortName()
 	}
 
 	tlsConfig, err := t.getTLSConfig(e)


### PR DESCRIPTION
Using a func that determine the default port name based on the controller strategy adopted

Close #5409

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
