### PR TITLE
chore(ci): Dump some cluster infos

### DIFF
--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -2920,6 +2920,9 @@ func DumpNamespace(t *testing.T, ctx context.Context, ns string) {
 		if err := util.Dump(ctx, TestClient(t), ns, t); err != nil {
 			t.Logf("Error while dumping namespace %s: %v\n", ns, err)
 		}
+		if err := util.DumpClusterState(ctx, TestClient(t), ns, t); err != nil {
+			t.Logf("Error while dumping cluster state: %v\n", err)
+		}
 	}
 }
 

--- a/e2e/support/util/dump.go
+++ b/e2e/support/util/dump.go
@@ -45,6 +45,33 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/openshift"
 )
 
+// DumpClusterState prints informations about the cluster state
+func DumpClusterState(ctx context.Context, c client.Client, ns string, t *testing.T) error {
+	t.Logf("-------------------- start dumping cluster state --------------------\n")
+
+	nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes.Items {
+		nodeReady := false
+		nodeConditions := node.Status.Conditions
+		for _, condition := range nodeConditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				nodeReady = true
+			}
+		}
+		t.Logf("node: Name='%s', Ready='%t'", node.ObjectMeta.Name, nodeReady)
+		if node.Spec.Taints != nil {
+			t.Logf("node taints: Taints='%s'", node.Spec.Taints)
+		}
+	}
+
+	t.Logf("-------------------- dumping cluster state --------------------\n")
+	return nil
+}
+
 // Dump prints all information about the given namespace to debug errors
 func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 	t.Logf("-------------------- start dumping namespace %s --------------------\n", ns)


### PR DESCRIPTION
On test failure, dump some cluster infos to see if there is a taint on the cluster.




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(ci): Dump some cluster infos
```
