### PR TITLE
feat(core): Mount configmap/secret resources in dedicated resources.d

### DIFF
--- a/docs/modules/ROOT/pages/configuration/runtime-resources.adoc
+++ b/docs/modules/ROOT/pages/configuration/runtime-resources.adoc
@@ -24,14 +24,14 @@ We want to use the materialized file in an integration:
 .resource-configmap-route.yaml
 ----
 - from:
-    uri: "file:/etc/camel/resources/my-cm/?fileName=my-configmap-key&noop=true&idempotent=false"
+    uri: "file:/etc/camel/resources.d/_configmaps/my-cm/?fileName=my-configmap-key&noop=true&idempotent=false"
     steps:
       - setBody:
           simple: "resource file content is: ${body}"
       - to: "log:info"
 ----
 
-You can see that we're expecting to use a _my-configmap-key_ file stored in the default resource location (_/etc/camel/resources/_). In order to materialize the `Configmap` will be as easy as running the `--resource` _configmap_ syntax:
+You can see that we're expecting to use a _my-configmap-key_ file stored in the default resource location (_/etc/camel/resources.d/_configmaps/_). In order to materialize the `Configmap` will be as easy as running the `--resource` _configmap_ syntax:
 
 ----
 kamel run --resource configmap:my-cm resource-configmap-route.yaml
@@ -58,14 +58,14 @@ We want to use the materialized secret file in an integration:
 .resource-secret-route.yaml
 ----
 - from:
-    uri: "file:/etc/camel/resources/my-sec/?fileName=my-secret-key&noop=true&idempotent=false"
+    uri: "file:/etc/camel/resources.d/_secrets/my-sec/?fileName=my-secret-key&noop=true&idempotent=false"
     steps:
       - setBody:
           simple: "secret file content is: ${body}"
       - to: "log:info"
 ----
 
-You can see that we're expecting to use a _my-secret-key_ file stored in the default resource location (_/etc/camel/resources/_). In order to materialize the `Secret` will be as easy as running the `--resource` _secret_ syntax:
+You can see that we're expecting to use a _my-secret-key_ file stored in the default resource location (_/etc/camel/resources.d/_secrets/_). In order to materialize the `Secret` will be as easy as running the `--resource` _secret_ syntax:
 
 ----
 kamel run --resource secret:my-sec resource-secret-route.yaml

--- a/e2e/common/config/files/resource-configmap-route.yaml
+++ b/e2e/common/config/files/resource-configmap-route.yaml
@@ -18,7 +18,7 @@
 # ---------------------------------------------------------------------------
 
 - from:
-    uri: "file:/etc/camel/resources/my-cm/?fileName=my-configmap-key&noop=true&idempotent=false"
+    uri: "file:/etc/camel/resources.d/_configmaps/my-cm/?fileName=my-configmap-key&noop=true&idempotent=false"
     steps:
       - setBody:
           simple: "resource file content is: ${body}"

--- a/e2e/common/config/files/resource-secret-route.yaml
+++ b/e2e/common/config/files/resource-secret-route.yaml
@@ -18,7 +18,7 @@
 # ---------------------------------------------------------------------------
 
 - from:
-    uri: "file:/etc/camel/resources/my-sec/?fileName=my-secret-key&noop=true&idempotent=false"
+    uri: "file:/etc/camel/resources.d/_secrets/my-sec/?fileName=my-secret-key&noop=true&idempotent=false"
     steps:
       - setBody:
           simple: "resource file content is: ${body}"

--- a/pkg/trait/jvm.go
+++ b/pkg/trait/jvm.go
@@ -205,8 +205,12 @@ func (t *jvmTrait) enableDebug(e *Environment) string {
 
 func (t *jvmTrait) prepareClasspathItems(container *corev1.Container) []string {
 	classpath := sets.NewSet()
+	// Deprecated: replaced by /etc/camel/resources.d/[_configmaps/_secrets] (camel.ResourcesConfigmapsMountPath/camel.ResourcesSecretsMountPath).
 	classpath.Add("./resources")
-	classpath.Add(filepath.ToSlash(camel.ConfigResourcesMountPath))
+	classpath.Add(filepath.ToSlash(camel.ResourcesConfigmapsMountPath))
+	classpath.Add(filepath.ToSlash(camel.ResourcesSecretsMountPath))
+	// Deprecated: replaced by /etc/camel/resources.d/[_configmaps/_secrets] (camel.ResourcesConfigmapsMountPath/camel.ResourcesSecretsMountPath).
+	//nolint: staticcheck
 	classpath.Add(filepath.ToSlash(camel.ResourcesDefaultMountPath))
 	if t.Classpath != "" {
 		classpath.Add(strings.Split(t.Classpath, ":")...)

--- a/pkg/trait/jvm_test.go
+++ b/pkg/trait/jvm_test.go
@@ -37,7 +37,9 @@ import (
 )
 
 var (
-	crMountPath = filepath.ToSlash(camel.ConfigResourcesMountPath)
+	cmrMountPath = filepath.ToSlash(camel.ResourcesConfigmapsMountPath)
+	scrMountPath = filepath.ToSlash(camel.ResourcesSecretsMountPath)
+	// Deprecated.
 	rdMountPath = filepath.ToSlash(camel.ResourcesDefaultMountPath)
 )
 
@@ -131,7 +133,7 @@ func TestConfigureJvmTraitExecutableSourcelessContainerWithJar(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"-cp",
-		fmt.Sprintf("./resources:%s:%s", crMountPath, rdMountPath),
+		fmt.Sprintf("./resources:%s:%s:%s", rdMountPath, cmrMountPath, scrMountPath),
 		"-jar", "my-path/to/my-app.jar",
 	}, d.Spec.Template.Spec.Containers[0].Args)
 }
@@ -172,7 +174,7 @@ func TestConfigureJvmTraitExecutableSourcelessContainerWithJarAndOptions(t *test
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"-Xmx1234M", "-Dmy-prop=abc",
-		"-cp", "./resources:/etc/camel/conf.d/_resources:/etc/camel/resources:deps/a.jar:deps/b.jar",
+		"-cp", "./resources:/etc/camel/resources:/etc/camel/resources.d/_configmaps:/etc/camel/resources.d/_secrets:deps/a.jar:deps/b.jar",
 		"-jar", "my-path/to/my-app.jar",
 	}, d.Spec.Template.Spec.Containers[0].Args)
 }
@@ -206,7 +208,7 @@ func TestConfigureJvmTraitWithJar(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"-cp",
-		fmt.Sprintf("./resources:%s:%s", crMountPath, rdMountPath),
+		fmt.Sprintf("./resources:%s:%s:%s", rdMountPath, cmrMountPath, scrMountPath),
 		"-jar", "my-path/to/my-app.jar",
 	}, d.Spec.Template.Spec.Containers[0].Args)
 }
@@ -246,7 +248,7 @@ func TestConfigureJvmTraitWithJarAndConfigs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"-Xmx1234M", "-Dmy-prop=abc",
-		"-cp", "./resources:/etc/camel/conf.d/_resources:/etc/camel/resources:deps/a.jar:deps/b.jar",
+		"-cp", "./resources:/etc/camel/resources:/etc/camel/resources.d/_configmaps:/etc/camel/resources.d/_secrets:deps/a.jar:deps/b.jar",
 		"-jar", "my-path/to/my-app.jar",
 	}, d.Spec.Template.Spec.Containers[0].Args)
 }
@@ -301,9 +303,10 @@ func TestApplyJvmTraitWithDeploymentResource(t *testing.T) {
 	assert.Equal(t, []string{
 		"-cp",
 		fmt.Sprintf(
-			"./resources:%s:%s:/mount/path:dependencies/*",
-			crMountPath,
+			"./resources:%s:%s:%s:/mount/path:dependencies/*",
 			rdMountPath,
+			cmrMountPath,
+			scrMountPath,
 		),
 		"io.quarkus.bootstrap.runner.QuarkusEntryPoint",
 	}, d.Spec.Template.Spec.Containers[0].Args)
@@ -335,7 +338,8 @@ func TestApplyJvmTraitWithKnativeResource(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"-cp",
-		fmt.Sprintf("./resources:%s:%s:/mount/path:dependencies/*", crMountPath, rdMountPath),
+		fmt.Sprintf("./resources:%s:%s:%s:/mount/path:dependencies/*",
+			rdMountPath, cmrMountPath, scrMountPath),
 		"io.quarkus.bootstrap.runner.QuarkusEntryPoint",
 	}, s.Spec.Template.Spec.Containers[0].Args)
 }
@@ -402,7 +406,7 @@ func TestApplyJvmTraitWithExternalKitType(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"-cp",
-		fmt.Sprintf("./resources:%s:%s:dependencies/*", crMountPath, rdMountPath),
+		fmt.Sprintf("./resources:%s:%s:%s:dependencies/*", rdMountPath, cmrMountPath, scrMountPath),
 		"io.quarkus.bootstrap.runner.QuarkusEntryPoint",
 	}, d.Spec.Template.Spec.Containers[0].Args)
 }
@@ -439,7 +443,9 @@ func TestApplyJvmTraitWithClasspath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"-cp",
-		fmt.Sprintf("./resources:%s:%s:/mount/path:%s:%s:dependencies/*", crMountPath, rdMountPath, "/path/to/another/dep.jar", "/path/to/my-dep.jar"),
+		fmt.Sprintf("./resources:%s:%s:%s:/mount/path:%s:%s:dependencies/*",
+			rdMountPath, cmrMountPath, scrMountPath,
+			"/path/to/another/dep.jar", "/path/to/my-dep.jar"),
 		"io.quarkus.bootstrap.runner.QuarkusEntryPoint",
 	}, d.Spec.Template.Spec.Containers[0].Args)
 }

--- a/pkg/util/camel/camel_util.go
+++ b/pkg/util/camel/camel_util.go
@@ -29,14 +29,17 @@ import (
 )
 
 var (
-	BasePath                  = "/etc/camel"
-	ConfDPath                 = filepath.Join(BasePath, "conf.d")
-	SourcesMountPath          = filepath.Join(BasePath, "sources")
-	ResourcesDefaultMountPath = filepath.Join(BasePath, "resources")
-	ConfigResourcesMountPath  = filepath.Join(ConfDPath, "_resources")
-	ConfigConfigmapsMountPath = filepath.Join(ConfDPath, "_configmaps")
-	ConfigSecretsMountPath    = filepath.Join(ConfDPath, "_secrets")
-	ServiceBindingsMountPath  = filepath.Join(ConfDPath, "_servicebindings")
+	BasePath         = "/etc/camel"
+	ConfDPath        = filepath.Join(BasePath, "conf.d")
+	ResourcesDPath   = filepath.Join(BasePath, "resources.d")
+	SourcesMountPath = filepath.Join(BasePath, "sources")
+	// Deprecated: replaced by /etc/camel/resources.d/[_configmaps/_secrets] (ResourcesConfigmapsMountPath/ResourcesSecretsMountPath).
+	ResourcesDefaultMountPath    = filepath.Join(BasePath, "resources")
+	ResourcesConfigmapsMountPath = filepath.Join(ResourcesDPath, "_configmaps")
+	ResourcesSecretsMountPath    = filepath.Join(ResourcesDPath, "_secrets")
+	ConfigConfigmapsMountPath    = filepath.Join(ConfDPath, "_configmaps")
+	ConfigSecretsMountPath       = filepath.Join(ConfDPath, "_secrets")
+	ServiceBindingsMountPath     = filepath.Join(ConfDPath, "_servicebindings")
 )
 
 func findBestMatch(catalogs []v1.CamelCatalog, runtime v1.RuntimeSpec) (*RuntimeCatalog, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -76,7 +76,7 @@ var ContainerPropertiesDirectory = "/etc/camel/conf.d"
 var ContainerRoutesDirectory = "/etc/camel/sources"
 
 // ContainerResourcesDirectory --.
-var ContainerResourcesDirectory = "/etc/camel/resources"
+var ContainerResourcesDirectory = "/etc/camel/resources.d"
 
 // ContainerQuarkusDirectoryName --.
 const ContainerQuarkusDirectoryName = "/quarkus"


### PR DESCRIPTION
* Replace /etc/camel/conf.d/_resources by  /etc/camel/resources.d/[_configmaps/_secrets]
* Deprecates `./resources` and `/etc/camel/resources`

Note: removal of `./resources` and `/etc/camel/resources` test run passed successfully so it can be done after the next release.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(core): Mount configmap/secret resources in dedicated resources.d.  Deprecates ./resources and /etc/camel/resources default paths.
```
