### PR TITLE
fix(e2e): Route trait schema valid in OCP

### DIFF
--- a/e2e/common/traits/route_test.go
+++ b/e2e/common/traits/route_test.go
@@ -200,7 +200,7 @@ func TestRunRoutes(t *testing.T) {
 			routeTrait, _, _ := unstructured.NestedMap(unstructuredIntegration.Object, "spec", "traits", "route")
 			g.Expect(routeTrait).ToNot(BeNil())
 			g.Expect(len(routeTrait)).To(Equal(1))
-			g.Expect(routeTrait["enabled"]).To(Equal(true))
+			g.Expect(routeTrait["annotations"]).ToNot(BeNil())
 
 			g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).Should(BeNil())
 		})


### PR DESCRIPTION
Route Trait should only contains `annotations` param in the test.
As it is skipped on non-openshift infra, we missed the error in the test code.

**Release Note**
```release-note
fix(e2e): Route trait schema valid in OCP
```
