### PR TITLE
fix(tests): fixed flaky Readiness condition with never ready route test in e2e/common/traits/health_test.go

### DIFF
--- a/e2e/common/traits/files/NeverReady.java
+++ b/e2e/common/traits/files/NeverReady.java
@@ -14,16 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import java.util.Map;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.health.HealthCheckResultBuilder;
+import org.apache.camel.impl.health.AbstractHealthCheck;
 
 public class NeverReady extends RouteBuilder {
     @Override
     public void configure() throws Exception {
-        from("timer:tick").id("never-ready")
-            .to("controlbus:route?routeId=never-ready&action=stop&async=true")
-            .setHeader("m").constant("string!")
-            .setBody().simple("Magic${header.m}")
-            .log("${body}");
+        getCamelContext().getRegistry().bind("NeverReadyCheck", new NeverReadyHealthCheck("never-ready"));
+    }
+
+    private static class NeverReadyHealthCheck extends AbstractHealthCheck {
+
+        protected NeverReadyHealthCheck(String id) {
+            super(id);
+        }
+
+        @Override
+        protected void doCall(HealthCheckResultBuilder builder, Map<String, Object> options) {
+            builder.down();
+        }
     }
 }


### PR DESCRIPTION
Due to how camel works stopping a route using the message bus inside the route can not assure that the route is reported always as stopped, there might be a small amount of time in which it can be reported as running.

Since the test is testing the behavior of camel k in the case that an integration is always reported not ready I took another approach by registering a custom healthcheck that force the reported condition to be never ready. 

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
