### PR TITLE
feat: dependencies default order strategy

### DIFF
--- a/e2e/common/misc/rest_test.go
+++ b/e2e/common/misc/rest_test.go
@@ -62,7 +62,7 @@ func TestRunRest(t *testing.T) {
 				name := RandomizedSuffixName("Peter")
 				route := Route(t, ctx, ns, "rest-consumer")
 				g.Eventually(route, TestTimeoutShort).ShouldNot(BeNil())
-				g.Eventually(RouteStatus(t, ctx, ns, "rest-consumer"), TestTimeoutMedium).Should(Equal("True"))
+				g.Eventually(RouteStatus(t, ctx, ns, "rest-consumer")).Should(Equal("True"))
 				url := fmt.Sprintf("http://%s/customers/%s", route().Spec.Host, name)
 				g.Eventually(httpRequest(url), TestTimeoutMedium).Should(Equal(fmt.Sprintf("%s Doe", name)))
 				g.Eventually(IntegrationLogs(t, ctx, ns, "rest-consumer"), TestTimeoutShort).Should(ContainSubstring(fmt.Sprintf("get %s", name)))

--- a/pkg/apis/camel/v1/trait/builder.go
+++ b/pkg/apis/camel/v1/trait/builder.go
@@ -36,7 +36,7 @@ type BuilderTrait struct {
 	BaseImage string `property:"base-image" json:"baseImage,omitempty"`
 	// Use the incremental image build option, to reuse existing containers (default `true`)
 	IncrementalImageBuild *bool `property:"incremental-image-build" json:"incrementalImageBuild,omitempty"`
-	// The build order strategy to use, either `dependencies`, `fifo` or `sequential` (default `sequential`)
+	// The build order strategy to use, either `dependencies`, `fifo` or `sequential` (default is the platform default)
 	// +kubebuilder:validation:Enum=dependencies;fifo;sequential
 	OrderStrategy string `property:"order-strategy" json:"orderStrategy,omitempty"`
 	// When using `pod` strategy, the minimum amount of CPU required by the pod builder.

--- a/pkg/platform/defaults.go
+++ b/pkg/platform/defaults.go
@@ -90,7 +90,7 @@ func ConfigureDefaults(ctx context.Context, c client.Client, p *v1.IntegrationPl
 	}
 
 	if p.Status.Build.BuildConfiguration.OrderStrategy == "" {
-		p.Status.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategySequential
+		p.Status.Build.BuildConfiguration.OrderStrategy = v1.BuildOrderStrategyDependencies
 		log.Debugf("Integration Platform %s [%s]: setting build order strategy %s", p.Name, p.Namespace, p.Status.Build.BuildConfiguration.OrderStrategy)
 	}
 

--- a/pkg/platform/defaults_test.go
+++ b/pkg/platform/defaults_test.go
@@ -49,7 +49,7 @@ func TestIntegrationPlatformDefaults(t *testing.T) {
 	assert.Equal(t, v1.IntegrationPlatformClusterKubernetes, ip.Status.Cluster)
 	assert.Equal(t, v1.TraitProfile(""), ip.Status.Profile)
 	assert.Equal(t, v1.BuildStrategyRoutine, ip.Status.Build.BuildConfiguration.Strategy)
-	assert.Equal(t, v1.BuildOrderStrategySequential, ip.Status.Build.BuildConfiguration.OrderStrategy)
+	assert.Equal(t, v1.BuildOrderStrategyDependencies, ip.Status.Build.BuildConfiguration.OrderStrategy)
 	assert.Equal(t, defaults.BaseImage(), ip.Status.Build.BaseImage)
 	assert.Equal(t, defaults.LocalRepository, ip.Status.Build.Maven.LocalRepository)
 	assert.Equal(t, int32(3), ip.Status.Build.MaxRunningBuilds) // default for build strategy routine

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -684,3 +684,13 @@ func TestBuilderTraitPlatforms(t *testing.T) {
 
 	assert.Equal(t, []string{"linux/amd64", "linux/arm64"}, env.Pipeline[2].Jib.Configuration.ImagePlatforms)
 }
+
+func TestBuilderTraitOrderStrategy(t *testing.T) {
+	env := createBuilderTestEnv(v1.IntegrationPlatformClusterKubernetes, v1.IntegrationPlatformBuildPublishStrategyJib, v1.BuildStrategyRoutine)
+	builderTrait := createNominalBuilderTraitTest()
+	builderTrait.OrderStrategy = "fifo"
+	err := builderTrait.Apply(env)
+	require.NoError(t, err)
+
+	assert.Equal(t, v1.BuildOrderStrategyFIFO, env.Pipeline[0].Builder.Configuration.OrderStrategy)
+}


### PR DESCRIPTION
<!-- Description -->

This should be a default setting in order to enhance the parallelism during builds.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat: dependencies default order strategy
```
