### PR TITLE
feat(api): show integration readiness

### DIFF
--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -43,6 +43,10 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: The integration readiness
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - description: The runtime version
       jsonPath: .status.runtimeProvider
       name: Runtime Provider

--- a/pkg/apis/camel/v1/integration_types.go
+++ b/pkg/apis/camel/v1/integration_types.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The integration phase"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="The integration readiness"
 // +kubebuilder:printcolumn:name="Runtime Provider",type=string,JSONPath=`.status.runtimeProvider`,description="The runtime version"
 // +kubebuilder:printcolumn:name="Runtime Version",type=string,JSONPath=`.status.runtimeVersion`,description="The runtime provider"
 // +kubebuilder:printcolumn:name="Kit",type=string,JSONPath=`.status.integrationKit.name`,description="The integration kit"

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -43,6 +43,10 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: The integration readiness
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - description: The runtime version
       jsonPath: .status.runtimeProvider
       name: Runtime Provider


### PR DESCRIPTION
Useful to get the readiness information from cluster tooling

```
$ kubectl get it -w
NAME   PHASE          READY   RUNTIME PROVIDER   RUNTIME VERSION   KIT                        REPLICAS
test   Building Kit           quarkus            3.8.1             kit-coqas3g4uf3s73fba8p0   
test   Deploying              quarkus            3.8.1             kit-coqas3g4uf3s73fba8p0   
test   Running        False   quarkus            3.8.1             kit-coqas3g4uf3s73fba8p0   1
test   Running        False   quarkus            3.8.1             kit-coqas3g4uf3s73fba8p0   1
test   Running        True    quarkus            3.8.1             kit-coqas3g4uf3s73fba8p0   1
```

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(api): show integration readiness
```
