### PR TITLE
fix(e2e): Tekton test permission failure with olm install command

### DIFF
--- a/e2e/advanced/tekton_test.go
+++ b/e2e/advanced/tekton_test.go
@@ -42,7 +42,7 @@ func TestTektonLikeBehavior(t *testing.T) {
 		g.Expect(CreateOperatorRoleBinding(t, ctx, ns)).To(Succeed())
 
 		g.Eventually(OperatorPod(t, ctx, ns)).Should(BeNil())
-		g.Expect(CreateKamelPod(t, ctx, ns, "tekton-task", "install", "--skip-cluster-setup", "--force")).To(Succeed())
+		g.Expect(CreateKamelPod(t, ctx, ns, "tekton-task", "install", "--skip-cluster-setup", "--olm=false", "--force")).To(Succeed())
 
 		g.Eventually(OperatorPod(t, ctx, ns)).ShouldNot(BeNil())
 	})


### PR DESCRIPTION
## Description

When running on an OLM install on OCP the test fails with the following log from the Kamel Pod:
```
Error: OLM is available but current user has not enough permissions to create the operator. You can either ask your administrator to provide permissions (preferred) or run the install command with the '--olm=false' flag
```

**Release Note**
```release-note
fix(e2e): Tekton test permission failure with olm install command
```
