### PR TITLE
feat(e2e): Rewrite tekton test to use run command

### DIFF
--- a/e2e/advanced/files/camel-k-tekton.yaml
+++ b/e2e/advanced/files/camel-k-tekton.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camel-k-tekton
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-integrations
+rules:
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - integrations
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - camelcatalogs
+  verbs:
+  - list
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-tekton-integrations
+subjects:
+- kind: ServiceAccount
+  name: camel-k-tekton
+roleRef:
+  kind: Role
+  name: camel-k-integrations
+  apiGroup: rbac.authorization.k8s.io

--- a/e2e/advanced/main_test.go
+++ b/e2e/advanced/main_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+
 	justCompile := GetEnvOrDefault("CAMEL_K_E2E_JUST_COMPILE", boolean.FalseString)
 	if justCompile == "true" {
 		os.Exit(m.Run())

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -285,6 +285,9 @@ func KamelInstallWithIDAndKameletCatalog(t *testing.T, ctx context.Context, oper
 }
 
 func kamelInstallWithContext(t *testing.T, ctx context.Context, operatorID string, namespace string, skipKameletCatalog bool, args ...string) error {
+	// This line prevents controller-runtime from complaining about log.SetLogger never being called
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
 	kamelInstallMutex.Lock()
 	defer kamelInstallMutex.Unlock()
 
@@ -2688,8 +2691,6 @@ func CreateOperatorRoleBinding(t *testing.T, ctx context.Context, ns string) err
 // CreateKamelPodWithIntegrationSource generates and deploy a Pod from current Camel K controller image that will run a `kamel xxxx` command.
 // The integration parameter represent an Integration source file contained in a ConfigMap or Secret defined and mounted on the as a Volume.
 func CreateKamelPodWithIntegrationSource(t *testing.T, ctx context.Context, ns string, name string, integration v1.ValueSource, command ...string) error {
-	// This line prevents controller-runtime from complaining about log.SetLogger never being called
-	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	var volumes []corev1.Volume
 	if integration.SecretKeyRef != nil {


### PR DESCRIPTION
Refactor the tekton test like task test to use it have it work the closely most  it is supposed to work:
* the Camel K operator is supposed to be already installed
* the tekton task consist of a `kamel run` command allowing to deploy a an integration from a file (here present via a volume from a configmap)

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(e2e): Rewrite tekton test to use run command
```
