### PR TITLE
[Release 2.3.x] fix(traits): don't skip for synthetic kits

### DIFF
--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -80,28 +80,32 @@ func (t *camelTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 
 func (t *camelTrait) Apply(e *Environment) error {
 	if e.IntegrationKit != nil && e.IntegrationKit.IsSynthetic() {
+		// Synthetic Integration Kit
+
 		// This is required as during init phase, the trait set by default these values
 		// which are widely used in the platform for different purposese.
 		if e.Integration != nil {
 			e.Integration.Status.RuntimeVersion = ""
 			e.Integration.Status.RuntimeProvider = ""
 		}
-		return nil
-	}
-	if e.CamelCatalog == nil {
-		if err := t.loadOrCreateCatalog(e, t.RuntimeVersion); err != nil {
-			return err
+	} else {
+		// Managed Integration
+		if e.CamelCatalog == nil {
+			if err := t.loadOrCreateCatalog(e, t.RuntimeVersion); err != nil {
+				return err
+			}
+		}
+		e.RuntimeVersion = e.CamelCatalog.Runtime.Version
+		if e.Integration != nil {
+			e.Integration.Status.RuntimeVersion = e.CamelCatalog.Runtime.Version
+			e.Integration.Status.RuntimeProvider = e.CamelCatalog.Runtime.Provider
+		}
+		if e.IntegrationKit != nil {
+			e.IntegrationKit.Status.RuntimeVersion = e.CamelCatalog.Runtime.Version
+			e.IntegrationKit.Status.RuntimeProvider = e.CamelCatalog.Runtime.Provider
 		}
 	}
-	e.RuntimeVersion = e.CamelCatalog.Runtime.Version
-	if e.Integration != nil {
-		e.Integration.Status.RuntimeVersion = e.CamelCatalog.Runtime.Version
-		e.Integration.Status.RuntimeProvider = e.CamelCatalog.Runtime.Provider
-	}
-	if e.IntegrationKit != nil {
-		e.IntegrationKit.Status.RuntimeVersion = e.CamelCatalog.Runtime.Version
-		e.IntegrationKit.Status.RuntimeProvider = e.CamelCatalog.Runtime.Provider
-	}
+
 	if e.IntegrationKitInPhase(v1.IntegrationKitPhaseReady) && e.IntegrationInRunningPhases() {
 		// Get all resources
 		maps := t.computeConfigMaps(e)

--- a/pkg/trait/camel_test.go
+++ b/pkg/trait/camel_test.go
@@ -206,6 +206,28 @@ func TestApplyCamelTraitWithProperties(t *testing.T) {
 	}, userPropertiesCm.Data)
 }
 
+func TestApplyCamelTraitSyntheticKitWithProperties(t *testing.T) {
+	trait, environment := createNominalCamelTest(false)
+	trait.Properties = []string{"a=b", "c=d"}
+	environment.IntegrationKit.Labels[v1.IntegrationKitTypeLabel] = v1.IntegrationKitTypeSynthetic
+
+	configured, condition, err := trait.Configure(environment)
+	require.NoError(t, err)
+	assert.Nil(t, condition)
+	assert.True(t, configured)
+
+	err = trait.Apply(environment)
+	require.NoError(t, err)
+
+	userPropertiesCm := environment.Resources.GetConfigMap(func(cm *corev1.ConfigMap) bool {
+		return cm.Labels["camel.apache.org/properties.type"] == "user"
+	})
+	assert.NotNil(t, userPropertiesCm)
+	assert.Equal(t, map[string]string{
+		"application.properties": "a=b\nc=d\n",
+	}, userPropertiesCm.Data)
+}
+
 func TestApplyCamelTraitWithSources(t *testing.T) {
 	trait, environment := createNominalCamelTest(true)
 

--- a/pkg/trait/kamelets.go
+++ b/pkg/trait/kamelets.go
@@ -79,14 +79,18 @@ func (t *kameletsTrait) Configure(e *Environment) (bool, *TraitCondition, error)
 	if !pointer.BoolDeref(t.Enabled, true) {
 		return false, NewIntegrationConditionUserDisabled("Kamelets"), nil
 	}
-	if e.CamelCatalog == nil {
-		return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
-	}
 	if !e.IntegrationInPhase(v1.IntegrationPhaseInitialization) && !e.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}
-
+	if t.MountPoint == "" {
+		t.MountPoint = filepath.Join(camel.BasePath, "kamelets")
+	}
 	if pointer.BoolDeref(t.Auto, true) {
+		if e.CamelCatalog == nil {
+			// Cannot execute this trait for synthetic IntegrationKit. In order to use it, the
+			// user has to specify forcefully auto=false option and pass a list of kamelets explicitly
+			return false, NewIntegrationConditionPlatformDisabledCatalogMissing(), nil
+		}
 		kamelets, err := kamelets.ExtractKameletFromSources(e.Ctx, e.Client, e.CamelCatalog, e.Resources, e.Integration)
 		if err != nil {
 			return false, nil, err
@@ -95,10 +99,6 @@ func (t *kameletsTrait) Configure(e *Environment) (bool, *TraitCondition, error)
 		if len(kamelets) > 0 {
 			sort.Strings(kamelets)
 			t.List = strings.Join(kamelets, ",")
-		}
-
-		if t.MountPoint == "" {
-			t.MountPoint = filepath.Join(camel.BasePath, "kamelets")
 		}
 	}
 

--- a/pkg/trait/mount.go
+++ b/pkg/trait/mount.go
@@ -69,11 +69,7 @@ func (t *mountTrait) Configure(e *Environment) (bool, *TraitCondition, error) {
 		}
 	}
 
-	// mount trait needs to be executed only when it has sources attached or any trait configuration
-	return len(e.Integration.AllSources()) > 0 ||
-		len(t.Configs) > 0 ||
-		len(t.Resources) > 0 ||
-		len(t.Volumes) > 0, condition, nil
+	return true, condition, nil
 }
 
 func (t *mountTrait) Apply(e *Environment) error {
@@ -113,10 +109,8 @@ func (t *mountTrait) Apply(e *Environment) error {
 	}
 
 	if visited {
-		// Volumes declared in the Integration resources (we skip for synthetic kits)
-		if e.IntegrationKit == nil || !e.IntegrationKit.IsSynthetic() {
-			e.configureVolumesAndMounts(volumes, &container.VolumeMounts)
-		}
+		// Volumes declared in the Integration resources
+		e.configureVolumesAndMounts(volumes, &container.VolumeMounts)
 		// Volumes declared in the trait config/resource options
 		err := t.configureVolumesAndMounts(volumes, &container.VolumeMounts)
 		if err != nil {


### PR DESCRIPTION
<!-- Description -->

This PR fix some regressions as identified in https://camel.zulipchat.com/#narrow/stream/257299-camel-k/topic/Catalog.20not.20found.20for.20sourceless.20integration.20after.20upgrade



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(traits): don't skip for synthetic kits
```
