### PR TITLE
Incorrect content of the build/_maven_overlay directory causes the build project failure

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -433,6 +433,7 @@ check-licenses:
 # The below are dependencies needed for maven structured logs. We must bundle into the final container image.
 maven-overlay:
 	@echo "####### Preparing maven dependencies bundle..."
+	rm -rf build/_maven_overlay
 	mkdir -p build/_maven_overlay
 	./script/maven_overlay.sh build/_maven_overlay
 


### PR DESCRIPTION
Fixes #5466
