### PR TITLE
[Release 2.3.x] fix(ctrl): synthetic Integration cannot set blockOwnerDeletion

### DIFF
--- a/pkg/controller/synthetic/synthetic.go
+++ b/pkg/controller/synthetic/synthetic.go
@@ -40,8 +40,7 @@ import (
 )
 
 var (
-	controller         = true
-	blockOwnerDeletion = true
+	controller = true
 )
 
 // ManageSyntheticIntegrations is the controller for synthetic Integrations. Consider that the lifecycle of the objects are driven
@@ -206,12 +205,11 @@ func (app *nonManagedCamelDeployment) Integration() *v1.Integration {
 	}
 	references := []metav1.OwnerReference{
 		{
-			APIVersion:         "apps/v1",
-			Kind:               "Deployment",
-			Name:               app.deploy.Name,
-			UID:                app.deploy.UID,
-			Controller:         &controller,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       app.deploy.Name,
+			UID:        app.deploy.UID,
+			Controller: &controller,
 		},
 	}
 	it.SetOwnerReferences(references)
@@ -251,12 +249,11 @@ func (app *NonManagedCamelCronjob) Integration() *v1.Integration {
 	}
 	references := []metav1.OwnerReference{
 		{
-			APIVersion:         "batch/v1",
-			Kind:               "CronJob",
-			Name:               app.cron.Name,
-			UID:                app.cron.UID,
-			Controller:         &controller,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			APIVersion: "batch/v1",
+			Kind:       "CronJob",
+			Name:       app.cron.Name,
+			UID:        app.cron.UID,
+			Controller: &controller,
 		},
 	}
 	it.SetOwnerReferences(references)
@@ -281,12 +278,11 @@ func (app *NonManagedCamelKnativeService) Integration() *v1.Integration {
 	}
 	references := []metav1.OwnerReference{
 		{
-			APIVersion:         servingv1.SchemeGroupVersion.String(),
-			Kind:               "Service",
-			Name:               app.ksvc.Name,
-			UID:                app.ksvc.UID,
-			Controller:         &controller,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			APIVersion: servingv1.SchemeGroupVersion.String(),
+			Kind:       "Service",
+			Name:       app.ksvc.Name,
+			UID:        app.ksvc.UID,
+			Controller: &controller,
 		},
 	}
 	it.SetOwnerReferences(references)

--- a/pkg/controller/synthetic/synthetic_test.go
+++ b/pkg/controller/synthetic/synthetic_test.go
@@ -118,12 +118,11 @@ func TestNonManagedDeployment(t *testing.T) {
 	}
 	references := []metav1.OwnerReference{
 		{
-			APIVersion:         "apps/v1",
-			Kind:               "Deployment",
-			Name:               deploy.Name,
-			UID:                deploy.UID,
-			Controller:         &controller,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       deploy.Name,
+			UID:        deploy.UID,
+			Controller: &controller,
 		},
 	}
 	expectedIt.SetOwnerReferences(references)
@@ -178,12 +177,11 @@ func TestNonManagedCronJob(t *testing.T) {
 	})
 	references := []metav1.OwnerReference{
 		{
-			APIVersion:         "batch/v1",
-			Kind:               "CronJob",
-			Name:               cron.Name,
-			UID:                cron.UID,
-			Controller:         &controller,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			APIVersion: "batch/v1",
+			Kind:       "CronJob",
+			Name:       cron.Name,
+			UID:        cron.UID,
+			Controller: &controller,
 		},
 	}
 	expectedIt.SetOwnerReferences(references)
@@ -237,12 +235,11 @@ func TestNonManagedKnativeService(t *testing.T) {
 	})
 	references := []metav1.OwnerReference{
 		{
-			APIVersion:         servingv1.SchemeGroupVersion.String(),
-			Kind:               "Service",
-			Name:               ksvc.Name,
-			UID:                ksvc.UID,
-			Controller:         &controller,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			APIVersion: servingv1.SchemeGroupVersion.String(),
+			Kind:       "Service",
+			Name:       ksvc.Name,
+			UID:        ksvc.UID,
+			Controller: &controller,
 		},
 	}
 	expectedIt.SetOwnerReferences(references)


### PR DESCRIPTION
Because the operator may not have permissions over the Deployment resource finalizers

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
