### PR TITLE
chore(build): Fix docker build warnings

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:17-jdk as base
+FROM eclipse-temurin:17-jdk AS base
 
 ARG IMAGE_ARCH
 
@@ -22,6 +22,7 @@ ARG MAVEN_HOME="/usr/share/maven"
 ARG MAVEN_DIST_URL="https://archive.apache.org/dist/maven/maven-3/${MAVEN_DEFAULT_VERSION}/binaries/apache-maven-${MAVEN_DEFAULT_VERSION}-bin.zip"
 ARG MVNW_DIR="/usr/share/maven/mvnw/"
 ARG MVN_REPO="/etc/maven/m2"
+ARG MAVEN_OPTS=""
 
 USER 0
 
@@ -43,6 +44,7 @@ RUN ${MVNW_DIR}/mvnw --version | grep "Maven home:" | sed 's/Maven home: //' >> 
     && cp -r /usr/share/maven/lib/. $(cat ${MVNW_DIR}default)/lib \
     && rm $(cat ${MVNW_DIR}default)/lib/maven-slf4j-provider* \
     && rm $(cat ${MVNW_DIR}default)/lib/slf4j-api-1.* 
+
 ENV MAVEN_OPTS="${MAVEN_OPTS} -Dlogback.configurationFile=${MAVEN_HOME}/conf/logback.xml"
 
 ADD build/_maven_output ${MVN_REPO}
@@ -63,10 +65,10 @@ USER 1001:0
 
 ADD build/_output/bin/kamel-${IMAGE_ARCH} /usr/local/bin/kamel
 
-FROM golang:1.21 as go
+FROM golang:1.21 AS go
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-FROM base as debug
+FROM base AS debug
 
 COPY --from=go /go/bin/dlv /usr/local/bin/dlv


### PR DESCRIPTION
Fix the following warnings in `make images`:

```
 4 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 16)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 66)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 70)
 - UndefinedVar: Usage of undefined variable '$MAVEN_OPTS' (line 46)
```

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(build): Fix docker build warnings
```
