### PR TITLE
Revisit final operator install message

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -375,15 +375,14 @@ func (o *installCmdOptions) installOperator(cmd *cobra.Command, output *kubernet
 		}
 	}
 
-	strategy := ""
+	message := "Camel K installed in namespace " + namespace
 	if olm {
-		strategy = "via OLM subscription"
+		message += " via OLM subscription"
 	}
 	if o.Global {
-		fmt.Fprintln(cmd.OutOrStdout(), "Camel K installed in namespace", namespace, strategy, "(global mode)")
-	} else {
-		fmt.Fprintln(cmd.OutOrStdout(), "Camel K installed in namespace", namespace, strategy)
+		message += " (global mode)"
 	}
+	fmt.Fprintln(cmd.OutOrStdout(), message)
 
 	return nil
 }


### PR DESCRIPTION
Simple change that removes the unwanted double space in front of '(global mode)'. i.e. we now have

```
Camel K installed in namespace default (global mode)
Camel K installed in namespace default via OLM subscription (global mode)
```