### PR TITLE
fix(kamelets): parse the url used to download kamelet

### DIFF
--- a/pkg/kamelet/repository/github_repository_test.go
+++ b/pkg/kamelet/repository/github_repository_test.go
@@ -19,6 +19,7 @@ package repository
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"testing"
 
@@ -49,4 +50,17 @@ func TestGithubRepository(t *testing.T) {
 		assert.Equal(t, kameletName, kamelet.Name)
 	}
 
+}
+
+func TestDownloadKamelet(t *testing.T) {
+	c := &http.Client{}
+	kamelet, err := downloadGithubKamelet(
+		context.Background(),
+		// the appended parameter test the strength of the func which should load the kamelet regardless any
+		// additional parameter provided
+		"https://raw.githubusercontent.com/apache/camel-kamelets/main/kamelets/timer-source.kamelet.yaml?test=test",
+		c,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "timer-source", kamelet.Name)
 }


### PR DESCRIPTION
Closes #5173

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(kamelets): parse the url used to download kamelet
```
