### PR TITLE
chore(builder): add -DskipTests

### DIFF
--- a/pkg/builder/quarkus.go
+++ b/pkg/builder/quarkus.go
@@ -216,6 +216,7 @@ func BuildQuarkusRunnerCommon(ctx context.Context, mc maven.Context, project mav
 		return err
 	}
 	mc.AddArgument("package")
+	mc.AddArgument("-Dmaven.test.skip=true")
 	// Run the Maven goal
 	if err := project.Command(mc).Do(ctx); err != nil {
 		return fmt.Errorf("failure while building project: %w", err)


### PR DESCRIPTION
We have no reason to try executing any test as we don't expect the presence of any test at all

The operator output is now the following one:
```
camel-k-operator-5f5bf4f7bb-2w2tz camel-k-operator {"level":"info","ts":"2024-05-31T09:27:58Z","logger":"camel-k.maven.build","msg":"--- maven-surefire-plugin:2.12.4:test (default-test) @ camel-k-integration ---"}
camel-k-operator-5f5bf4f7bb-2w2tz camel-k-operator {"level":"info","ts":"2024-05-31T09:27:59Z","logger":"camel-k.maven.build","msg":"Tests are skipped."}
camel-k-operator-5f5bf4f7bb-2w2tz camel-k-operator {"level":"info","ts":"2024-05-31T09:27:59Z","logger":"camel-k.maven.build","msg":""}
camel-k-operator-5f5bf4f7bb-2w2tz camel-k-operator {"level":"info","ts":"2024-05-31T09:27:59Z","logger":"camel-k.maven.build","msg":"--- maven-jar-plugin:2.4:jar (default-jar) @ camel-k-integration ---"}
camel-k-operator-5f5bf4f7bb-2w2tz camel-k-operator {"level":"info","ts":"2024-05-31T09:27:59Z","logger":"camel-k.maven.build","msg":"Tests are skipped."}
camel-k-operator-5f5bf4f7bb-2w2tz camel-k-operator {"level":"info","ts":"2024-05-31T09:27:59Z","logger":"camel-k.maven.build","msg":""}
```

Closes #5472

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(builder): add -DskipTests
```
