### PR TITLE
Fix e2e test when pod runs in openshift with correct security configuration

### DIFF
--- a/e2e/advanced/deployment_test.go
+++ b/e2e/advanced/deployment_test.go
@@ -29,14 +29,23 @@ import (
 	"os/exec"
 
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/apache/camel-k/v2/e2e/support"
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/v2/pkg/util/openshift"
 )
 
 func TestDeploymentFailureShouldReportIntegrationCondition(t *testing.T) {
 	t.Parallel()
+
+	ocp, err := openshift.IsOpenShift(TestClient(t))
+	require.NoError(t, err)
+	if ocp {
+		t.Skip("Avoid running on OpenShift, when in this platform, it correctly sets the configuration to run as unprivileged as possible and the pod runs fine.")
+		return
+	}
 
 	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 		operatorID := "camel-k-failing-deploy"
@@ -60,7 +69,6 @@ func TestDeploymentFailureShouldReportIntegrationCondition(t *testing.T) {
 				"--overwrite",
 				"ns",
 				nsRestr,
-				"pod-security.kubernetes.io/enforce=baseline",
 				"pod-security.kubernetes.io/enforce-version=latest",
 				"pod-security.kubernetes.io/enforce=restricted",
 				"pod-security.kubernetes.io/warn-version=latest",


### PR DESCRIPTION
<!-- Description -->

The e2e test sets the namespace to a restricted PSA.
When the integration is run in openshift, it sets the correct `securityContext` to run with no privileges:
``` 
securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
    - ALL
  runAsNonRoot: true
  runAsUser: 1000650000
  seccompProfile:
    type: RuntimeDefault
```

The pod runs just fine with no errors.
So, this is just to disable this test in openshift.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
