### PR TITLE
fix(ci): raise again default resource footprint

### DIFF
--- a/pkg/resources/config/manager/operator-deployment.yaml
+++ b/pkg/resources/config/manager/operator-deployment.yaml
@@ -80,8 +80,8 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "500m"
+              memory: "4Gi"
+              cpu: "1"
             limits:
               memory: "8Gi"
               cpu: "2"

--- a/script/Makefile
+++ b/script/Makefile
@@ -107,7 +107,7 @@ TEST_PREBUILD = build
 # Tests may run in parallel to each other. This count sets the amount of tests run in parallel.
 # (default value would be otherwise GOMAXPROCS)
 TEST_COMMON_PARALLEL_COUNT ?= 2
-TEST_ADVANCED_PARALLEL_COUNT ?= 4
+TEST_ADVANCED_PARALLEL_COUNT ?= 2
 
 # OLM (Operator Lifecycle Manager and Operator Hub): uncomment to override operator settings at build time
 #GOLDFLAGS += -X github.com/apache/camel-k/v2/pkg/util/olm.DefaultOperatorName=camel-k-operator


### PR DESCRIPTION
* Raise the default resources request for the deployment
* Only run 2 test in parallel for common advanced e2e tests

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ci): raise again default resource footprint
```
