### PR TITLE
chore(trait): revert default health enabled

### DIFF
--- a/e2e/install/upgrade/cli_upgrade_test.go
+++ b/e2e/install/upgrade/cli_upgrade_test.go
@@ -98,7 +98,11 @@ func TestCLIOperatorUpgrade(t *testing.T) {
 		g.Eventually(PlatformVersion(t, ctx, ns), TestTimeoutMedium).Should(Equal(defaults.Version))
 
 		// Check the Integration hasn't been upgraded
-		g.Consistently(IntegrationVersion(t, ctx, ns, name), 5*time.Second, 1*time.Second).Should(Equal(version))
+		g.Consistently(IntegrationVersion(t, ctx, ns, name), 15*time.Second, 3*time.Second).Should(Equal(version))
+		// Make sure that any Pod rollout is completing successfully
+		// otherwise we are probably in front of a non breaking compatibility change
+		g.Consistently(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady),
+			2*time.Minute, 15*time.Second).Should(Equal(corev1.ConditionTrue))
 
 		// Force the Integration upgrade
 		g.Expect(Kamel(t, ctx, "rebuild", name, "-n", ns).Execute()).To(Succeed())

--- a/pkg/apis/camel/v1/trait/health.go
+++ b/pkg/apis/camel/v1/trait/health.go
@@ -19,7 +19,7 @@ package trait
 
 // The health trait is responsible for configuring the health probes on the integration container.
 //
-// NOTE: this trait is enabled by default.
+// NOTE: this trait is disabled by default.
 //
 // +camel-k:trait=health.
 type HealthTrait struct {

--- a/pkg/trait/health.go
+++ b/pkg/trait/health.go
@@ -71,7 +71,7 @@ func (t *healthTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 		}
 	}
 
-	return pointer.BoolDeref(t.Enabled, true), nil, nil
+	return pointer.BoolDeref(t.Enabled, false), nil, nil
 }
 
 func (t *healthTrait) Apply(e *Environment) error {

--- a/pkg/trait/health_test.go
+++ b/pkg/trait/health_test.go
@@ -119,19 +119,8 @@ func TestHealthTrait(t *testing.T) {
 	assert.Equal(t, "/q/health/started", d.Spec.Template.Spec.Containers[0].StartupProbe.HTTPGet.Path)
 }
 
-func TestConfigureHealthTraitDoesSucceed(t *testing.T) {
+func TestConfigureHealthTraitDefault(t *testing.T) {
 	ht, environment := createNominalHealthTrait(t)
-	configured, condition, err := ht.Configure(environment)
-
-	assert.True(t, configured)
-	assert.Nil(t, err)
-	assert.Nil(t, condition)
-}
-
-func TestConfigureHealthTraitDisabled(t *testing.T) {
-	enabled := false
-	ht, environment := createNominalHealthTrait(t)
-	ht.Enabled = &enabled
 	configured, condition, err := ht.Configure(environment)
 
 	assert.False(t, configured)
@@ -139,8 +128,21 @@ func TestConfigureHealthTraitDisabled(t *testing.T) {
 	assert.Nil(t, condition)
 }
 
-func TestApplyHealthTraitDefault(t *testing.T) {
+func TestConfigureHealthTraitEnabled(t *testing.T) {
+	enabled := true
 	ht, environment := createNominalHealthTrait(t)
+	ht.Enabled = &enabled
+	configured, condition, err := ht.Configure(environment)
+
+	assert.True(t, configured)
+	assert.Nil(t, err)
+	assert.Nil(t, condition)
+}
+
+func TestApplyHealthTraitDefault(t *testing.T) {
+	enabled := true
+	ht, environment := createNominalHealthTrait(t)
+	ht.Enabled = &enabled
 	configured, condition, err := ht.Configure(environment)
 	assert.True(t, configured)
 	assert.Nil(t, err)
@@ -155,6 +157,7 @@ func TestApplyHealthTraitDefault(t *testing.T) {
 func TestApplyHealthTraitLivenessDefault(t *testing.T) {
 	enabled := true
 	ht, environment := createNominalHealthTrait(t)
+	ht.Enabled = &enabled
 	ht.LivenessProbeEnabled = &enabled
 	configured, condition, err := ht.Configure(environment)
 	assert.True(t, configured)
@@ -171,6 +174,7 @@ func TestApplyHealthTraitLivenessDefault(t *testing.T) {
 func TestApplyHealthTraitStartupDefault(t *testing.T) {
 	enabled := true
 	ht, environment := createNominalHealthTrait(t)
+	ht.Enabled = &enabled
 	ht.StartupProbeEnabled = &enabled
 	configured, condition, err := ht.Configure(environment)
 	assert.True(t, configured)

--- a/pkg/trait/trait_test.go
+++ b/pkg/trait/trait_test.go
@@ -562,7 +562,7 @@ func TestExecutedTraitsCondition(t *testing.T) {
 		v1.IntegrationConditionTraitInfo,
 		corev1.ConditionTrue,
 		"TraitConfiguration",
-		"Applied traits: camel,environment,logging,deployer,deployment,gc,container,security-context,mount,health,quarkus,jvm,owner",
+		"Applied traits: camel,environment,logging,deployer,deployment,gc,container,security-context,mount,quarkus,jvm,owner",
 	)
 	assert.Contains(t, conditions, expectedCondition)
 }


### PR DESCRIPTION
<!-- Description -->

This PR partially reverts the work done in #5096. While working on the upgrade I realized we must strengthen the test and make sure that any automatic Pod rollout, after the operator upgrade, must finish successfully. This lead to the verification that the health trait set by default in the aforementioned PR does introduce a breaking compatibility change, as it requires a rebuild of the application due to the need to get the Camel health dependencies. This would have turn all Integrations in an unready status as soon we have moved to upcoming release version.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(trait): revert default health enabled
```
