### PR TITLE
fix(e2e): strengthen upgrade test scenario

### DIFF
--- a/e2e/install/upgrade/cli_upgrade_test.go
+++ b/e2e/install/upgrade/cli_upgrade_test.go
@@ -96,7 +96,12 @@ func TestCLIOperatorUpgrade(t *testing.T) {
 		// Check the IntegrationPlatform has been reconciled
 		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 		g.Eventually(PlatformVersion(t, ctx, ns), TestTimeoutMedium).Should(Equal(defaults.Version))
-
+		// Check the Integration Pod is not rolling a new Pod automatically
+		// This is extremely important as we don't want an upgrade to restart any Integration, unless specified by the user
+		var numberOfPods = func(pods *int32) bool {
+			return *pods == 1
+		}
+		g.Consistently(IntegrationPodsNumbers(t, ctx, ns, name), 1*time.Minute, 1*time.Second).Should(Satisfy(numberOfPods))
 		// Check the Integration hasn't been upgraded
 		g.Consistently(IntegrationVersion(t, ctx, ns, name), 5*time.Second, 1*time.Second).Should(Equal(version))
 

--- a/e2e/install/upgrade/olm_upgrade_test.go
+++ b/e2e/install/upgrade/olm_upgrade_test.go
@@ -201,6 +201,13 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 			// Clear the KAMEL_BIN environment variable so that the current version is used from now on
 			g.Expect(os.Setenv("KAMEL_BIN", "")).To(Succeed())
 
+			// Check the Integration Pod is not rolling a new Pod automatically
+			// This is extremely important as we don't want an upgrade to restart any Integration, unless specified by the user
+			var numberOfPods = func(pods *int32) bool {
+				return *pods == 1
+			}
+			g.Consistently(IntegrationPodsNumbers(t, ctx, ns, name), 1*time.Minute, 1*time.Second).Should(Satisfy(numberOfPods))
+
 			// Check the Integration hasn't been upgraded
 			g.Consistently(IntegrationVersion(t, ctx, ns, name), 5*time.Second, 1*time.Second).
 				Should(ContainSubstring(prevIPVersionPrefix))


### PR DESCRIPTION
An IntegrationPod should not be rolled over during the operator upgrade. Draft PR to validate the assumption provided in #5491

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
