### PR TITLE
[Backport 2.3.x] fix(ci): merge helm with older index

### DIFF
--- a/script/release_helm.sh
+++ b/script/release_helm.sh
@@ -19,8 +19,9 @@ set -e
 
 location=$(dirname $0)
 rootdir=$(realpath $location/..)
-targetdir=$rootdir/docs/charts
 version=$1
+targetdir=$rootdir/docs/charts/$version
+helm_index=$rootdir/docs/charts/index.yaml
 
 mkdir -p $targetdir
 
@@ -28,4 +29,7 @@ cd $rootdir/helm
 
 helm package ./camel-k --version $version
 mv camel-k-*.tgz $targetdir/
-helm repo index $targetdir --url https://apache.github.io/camel-k/charts/
+helm repo index $targetdir --url https://apache.github.io/camel-k/charts/ --merge $helm_index
+# Required to prevent https://github.com/helm/helm/issues/7363
+mv $targetdir/* $targetdir/../.
+rm -rf $targetdir


### PR DESCRIPTION
Closes #5575

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
