### PR TITLE
fix(e2e): always build bundle and set local config

### DIFF
--- a/.github/actions/kamel-build/action.yml
+++ b/.github/actions/kamel-build/action.yml
@@ -55,13 +55,9 @@ runs:
         image-namespace: ${{ inputs.image-namespace }}
         make-rules: ${{ inputs.make-rules }}
 
-    #
-    # By default do not build the image bundle
-    #
     - id: build-kamel-bundle
       name: Build Kamel Metadata Bundle
       uses: ./.github/actions/kamel-build-bundle
-      if: ${{ inputs.build-bundle == 'true' }}
       with:
         image-registry-push-host: ${{ inputs.image-registry-push-host }}
         image-registry-pull-host: ${{ inputs.image-registry-pull-host }}

--- a/e2e/install/helm/setup_test.go
+++ b/e2e/install/helm/setup_test.go
@@ -38,11 +38,13 @@ import (
 )
 
 func TestHelmInstallRunUninstall(t *testing.T) {
+	// Ensure no CRDs are already installed
+	ctx := TestContext()
+	Cleanup(t, ctx)
+	KAMEL_INSTALL_REGISTRY := os.Getenv("KAMEL_INSTALL_REGISTRY")
+
 	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
-		// Ensure no CRDs are already installed
-		Cleanup(t, ctx)
-		KAMEL_INSTALL_REGISTRY := os.Getenv("KAMEL_INSTALL_REGISTRY")
-		CheckLocalInstallRegistry(t, g)
+		g.Expect(KAMEL_INSTALL_REGISTRY).NotTo(Equal(""))
 		os.Setenv("CAMEL_K_TEST_MAKE_DIR", "../../../")
 		ExpectExecSucceed(t, g, Make(t, "release-helm"))
 		ExpectExecSucceed(t, g,

--- a/e2e/install/kustomize/setup_test.go
+++ b/e2e/install/kustomize/setup_test.go
@@ -40,18 +40,16 @@ import (
 )
 
 func TestKustomizeNamespaced(t *testing.T) {
-	g := NewWithT(t)
-	CheckLocalInstallRegistry(t, g)
 	// TODO, likely we need to adjust this test with a Kustomize overlay for Openshift
 	// which would not require the registry setting
-	registry := os.Getenv("KIND_REGISTRY")
+	KAMEL_INSTALL_REGISTRY := os.Getenv("KAMEL_INSTALL_REGISTRY")
 	kustomizeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	ctx := TestContext()
-	g.Expect(registry).NotTo(Equal(""))
 	// Ensure no CRDs are already installed
 	Cleanup(t, ctx)
 
 	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		g.Expect(KAMEL_INSTALL_REGISTRY).NotTo(Equal(""))
 		// We must change a few values in the Kustomize config
 		ExpectExecSucceed(t, g,
 			exec.Command(
@@ -70,7 +68,7 @@ func TestKustomizeNamespaced(t *testing.T) {
 			exec.Command(
 				"sed",
 				"-i",
-				fmt.Sprintf("s/address: .*/address: %s/", registry),
+				fmt.Sprintf("s/address: .*/address: %s/", KAMEL_INSTALL_REGISTRY),
 				fmt.Sprintf("%s/overlays/platform/integration-platform.yaml", kustomizeDir),
 			))
 		ExpectExecSucceed(t, g, Kubectl(
@@ -100,7 +98,7 @@ func TestKustomizeNamespaced(t *testing.T) {
 		)
 		g.Eventually(Platform(t, ctx, ns)).ShouldNot(BeNil())
 		g.Eventually(PlatformHas(t, ctx, ns, func(pl *v1.IntegrationPlatform) bool {
-			return pl.Status.Build.Registry.Address == registry
+			return pl.Status.Build.Registry.Address == KAMEL_INSTALL_REGISTRY
 		}), TestTimeoutShort).Should(BeTrue())
 
 		// Test a simple integration is running
@@ -139,18 +137,16 @@ func TestKustomizeNamespaced(t *testing.T) {
 }
 
 func TestKustomizeDescoped(t *testing.T) {
-	g := NewWithT(t)
-	CheckLocalInstallRegistry(t, g)
 	// TODO, likely we need to adjust this test with a Kustomize overlay for Openshift
 	// which would not require the registry setting
-	registry := os.Getenv("KIND_REGISTRY")
+	KAMEL_INSTALL_REGISTRY := os.Getenv("KAMEL_INSTALL_REGISTRY")
 	kustomizeDir := testutil.MakeTempCopyDir(t, "../../../install")
 	ctx := TestContext()
-	g.Expect(registry).NotTo(Equal(""))
 	// Ensure no CRDs are already installed
 	Cleanup(t, ctx)
 
 	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		g.Expect(KAMEL_INSTALL_REGISTRY).NotTo(Equal(""))
 		// We must change a few values in the Kustomize config
 		ExpectExecSucceed(t, g,
 			exec.Command(
@@ -169,7 +165,7 @@ func TestKustomizeDescoped(t *testing.T) {
 			exec.Command(
 				"sed",
 				"-i",
-				fmt.Sprintf("s/address: .*/address: %s/", registry),
+				fmt.Sprintf("s/address: .*/address: %s/", KAMEL_INSTALL_REGISTRY),
 				fmt.Sprintf("%s/overlays/platform/integration-platform.yaml", kustomizeDir),
 			))
 		ExpectExecSucceed(t, g, Kubectl(

--- a/e2e/install/upgrade/kustomize_upgrade_test.go
+++ b/e2e/install/upgrade/kustomize_upgrade_test.go
@@ -91,8 +91,8 @@ func TestKustomizeUpgrade(t *testing.T) {
 
 			// Upgrade the operator by installing the current version
 			registry := os.Getenv("KIND_REGISTRY")
-			kustomizeDir := testutil.MakeTempCopyDir(t, "../../../install")
 			g.Expect(registry).NotTo(Equal(""))
+			kustomizeDir := testutil.MakeTempCopyDir(t, "../../../install")
 			// We must change a few values in the Kustomize config
 			ExpectExecSucceed(t, g,
 				exec.Command(

--- a/script/Makefile
+++ b/script/Makefile
@@ -322,7 +322,7 @@ test-install: do-build
 	FAILED=0; STAGING_RUNTIME_REPO="$(STAGING_RUNTIME_REPO)"; \
 	go test -timeout 40m -v ./e2e/install/cli -tags=integration $(TEST_INSTALL_RUN) $(GOTESTFMT) || ((FAILED++)); \
 	go test -timeout 40m -v ./e2e/install/kustomize -tags=integration $(TEST_INSTALL_RUN) $(GOTESTFMT) || ((FAILED++)); \
-	go test -timeout 40m -v ./e2e/install/helm -tags=integration $(TEST_INSTALL_RUN) $(GOTESTFMT) || ((FAILED++)); \
+	go test -timeout 60m -v ./e2e/install/helm -tags=integration $(TEST_INSTALL_RUN) $(GOTESTFMT) || ((FAILED++)); \
 	exit $${FAILED}
 
 #
@@ -767,7 +767,7 @@ $(GOIMPORT): $(LOCALBIN)
 #####
 
 KUSTOMIZE_DIR = "install/overlays/kubernetes/descoped"
-MINIKUBE_REGISTRY = "$(shell kubectl -n kube-system get service registry -o jsonpath='{.spec.clusterIP}')"
+MINIKUBE_REGISTRY = "$(shell kubectl -n kube-system get service registry -o jsonpath='{.spec.clusterIP}' 2> /dev/null)"
 DEFAULT_NS = "camel-k"
 
 .PHONY: install install-k8s-global install-k8s-ns install-openshift-global install-openshift-ns


### PR DESCRIPTION
Closes #5632

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): always build bundle and set local config
```
