### PR TITLE
feat(#5121): adding timeZone property to the Cron trait spec

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -6646,6 +6646,13 @@ string
 The CronJob schedule for the whole integration. If multiple routes are declared, they must have the same schedule for this
 mechanism to work correctly.
 
+|`timeZone` +
+string
+|
+
+
+The timezone that the CronJob will run on
+
 |`components` +
 string
 |

--- a/docs/modules/traits/pages/cron.adoc
+++ b/docs/modules/traits/pages/cron.adoc
@@ -49,6 +49,10 @@ The following configuration options are available:
 | The CronJob schedule for the whole integration. If multiple routes are declared, they must have the same schedule for this
 mechanism to work correctly.
 
+| cron.timeZone
+| string
+| The timezone that the CronJob will run on
+
 | cron.components
 | string
 | A comma separated list of the Camel components that need to be customized in order for them to work when the schedule is triggered externally by Kubernetes.

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -854,6 +854,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait
@@ -2883,6 +2886,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait

--- a/helm/camel-k/crds/crd-integration-profile.yaml
+++ b/helm/camel-k/crds/crd-integration-profile.yaml
@@ -731,6 +731,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait
@@ -2643,6 +2646,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -6795,6 +6795,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -7079,6 +7079,9 @@ spec:
                               jobs executions will be counted as failed ones.
                             format: int64
                             type: integer
+                          timeZone:
+                            description: The timezone that the CronJob will run on
+                            type: string
                         type: object
                       dependencies:
                         description: The configuration of Dependencies trait

--- a/helm/camel-k/crds/crd-pipe.yaml
+++ b/helm/camel-k/crds/crd-pipe.yaml
@@ -7077,6 +7077,9 @@ spec:
                               jobs executions will be counted as failed ones.
                             format: int64
                             type: integer
+                          timeZone:
+                            description: The timezone that the CronJob will run on
+                            type: string
                         type: object
                       dependencies:
                         description: The configuration of Dependencies trait

--- a/pkg/apis/camel/v1/trait/cron.go
+++ b/pkg/apis/camel/v1/trait/cron.go
@@ -42,6 +42,8 @@ type CronTrait struct {
 	// The CronJob schedule for the whole integration. If multiple routes are declared, they must have the same schedule for this
 	// mechanism to work correctly.
 	Schedule string `property:"schedule" json:"schedule,omitempty"`
+	// The timezone that the CronJob will run on
+	TimeZone *string `property:"timeZone" json:"timeZone,omitempty"`
 	// A comma separated list of the Camel components that need to be customized in order for them to work when the schedule is triggered externally by Kubernetes.
 	// A specific customizer is activated for each specified component. E.g. for the `timer` component, the `cron-timer` customizer is
 	// activated (it's present in the `org.apache.camel.k:camel-k-cron` library).

--- a/pkg/apis/camel/v1/trait/zz_generated.deepcopy.go
+++ b/pkg/apis/camel/v1/trait/zz_generated.deepcopy.go
@@ -228,6 +228,11 @@ func (in *ContainerTrait) DeepCopy() *ContainerTrait {
 func (in *CronTrait) DeepCopyInto(out *CronTrait) {
 	*out = *in
 	in.Trait.DeepCopyInto(&out.Trait)
+	if in.TimeZone != nil {
+		in, out := &in.TimeZone, &out.TimeZone
+		*out = new(string)
+		**out = **in
+	}
 	if in.Fallback != nil {
 		in, out := &in.Fallback, &out.Fallback
 		*out = new(bool)

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -854,6 +854,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait
@@ -2883,6 +2886,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -731,6 +731,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait
@@ -2643,6 +2646,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -6795,6 +6795,9 @@ spec:
                           jobs executions will be counted as failed ones.
                         format: int64
                         type: integer
+                      timeZone:
+                        description: The timezone that the CronJob will run on
+                        type: string
                     type: object
                   dependencies:
                     description: The configuration of Dependencies trait

--- a/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
@@ -7079,6 +7079,9 @@ spec:
                               jobs executions will be counted as failed ones.
                             format: int64
                             type: integer
+                          timeZone:
+                            description: The timezone that the CronJob will run on
+                            type: string
                         type: object
                       dependencies:
                         description: The configuration of Dependencies trait

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -7077,6 +7077,9 @@ spec:
                               jobs executions will be counted as failed ones.
                             format: int64
                             type: integer
+                          timeZone:
+                            description: The timezone that the CronJob will run on
+                            type: string
                         type: object
                       dependencies:
                         description: The configuration of Dependencies trait

--- a/pkg/trait/cron.go
+++ b/pkg/trait/cron.go
@@ -242,7 +242,6 @@ func (t *cronTrait) getCronJobFor(e *Environment) *batchv1.CronJob {
 	if t.BackoffLimit != nil {
 		backoffLimit = *t.BackoffLimit
 	}
-
 	cronjob := batchv1.CronJob{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "CronJob",
@@ -258,6 +257,7 @@ func (t *cronTrait) getCronJobFor(e *Environment) *batchv1.CronJob {
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule:                t.Schedule,
+			TimeZone:                t.TimeZone,
 			ConcurrencyPolicy:       batchv1.ConcurrencyPolicy(t.ConcurrencyPolicy),
 			StartingDeadlineSeconds: t.StartingDeadlineSeconds,
 			JobTemplate: batchv1.JobTemplateSpec{

--- a/pkg/trait/cron_test.go
+++ b/pkg/trait/cron_test.go
@@ -635,4 +635,94 @@ func TestCronWithBackoffLimit(t *testing.T) {
 
 	assert.NotNil(t, cronJob.Spec.JobTemplate.Spec.BackoffLimit)
 	assert.EqualValues(t, *cronJob.Spec.JobTemplate.Spec.BackoffLimit, 5)
+
+	assert.Nil(t, cronJob.Spec.TimeZone)
+}
+
+func TestCronWithTimeZone(t *testing.T) {
+	catalog, err := camel.DefaultCatalog()
+	require.NoError(t, err)
+
+	client, _ := test.NewFakeClient()
+	traitCatalog := NewCatalog(nil)
+
+	timeZone := "America/Sao_Paulo"
+
+	environment := Environment{
+		CamelCatalog: catalog,
+		Catalog:      traitCatalog,
+		Client:       client,
+		Integration: &v1.Integration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "ns",
+			},
+			Status: v1.IntegrationStatus{
+				Phase: v1.IntegrationPhaseDeploying,
+			},
+			Spec: v1.IntegrationSpec{
+				Sources: []v1.SourceSpec{
+					{
+						DataSpec: v1.DataSpec{
+							Name:    "routes.java",
+							Content: `from("cron:tab?schedule=0 0/2 * * ?").to("log:test")`,
+						},
+						Language: v1.LanguageJavaSource,
+					},
+				},
+				Traits: v1.Traits{
+					Cron: &traitv1.CronTrait{
+						TimeZone: &timeZone,
+					},
+				},
+			},
+		},
+		IntegrationKit: &v1.IntegrationKit{
+			Status: v1.IntegrationKitStatus{
+				Phase: v1.IntegrationKitPhaseReady,
+			},
+		},
+		Platform: &v1.IntegrationPlatform{
+			Spec: v1.IntegrationPlatformSpec{
+				Build: v1.IntegrationPlatformBuildSpec{
+					RuntimeVersion: catalog.Runtime.Version,
+				},
+			},
+			Status: v1.IntegrationPlatformStatus{
+				Phase: v1.IntegrationPlatformPhaseReady,
+			},
+		},
+		EnvVars:        make([]corev1.EnvVar, 0),
+		ExecutedTraits: make([]Trait, 0),
+		Resources:      kubernetes.NewCollection(),
+	}
+	environment.Platform.ResyncStatusFullConfig()
+
+	c, err := NewFakeClient("ns")
+	require.NoError(t, err)
+
+	tc := NewCatalog(c)
+
+	expectedCondition := NewIntegrationCondition(
+		"Deployment",
+		v1.IntegrationConditionDeploymentAvailable,
+		corev1.ConditionFalse,
+		"DeploymentAvailable",
+		"controller strategy: cron-job",
+	)
+	conditions, err := tc.apply(&environment)
+	require.NoError(t, err)
+	assert.Contains(t, conditions, expectedCondition)
+	assert.NotEmpty(t, environment.ExecutedTraits)
+
+	ct, _ := environment.GetTrait("cron").(*cronTrait)
+	assert.NotNil(t, ct)
+	assert.Nil(t, ct.Fallback)
+	assert.Contains(t, environment.Interceptors, "cron")
+
+	cronJob := environment.Resources.GetCronJob(func(job *batchv1.CronJob) bool { return true })
+	assert.NotNil(t, cronJob)
+
+	assert.NotNil(t, cronJob.Spec.TimeZone)
+	assert.EqualValues(t, *cronJob.Spec.TimeZone, "America/Sao_Paulo")
 }


### PR DESCRIPTION
<!-- Description -->



closes #5121 
<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat: Added support for timezone configuration at the cron trait.
```
