### PR TITLE
[backport 2.3] Enhance offline script and documentation (#5447)

### DIFF
--- a/docs/modules/ROOT/pages/installation/advanced/offline.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/offline.adoc
@@ -13,15 +13,17 @@ We can easily identify those components which requires access to the Internet an
 
 The xref:installation/registry/registry.adoc[registry] is the component in charge to host the containers which are built from the operator and are used by the cluster to run the Camel applications. This component could be provided out of the box by the cluster, or should be operated by you (see the guide on xref:installation/registry/own.adoc[how to run your own registry]).
 
-As we're in a disconnected environment, we assume this component to be accessible by the cluster (through an IP or URL). However, the cluster need to use the Camel K container image in order to be installed. You therefore need to make sure that the cluster registry has preloaded the Camel K container image, which is `apache/camel-k:2.0.0` (or any version you're willing to use).
+As we're in a disconnected environment, we assume this component to be accessible by the cluster (through an IP or URL). However, the cluster need to use the Camel K container image in order to be installed. You therefore need to make sure that the cluster registry has preloaded the Camel K container image, which is `docker.io/apache/camel-k:2.3.0` (or any version you're willing to use).
 
-We cannot provide any specific guideline on how to preload images in the cluster registry (as it vary on your infrastructure). However we expect this to be part of the documentation of the cluster in a disconnected mode. At the same manner, you'll need to make sure to include the following images which will be required by Camel K during its operations:
+We cannot provide any specific guideline on how to preload images in the cluster registry (as it vary on your infrastructure). However we expect this to be part of the documentation of the cluster in a disconnected mode. At the same manner, you'll need to make sure to include the following images which will be required by Camel K during its operations, note that in a disconnected cluster we have to use the digest URLs and not the tag.
 
-* `quay.io/quarkus/quarkus-micro-image:2.0`
 * `eclipse-temurin:17` (or any other base image you want to use)
-* `quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.0-jdk-17`
+* `quay.io/quarkus/quarkus-micro-image:2.0`
+* `quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21`
 
-The last one is the image used in the Camel K Runtime 2.16.0 version (the default one at the time of writing). Make sure to identify in the catalog (`.spec.runtime.metadata.quarkus.native-builder-image`) the one required in your installation.
+An example of a digest URL of Camel K 2.3.0: `docker.io/apache/camel-k@sha256:a043af04c9b816f0dfd5db64ba69bae192d73dd726df83aaf2002559a111a786`
+
+The last one is the image used in the Camel K Runtime 3.8.1 version (the default one at the time of writing). Make sure to identify in the https://repo1.maven.org/maven2/org/apache/camel/k/camel-k-catalog/3.8.1/camel-k-catalog-3.8.1-catalog.yaml[camel-k-catalog] (`.spec.runtime.metadata.quarkus.native-builder-image`) the one required in your installation.
 
 If all the above is set, then, you should be ready to pull and push from the container registry in Camel K as well.
 
@@ -32,26 +34,31 @@ WARNING: This guide is a best effort development done to help the final user to 
 
 The procedure contains a script that will package the entire set of Camel K Runtime dependencies required by Maven build in order to run offline builds.
 
-It requires that the Maven version from where you're running the scripts (likely your machine) is the same used in the Camel K operator target version (ie, 3.8.6 for Camel K version 2.0.0) - required to enforce reproducible builds.
+It requires that the Maven version from where you're running the scripts (likely your machine) is the same used in the Camel K operator target version (ie, 3.8.6 for Camel K version 2.3.0) - required to enforce reproducible builds. The script will download the correct version if needed.
 
 It's quite important to know that the operator will expect the dependencies to be owned by 1001 user. So, make sure that the script is executed by such a USER to avoid the maven build to fail due to privileges faults.
 
-The output of the script is a tar file containing all the tree of dependencies expected by Maven, allowing the target building system (ie, the Camel K operator) to be executed with `--offline` option.
+The output of the script is a tar.gz file containing all the tree of dependencies expected by Maven, allowing the target building system (ie, the Camel K operator).
 
-NOTE: it may not work in Quarkus native mode as the native build may require additional dependencies not available in the bundle.
+NOTE: It may not work in Quarkus native mode as the native build may require additional dependencies not available in the bundle.
+
 
 [[maven-script]]
 === Offliner script
 
-The script is available in https://github.com/apache/camel-k[Camel K github repository]. You need to clone it and follow the instructions.
+The script is available in https://github.com/apache/camel-k/blob/main/script/offline_dependencies.sh[Camel K github repository].
 
 You can run:
 
 ```bash
-./script/offline_dependencies.sh <camel-k-runtime-version> --with <path/to/maven/version/matching/target>
+./script/offline_dependencies.sh
+usage: ./script/offline_dependencies.sh -v <Camel K Runtime version> [optional parameters]
+-m path to mvn command
+-r URL address of the maven repository manager
+-d local directory to add the offline dependencies
 ```
 
-After some time (up to 1 hour time), all the packaged dependencies will be available in a _tar.gz_ file in _/build/_ directory. It's a big file as it contains all the transitive dependencies required by *all Camel components*.
+It may take 5 minutes, to resolve all the packaged dependencies will be available in a _tar.gz_ file. It's a big file as it contains all the transitive dependencies required by *all Camel components* configured in the camel-k-catalog.
 
 [[maven-offline]]
 === Configure Operator build offline
@@ -82,7 +89,41 @@ The downside of this procedure is that since the Pod is ephemeral, the content o
 
 The best practice we suggest is to always use a Maven Proxy. This is also the case of an offline installation. In such case you can check your Maven Repository Manager documentation and verify how to upload dependencies using the file created in the chapter above. You may also need to verify how to turn any possible access to the internet off.
 
-In this configuration, you won't need to perform any change on the Camel K operator (assuming the operator is already configured to use this proxy).
+Then you have to create a custom maven settings.xml file with the mirror of `central` maven repository and add your maven repository manager, then inform Camel K Operator, to use this custom maven settings.xml file.
+
+You can download a https://github.com/apache/camel-k/blob/main/script/[template settings.xml] and change it accordingly to the following script, then create a ConfigMap from the settings.xml file.
+
+```
+repo=http://<address>:<port>/<path>
+sed "s,_local-maven-proxy_,${repo},g" maven-settings-offline-template.xml > maven-settings-offline.xml
+kubectl create configmap local-maven-settings-offline --from-file=settings.xml=maven-settings-offline.xml
+```
+
+Now you have to inform Camel K to use this settings.xml when building the integrations.
+
+If you have already installed Camel K, then you can patch the `IntegrationPlatform/camel-k`, verify you environment for custom name and namespace:
+
+```
+kubectl patch itp/camel-k --type=merge -p '{"spec": {"build": {"maven": {"settings": {"configMapKeyRef": {"key": "settings.xml", "name": "local-maven-settings-offline"}}}}}}'
+```
+
+If you want to install Camel K with this custom maven settings.xml, use the parameter `--maven-settings`:
+
+```
+kamel install --maven-settings configmap:local-maven-settings-offline
+```
+
+[[itp-build-native]]
+=== Quarkus Native Build
+
+If you are doing quarkus native builds, then you have to use the container image with digest address. The xref:traits:quarkus.adoc[quarkus trait] contains two parameters to set the `nativeBaseImage` and `nativeBuilderImage`.
+You can permanently set the quarkus parameter at the `IntegrationPlatform` or `IntegrationProfile` as a global configuration.
+The following example sets the `IntegrationPlatform/camel-k`. Be sure to verify the correct container image address digest values.
+
+```
+kubectl patch itp/camel-k --type=merge -p '{"spec": {"traits": {"quarkus": {"nativeBaseImage": "quay.io/quarkus/quarkus-micro-image@sha256:<digest>", "nativeBuilderImage": "quay.io/quarkus/ubi-quarkus-mandrel-builder-image@sha256:<digest>"}}}}'
+
+```
 
 [[maven-offline-volume]]
 === Run in a volume

--- a/script/maven-settings-offline-template.xml
+++ b/script/maven-settings-offline-template.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <profiles>
+      <profile>
+        <id>camel-k</id>
+        <activation>
+          <activeByDefault>true</activeByDefault>
+        </activation>
+        <repositories>
+          <repository>
+            <id>repository-000</id>
+            <url>_local-maven-proxy_</url>
+            <snapshots>
+              <enabled>false</enabled>
+              <checksumPolicy>fail</checksumPolicy>
+            </snapshots>
+            <releases>
+              <enabled>true</enabled>
+              <checksumPolicy>fail</checksumPolicy>
+            </releases>
+          </repository>
+        </repositories>
+        <pluginRepositories>
+          <pluginRepository>
+            <id>repository-000</id>
+            <url>_local-maven-proxy_</url>
+            <snapshots>
+              <enabled>false</enabled>
+              <checksumPolicy>fail</checksumPolicy>
+            </snapshots>
+            <releases>
+              <enabled>true</enabled>
+              <checksumPolicy>fail</checksumPolicy>
+            </releases>
+          </pluginRepository>
+        </pluginRepositories>
+      </profile>
+    </profiles>
+    <mirrors>
+        <mirror>
+            <id>local-central-mirror</id>
+            <name>local-central-mirror</name>
+            <mirrorOf>central</mirrorOf>
+            <url>_local-maven-proxy_</url>
+        </mirror>
+    </mirrors>
+</settings>

--- a/script/offline_dependencies.sh
+++ b/script/offline_dependencies.sh
@@ -17,79 +17,315 @@
 
 set -e
 
-location=$(dirname $0)
-rootdir=$location/../
-outputLocation=${rootdir}build/_offline
+mvnCmd=$(which mvn)
+remote_repo=https://repo1.maven.org/maven2
+start_time=$(date -u +"%s")
 
-if [ "$#" -lt 3 ]; then
-  echo "usage: $0 <Camel K runtime version> --with <path/to/maven/version>"
-  exit 1
+while getopts ":v:m:r:d:" opt; do
+  case "${opt}" in
+    m)
+      mvnCmd="${OPTARG}"
+      ;;
+    r)
+      remote_repo="${OPTARG}"
+      ;;
+    v)
+      runtime_version="${OPTARG}"
+      ;;
+    d)
+      offline_dir="${OPTARG}"
+      ;;
+    *)
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z ${runtime_version} ]; then
+    echo "usage: $0 -v <Camel K Runtime version> [optional parameters]"
+    echo "  -m path to mvn command"
+    echo "  -r URL address of the maven repository manager"
+    echo "  -d local directory to add the offline dependencies"
+    exit 1
 fi
 
-# Non reproducible builds: we must use the exact maven version used by the operator
-# Change the mvnCmd variable to include the maven version you're willing to use ie, /usr/share/apache-maven-3.8.6/bin/mvn
-if [ ! "$2" == "--with" ]; then
-  echo "usage: $0 <Camel K runtime version> --with <path/to/maven/version>"
-  exit 2
+offline=./_offline-${runtime_version}
+if [ ! -z ${offline_dir} ]; then
+    offline=${offline_dir}
 fi
 
-runtime_version="$1"
-mvnCmd="$3"
+offline_repo=${offline}/repo
 
-echo "WARN: Running the script with the following maven version. Make sure maven version matches the target!"
+# the pom.xml is the one containing all the dependencies from the camel-catalog file
+# it is used when running the go-offline and quarkus:go-offline goals to resolve all dependencies
+pom=${offline}/pom.xml
+# the pom-min.xml is used to actually build the project
+# it was noted that some transitive dependencies are not correctly resolve when using the go-offlilne plugin goals
+# then this was required to resolve some transitive dependencies.
+pom_min=${offline}/pom-min.xml
+
+############# SETUP MAVEN
+# get the maven version used by camel-k-operator
+camelk_mvn_ver=$(curl -s https://raw.githubusercontent.com/apache/camel-k/release-2.3.x/build/Dockerfile|grep MAVEN_DEFAULT_VERSION= |cut -d\" -f2)
+# get the maven version set by the user from the parameters
+mvn_ver=$($mvnCmd --version |grep "Apache Maven"|awk '{print $3}')
+# the maven version executing the task MUST be exactly the same versin as set by the camel-k-operator
+if [ "${camelk_mvn_ver}" != "${mvn_ver}" ]; then
+    # if the maven version is different, download the correct maven version
+    url="https://archive.apache.org/dist/maven/maven-3/${camelk_mvn_ver}/binaries/apache-maven-${camelk_mvn_ver}-bin.tar.gz"
+    echo "WARNING: Wrong Maven version \"${mvn_ver}\", it must be the same as in camel-k operator: \"${camelk_mvn_ver}\""
+    echo "         This script will attempt to download it from: ${url}"
+    install_dir=`mktemp -d --suffix _maven`
+    curl -fsSL ${url} | tar zx --strip-components=1 -C ${install_dir}
+    trap "{ rm -r "${install_dir}" ; exit 255; }" SIGINT SIGTERM ERR EXIT
+    mvnCmd=${install_dir}/bin/mvn
+fi
+
+mkdir -p ${offline_repo}
+# ignore file not found
+rm -f ${pom} 2> /dev/null
+
 $mvnCmd --version | grep "Apache Maven"
+## END SETUP MAVEN
 
-echo "INFO: downloading catalog for Camel K runtime $1..."
-${location}/get_catalog.sh $1 $2
+############# SETUP CAMEL CATALOG
+url=${remote_repo}/org/apache/camel/k/camel-k-catalog/${runtime_version}/camel-k-catalog-${runtime_version}-catalog.yaml
+response_code=$(curl -o /dev/null --silent -Iw '%{http_code}' ${url})
 
-catalog="$rootdir/pkg/resources/resources/camel-catalog-$runtime_version.yaml"
+if [ 200 != ${response_code} ]; then
+    echo "ERROR: Camel K Runtime version ${runtime_version} catalog doesn't exist at ${url}"
+    exit 1
+fi
+catalog="${offline}/camel-catalog-${runtime_version}.yaml"
+echo "INFO: downloading catalog for Camel K Runtime ${runtime_version}"
+curl -sfSL ${url} -o ${catalog}
+## END SETUP CAMEL CATALOG
+
+############# SETUP POM PROJECT
 ckr_version=$(yq .spec.runtime.version $catalog)
 cq_version=$(yq '.spec.runtime.metadata."camel-quarkus.version"' $catalog)
 quarkus_version=$(yq '.spec.runtime.metadata."quarkus.version"' $catalog)
+jibVersion=$(curl -s https://raw.githubusercontent.com/apache/camel-k/release-2.3.x/pkg/util/jib/configuration.go|grep 'const JibMavenPluginVersionDefault'|cut -d\" -f2)
+jibLayerFilterVersion=$(curl -s https://raw.githubusercontent.com/apache/camel-k/release-2.3.x/pkg/util/jib/configuration.go|grep 'const JibLayerFilterExtensionMavenVersionDefault'|cut -d\" -f2)
 
-echo "INFO: configuring offline dependencies for Camel K Runtime $ckr_version, Camel Quarkus $cq_version and Quarkus version $quarkus_version"
-
+echo "INFO: configuring offline dependencies for Camel K Runtime $ckr_version, Camel Quarkus $cq_version and Quarkus Platform version $quarkus_version"
 echo "INFO: preparing a base project to download maven dependencies..."
 
-$mvnCmd -q clean package \
-    -f $location/camel-k-runtime-archetype/pom.xml \
-    -Dmaven.repo.local=$outputLocation \
-    -DRUNTIME_VERSION_CMD=$ckr_version \
-    -DQUARKUS_VERSION_CMD=$quarkus_version \
-    -s $location/maven-settings.xml
+cat <<EOF > ${pom}
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.camel.k.integration</groupId>
+    <artifactId>camel-k-integration-offline</artifactId>
+    <version>0.1</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.package.type>fast-jar</quarkus.package.type>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-runtime-bom</artifactId>
+                <version>$runtime_version</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+EOF
 
-sed 's/- //g' $catalog | grep "groupId\|artifactId" | paste -d " "  - - | awk '{print $2,":",$4}' | tr -d " " | sort | uniq > /tmp/ck.dependencies
+# collect all artifacts from the camel-catalog and add them to the pom file
+sed 's/- //g' $catalog | grep "groupId\|artifactId" | paste -d " "  - - |awk '{print $2":"$4}'|sort|uniq|while read line; do
+#     echo $line;
+    g=$(echo $line|cut -d: -f1);
+    a=$(echo $line|cut -d: -f2);
 
-dependencies=$(cat /tmp/ck.dependencies)
-
-# TODO: include this dependency in the catalog
-$mvnCmd -q dependency:get -Dartifact=org.apache.camel.k:camel-k-runtime-bom:$runtime_version:pom -Dmaven.repo.local=$outputLocation -s $location/maven-settings.xml
-
-for d in $dependencies
-do
-    mvn_dep=""
-    mvn_dep_deployment=""
-    if [[ $d == org.apache.camel.quarkus* ]]; then
-        mvn_dep="$d:$cq_version"
-        mvn_dep_deployment="$d-deployment:$cq_version"
-    elif [[ $d == org.apache.camel.k* ]]; then
-        mvn_dep="$d:$ckr_version"
-    else
-        echo "WARN: cannot parse $d kind of dependency (likely it misses the version), skipping as it should be imported transitively. If not, add manually to your bundle."
-        continue
+    # there is no opentracing extension in CEQ, but it was present at the time camel-catalog, skipping it.
+    if [[ $a == *opentracing ]]; then
+        continue;
     fi
-    echo "INFO: downloading $mvn_dep and its transitive dependencies..."
-    $mvnCmd -q dependency:get -Dartifact=$mvn_dep -Dmaven.repo.local=$outputLocation -s $location/maven-settings.xml
-    if [[ ! $mvn_dep_deployment == "" ]]; then
-        $mvnCmd -q dependency:get -Dartifact=$mvn_dep_deployment -Dmaven.repo.local=$outputLocation -s $location/maven-settings.xml
+
+    # the jolokia agent must set the classifier
+    if [[ $a == "jolokia-agent-jvm" ]]; then
+      cat <<EOF >> ${pom};
+      <dependency>
+          <groupId>$g</groupId>
+          <artifactId>$a</artifactId>
+          <classifier>javaagent</classifier>
+      </dependency>
+EOF
+        continue;
     fi
+
+    cat <<EOF >> ${pom};
+      <dependency>
+          <groupId>$g</groupId>
+          <artifactId>$a</artifactId>
+      </dependency>
+EOF
+
 done
 
+# tweak the jib dependency to retrieve the correct dependencies
+cat <<EOF >> ${pom}
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus_version}</version>
+        <executions>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>${jibVersion}</version>
+        <executions>
+        </executions>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-layer-filter-extension-maven</artifactId>
+                <version>${jibLayerFilterVersion}</version>
+            </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+
+EOF
+
+# project with minimum pom dependencies, only to run the mvn package to resolve the dependencies
+# this is necessary since the quarkus-maven-plugin resolves some transitive dependencies not resolved by quarkus:go-offline
+
+cat <<EOF > ${pom_min}
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.camel.k.integration</groupId>
+    <artifactId>camel-k-integration-offline-min</artifactId>
+    <version>0.1</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.package.type>fast-jar</quarkus.package.type>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-runtime-bom</artifactId>
+                <version>$runtime_version</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+EOF
+
+sed 's/- //g' $catalog | grep "groupId\|artifactId" | paste -d " "  - - |awk '{print $2":"$4}'|sort|uniq|while read line; do
+#     echo $line;
+    g=$(echo $line|cut -d: -f1);
+    a=$(echo $line|cut -d: -f2);
+
+    # only adds these dependencies
+    if [[ $g == org.apache.camel.k ]] || [[ $a == *timer ]] || [[ $a == *log ]] || [[ $a == *knative ]] || [[ $a == *-core ]] || [[ $a == *-http ]] || [[ $a == *dsl ]]; then
+      cat <<EOF >> ${pom_min};
+        <dependency>
+            <groupId>$g</groupId>
+            <artifactId>$a</artifactId>
+        </dependency>
+EOF
+    fi
+
+done
+
+# tweak the jib dependency to retrieve the correct dependencies
+cat <<EOF >> ${pom_min}
+    </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus_version}</version>
+        <executions>
+          <execution>
+            <id>build-integration</id>
+            <goals>
+                <goal>build</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <quarkus.camel.routes-discovery.enabled>false</quarkus.camel.routes-discovery.enabled>
+                <quarkus.banner.enabled>false</quarkus.banner.enabled>
+                <quarkus.camel.servlet.url-patterns>/*</quarkus.camel.servlet.url-patterns>
+                <quarkus.hibernate-orm.enabled>false</quarkus.hibernate-orm.enabled>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+
+EOF
+
+# add a single route to compile
+mkdir -p ${offline}/src/main/java/foo
+cat <<EOF > ${offline}/src/main/java/foo/Foo.java
+package foo;
+
+import java.lang.Exception;
+import java.lang.Override;
+import org.apache.camel.builder.RouteBuilder;
+
+public class Foo extends RouteBuilder {
+
+  @Override
+  public void configure() throws Exception {
+    from("timer:java?period=200000")
+        .to("log:info");
+  }
+}
+
+EOF
+############# END SETUP POM PROJECT
+
+# resolve and download artifacts in parallel
+perf_params="-Dmaven.artifact.threads=6 -T 6 -Daether.dependencyCollector.impl=bf"
+silent="-ntp -Dsilent=true"
+$mvnCmd ${perf_params} ${silent} -Dmaven.repo.local=$offline_repo dependency:go-offline quarkus:go-offline -f ${pom}
+$mvnCmd ${perf_params} ${silent} -Dmaven.repo.local=$offline_repo package -f ${pom_min}
+
+# remove _remote.repositories as they interfere with the original repo resolver when running in the camel-k-operator pod
+find $offline_repo -type f -name _remote.repositories -delete
+
 # we can bundle into a single archive now
-echo "INFO: building ${rootdir}build/camel-k-runtime-$runtime_version-maven-offline.tar.gz archive..."
-pushd $outputLocation
-tar -czf ../camel-k-runtime-$runtime_version-maven-offline.tar.gz *
-popd
-echo "INFO: deleting cached dependencies..."
-rm -rf $outputLocation
-echo "Success: your bundled set of offline dependencies is available in camel-k-runtime-$runtime_version-maven-offline.tar.gz file."
+offline_file=${offline}/camel-k-runtime-$runtime_version-maven-offline.tar.gz
+echo "INFO: building ${offline_file} archive"
+tar -czf ${offline_file} -C $offline_repo .
+
+# not removig the cached dependencies, since if any failure occurs while executing the script, it can run again and continue the operation.
+# echo "INFO: deleting cached dependencies..."
+# rm -rf $offline_repo
+
+echo "Success: your bundled set of offline dependencies is available in ${offline_file} file."
+echo "The maven artifacts are in $offline_repo taking space, you may want to remove it later."
+end_time=$(date -u +"%s")
+elapsed=$(($end_time-$start_time))
+echo "Elapsed Time: "$(date -u -d "@${elapsed}" +%T)


### PR DESCRIPTION
- Enhance the offline script to use quarkus:go-offline and to build a minimum project to resolve dependencies not resolved with the previous script
- Enhance documentation

(cherry picked from commit 6fee6d6a0026817103db246c03b21952fd147276)

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Enhance the offline script and documentation.
```
