### PR TITLE
fix(e2e): add readiness workaround as expected by Camel framework

### DIFF
--- a/e2e/common/traits/health_test.go
+++ b/e2e/common/traits/health_test.go
@@ -358,12 +358,14 @@ func TestHealthTrait(t *testing.T) {
 		t.Run("Readiness condition with never ready route", func(t *testing.T) {
 			name := RandomizedSuffixName("never-ready")
 
-			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/NeverReady.java", "--name", name, "-t", "health.enabled=true").Execute()).To(Succeed())
+			g.Expect(KamelRunWithID(t, ctx, operatorID, ns, "files/NeverReady.java", "--name", name, "-t", "health.enabled=true",
+				// TODO remove these workaround properties when https://issues.apache.org/jira/browse/CAMEL-20244 is fixed
+				"-p", "camel.route-controller.unhealthyOnRestarting=true",
+				"-p", "camel.route-controller.unhealthyOnExhausted=true",
+			).Execute()).To(Succeed())
 
 			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
-			// Wait for the integration condition to become ready=false and then check that it remains not ready for some time - fixes some test flakiness
-			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionFalse))
 			g.Consistently(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), 1*time.Minute).
 				Should(Equal(corev1.ConditionFalse))
 			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseError))


### PR DESCRIPTION
* moved back the check to correctly expect constantly the readiness to be False
* added the properties as expected by Camel

Closes #5351

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): add readiness workaround as expected by Camel framework
```
