### PR TITLE
fix(e2e): Flaky TestOperatorIDFiltering tests

### DIFF
--- a/e2e/advanced/operator_id_filtering_test.go
+++ b/e2e/advanced/operator_id_filtering_test.go
@@ -55,7 +55,7 @@ func TestOperatorIDFiltering(t *testing.T) {
 				})
 
 				t.Run("Operators run scoped integrations", func(t *testing.T) {
-					g.Expect(KamelRunWithID(t, ctx, "operator-x", ns, "files/yaml.yaml", "--name", "moving", "--force").Execute()).To(Succeed())
+					g.Expect(KamelRunWithID(t, ctx, "operator-x", ns, "files/yaml.yaml", "--name", "moving", "-t", "container.limit-cpu=200m", "--force").Execute()).To(Succeed())
 					g.Expect(AssignIntegrationToOperator(t, ctx, ns, "moving", operator1)).To(Succeed())
 					g.Eventually(IntegrationPhase(t, ctx, ns, "moving"), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseRunning))
 					g.Eventually(IntegrationPodPhase(t, ctx, ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
@@ -101,7 +101,7 @@ func TestOperatorIDFiltering(t *testing.T) {
 						},
 					}
 					g.Expect(TestClient(t).Create(ctx, &externalKit)).Should(BeNil())
-					g.Expect(KamelRunWithID(t, ctx, operator2, ns, "files/yaml.yaml", "--name", "pre-built", "--kit", "external", "--force").Execute()).To(Succeed())
+					g.Expect(KamelRunWithID(t, ctx, operator2, ns, "files/yaml.yaml", "--name", "pre-built", "--kit", "external", "-t", "container.limit-cpu=200m", "--force").Execute()).To(Succeed())
 					g.Consistently(IntegrationPhase(t, ctx, ns, "pre-built"), 10*time.Second).ShouldNot(Equal(v1.IntegrationPhaseBuildingKit))
 					g.Eventually(IntegrationPhase(t, ctx, ns, "pre-built"), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
 					g.Eventually(IntegrationStatusImage(t, ctx, ns, "pre-built"), TestTimeoutShort).Should(Equal(kitImage))
@@ -111,7 +111,7 @@ func TestOperatorIDFiltering(t *testing.T) {
 				})
 
 				t.Run("Operators can run scoped Pipes", func(t *testing.T) {
-					g.Expect(KamelBindWithID(t, ctx, "operator-x", ns, "timer-source?message=Hello", "log-sink", "--name", "klb", "--force").Execute()).To(Succeed())
+					g.Expect(KamelBindWithID(t, ctx, "operator-x", ns, "timer-source?message=Hello", "log-sink", "--name", "klb", "-t", "container.limit-cpu=200m", "--force").Execute()).To(Succeed())
 					g.Consistently(Integration(t, ctx, ns, "klb"), 10*time.Second).Should(BeNil())
 					g.Expect(AssignPipeToOperator(t, ctx, ns, "klb", operator1)).To(Succeed())
 					g.Eventually(Integration(t, ctx, ns, "klb"), TestTimeoutShort).ShouldNot(BeNil())

--- a/e2e/advanced/operator_id_filtering_test.go
+++ b/e2e/advanced/operator_id_filtering_test.go
@@ -57,7 +57,7 @@ func TestOperatorIDFiltering(t *testing.T) {
 				t.Run("Operators run scoped integrations", func(t *testing.T) {
 					g.Expect(KamelRunWithID(t, ctx, "operator-x", ns, "files/yaml.yaml", "--name", "moving", "--force").Execute()).To(Succeed())
 					g.Expect(AssignIntegrationToOperator(t, ctx, ns, "moving", operator1)).To(Succeed())
-					g.Eventually(IntegrationPhase(t, ctx, ns, "moving"), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseRunning))
+					g.Eventually(IntegrationPhase(t, ctx, ns, "moving"), TestTimeoutLong).Should(Equal(v1.IntegrationPhaseRunning))
 					g.Eventually(IntegrationPodPhase(t, ctx, ns, "moving"), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 					g.Eventually(IntegrationLogs(t, ctx, ns, "moving"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 				})


### PR DESCRIPTION
Ref #5521 

Flaky TestOperatorIDFiltering tests:
* increase timeout of kit build
* add custom resources values for kustomize installation
* reduce resources usage for the operators of the TestOperatorIDFiltering test

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): Increase timeout of kit build and cutom resources values for kustomize installation
```
