### PR TITLE
fix(ci): Reduce parallelism for smoke tests

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -290,7 +290,7 @@ test-smoke:
 	go test -p $(TEST_COMMON_PARALLEL_COUNT) -timeout 30m -v \
 		./e2e/common/languages \
 		./e2e/common/traits \
-		--parallel $(TEST_COMMON_PARALLEL_COUNT) \
+		--parallel 1 \
 	  -tags=integration $(GOTESTFMT) || ((FAILED++)); \
 	exit $${FAILED}
 


### PR DESCRIPTION
Ref #5696

Most of the failures on the nightly builds are due to kit builds still filling the build queue even after timeout. 
Sinde the common test have been set to `--parallel 1` it make sense to set the same value for smoke-tests. 

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ci): Reduce parallelism for smoke tests
```
