### PR TITLE
fix(traits): annotations refactoring 

### DIFF
--- a/addons/addons_test.go
+++ b/addons/addons_test.go
@@ -20,8 +20,6 @@ package addons
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/apache/camel-k/v2/addons/master"
 	"github.com/apache/camel-k/v2/addons/telemetry"
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -49,40 +47,6 @@ func TestTraitConfiguration(t *testing.T) {
 						}),
 					},
 				},
-			},
-		},
-	}
-	c := trait.NewCatalog(nil)
-	require.NoError(t, c.Configure(&env))
-
-	require.NotNil(t, c.GetTrait("master"))
-	master, ok := c.GetTrait("master").(*master.TestMasterTrait)
-	require.True(t, ok)
-	assert.True(t, *master.Enabled)
-	assert.Equal(t, "test-lock", *master.ResourceName)
-	assert.Equal(t, "test-label", *master.LabelKey)
-	assert.Equal(t, "test-value", *master.LabelValue)
-
-	require.NotNil(t, c.GetTrait("telemetry"))
-	telemetry, ok := c.GetTrait("telemetry").(*telemetry.TestTelemetryTrait)
-	require.True(t, ok)
-	assert.True(t, *telemetry.Enabled)
-}
-
-func TestTraitConfigurationFromAnnotations(t *testing.T) {
-	env := trait.Environment{
-		Integration: &v1.Integration{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					"trait.camel.apache.org/master.enabled":       "true",
-					"trait.camel.apache.org/master.resource-name": "test-lock",
-					"trait.camel.apache.org/master.label-key":     "test-label",
-					"trait.camel.apache.org/master.label-value":   "test-value",
-					"trait.camel.apache.org/telemetry.enabled":    "true",
-				},
-			},
-			Spec: v1.IntegrationSpec{
-				Profile: v1.TraitProfileKubernetes,
 			},
 		},
 	}

--- a/e2e/common/misc/pipe_with_image_test.go
+++ b/e2e/common/misc/pipe_with_image_test.go
@@ -55,10 +55,9 @@ func TestPipeWithImage(t *testing.T) {
 
 			g.Eventually(IntegrationGeneration(t, ctx, ns, bindingID)).
 				Should(gstruct.PointTo(BeNumerically("==", 1)))
-			g.Eventually(Integration(t, ctx, ns, bindingID)).Should(WithTransform(Annotations, And(
+			g.Eventually(Integration(t, ctx, ns, bindingID)).Should(WithTransform(Annotations,
 				HaveKeyWithValue("test", "1"),
-				HaveKeyWithValue("trait.camel.apache.org/container.image", expectedImage),
-			)))
+			))
 			g.Eventually(IntegrationStatusImage(t, ctx, ns, bindingID)).
 				Should(Equal(expectedImage))
 			g.Eventually(IntegrationPodPhase(t, ctx, ns, bindingID), TestTimeoutShort).
@@ -73,10 +72,9 @@ func TestPipeWithImage(t *testing.T) {
 			g.Expect(KamelBindWithID(t, ctx, operatorID, ns, "my-own-timer-source", "my-own-log-sink", "--annotation", "trait.camel.apache.org/container.image="+expectedImage, "--annotation", "trait.camel.apache.org/jvm.enabled=false", "--annotation", "trait.camel.apache.org/kamelets.enabled=false", "--annotation", "trait.camel.apache.org/dependencies.enabled=false", "--annotation", "test=2", "--name", bindingID).Execute()).To(Succeed())
 			g.Eventually(IntegrationGeneration(t, ctx, ns, bindingID)).
 				Should(gstruct.PointTo(BeNumerically("==", 1)))
-			g.Eventually(Integration(t, ctx, ns, bindingID)).Should(WithTransform(Annotations, And(
+			g.Eventually(Integration(t, ctx, ns, bindingID)).Should(WithTransform(Annotations,
 				HaveKeyWithValue("test", "2"),
-				HaveKeyWithValue("trait.camel.apache.org/container.image", expectedImage),
-			)))
+			))
 			g.Eventually(IntegrationStatusImage(t, ctx, ns, bindingID)).
 				Should(Equal(expectedImage))
 			g.Eventually(IntegrationPodPhase(t, ctx, ns, bindingID), TestTimeoutShort).

--- a/pkg/cmd/bind.go
+++ b/pkg/cmd/bind.go
@@ -175,7 +175,7 @@ func (o *bindCmdOptions) validate(cmd *cobra.Command, args []string) error {
 	}
 	catalog := trait.NewCatalog(client)
 
-	return validateTraits(catalog, extractTraitNames(o.Traits))
+	return trait.ValidateTraits(catalog, extractTraitNames(o.Traits))
 }
 
 func (o *bindCmdOptions) run(cmd *cobra.Command, args []string) error {
@@ -236,7 +236,7 @@ func (o *bindCmdOptions) run(cmd *cobra.Command, args []string) error {
 			binding.Spec.Integration = &v1.IntegrationSpec{}
 		}
 		catalog := trait.NewCatalog(client)
-		if err := configureTraits(o.Traits, &binding.Spec.Integration.Traits, catalog); err != nil {
+		if err := trait.ConfigureTraits(o.Traits, &binding.Spec.Integration.Traits, catalog); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/kit_create.go
+++ b/pkg/cmd/kit_create.go
@@ -153,7 +153,7 @@ func (command *kitCreateCommandOptions) run(cmd *cobra.Command, args []string) e
 	if err := command.parseAndConvertToTrait(command.Secrets, "mount.config"); err != nil {
 		return err
 	}
-	if err := configureTraits(command.Traits, &kit.Spec.Traits, catalog); err != nil {
+	if err := trait.ConfigureTraits(command.Traits, &kit.Spec.Traits, catalog); err != nil {
 		return err
 	}
 	existed := false

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -297,7 +297,7 @@ func (o *runCmdOptions) validate(cmd *cobra.Command) error {
 	}
 	catalog := trait.NewCatalog(client)
 
-	return validateTraits(catalog, extractTraitNames(o.Traits))
+	return trait.ValidateTraits(catalog, extractTraitNames(o.Traits))
 }
 
 func filterBuildPropertyFiles(maybePropertyFiles []string) []string {
@@ -561,7 +561,7 @@ func (o *runCmdOptions) createOrUpdateIntegration(cmd *cobra.Command, c client.C
 
 	if len(o.Traits) > 0 {
 		catalog := trait.NewCatalog(c)
-		if err := configureTraits(o.Traits, &integration.Spec.Traits, catalog); err != nil {
+		if err := trait.ConfigureTraits(o.Traits, &integration.Spec.Traits, catalog); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -449,7 +449,7 @@ func TestConfigureTraits(t *testing.T) {
 	catalog := trait.NewCatalog(client)
 
 	traits := v1.Traits{}
-	err = configureTraits(runCmdOptions.Traits, &traits, catalog)
+	err = trait.ConfigureTraits(runCmdOptions.Traits, &traits, catalog)
 
 	require.NoError(t, err)
 	traitMap, err := trait.ToTraitMap(traits)

--- a/pkg/controller/integration/build_kit.go
+++ b/pkg/controller/integration/build_kit.go
@@ -99,7 +99,7 @@ kits:
 			k := &existingKits[i]
 
 			action.L.Debug("Comparing existing kit with environment", "env kit", kit.Name, "existing kit", k.Name)
-			match, err := kitMatches(&kit, k)
+			match, err := kitMatches(action.client, &kit, k)
 			if err != nil {
 				return nil, fmt.Errorf("error occurred matches integration kits with environment for integration %s/%s: %w",
 					integration.Namespace, integration.Name, err)

--- a/pkg/controller/integration/integration_controller.go
+++ b/pkg/controller/integration/integration_controller.go
@@ -85,7 +85,7 @@ func newReconciler(mgr manager.Manager, c client.Client) reconcile.Reconciler {
 	)
 }
 
-func integrationUpdateFunc(old *v1.Integration, it *v1.Integration) bool {
+func integrationUpdateFunc(c client.Client, old *v1.Integration, it *v1.Integration) bool {
 	// Observe the time to first readiness metric
 	previous := old.Status.GetCondition(v1.IntegrationConditionReady)
 	next := it.Status.GetCondition(v1.IntegrationConditionReady)
@@ -99,7 +99,7 @@ func integrationUpdateFunc(old *v1.Integration, it *v1.Integration) bool {
 	updateIntegrationPhase(it.Name, string(it.Status.Phase))
 	// If traits have changed, the reconciliation loop must kick in as
 	// traits may have impact
-	sameTraits, err := trait.IntegrationsHaveSameTraits(old, it)
+	sameTraits, err := trait.IntegrationsHaveSameTraits(c, old, it)
 	if err != nil {
 		Log.ForIntegration(it).Error(
 			err,
@@ -324,7 +324,7 @@ func add(ctx context.Context, mgr manager.Manager, c client.Client, r reconcile.
 						return false
 					}
 
-					return integrationUpdateFunc(old, it)
+					return integrationUpdateFunc(c, old, it)
 				},
 				DeleteFunc: func(e event.DeleteEvent) bool {
 					// Evaluates to false if the object has been confirmed deleted

--- a/pkg/controller/integration/kits.go
+++ b/pkg/controller/integration/kits.go
@@ -121,11 +121,11 @@ func integrationMatches(ctx context.Context, c client.Client, integration *v1.In
 		return false, err
 	}
 
-	itc, err := trait.NewSpecTraitsOptionsForIntegrationAndPlatform(integration, pl)
+	itc, err := trait.NewSpecTraitsOptionsForIntegrationAndPlatform(c, integration, pl)
 	if err != nil {
 		return false, err
 	}
-	ikc, err := trait.NewSpecTraitsOptionsForIntegrationKit(kit)
+	ikc, err := trait.NewSpecTraitsOptionsForIntegrationKit(c, kit)
 	if err != nil {
 		return false, err
 	}
@@ -170,7 +170,7 @@ func statusMatches(integration *v1.Integration, kit *v1.IntegrationKit, ilog *lo
 }
 
 // kitMatches returns whether the kit matches with the existing target kit.
-func kitMatches(kit *v1.IntegrationKit, target *v1.IntegrationKit) (bool, error) {
+func kitMatches(c client.Client, kit *v1.IntegrationKit, target *v1.IntegrationKit) (bool, error) {
 	version := kit.Status.Version
 	if version == "" {
 		// Defaults with the version that is going to be set during the kit initialization
@@ -184,11 +184,11 @@ func kitMatches(kit *v1.IntegrationKit, target *v1.IntegrationKit) (bool, error)
 	}
 
 	// We cannot have yet the status set
-	c1, err := trait.NewSpecTraitsOptionsForIntegrationKit(kit)
+	c1, err := trait.NewSpecTraitsOptionsForIntegrationKit(c, kit)
 	if err != nil {
 		return false, err
 	}
-	c2, err := trait.NewSpecTraitsOptionsForIntegrationKit(target)
+	c2, err := trait.NewSpecTraitsOptionsForIntegrationKit(c, target)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/integration/kits_test.go
+++ b/pkg/controller/integration/kits_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
+	"github.com/apache/camel-k/v2/pkg/client"
 
 	"github.com/apache/camel-k/v2/pkg/trait"
 	"github.com/apache/camel-k/v2/pkg/util/test"
@@ -279,7 +280,10 @@ func TestHasMatchingTraits_KitNoTraitShouldNotBePicked(t *testing.T) {
 		},
 	}
 
-	ok, err := integrationAndKitHaveSameTraits(integration, kit)
+	c, err := test.NewFakeClient(integration, kit)
+	require.NoError(t, err)
+
+	ok, err := integrationAndKitHaveSameTraits(c, integration, kit)
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
@@ -326,8 +330,9 @@ func TestHasMatchingTraits_KitSameTraitShouldBePicked(t *testing.T) {
 			},
 		},
 	}
-
-	ok, err := integrationAndKitHaveSameTraits(integration, kit)
+	c, err := test.NewFakeClient(integration, kit)
+	require.NoError(t, err)
+	ok, err := integrationAndKitHaveSameTraits(c, integration, kit)
 	require.NoError(t, err)
 	assert.True(t, ok)
 }
@@ -429,12 +434,12 @@ func TestHasNotMatchingSources(t *testing.T) {
 	assert.False(t, hsm2)
 }
 
-func integrationAndKitHaveSameTraits(i1 *v1.Integration, i2 *v1.IntegrationKit) (bool, error) {
-	itOpts, err := trait.NewSpecTraitsOptionsForIntegration(i1)
+func integrationAndKitHaveSameTraits(c client.Client, i1 *v1.Integration, i2 *v1.IntegrationKit) (bool, error) {
+	itOpts, err := trait.NewSpecTraitsOptionsForIntegration(c, i1)
 	if err != nil {
 		return false, err
 	}
-	ikOpts, err := trait.NewSpecTraitsOptionsForIntegrationKit(i2)
+	ikOpts, err := trait.NewSpecTraitsOptionsForIntegrationKit(c, i2)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/integrationkit/monitor.go
+++ b/pkg/controller/integrationkit/monitor.go
@@ -19,9 +19,11 @@ package integrationkit
 
 import (
 	"context"
+	"strings"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/util/digest"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // NewMonitorAction creates a new monitoring handling action for the kit.
@@ -64,5 +66,29 @@ func (action *monitorAction) Handle(ctx context.Context, kit *v1.IntegrationKit)
 		return kit, nil
 	}
 
+	action.checkTraitAnnotationsDeprecatedNotice(kit)
+
 	return nil, nil
+}
+
+// Deprecated: to be removed in future versions, when we won't support any longer trait annotations into IntegrationKits.
+func (action *monitorAction) checkTraitAnnotationsDeprecatedNotice(integrationKit *v1.IntegrationKit) {
+	if integrationKit.Annotations != nil {
+		for k := range integrationKit.Annotations {
+			if strings.HasPrefix(k, v1.TraitAnnotationPrefix) {
+				integrationKit.Status.SetCondition(
+					v1.IntegrationKitConditionType("AnnotationTraitsDeprecated"),
+					corev1.ConditionTrue,
+					"DeprecationNotice",
+					"Annotation traits configuration is deprecated and will be removed soon. Use .spec.traits configuration instead.",
+				)
+
+				action.L.Infof(
+					"WARN: annotation traits configuration is deprecated and will be removed soon. Use .spec.traits configuration for %s integration kit instead.",
+					integrationKit.Name,
+				)
+				return
+			}
+		}
+	}
 }

--- a/pkg/controller/kameletbinding/monitor.go
+++ b/pkg/controller/kameletbinding/monitor.go
@@ -82,7 +82,7 @@ func (action *monitorAction) Handle(ctx context.Context, binding *v1alpha1.Kamel
 	integrationProfileNamespaceChanged := v1.GetIntegrationProfileNamespaceAnnotation(binding) != "" &&
 		(v1.GetIntegrationProfileNamespaceAnnotation(binding) != v1.GetIntegrationProfileNamespaceAnnotation(&it))
 
-	sameTraits, err := trait.IntegrationAndKameletBindingSameTraits(&it, binding)
+	sameTraits, err := trait.IntegrationAndKameletBindingSameTraits(action.client, &it, binding)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/pipe/integration.go
+++ b/pkg/controller/pipe/integration.go
@@ -22,11 +22,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/v2/pkg/trait"
 
 	"github.com/apache/camel-k/v2/pkg/client"
 	"github.com/apache/camel-k/v2/pkg/platform"
@@ -49,6 +51,10 @@ func CreateIntegrationFor(ctx context.Context, c client.Client, binding *v1.Pipe
 	annotations := util.CopyMap(binding.Annotations)
 	// avoid propagating the icon to the integration as it's heavyweight and not needed
 	delete(annotations, v1.AnnotationIcon)
+	traits, err := extractAndDeleteTraits(c, annotations)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal trait annotations %w", err)
+	}
 
 	it := v1.Integration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -80,6 +86,14 @@ func CreateIntegrationFor(ctx context.Context, c client.Client, binding *v1.Pipe
 	// start from the integration spec defined in the binding
 	if binding.Spec.Integration != nil {
 		it.Spec = *binding.Spec.Integration.DeepCopy()
+	}
+
+	if &it.Spec != nil && traits != nil {
+		it.Spec = v1.IntegrationSpec{}
+	}
+
+	if traits != nil {
+		it.Spec.Traits = *traits
 	}
 
 	// Set replicas (or override podspecable value) if present
@@ -208,6 +222,56 @@ func CreateIntegrationFor(ctx context.Context, c client.Client, binding *v1.Pipe
 	it.Spec.Flows = append(it.Spec.Flows, v1.Flow{RawMessage: encodedRoute})
 
 	return &it, nil
+}
+
+// extractAndDeleteTraits will extract the annotation traits into v1.Traits struct, removing from the value from the input map.
+func extractAndDeleteTraits(c client.Client, annotations map[string]string) (*v1.Traits, error) {
+	// structure that will be marshalled into a v1.Traits as it was a kamel run command
+	catalog := trait.NewCatalog(c)
+	traitsPlainParams := []string{}
+	for k, v := range annotations {
+		if strings.HasPrefix(k, v1.TraitAnnotationPrefix) {
+			key := strings.ReplaceAll(k, v1.TraitAnnotationPrefix, "")
+			traitId := strings.Split(key, ".")[0]
+			if err := trait.ValidateTrait(catalog, traitId); err != nil {
+				return nil, err
+			}
+			traitArrayParams := extractAsArray(v)
+			for _, param := range traitArrayParams {
+				traitsPlainParams = append(traitsPlainParams, fmt.Sprintf("%s=%s", key, param))
+			}
+			delete(annotations, k)
+		}
+	}
+	if len(traitsPlainParams) == 0 {
+		return nil, nil
+	}
+	var traits v1.Traits
+	if err := trait.ConfigureTraits(traitsPlainParams, &traits, catalog); err != nil {
+		return nil, err
+	}
+
+	return &traits, nil
+}
+
+// extractTraitValue can detect if the value is an array representation as ["prop1=1", "prop2=2"] and
+// return an array with the values or with the single value passed as a parameter.
+func extractAsArray(value string) []string {
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		arrayValue := []string{}
+		data := value[1 : len(value)-1]
+		vals := strings.Split(data, ",")
+		for _, v := range vals {
+			prop := strings.Trim(v, " ")
+			if strings.HasPrefix(prop, `"`) && strings.HasSuffix(prop, `"`) {
+				prop = prop[1 : len(prop)-1]
+			}
+			arrayValue = append(arrayValue, prop)
+		}
+		return arrayValue
+	}
+
+	return []string{value}
 }
 
 func configureBinding(integration *v1.Integration, bindings ...*bindings.Binding) error {

--- a/pkg/controller/pipe/integration_test.go
+++ b/pkg/controller/pipe/integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestCreateIntegrationForPipe(t *testing.T) {
@@ -186,4 +187,74 @@ func expectedNominalRouteWithDataType(name string) string {
       uri: kamelet:my-source/source
     id: binding
 `
+}
+
+func TestExtractTraitAnnotations(t *testing.T) {
+	client, err := test.NewFakeClient()
+	require.NoError(t, err)
+	annotations := map[string]string{
+		"my-personal-annotation":                                 "hello",
+		v1.TraitAnnotationPrefix + "service.enabled":             "true",
+		v1.TraitAnnotationPrefix + "container.image-pull-policy": "Never",
+		v1.TraitAnnotationPrefix + "camel.runtime-version":       "1.2.3",
+		v1.TraitAnnotationPrefix + "camel.properties":            `["prop1=1", "prop2=2"]`,
+		v1.TraitAnnotationPrefix + "environment.vars":            `["env1=1"]`,
+	}
+	traits, err := extractAndDeleteTraits(client, annotations)
+	require.NoError(t, err)
+	assert.Equal(t, pointer.Bool(true), traits.Service.Enabled)
+	assert.Equal(t, corev1.PullNever, traits.Container.ImagePullPolicy)
+	assert.Equal(t, "1.2.3", traits.Camel.RuntimeVersion)
+	assert.Equal(t, []string{"prop1=1", "prop2=2"}, traits.Camel.Properties)
+	assert.Equal(t, []string{"env1=1"}, traits.Environment.Vars)
+	assert.Len(t, annotations, 1)
+	assert.Empty(t, annotations[v1.TraitAnnotationPrefix+"service.enabled"])
+	assert.Empty(t, annotations[v1.TraitAnnotationPrefix+"container.image-pull-policy"])
+	assert.Empty(t, annotations[v1.TraitAnnotationPrefix+"camel.runtime-version"])
+	assert.Empty(t, annotations[v1.TraitAnnotationPrefix+"camel.properties"])
+	assert.Empty(t, annotations[v1.TraitAnnotationPrefix+"environment.vars"])
+	assert.Equal(t, "hello", annotations["my-personal-annotation"])
+}
+
+func TestExtractTraitAnnotationsError(t *testing.T) {
+	client, err := test.NewFakeClient()
+	require.NoError(t, err)
+	annotations := map[string]string{
+		"my-personal-annotation":                       "hello",
+		v1.TraitAnnotationPrefix + "servicefake.bogus": "true",
+	}
+	traits, err := extractAndDeleteTraits(client, annotations)
+	require.Error(t, err)
+	assert.Equal(t, "trait servicefake does not exist in catalog", err.Error())
+	assert.Nil(t, traits)
+	assert.Len(t, annotations, 2)
+}
+
+func TestExtractTraitAnnotationsEmpty(t *testing.T) {
+	client, err := test.NewFakeClient()
+	require.NoError(t, err)
+	annotations := map[string]string{
+		"my-personal-annotation": "hello",
+	}
+	traits, err := extractAndDeleteTraits(client, annotations)
+	require.NoError(t, err)
+	assert.Nil(t, traits)
+	assert.Len(t, annotations, 1)
+}
+
+func TestCreateIntegrationTraitsForPipeWithTraitAnnotations(t *testing.T) {
+	client, err := test.NewFakeClient()
+	require.NoError(t, err)
+
+	pipe := nominalPipe("my-pipe")
+	pipe.Annotations[v1.TraitAnnotationPrefix+"service.enabled"] = "true"
+
+	it, err := CreateIntegrationFor(context.TODO(), client, &pipe)
+	require.NoError(t, err)
+	assert.Equal(t, "my-pipe", it.Name)
+	assert.Equal(t, "default", it.Namespace)
+	assert.Equal(t, map[string]string{
+		"my-annotation": "my-annotation-val",
+	}, it.Annotations)
+	assert.Equal(t, pointer.Bool(true), it.Spec.Traits.Service.Enabled)
 }

--- a/pkg/controller/pipe/monitor.go
+++ b/pkg/controller/pipe/monitor.go
@@ -72,7 +72,7 @@ func (action *monitorAction) Handle(ctx context.Context, pipe *v1.Pipe) (*v1.Pip
 	integrationProfileNamespaceChanged := v1.GetIntegrationProfileNamespaceAnnotation(pipe) != "" &&
 		(v1.GetIntegrationProfileNamespaceAnnotation(pipe) != v1.GetIntegrationProfileNamespaceAnnotation(&it))
 
-	sameTraits, err := trait.IntegrationAndPipeSameTraits(&it, pipe)
+	sameTraits, err := trait.IntegrationAndPipeSameTraits(action.client, &it, pipe)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/pipe/monitor_test.go
+++ b/pkg/controller/pipe/monitor_test.go
@@ -312,8 +312,56 @@ func TestPipeIntegrationCreatingFromPipeCreatingPhase(t *testing.T) {
 	// We calculate the integration the same way it does the operator
 	// as we don't expect it to change in this test.
 	it, err := CreateIntegrationFor(context.TODO(), c, pipe)
-	it.Status.Phase = v1.IntegrationPhaseBuildingKit
 	require.NoError(t, err)
+	it.Status.Phase = v1.IntegrationPhaseBuildingKit
+	c, err = test.NewFakeClient(pipe, it)
+	require.NoError(t, err)
+
+	a := NewMonitorAction()
+	a.InjectLogger(log.Log)
+	a.InjectClient(c)
+	assert.Equal(t, "monitor", a.Name())
+	assert.True(t, a.CanHandle(pipe))
+	handledPipe, err := a.Handle(context.TODO(), pipe)
+	require.NoError(t, err)
+	assert.Equal(t, v1.PipePhaseCreating, handledPipe.Status.Phase)
+	assert.Equal(t, corev1.ConditionFalse, handledPipe.Status.GetCondition(v1.PipeConditionReady).Status)
+	assert.Equal(t, "Integration \"my-pipe\" is in \"Creating\" phase", handledPipe.Status.GetCondition(v1.PipeConditionReady).Message)
+}
+
+func TestPipeIntegrationPipeTraitAnnotations(t *testing.T) {
+	pipe := &v1.Pipe{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       v1.PipeKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "my-pipe",
+			Annotations: map[string]string{
+				"trait.camel.apache.org/camel.runtime-version": "1.2.3",
+			},
+		},
+		Spec: v1.PipeSpec{
+			Source: v1.Endpoint{
+				URI: pointer.String("timer:tick"),
+			},
+			Sink: v1.Endpoint{
+				URI: pointer.String("log:info"),
+			},
+		},
+		Status: v1.PipeStatus{
+			Phase: v1.PipePhaseCreating,
+		},
+	}
+
+	c, err := test.NewFakeClient(pipe)
+	require.NoError(t, err)
+	// We calculate the integration the same way it does the operator
+	// as we don't expect it to change in this test.
+	it, err := CreateIntegrationFor(context.TODO(), c, pipe)
+	require.NoError(t, err)
+	it.Status.Phase = v1.IntegrationPhaseBuildingKit
 	c, err = test.NewFakeClient(pipe, it)
 	require.NoError(t, err)
 

--- a/pkg/controller/pipe/pipe_controller.go
+++ b/pkg/controller/pipe/pipe_controller.go
@@ -47,7 +47,7 @@ import (
 // Add creates a new Pipe Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(ctx context.Context, mgr manager.Manager, c client.Client) error {
-	return add(mgr, newReconciler(mgr, c))
+	return add(mgr, newReconciler(mgr, c), c)
 }
 
 func newReconciler(mgr manager.Manager, c client.Client) reconcile.Reconciler {
@@ -65,14 +65,14 @@ func newReconciler(mgr manager.Manager, c client.Client) reconcile.Reconciler {
 	)
 }
 
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
-	c, err := controller.New("pipe-controller", mgr, controller.Options{Reconciler: r})
+func add(mgr manager.Manager, r reconcile.Reconciler, c client.Client) error {
+	ctrl, err := controller.New("pipe-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}
 
 	// Watch for changes to primary resource Pipe
-	err = c.Watch(source.Kind(mgr.GetCache(), &v1.Pipe{}),
+	err = ctrl.Watch(source.Kind(mgr.GetCache(), &v1.Pipe{}),
 		&handler.EnqueueRequestForObject{},
 		platform.FilteringFuncs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
@@ -87,7 +87,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 				// If traits have changed, the reconciliation loop must kick in as
 				// traits may have impact
-				sameTraits, err := trait.PipesHaveSameTraits(oldPipe, newPipe)
+				sameTraits, err := trait.PipesHaveSameTraits(c, oldPipe, newPipe)
 				if err != nil {
 					Log.ForPipe(newPipe).Error(
 						err,
@@ -114,7 +114,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch Integration to propagate changes downstream
-	err = c.Watch(source.Kind(mgr.GetCache(), &v1.Integration{}),
+	err = ctrl.Watch(source.Kind(mgr.GetCache(), &v1.Integration{}),
 		handler.EnqueueRequestForOwner(
 			mgr.GetScheme(),
 			mgr.GetRESTMapper(),

--- a/pkg/trait/quarkus.go
+++ b/pkg/trait/quarkus.go
@@ -20,7 +20,6 @@ package trait
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/rs/xid"
 
@@ -275,11 +274,6 @@ func (t *quarkusTrait) newIntegrationKit(e *Environment, packageType quarkusPack
 			// set integration profile namespace to the integration namespace.
 			// this is because the kit may live in another namespace and needs to resolve the integration profile from the integration namespace.
 			v1.SetAnnotation(&kit.ObjectMeta, v1.IntegrationProfileNamespaceAnnotation, e.Integration.Namespace)
-		}
-	}
-	for k, v := range integration.Annotations {
-		if strings.HasPrefix(k, v1.TraitAnnotationPrefix) {
-			v1.SetAnnotation(&kit.ObjectMeta, k, v)
 		}
 	}
 	operatorID := defaults.OperatorID()

--- a/pkg/trait/quarkus_test.go
+++ b/pkg/trait/quarkus_test.go
@@ -70,25 +70,6 @@ func TestApplyQuarkusTraitDefaultKitLayout(t *testing.T) {
 	assert.Equal(t, environment.IntegrationKits[0].Labels[v1.IntegrationKitLayoutLabel], v1.IntegrationKitLayoutFastJar)
 }
 
-func TestApplyQuarkusTraitAnnotationKitConfiguration(t *testing.T) {
-	quarkusTrait, environment := createNominalQuarkusTest()
-	environment.Integration.Status.Phase = v1.IntegrationPhaseBuildingKit
-
-	v1.SetAnnotation(&environment.Integration.ObjectMeta, v1.TraitAnnotationPrefix+"quarkus.foo", "camel-k")
-
-	configured, condition, err := quarkusTrait.Configure(environment)
-	assert.True(t, configured)
-	require.NoError(t, err)
-	assert.Nil(t, condition)
-
-	err = quarkusTrait.Apply(environment)
-	require.NoError(t, err)
-	assert.Len(t, environment.IntegrationKits, 1)
-	assert.Equal(t, v1.IntegrationKitLayoutFastJar, environment.IntegrationKits[0].Labels[v1.IntegrationKitLayoutLabel])
-	assert.Equal(t, "camel-k", environment.IntegrationKits[0].Annotations[v1.TraitAnnotationPrefix+"quarkus.foo"])
-
-}
-
 func TestQuarkusTraitBuildModeOrder(t *testing.T) {
 	quarkusTrait, environment := createNominalQuarkusTest()
 	quarkusTrait.Modes = []traitv1.QuarkusMode{traitv1.NativeQuarkusMode, traitv1.JvmQuarkusMode}

--- a/pkg/trait/trait_configure.go
+++ b/pkg/trait/trait_configure.go
@@ -36,6 +36,7 @@ func (c *Catalog) Configure(env *Environment) error {
 		if err := c.configureTraits(env.Platform.Status.Traits); err != nil {
 			return err
 		}
+		// Deprecated: to be removed in future version
 		if err := c.configureTraitsFromAnnotations(env.Platform.Annotations); err != nil {
 			return err
 		}
@@ -49,6 +50,7 @@ func (c *Catalog) Configure(env *Environment) error {
 		if err := c.configureTraits(env.IntegrationKit.Spec.Traits); err != nil {
 			return err
 		}
+		// Deprecated: to be removed in future version
 		if err := c.configureTraitsFromAnnotations(env.IntegrationKit.Annotations); err != nil {
 			return err
 		}
@@ -57,6 +59,7 @@ func (c *Catalog) Configure(env *Environment) error {
 		if err := c.configureTraits(env.Integration.Spec.Traits); err != nil {
 			return err
 		}
+		// Deprecated: to be removed in future version
 		if err := c.configureTraitsFromAnnotations(env.Integration.Annotations); err != nil {
 			return err
 		}
@@ -117,6 +120,7 @@ func decodeTrait(in map[string]interface{}, target Trait) error {
 	return json.Unmarshal(data, target)
 }
 
+// Deprecated: to be removed in future versions.
 func (c *Catalog) configureTraitsFromAnnotations(annotations map[string]string) error {
 	options := make(map[string]map[string]interface{}, len(annotations))
 	for k, v := range annotations {
@@ -154,6 +158,7 @@ func (c *Catalog) configureTraitsFromAnnotations(annotations map[string]string) 
 	return c.configureFromOptions(options)
 }
 
+// Deprecated: to be removed in future versions.
 func (c *Catalog) configureFromOptions(traits map[string]map[string]interface{}) error {
 	for id, config := range traits {
 		t := c.GetTrait(id)
@@ -167,6 +172,7 @@ func (c *Catalog) configureFromOptions(traits map[string]map[string]interface{})
 	return nil
 }
 
+// Deprecated: to be removed in future versions.
 func configureTrait(id string, config map[string]interface{}, trait interface{}) error {
 	md := mapstructure.Metadata{}
 

--- a/pkg/trait/trait_support.go
+++ b/pkg/trait/trait_support.go
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package trait
 
 import (
 	"encoding/json"
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/v2/pkg/trait"
 	"github.com/apache/camel-k/v2/pkg/util"
 	"github.com/mitchellh/mapstructure"
 )
@@ -38,18 +37,26 @@ var knownAddons = []string{"keda", "master", "strimzi", "3scale", "tracing"}
 
 var traitConfigRegexp = regexp.MustCompile(`^([a-z0-9-]+)((?:\.[a-z0-9-]+)(?:\[[0-9]+\]|\..+)*)=(.*)$`)
 
-func validateTraits(catalog *trait.Catalog, traits []string) error {
+func ValidateTrait(catalog *Catalog, trait string) error {
+	tr := catalog.GetTrait(trait)
+	if tr == nil {
+		return fmt.Errorf("trait %s does not exist in catalog", trait)
+	}
+
+	return nil
+}
+
+func ValidateTraits(catalog *Catalog, traits []string) error {
 	for _, t := range traits {
-		tr := catalog.GetTrait(t)
-		if tr == nil {
-			return fmt.Errorf("trait %s does not exist in catalog", t)
+		if err := ValidateTrait(catalog, t); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-func configureTraits(options []string, traits interface{}, catalog trait.Finder) error {
+func ConfigureTraits(options []string, traits interface{}, catalog Finder) error {
 	config, err := optionsToMap(options)
 	if err != nil {
 		return err
@@ -144,7 +151,7 @@ func optionsToMap(options []string) (optionMap, error) {
 	return optionMap, nil
 }
 
-func configureAddons(config optionMap, traits interface{}, catalog trait.Finder) error {
+func configureAddons(config optionMap, traits interface{}, catalog Finder) error {
 	// Addon traits require raw message mapping
 	addons := make(map[string]v1.AddonTrait)
 	for id, props := range config {

--- a/pkg/trait/util_test.go
+++ b/pkg/trait/util_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
+	"github.com/apache/camel-k/v2/pkg/util/test"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -174,6 +175,8 @@ func TestToTrait(t *testing.T) {
 }
 
 func TestSameTraits(t *testing.T) {
+	c, err := test.NewFakeClient()
+	require.NoError(t, err)
 	t.Run("empty traits", func(t *testing.T) {
 		oldKlb := &v1.Pipe{
 			Spec: v1.PipeSpec{
@@ -190,7 +193,7 @@ func TestSameTraits(t *testing.T) {
 			},
 		}
 
-		ok, err := PipesHaveSameTraits(oldKlb, newKlb)
+		ok, err := PipesHaveSameTraits(c, oldKlb, newKlb)
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})
@@ -219,7 +222,7 @@ func TestSameTraits(t *testing.T) {
 			},
 		}
 
-		ok, err := PipesHaveSameTraits(oldKlb, newKlb)
+		ok, err := PipesHaveSameTraits(c, oldKlb, newKlb)
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})
@@ -248,7 +251,7 @@ func TestSameTraits(t *testing.T) {
 			},
 		}
 
-		ok, err := PipesHaveSameTraits(oldKlb, newKlb)
+		ok, err := PipesHaveSameTraits(c, oldKlb, newKlb)
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
@@ -273,7 +276,7 @@ func TestSameTraits(t *testing.T) {
 			},
 		}
 
-		ok, err := PipesHaveSameTraits(oldKlb, newKlb)
+		ok, err := PipesHaveSameTraits(c, oldKlb, newKlb)
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})
@@ -294,7 +297,7 @@ func TestSameTraits(t *testing.T) {
 			},
 		}
 
-		ok, err := PipesHaveSameTraits(oldKlb, newKlb)
+		ok, err := PipesHaveSameTraits(c, oldKlb, newKlb)
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})
@@ -319,7 +322,7 @@ func TestSameTraits(t *testing.T) {
 			},
 		}
 
-		ok, err := PipesHaveSameTraits(oldKlb, newKlb)
+		ok, err := PipesHaveSameTraits(c, oldKlb, newKlb)
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
@@ -340,7 +343,7 @@ func TestSameTraits(t *testing.T) {
 			},
 		}
 
-		ok, err := PipesHaveSameTraits(oldKlb, newKlb)
+		ok, err := PipesHaveSameTraits(c, oldKlb, newKlb)
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
@@ -392,46 +395,28 @@ func TestHasMathchingTraitsMissing(t *testing.T) {
 	assert.True(t, b1)
 }
 
-func TestFromAnnotationsPlain(t *testing.T) {
-	meta := metav1.ObjectMeta{
-		Annotations: map[string]string{
-			"trait.camel.apache.org/trait.prop1": "hello1",
-			"trait.camel.apache.org/trait.prop2": "hello2",
+func TestIntegrationAndPipeSameTraits(t *testing.T) {
+	pipe := &v1.Pipe{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"trait.camel.apache.org/camel.runtime-version": "1.2.3",
+			},
 		},
 	}
-	opt, err := FromAnnotations(&meta)
-	require.NoError(t, err)
-	tt, ok := opt.Get("trait")
-	assert.True(t, ok)
-	assert.Equal(t, "hello1", tt["prop1"])
-	assert.Equal(t, "hello2", tt["prop2"])
-}
 
-func TestFromAnnotationsArray(t *testing.T) {
-	meta := metav1.ObjectMeta{
-		Annotations: map[string]string{
-			"trait.camel.apache.org/trait.prop1": "[hello,world]",
-			// The func should trim empty spaces as well
-			"trait.camel.apache.org/trait.prop2": "[\"hello=1\", \"world=2\"]",
+	integration := &v1.Integration{
+		Spec: v1.IntegrationSpec{
+			Traits: v1.Traits{
+				Camel: &traitv1.CamelTrait{
+					RuntimeVersion: "1.2.3",
+				},
+			},
 		},
 	}
-	opt, err := FromAnnotations(&meta)
+	c, err := test.NewFakeClient(pipe, integration)
 	require.NoError(t, err)
-	tt, ok := opt.Get("trait")
-	assert.True(t, ok)
-	assert.Equal(t, []string{"hello", "world"}, tt["prop1"])
-	assert.Equal(t, []string{"\"hello=1\"", "\"world=2\""}, tt["prop2"])
-}
 
-func TestFromAnnotationsArrayEmpty(t *testing.T) {
-	meta := metav1.ObjectMeta{
-		Annotations: map[string]string{
-			"trait.camel.apache.org/trait.prop": "[]",
-		},
-	}
-	opt, err := FromAnnotations(&meta)
+	result, err := IntegrationAndPipeSameTraits(c, integration, pipe)
 	require.NoError(t, err)
-	tt, ok := opt.Get("trait")
-	assert.True(t, ok)
-	assert.Equal(t, []string{}, tt["prop"])
+	assert.True(t, result)
 }

--- a/pkg/util/digest/digest.go
+++ b/pkg/util/digest/digest.go
@@ -336,6 +336,7 @@ func sortedTraitsMapKeys(m map[string]map[string]interface{}) []string {
 	return res
 }
 
+// Deprecated: to be removed in future versions.
 func sortedTraitAnnotationsKeys(it *v1.Integration) []string {
 	res := make([]string, 0, len(it.Annotations))
 	for k := range it.Annotations {


### PR DESCRIPTION
<!-- Description -->

This PR is fixing #5620 and it's adding the proper support to compare traits coming from the spec with specs coming from the annotations. With the PR, the Pipe is in charge to transform the annotations into `.spec.traits` directly, in order to let the Integration to know what to do with them (ie, transferring to the Kit only those that it knows they must be transferred).

Beside that, I've introduced a deprecation notice for supporting trait annotations in Integration, IntegrationKit and IntegrationPlatform as it does not make sense to support both configurations. They will be removed in future versions.

As specified in the code comment, the introduction of certain signature functions change is required to properly support the feature (although deprecated) and will be changed back when we will remove the support for this feature.

Closes #5620 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(traits): annotations refactoring 
```
