### PR TITLE
[Backport 2.3.x] chore(cmd): error if no default catalog found

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -863,6 +863,9 @@ func (o *runCmdOptions) applyDependencies(cmd *cobra.Command, c client.Client, i
 				if err != nil {
 					return err
 				}
+				if catalog == nil {
+					return fmt.Errorf("error trying to load the default Camel catalog")
+				}
 			}
 			addDependency(cmd, it, item, catalog)
 		}


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
