### PR TITLE
cleanup golagci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
   enable-all: true
   disable:
     - cyclop
-    - deadcode
     - depguard
     - dupl
     - exhaustive
@@ -39,36 +38,22 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - gocognit
-    - goconst
     - gocyclo
     - godox
     - err113
     - gofumpt
-    - golint
     - gomnd
-    - gomoddirectives
-    - ifshort
-    - interfacer
     - ireturn
     - lll
-    - maligned
-    - nakedret
     - nestif
     - nilnil
     - nlreturn
     - nolintlint
-    - nosnakecase
     - paralleltest
     - revive
-    - rowserrcheck
-    - scopelint
-    - structcheck
-    - sqlclosecheck
     - tagalign
     - tagliatelle
-    - tenv
     - testpackage
-    - varcheck
     - varnamelen
     - wastedassign
     - whitespace
@@ -79,3 +64,4 @@ linters:
     #       lint violation make a lot of sense so we should re-enable the lints below and work to fix the findings
     - mnd
     - perfsprint
+    - goconst

--- a/script/Makefile
+++ b/script/Makefile
@@ -38,6 +38,7 @@ GOVULNCHECK_VERSION ?= latest
 
 LINTER ?= $(LOCALBIN)/golangci-lint
 GOVULNCHECK ?= $(LOCALBIN)/govulncheck
+GOIMPORT ?= $(LOCALBIN)/goimports
 
 BASE_IMAGE := eclipse-temurin:17
 LOCAL_REPOSITORY := /etc/maven/m2
@@ -443,6 +444,11 @@ lint-fix: golangci-lint
 vuln: govulncheck
 	@$(GOVULNCHECK) ./...
 
+.PHONY: fmt
+fmt: goimport
+	$(GOIMPORT) -l -w .
+	go fmt ./...
+
 dir-licenses:
 	./script/vendor-license-directory.sh
 
@@ -743,3 +749,10 @@ govulncheck: $(GOVULNCHECK)
 $(GOVULNCHECK): $(LOCALBIN)
 	@test -s $(GOVULNCHECK) || \
 	GOBIN=$(LOCALBIN) go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+
+.PHONY: goimport
+goimport: $(GOIMPORT)
+$(GOIMPORT): $(LOCALBIN)
+	@test -s $(LOCALBIN)/goimport || \
+	GOBIN=$(LOCALBIN) go install golang.org/x/tools/cmd/goimports@latest
+


### PR DESCRIPTION
This PR aims to reduce the number of excluded lints, ideally we should revisit the usefulness of the disabled ones and re-enable them. 