### PR TITLE
[Backport 2.3.x] fix(trait): camel catalog regression

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -6980,6 +6980,13 @@ int32
 
 Minimum consecutive failures for the liveness probe to be considered failed after having succeeded.
 
+|`livenessProbe` +
+string
+|
+
+
+The liveness probe path to use (default provided by the Catalog runtime used).
+
 |`readinessProbeEnabled` +
 bool
 |
@@ -7029,6 +7036,13 @@ int32
 
 Minimum consecutive failures for the readiness probe to be considered failed after having succeeded.
 
+|`readinessProbe` +
+string
+|
+
+
+The readiness probe path to use (default provided by the Catalog runtime used).
+
 |`startupProbeEnabled` +
 bool
 |
@@ -7077,6 +7091,13 @@ int32
 
 
 Minimum consecutive failures for the startup probe to be considered failed after having succeeded.
+
+|`startupProbe` +
+string
+|
+
+
+The startup probe path to use (default provided by the Catalog runtime used).
 
 
 |===

--- a/docs/modules/traits/pages/health.adoc
+++ b/docs/modules/traits/pages/health.adoc
@@ -55,6 +55,10 @@ The following configuration options are available:
 | int32
 | Minimum consecutive failures for the liveness probe to be considered failed after having succeeded.
 
+| health.liveness-probe
+| string
+| The liveness probe path to use (default provided by the Catalog runtime used).
+
 | health.readiness-probe-enabled
 | bool
 | Configures the readiness probe for the integration container (default `true`).
@@ -83,6 +87,10 @@ The following configuration options are available:
 | int32
 | Minimum consecutive failures for the readiness probe to be considered failed after having succeeded.
 
+| health.readiness-probe
+| string
+| The readiness probe path to use (default provided by the Catalog runtime used).
+
 | health.startup-probe-enabled
 | bool
 | Configures the startup probe for the integration container (default `false`).
@@ -110,6 +118,10 @@ The following configuration options are available:
 | health.startup-failure-threshold
 | int32
 | Minimum consecutive failures for the startup probe to be considered failed after having succeeded.
+
+| health.startup-probe
+| string
+| The startup probe path to use (default provided by the Catalog runtime used).
 
 |===
 

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -992,6 +992,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -1024,6 +1028,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -1056,6 +1064,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).
@@ -2903,6 +2915,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -2935,6 +2951,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -2967,6 +2987,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).

--- a/helm/camel-k/crds/crd-integration-profile.yaml
+++ b/helm/camel-k/crds/crd-integration-profile.yaml
@@ -869,6 +869,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -901,6 +905,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -933,6 +941,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).
@@ -2663,6 +2675,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -2695,6 +2711,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -2727,6 +2747,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -6888,6 +6888,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -6920,6 +6924,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -6952,6 +6960,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -7176,6 +7176,10 @@ spec:
                             description: How often to perform the liveness probe.
                             format: int32
                             type: integer
+                          livenessProbe:
+                            description: The liveness probe path to use (default provided
+                              by the Catalog runtime used).
+                            type: string
                           livenessProbeEnabled:
                             description: Configures the liveness probe for the integration
                               container (default `false`).
@@ -7208,6 +7212,10 @@ spec:
                             description: How often to perform the readiness probe.
                             format: int32
                             type: integer
+                          readinessProbe:
+                            description: The readiness probe path to use (default
+                              provided by the Catalog runtime used).
+                            type: string
                           readinessProbeEnabled:
                             description: Configures the readiness probe for the integration
                               container (default `true`).
@@ -7240,6 +7248,10 @@ spec:
                             description: How often to perform the startup probe.
                             format: int32
                             type: integer
+                          startupProbe:
+                            description: The startup probe path to use (default provided
+                              by the Catalog runtime used).
+                            type: string
                           startupProbeEnabled:
                             description: Configures the startup probe for the integration
                               container (default `false`).

--- a/helm/camel-k/crds/crd-pipe.yaml
+++ b/helm/camel-k/crds/crd-pipe.yaml
@@ -7174,6 +7174,10 @@ spec:
                             description: How often to perform the liveness probe.
                             format: int32
                             type: integer
+                          livenessProbe:
+                            description: The liveness probe path to use (default provided
+                              by the Catalog runtime used).
+                            type: string
                           livenessProbeEnabled:
                             description: Configures the liveness probe for the integration
                               container (default `false`).
@@ -7206,6 +7210,10 @@ spec:
                             description: How often to perform the readiness probe.
                             format: int32
                             type: integer
+                          readinessProbe:
+                            description: The readiness probe path to use (default
+                              provided by the Catalog runtime used).
+                            type: string
                           readinessProbeEnabled:
                             description: Configures the readiness probe for the integration
                               container (default `true`).
@@ -7238,6 +7246,10 @@ spec:
                             description: How often to perform the startup probe.
                             format: int32
                             type: integer
+                          startupProbe:
+                            description: The startup probe path to use (default provided
+                              by the Catalog runtime used).
+                            type: string
                           startupProbeEnabled:
                             description: Configures the startup probe for the integration
                               container (default `false`).

--- a/pkg/apis/camel/v1/trait/health.go
+++ b/pkg/apis/camel/v1/trait/health.go
@@ -39,6 +39,8 @@ type HealthTrait struct {
 	LivenessSuccessThreshold int32 `property:"liveness-success-threshold" json:"livenessSuccessThreshold,omitempty"`
 	// Minimum consecutive failures for the liveness probe to be considered failed after having succeeded.
 	LivenessFailureThreshold int32 `property:"liveness-failure-threshold" json:"livenessFailureThreshold,omitempty"`
+	// The liveness probe path to use (default provided by the Catalog runtime used).
+	LivenessProbe string `property:"liveness-probe" json:"livenessProbe,omitempty"`
 
 	// Configures the readiness probe for the integration container (default `true`).
 	ReadinessProbeEnabled *bool `property:"readiness-probe-enabled" json:"readinessProbeEnabled,omitempty"`
@@ -54,6 +56,8 @@ type HealthTrait struct {
 	ReadinessSuccessThreshold int32 `property:"readiness-success-threshold" json:"readinessSuccessThreshold,omitempty"`
 	// Minimum consecutive failures for the readiness probe to be considered failed after having succeeded.
 	ReadinessFailureThreshold int32 `property:"readiness-failure-threshold" json:"readinessFailureThreshold,omitempty"`
+	// The readiness probe path to use (default provided by the Catalog runtime used).
+	ReadinessProbe string `property:"readiness-probe" json:"readinessProbe,omitempty"`
 
 	// Configures the startup probe for the integration container (default `false`).
 	StartupProbeEnabled *bool `property:"startup-probe-enabled" json:"startupProbeEnabled,omitempty"`
@@ -69,4 +73,6 @@ type HealthTrait struct {
 	StartupSuccessThreshold int32 `property:"startup-success-threshold" json:"startupSuccessThreshold,omitempty"`
 	// Minimum consecutive failures for the startup probe to be considered failed after having succeeded.
 	StartupFailureThreshold int32 `property:"startup-failure-threshold" json:"startupFailureThreshold,omitempty"`
+	// The startup probe path to use (default provided by the Catalog runtime used).
+	StartupProbe string `property:"startup-probe" json:"startupProbe,omitempty"`
 }

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -992,6 +992,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -1024,6 +1028,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -1056,6 +1064,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).
@@ -2903,6 +2915,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -2935,6 +2951,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -2967,6 +2987,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -869,6 +869,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -901,6 +905,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -933,6 +941,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).
@@ -2663,6 +2675,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -2695,6 +2711,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -2727,6 +2747,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -6888,6 +6888,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessProbe:
+                        description: The liveness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       livenessProbeEnabled:
                         description: Configures the liveness probe for the integration
                           container (default `false`).
@@ -6920,6 +6924,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessProbe:
+                        description: The readiness probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       readinessProbeEnabled:
                         description: Configures the readiness probe for the integration
                           container (default `true`).
@@ -6952,6 +6960,10 @@ spec:
                         description: How often to perform the startup probe.
                         format: int32
                         type: integer
+                      startupProbe:
+                        description: The startup probe path to use (default provided
+                          by the Catalog runtime used).
+                        type: string
                       startupProbeEnabled:
                         description: Configures the startup probe for the integration
                           container (default `false`).

--- a/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
@@ -7176,6 +7176,10 @@ spec:
                             description: How often to perform the liveness probe.
                             format: int32
                             type: integer
+                          livenessProbe:
+                            description: The liveness probe path to use (default provided
+                              by the Catalog runtime used).
+                            type: string
                           livenessProbeEnabled:
                             description: Configures the liveness probe for the integration
                               container (default `false`).
@@ -7208,6 +7212,10 @@ spec:
                             description: How often to perform the readiness probe.
                             format: int32
                             type: integer
+                          readinessProbe:
+                            description: The readiness probe path to use (default
+                              provided by the Catalog runtime used).
+                            type: string
                           readinessProbeEnabled:
                             description: Configures the readiness probe for the integration
                               container (default `true`).
@@ -7240,6 +7248,10 @@ spec:
                             description: How often to perform the startup probe.
                             format: int32
                             type: integer
+                          startupProbe:
+                            description: The startup probe path to use (default provided
+                              by the Catalog runtime used).
+                            type: string
                           startupProbeEnabled:
                             description: Configures the startup probe for the integration
                               container (default `false`).

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -7174,6 +7174,10 @@ spec:
                             description: How often to perform the liveness probe.
                             format: int32
                             type: integer
+                          livenessProbe:
+                            description: The liveness probe path to use (default provided
+                              by the Catalog runtime used).
+                            type: string
                           livenessProbeEnabled:
                             description: Configures the liveness probe for the integration
                               container (default `false`).
@@ -7206,6 +7210,10 @@ spec:
                             description: How often to perform the readiness probe.
                             format: int32
                             type: integer
+                          readinessProbe:
+                            description: The readiness probe path to use (default
+                              provided by the Catalog runtime used).
+                            type: string
                           readinessProbeEnabled:
                             description: Configures the readiness probe for the integration
                               container (default `true`).
@@ -7238,6 +7246,10 @@ spec:
                             description: How often to perform the startup probe.
                             format: int32
                             type: integer
+                          startupProbe:
+                            description: The startup probe path to use (default provided
+                              by the Catalog runtime used).
+                            type: string
                           startupProbeEnabled:
                             description: Configures the startup probe for the integration
                               container (default `false`).

--- a/pkg/trait/health.go
+++ b/pkg/trait/health.go
@@ -53,18 +53,45 @@ func newHealthTrait() Trait {
 }
 
 func (t *healthTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
-	if e.CamelCatalog == nil {
-		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
-	}
 	if e.Integration == nil ||
-		!e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
+		(!e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases()) ||
+		!pointer.BoolDeref(t.Enabled, false) {
 		return false, nil, nil
 	}
 	if !pointer.BoolDeref(t.Enabled, false) {
 		return false, nil, nil
 	}
 
+	t.setProbesValues(e)
+
 	return true, nil, nil
+}
+
+func (t *healthTrait) setProbesValues(e *Environment) {
+	if t.LivenessProbe == "" {
+		if e.CamelCatalog != nil && e.CamelCatalog.Runtime.Capabilities["health"].Metadata != nil {
+			t.LivenessProbe = e.CamelCatalog.Runtime.Capabilities["health"].Metadata["defaultLivenessProbePath"]
+		} else {
+			// Deprecated: to be removed
+			t.LivenessProbe = defaultLivenessProbePath
+		}
+	}
+	if t.ReadinessProbe == "" {
+		if e.CamelCatalog != nil && e.CamelCatalog.Runtime.Capabilities["health"].Metadata != nil {
+			t.ReadinessProbe = e.CamelCatalog.Runtime.Capabilities["health"].Metadata["defaultReadinessProbePath"]
+		} else {
+			// Deprecated: to be removed
+			t.ReadinessProbe = defaultReadinessProbePath
+		}
+	}
+	if t.StartupProbe == "" {
+		if e.CamelCatalog != nil && e.CamelCatalog.Runtime.Capabilities["health"].Metadata != nil {
+			t.StartupProbe = e.CamelCatalog.Runtime.Capabilities["health"].Metadata["defaultStartupProbePath"]
+		} else {
+			// Deprecated: to be removed
+			t.StartupProbe = defaultStartupProbePath
+		}
+	}
 }
 
 func (t *healthTrait) Apply(e *Environment) error {
@@ -96,38 +123,30 @@ func (t *healthTrait) Apply(e *Environment) error {
 	p := intstr.FromInt(int(containerPort.ContainerPort))
 	port = &p
 
-	if e.CamelCatalog.Runtime.Capabilities["health"].Metadata != nil {
-		t.setCatalogConfiguration(container, port, e.CamelCatalog.Runtime.Capabilities["health"].Metadata)
-	} else {
-		t.setDefaultConfiguration(container, port)
+	return t.setProbes(container, port)
+}
+
+func (t *healthTrait) setProbes(container *corev1.Container, port *intstr.IntOrString) error {
+	if pointer.BoolDeref(t.LivenessProbeEnabled, false) {
+		if t.LivenessProbe == "" {
+			return fmt.Errorf("you need to configure a liveness probe explicitly or in your catalog")
+		}
+		container.LivenessProbe = t.newLivenessProbe(port, t.LivenessProbe)
+	}
+	if pointer.BoolDeref(t.ReadinessProbeEnabled, true) {
+		if t.ReadinessProbe == "" {
+			return fmt.Errorf("you need to configure a readiness probe explicitly or in your catalog")
+		}
+		container.ReadinessProbe = t.newReadinessProbe(port, t.ReadinessProbe)
+	}
+	if pointer.BoolDeref(t.StartupProbeEnabled, false) {
+		if t.StartupProbe == "" {
+			return fmt.Errorf("you need to configure a startup probe explicitly or in your catalog")
+		}
+		container.StartupProbe = t.newStartupProbe(port, t.StartupProbe)
 	}
 
 	return nil
-}
-
-func (t *healthTrait) setCatalogConfiguration(container *corev1.Container, port *intstr.IntOrString, metadata map[string]string) {
-	if pointer.BoolDeref(t.LivenessProbeEnabled, false) {
-		container.LivenessProbe = t.newLivenessProbe(port, metadata["defaultLivenessProbePath"])
-	}
-	if pointer.BoolDeref(t.ReadinessProbeEnabled, true) {
-		container.ReadinessProbe = t.newReadinessProbe(port, metadata["defaultReadinessProbePath"])
-	}
-	if pointer.BoolDeref(t.StartupProbeEnabled, false) {
-		container.StartupProbe = t.newStartupProbe(port, metadata["defaultStartupProbePath"])
-	}
-}
-
-// Deprecated: to be removed in future release in favor of func setCatalogConfiguration().
-func (t *healthTrait) setDefaultConfiguration(container *corev1.Container, port *intstr.IntOrString) {
-	if pointer.BoolDeref(t.LivenessProbeEnabled, false) {
-		container.LivenessProbe = t.newLivenessProbe(port, defaultLivenessProbePath)
-	}
-	if pointer.BoolDeref(t.ReadinessProbeEnabled, true) {
-		container.ReadinessProbe = t.newReadinessProbe(port, defaultReadinessProbePath)
-	}
-	if pointer.BoolDeref(t.StartupProbeEnabled, false) {
-		container.StartupProbe = t.newStartupProbe(port, defaultStartupProbePath)
-	}
 }
 
 func (t *healthTrait) newLivenessProbe(port *intstr.IntOrString, path string) *corev1.Probe {

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -150,7 +150,7 @@ func (t *knativeTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 	return true, nil, nil
 }
 
-// This is true only when the user set the enabled flag on and the auto flag off
+// This is true only when the user set the enabled flag on and the auto flag off.
 func (t *knativeTrait) isForcefullyEnabled() bool {
 	return pointer.BoolDeref(t.Enabled, false) && !pointer.BoolDeref(t.Auto, true)
 }

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -74,6 +74,12 @@ func (t *knativeTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 		return false, NewIntegrationConditionUserDisabled("Knative"), nil
 	}
 	if e.CamelCatalog == nil {
+		if t.isForcefullyEnabled() {
+			// Likely a sourceless Integration. Here we must verify the user has forcefully enabled the feature in order to turn it on
+			// as we don't have the possibility to scan the Integration source to verify if there is any endpoint suitable with
+			// Knative
+			return true, nil, nil
+		}
 		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
 	}
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
@@ -142,6 +148,11 @@ func (t *knativeTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 	}
 
 	return true, nil, nil
+}
+
+// This is true only when the user set the enabled flag on and the auto flag off
+func (t *knativeTrait) isForcefullyEnabled() bool {
+	return pointer.BoolDeref(t.Enabled, false) && !pointer.BoolDeref(t.Auto, true)
 }
 
 func filterMetaItems(catalog *camel.RuntimeCatalog, sources []v1.SourceSpec, cst knativeapi.CamelServiceType, uriType string) ([]string, error) {

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -145,13 +145,30 @@ func (t *knativeServiceTrait) Apply(e *Environment) error {
 }
 
 func (t *knativeServiceTrait) SelectControllerStrategy(e *Environment) (*ControllerStrategy, error) {
-	if !pointer.BoolDeref(t.Enabled, true) || e.CamelCatalog == nil {
-		// explicitly disabled or sourceless Integration (missing catalog)
+	if !pointer.BoolDeref(t.Enabled, true) {
+		// explicitly disabled by the user
 		return nil, nil
 	}
 
 	// Knative serving is required
 	if ok, _ := knative.IsServingInstalled(e.Client); !ok {
+		if t.isForcefullyEnabled() {
+			// User has forcefully request to use this feature.
+			// Warn the user that he requested a feature but it cannot be fulfilled due to missing
+			// API installation
+			return nil, fmt.Errorf("missing Knative Service API, cannot enable Knative service trait")
+		}
+		return nil, nil
+	}
+
+	if e.CamelCatalog == nil {
+		if t.isForcefullyEnabled() {
+			// Likely a sourceless Integration. Here we must verify the user has forcefully enabled the feature in order to turn it on
+			// as we don't have the possibility to scan the Integration source to verify if there is any endpoint suitable with
+			// Knative
+			knativeServiceStrategy := ControllerStrategyKnativeService
+			return &knativeServiceStrategy, nil
+		}
 		return nil, nil
 	}
 
@@ -170,6 +187,11 @@ func (t *knativeServiceTrait) SelectControllerStrategy(e *Environment) (*Control
 		return &knativeServiceStrategy, nil
 	}
 	return nil, nil
+}
+
+// This is true only when the user set the enabled flag on and the auto flag off
+func (t *knativeServiceTrait) isForcefullyEnabled() bool {
+	return pointer.BoolDeref(t.Enabled, false) && !pointer.BoolDeref(t.Auto, true)
 }
 
 func (t *knativeServiceTrait) ControllerStrategySelectorOrder() int {

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -189,7 +189,7 @@ func (t *knativeServiceTrait) SelectControllerStrategy(e *Environment) (*Control
 	return nil, nil
 }
 
-// This is true only when the user set the enabled flag on and the auto flag off
+// This is true only when the user set the enabled flag on and the auto flag off.
 func (t *knativeServiceTrait) isForcefullyEnabled() bool {
 	return pointer.BoolDeref(t.Enabled, false) && !pointer.BoolDeref(t.Auto, true)
 }

--- a/pkg/trait/logging.go
+++ b/pkg/trait/logging.go
@@ -55,15 +55,12 @@ func (l loggingTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 	if !pointer.BoolDeref(l.Enabled, true) {
 		return false, NewIntegrationConditionUserDisabled("Logging"), nil
 	}
-	if e.CamelCatalog == nil {
-		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
-	}
 
 	return e.IntegrationInRunningPhases(), nil, nil
 }
 
 func (l loggingTrait) Apply(e *Environment) error {
-	if e.CamelCatalog.Runtime.Capabilities["logging"].RuntimeProperties != nil {
+	if e.CamelCatalog != nil && e.CamelCatalog.Runtime.Capabilities["logging"].RuntimeProperties != nil {
 		l.setCatalogConfiguration(e)
 	} else {
 		l.setEnvConfiguration(e)

--- a/pkg/trait/logging_test.go
+++ b/pkg/trait/logging_test.go
@@ -31,6 +31,7 @@ import (
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
+	"github.com/apache/camel-k/v2/pkg/util/envvar"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/test"
 )
@@ -150,4 +151,22 @@ func TestJsonLoggingTrait(t *testing.T) {
 	assert.Equal(t, "${camel.k.logging.json}", env.ApplicationProperties["quarkus.log.console.json"])
 	assert.Equal(t, "${camel.k.logging.jsonPrettyPrint}", env.ApplicationProperties["quarkus.log.console.json.pretty-print"])
 	assert.Equal(t, "", env.ApplicationProperties["quarkus.console.color"])
+}
+
+func TestDefaultQuarkusLogging(t *testing.T) {
+	env := createDefaultLoggingTestEnv(t)
+	// Simulate a synthetic Integration Kit for which the catalog is not available
+	env.CamelCatalog = nil
+	env.IntegrationKit.Labels = map[string]string{
+		v1.IntegrationKitTypeLabel: v1.IntegrationKitTypeSynthetic,
+	}
+	env.EnvVars = []corev1.EnvVar{}
+	conditions, err := NewLoggingTestCatalog().apply(env)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, conditions)
+	assert.NotEmpty(t, env.ExecutedTraits)
+
+	assert.Equal(t, &corev1.EnvVar{Name: "QUARKUS_LOG_LEVEL", Value: "INFO"}, envvar.Get(env.EnvVars, envVarQuarkusLogLevel))
+	assert.Equal(t, &corev1.EnvVar{Name: "QUARKUS_LOG_CONSOLE_JSON", Value: "false"}, envvar.Get(env.EnvVars, envVarQuarkusLogConsoleJSON))
 }


### PR DESCRIPTION
<!-- Description -->

See #5524



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
