### PR TITLE
fix(maven): move check for MAVEN_CMD before maven wrapper setup

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -142,6 +142,7 @@ func findLocal(ctx context.Context, c k8sclient.Reader, namespace string) (*v1.I
 		operatorID := defaults.OperatorID()
 		if operatorID != "" {
 			if p, err := get(ctx, c, operatorNamespace, operatorID); err == nil {
+				log.Debugf("Found integration platform %s for operator %s in namespace %s", operatorID, operatorID, operatorNamespace)
 				return p, nil
 			}
 		}
@@ -156,7 +157,7 @@ func findLocal(ctx context.Context, c k8sclient.Reader, namespace string) (*v1.I
 	for _, platform := range lst.Items {
 		platform := platform // pin
 		if IsActive(&platform) {
-			log.Debugf("Found active integration platform %s", platform.Name)
+			log.Debugf("Found active integration platform %s in namespace %s", platform.Name, namespace)
 			return &platform, nil
 		} else {
 			fallback = &platform
@@ -164,7 +165,7 @@ func findLocal(ctx context.Context, c k8sclient.Reader, namespace string) (*v1.I
 	}
 
 	if fallback != nil {
-		log.Debugf("Found inactive integration platform %s", fallback.Name)
+		log.Debugf("Found inactive integration platform %s in namespace %s", fallback.Name, namespace)
 		return fallback, nil
 	}
 

--- a/pkg/util/maven/maven_command.go
+++ b/pkg/util/maven/maven_command.go
@@ -44,17 +44,21 @@ func (c *Command) Do(ctx context.Context) error {
 		return err
 	}
 
-	if e, ok := os.LookupEnv("MAVEN_WRAPPER"); (ok && e == "true") || !ok {
-		// Prepare maven wrapper helps when running the builder as Pod as it makes
-		// the builder container, Maven agnostic
-		if err := c.prepareMavenWrapper(ctx); err != nil {
-			return err
-		}
-	}
-
-	mvnCmd := "./mvnw"
+	mvnCmd := ""
 	if c, ok := os.LookupEnv("MAVEN_CMD"); ok {
 		mvnCmd = c
+	}
+
+	if mvnCmd == "" {
+		if e, ok := os.LookupEnv("MAVEN_WRAPPER"); (ok && e == "true") || !ok {
+			// Prepare maven wrapper helps when running the builder as Pod as it makes
+			// the builder container, Maven agnostic
+			if err := c.prepareMavenWrapper(ctx); err != nil {
+				return err
+			}
+		}
+
+		mvnCmd = "./mvnw"
 	}
 
 	args := make([]string, 0)


### PR DESCRIPTION
`MAVEN_CMD` has the precedence over the maven wrapper, either set via the
`MAVEN_WRAPPER` env var or copied from a local path. This commit changes
the evaluation order to reflect ordering which avoid to perform a
useless file copy and also make it easy to run the operator off cluster
since the `mvnw` location may not exist

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
