### PR TITLE
[Backport 2.3.x] feat(4893) YAML DSL route configuration support

### DIFF
--- a/pkg/util/camel/camel_runtime_catalog.go
+++ b/pkg/util/camel/camel_runtime_catalog.go
@@ -183,10 +183,25 @@ func (c *RuntimeCatalog) VisitSchemes(visitor func(string, v1.CamelScheme) bool)
 
 // DecodeComponent parses the given URI and return a camel artifact and a scheme.
 func (c *RuntimeCatalog) DecodeComponent(uri string) (*v1.CamelArtifact, *v1.CamelScheme) {
-	uriSplit := strings.SplitN(uri, ":", 2)
-	if len(uriSplit) < 2 {
-		return nil, nil
+
+	var uriSplit []string
+
+	// Decode URI using formats http://my-site/test?param=value or log:info
+	switch {
+	case strings.Contains(uri, ":"):
+		uriSplit = strings.SplitN(uri, ":", 2)
+		if len(uriSplit) < 2 {
+			return nil, nil
+		}
+	case strings.Contains(uri, "?"):
+		uriSplit = strings.SplitN(uri, "?", 2)
+		if len(uriSplit) < 2 {
+			return nil, nil
+		}
+	default:
+		uriSplit = append(uriSplit, uri)
 	}
+
 	uriStart := uriSplit[0]
 	var schemeRef *v1.CamelScheme
 	if scheme, ok := c.GetScheme(uriStart); ok {

--- a/pkg/util/camel/camel_runtime_catalog_test.go
+++ b/pkg/util/camel/camel_runtime_catalog_test.go
@@ -57,11 +57,12 @@ func TestIsResolvable(t *testing.T) {
 		expected bool
 	}{
 		// static dependencies
+		{desc: "Basic static dependency single component", uri: "log", expected: true},
 		{desc: "Basic static dependency", uri: "log:info", expected: true},
 		{desc: "Basic static dependency with path and param", uri: "http://my-site/test?param=value", expected: true},
 		{desc: "Basic static dependency with path and param placeholder", uri: "http://my-site/test?{{params}}", expected: true},
 		{desc: "Basic static dependency with path placeholder and param", uri: "http://my-site/{{path}}?key=val", expected: true},
-
+		{desc: "Basic static dependency with path placeholder and name", uri: "direct?name=val", expected: true},
 		// placeholders
 		{desc: "Basic", uri: "{{url}}", expected: false},
 		{desc: "With query param placeholder", uri: "{{url}}?authMethod={{authMethod}}", expected: false},
@@ -77,6 +78,29 @@ func TestIsResolvable(t *testing.T) {
 			if got := catalog.IsResolvable(testCase.uri); got != testCase.expected {
 				t.Errorf("IsResolvable(%v) = %v, want %v", testCase.uri, got, testCase.expected)
 
+			}
+		})
+	}
+}
+
+func TestDecodeComponent(t *testing.T) {
+	catalog, err := DefaultCatalog()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc       string
+		uri        string
+		expectedID string
+	}{
+		{desc: "Basic static dependency", uri: "direct", expectedID: "direct"},
+		{desc: "Basic static dependency", uri: "log:info", expectedID: "log"},
+		{desc: "Basic static dependency witch path and name", uri: "direct?name=route", expectedID: "direct"},
+		{desc: "Basic static dependency with path and param placeholder", uri: "http://my-site/test?{{params}}", expectedID: "http"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			if _, gotScheme := catalog.DecodeComponent(testCase.uri); gotScheme.ID != testCase.expectedID {
+				t.Errorf("DecodeComponent(%v) = %v, want %v", testCase.uri, gotScheme.ID, testCase.expectedID)
 			}
 		})
 	}


### PR DESCRIPTION
Backport of #4893 


**Release Note**
```release-note
Fix #4893: Support YAML DSL routes configuration
```
