### PR TITLE
[Backport 2.3.x]: fix(e2e): Tekton test permission failure with olm install command

### DIFF
--- a/e2e/advanced/tekton_test.go
+++ b/e2e/advanced/tekton_test.go
@@ -42,7 +42,7 @@ func TestTektonLikeBehavior(t *testing.T) {
 		g.Expect(CreateOperatorRoleBinding(t, ctx, ns)).To(Succeed())
 
 		g.Eventually(OperatorPod(t, ctx, ns)).Should(BeNil())
-		g.Expect(CreateKamelPod(t, ctx, ns, "tekton-task", "install", "--skip-cluster-setup", "--force")).To(Succeed())
+		g.Expect(CreateKamelPod(t, ctx, ns, "tekton-task", "install", "--skip-cluster-setup", "--olm=false", "--force")).To(Succeed())
 
 		g.Eventually(OperatorPod(t, ctx, ns)).ShouldNot(BeNil())
 	})


### PR DESCRIPTION
Backport of https://github.com/apache/camel-k/pull/5505


**Release Note**
```release-note
fix(e2e): Tekton test permission failure with olm install command
```
