### PR TITLE
[Release 2.3.x] fix(e2e): don't rollout Pods on operator upgrade

### DIFF
--- a/e2e/install/upgrade/cli_upgrade_test.go
+++ b/e2e/install/upgrade/cli_upgrade_test.go
@@ -96,7 +96,12 @@ func TestCLIOperatorUpgrade(t *testing.T) {
 		// Check the IntegrationPlatform has been reconciled
 		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 		g.Eventually(PlatformVersion(t, ctx, ns), TestTimeoutMedium).Should(Equal(defaults.Version))
-
+		// Check the Integration Pod is not rolling a new Pod automatically
+		// This is extremely important as we don't want an upgrade to restart any Integration, unless specified by the user
+		var numberOfPods = func(pods *int32) bool {
+			return *pods == 1
+		}
+		g.Consistently(IntegrationPodsNumbers(t, ctx, ns, name), 1*time.Minute, 1*time.Second).Should(Satisfy(numberOfPods))
 		// Check the Integration hasn't been upgraded
 		g.Consistently(IntegrationVersion(t, ctx, ns, name), 5*time.Second, 1*time.Second).Should(Equal(version))
 

--- a/e2e/install/upgrade/olm_upgrade_test.go
+++ b/e2e/install/upgrade/olm_upgrade_test.go
@@ -207,6 +207,7 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 				return *pods == 1
 			}
 			g.Consistently(IntegrationPodsNumbers(t, ctx, ns, name), 1*time.Minute, 1*time.Second).Should(Satisfy(numberOfPods))
+			g.Consistently(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
 
 			// Check the Integration hasn't been upgraded
 			g.Consistently(IntegrationVersion(t, ctx, ns, name), 5*time.Second, 1*time.Second).

--- a/e2e/install/upgrade/olm_upgrade_test.go
+++ b/e2e/install/upgrade/olm_upgrade_test.go
@@ -201,6 +201,13 @@ func TestOLMOperatorUpgrade(t *testing.T) {
 			// Clear the KAMEL_BIN environment variable so that the current version is used from now on
 			g.Expect(os.Setenv("KAMEL_BIN", "")).To(Succeed())
 
+			// Check the Integration Pod is not rolling a new Pod automatically
+			// This is extremely important as we don't want an upgrade to restart any Integration, unless specified by the user
+			var numberOfPods = func(pods *int32) bool {
+				return *pods == 1
+			}
+			g.Consistently(IntegrationPodsNumbers(t, ctx, ns, name), 1*time.Minute, 1*time.Second).Should(Satisfy(numberOfPods))
+
 			// Check the Integration hasn't been upgraded
 			g.Consistently(IntegrationVersion(t, ctx, ns, name), 5*time.Second, 1*time.Second).
 				Should(ContainSubstring(prevIPVersionPrefix))

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -1056,6 +1056,16 @@ func IntegrationVersion(t *testing.T, ctx context.Context, ns string, name strin
 	}
 }
 
+func IntegrationRuntimeVersion(t *testing.T, ctx context.Context, ns string, name string) func() string {
+	return func() string {
+		it := Integration(t, ctx, ns, name)()
+		if it == nil {
+			return ""
+		}
+		return it.Status.RuntimeVersion
+	}
+}
+
 func IntegrationTraitProfile(t *testing.T, ctx context.Context, ns string, name string) func() v1.TraitProfile {
 	return func() v1.TraitProfile {
 		it := Integration(t, ctx, ns, name)()

--- a/pkg/trait/environment.go
+++ b/pkg/trait/environment.go
@@ -70,12 +70,12 @@ func (t *environmentTrait) Configure(e *Environment) (bool, *TraitCondition, err
 }
 
 func (t *environmentTrait) Apply(e *Environment) error {
-	envvar.SetVal(&e.EnvVars, envVarCamelKVersion, defaults.Version)
+	envvar.SetVal(&e.EnvVars, envVarCamelKVersion, e.Integration.Status.Version)
 	envvar.SetVal(&e.EnvVars, envVarOperatorID, defaults.OperatorID())
 	if e.Integration != nil {
 		envvar.SetVal(&e.EnvVars, envVarCamelKIntegration, e.Integration.Name)
 	}
-	envvar.SetVal(&e.EnvVars, envVarCamelKRuntimeVersion, e.RuntimeVersion)
+	envvar.SetVal(&e.EnvVars, envVarCamelKRuntimeVersion, e.Integration.Status.RuntimeVersion)
 	envvar.SetVal(&e.EnvVars, envVarMountPathConfigMaps, camel.ConfigConfigmapsMountPath)
 	envvar.SetVal(&e.EnvVars, envVarMountPathSecrets, camel.ConfigSecretsMountPath)
 


### PR DESCRIPTION
<!-- Description -->

This PR is making sure that we use Integration status version and runtime version for environment variables. During upgrade process those parameter are not updated as the Integration digest is not changing either.

We cannot move this yet on main branch as there are other changes there affecting Deployment that would require additional attention.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): don't rollout Pods on operator upgrade
```
