### PR TITLE
chore(e2e): Allow to disable copy optimizations on E2E tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,4 +1,4 @@
-# Camel K End To End tests
+# Camel K End-To-End tests
 
 This directory contains the suite of test that are run on a CI to ensure the stability of the product and no regression are introduced at each PR. The full documentation can be found at https://camel.apache.org/camel-k/next/contributing/e2e.html
 
@@ -31,9 +31,9 @@ Additional set of test that cover the main common features but that requires som
 
 Test suite that cover the different installation procedures we offer and any upgrade scenario.
 
-### KNative
+### Knative
 
-Test suite that cover the features associated with KNative. This test will assume the presence of a namespaced operator (installation provided by the same test execution suite) togheter with KNative operator configuration.
+Test suite that cover the features associated with Knative. This test will assume the presence of a namespaced operator (installation provided by the same test execution suite) togheter with Knative operator configuration.
 
 ### Native
 
@@ -45,4 +45,31 @@ Test suite that cover the features associated with Telemetry feature. The test e
 
 ### Yaks
 
-Test suite that cover certain KNative features togheter with YAKS operator.
+Test suite that cover certain Knative features togheter with YAKS operator.
+
+## Environment variables
+
+You can set some environment variables to change the behavior of the E2E test suite.
+
+| Env                                     | Default                                 | Description                                                                                                                                   |
+|-----------------------------------------|-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| CAMEL_K_TEST_SKIP_PROBLEMATIC           | false                                   | Skips tests that are marked to be problematic (flaky) on certain environments (e.g. on OpenShift).                                            |
+| CAMEL_K_TEST_SAVE_FAILED_TEST_NAMESPACE | false                                   | Used to not remove the temporary test namespaces after the test run. Enables better analysis of resources after the test                      |
+| CAMEL_K_TEST_LOG_LEVEL                  | info                                    | Logging level used to run the tests and used in Maven commands run by the operator (if level is `debug` the Maven commands use `-X` option).  |
+| CAMEL_K_TEST_MAVEN_CLI_OPTIONS          | {}                                      | Maven CLI options used to run Camel K integrations during the tests.                                                                          |
+| CAMEL_K_TEST_OPERATOR_IMAGE             | docker.io/apache/camel-k:2.4.0-SNAPSHOT | Camel K operator image used in operator installation.                                                                                         |
+| CAMEL_K_TEST_OPERATOR_IMAGE_PULL_POLICY | -                                       | Operator image pull policy.                                                                                                                   |
+| CAMEL_K_TEST_IMAGE_NAME                 | docker.io/apache/camel-k                | Camel K operator image name used in operator installation.                                                                                    |
+| CAMEL_K_TEST_IMAGE_VERSION              | 2.4.0-SNAPSHOT                          | Camel K operator image version used in operator installation. Value is retrieved from `pkg/util/defaults/defaults.go`                         |
+| CAMEL_K_TEST_NO_OLM_OPERATOR_IMAGE      | docker.io/apache/camel-k:2.4.0-SNAPSHOT | Camel K operator image used in non OLM based operator installation.                                                                           |
+| CAMEL_K_TEST_RUNTIME_VERSION            | 3.8.1                                   | Camel K runtime version used for the integrations. Value is retrieved from `pkg/util/defaults/defaults.go`                                    |
+| CAMEL_K_TEST_BASE_IMAGE                 | eclipse-temurin:17                      | Camel K runtime base image used for the integrations. Value is retrieved from `pkg/util/defaults/defaults.go`                                 |
+| CAMEL_K_TEST_TIMEOUT_SHORT              | 1                                       | Customize the timeouts (in minutes) used in test assertions.                                                                                  |
+| CAMEL_K_TEST_TIMEOUT_MEDIUM             | 5                                       | Customize the timeouts (in minutes) used in test assertions.                                                                                  |
+| CAMEL_K_TEST_TIMEOUT_LONG               | 15                                      | Customize the timeouts (in minutes) used in test assertions.                                                                                  |
+| CAMEL_K_TEST_MAVEN_CA_PEM_PATH          | -                                       | Optional Maven certificate path.                                                                                                              |
+| CAMEL_K_TEST_COPY_CATALOG               | true                                    | Enable/disable the optimization to copy the Camel Catalog from default operator namespace for each test namespace.                            |
+| CAMEL_K_TEST_COPY_INTEGRATION_KITS      | true                                    | Enable/disable the optimization to copy integration kits from default operator namespace for each test namespace.                             |
+| CAMEL_K_TEST_NS                         | -                                       | Custom test namespace name used to create temporary namespaces.                                                                               |
+| CAMEL_K_TEST_MAKE_DIR                   | -                                       | Used in Helm and Kustomize install tests as Makefile root dir.                                                                                |
+| CAMEL_K_TEST_MAKE_ARGS                  | -                                       | Used in Helm and Kustomize install tests as Makefile arguments.                                                                               |

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1999,6 +1999,11 @@ func PlatformByName(t *testing.T, ctx context.Context, ns string, name string) f
 }
 
 func CopyIntegrationKits(t *testing.T, ctx context.Context, ns, operatorID string) error {
+	if value, ok := os.LookupEnv("CAMEL_K_TEST_COPY_INTEGRATION_KITS"); ok && value == "false" {
+		fmt.Println("Copy integration kits optimization is disabled")
+		return nil
+	}
+
 	opns := GetEnvOrDefault("CAMEL_K_GLOBAL_OPERATOR_NS", TestDefaultNamespace)
 
 	lst := v1.NewIntegrationKitList()
@@ -2034,6 +2039,11 @@ func CopyIntegrationKits(t *testing.T, ctx context.Context, ns, operatorID strin
 }
 
 func CopyCamelCatalog(t *testing.T, ctx context.Context, ns, operatorID string) error {
+	if value, ok := os.LookupEnv("CAMEL_K_TEST_COPY_CATALOG"); ok && value == "false" {
+		fmt.Println("Copy catalog optimization is disabled")
+		return nil
+	}
+
 	catalogName := fmt.Sprintf("camel-catalog-%s", strings.ToLower(defaults.DefaultRuntimeVersion))
 	opns := GetEnvOrDefault("CAMEL_K_GLOBAL_OPERATOR_NS", TestDefaultNamespace)
 


### PR DESCRIPTION
- Provide envvars to the user to enable/disable copy catalog e2e test optimization
- Provide envvars to the user to enable/disable copy integration kit e2e test optimization
- Add some documentation on available e2e test envvars

**Release Note**
```release-note
NONE
```
