### PR TITLE
feat(ci): bring back Quarkus native execution on PR and pushes

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -19,16 +19,26 @@ name: native
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CAMEL_K_TEST_TIMEOUT_LONG: 30m
+  CAMEL_K_TEST_TIMEOUT_SHORT: 5m
+  CAMEL_K_TEST_TIMEOUT_MEDIUM: 10m
+  CAMEL_K_TEST_TIMEOUT_LONG: 15m
   CAMEL_K_TEST_TIMEOUT_VERY_LONG: 60m
 
 on:
   pull_request:
-    types:
-      - labeled
-      - opened
-      - synchronize
-      - reopened
+    branches:
+      - main
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - 'java/**'
+      - 'proposals/**'
+      - '**.adoc'
+      - '**.md'
+      - 'KEYS'
+      - 'LICENSE'
+      - 'NOTICE'
+  push:
     branches:
       - main
       - "release-*"
@@ -66,7 +76,6 @@ concurrency:
 
 jobs:
   quarkus-native:
-    if: contains(github.event.pull_request.labels.*.name, 'trigger native test')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly-native-test.yml
+++ b/.github/workflows/nightly-native-test.yml
@@ -24,6 +24,8 @@ env:
   CAMEL_K_TEST_TIMEOUT_LONG: 15m
   CAMEL_K_TEST_TIMEOUT_VERY_LONG: 60m
 
+# We can disable as at the moment we're running this check on each PR and push
+# We keep the source in case it is required to be enabled again in the future.
 on:
   schedule:
     - cron:  '45 3 * * *'


### PR DESCRIPTION
Closes #5598

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(ci): bring back Quarkus native execution on PR and pushes
```
