### PR TITLE
(#5654) Added emptyDir support to mount trait

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -7899,6 +7899,13 @@ Syntax: [configmap{vbar}secret]:name[/key][@path], where name represents the res
 
 A list of Persistent Volume Claims to be mounted. Syntax: [pvcname:/container/path]
 
+|`emptyDirs` +
+[]string
+|
+
+
+A list of EmptyDir volumes to be mounted. Syntax: [name:/container/path]
+
 |`hotReload` +
 bool
 |

--- a/docs/modules/traits/pages/mount.adoc
+++ b/docs/modules/traits/pages/mount.adoc
@@ -47,6 +47,10 @@ Syntax: [configmap\|secret]:name[/key][@path], where name represents the resourc
 | []string
 | A list of Persistent Volume Claims to be mounted. Syntax: [pvcname:/container/path]
 
+| mount.empty-dirs
+| []string
+| A list of EmptyDir volumes to be mounted. Syntax: [name:/container/path]
+
 | mount.hot-reload
 | bool
 | Enable "hot reload" when a secret/configmap mounted is edited (default `false`). The configmap/secret must be

--- a/helm/camel-k/crds/crd-integration-platform.yaml
+++ b/helm/camel-k/crds/crd-integration-platform.yaml
@@ -1591,6 +1591,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
@@ -3627,6 +3633,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean

--- a/helm/camel-k/crds/crd-integration-profile.yaml
+++ b/helm/camel-k/crds/crd-integration-profile.yaml
@@ -1468,6 +1468,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
@@ -3387,6 +3393,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean

--- a/helm/camel-k/crds/crd-integration.yaml
+++ b/helm/camel-k/crds/crd-integration.yaml
@@ -7532,6 +7532,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean

--- a/helm/camel-k/crds/crd-kamelet-binding.yaml
+++ b/helm/camel-k/crds/crd-kamelet-binding.yaml
@@ -7826,6 +7826,12 @@ spec:
                               for backward compatibility.'
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                          emptyDirs:
+                            description: 'A list of EmptyDir volumes to be mounted.
+                              Syntax: [name:/container/path]'
+                            items:
+                              type: string
+                            type: array
                           enabled:
                             description: 'Deprecated: no longer in use.'
                             type: boolean

--- a/helm/camel-k/crds/crd-pipe.yaml
+++ b/helm/camel-k/crds/crd-pipe.yaml
@@ -7824,6 +7824,12 @@ spec:
                               for backward compatibility.'
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                          emptyDirs:
+                            description: 'A list of EmptyDir volumes to be mounted.
+                              Syntax: [name:/container/path]'
+                            items:
+                              type: string
+                            type: array
                           enabled:
                             description: 'Deprecated: no longer in use.'
                             type: boolean

--- a/pkg/apis/camel/v1/trait/mount.go
+++ b/pkg/apis/camel/v1/trait/mount.go
@@ -34,6 +34,8 @@ type MountTrait struct {
 	Resources []string `property:"resources" json:"resources,omitempty"`
 	// A list of Persistent Volume Claims to be mounted. Syntax: [pvcname:/container/path]
 	Volumes []string `property:"volumes" json:"volumes,omitempty"`
+	// A list of EmptyDir volumes to be mounted. Syntax: [name:/container/path]
+	EmptyDirs []string `property:"empty-dirs" json:"emptyDirs,omitempty"`
 	// Enable "hot reload" when a secret/configmap mounted is edited (default `false`). The configmap/secret must be
 	// marked with `camel.apache.org/integration` label to be taken in account. The resource will be watched for any kind change, also for
 	// changes in metadata.

--- a/pkg/apis/camel/v1/trait/zz_generated.deepcopy.go
+++ b/pkg/apis/camel/v1/trait/zz_generated.deepcopy.go
@@ -793,6 +793,11 @@ func (in *MountTrait) DeepCopyInto(out *MountTrait) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EmptyDirs != nil {
+		in, out := &in.EmptyDirs, &out.EmptyDirs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.HotReload != nil {
 		in, out := &in.HotReload, &out.HotReload
 		*out = new(bool)

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -1591,6 +1591,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
@@ -3627,6 +3633,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -1468,6 +1468,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean
@@ -3387,6 +3393,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -7532,6 +7532,12 @@ spec:
                           for backward compatibility.'
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      emptyDirs:
+                        description: 'A list of EmptyDir volumes to be mounted. Syntax:
+                          [name:/container/path]'
+                        items:
+                          type: string
+                        type: array
                       enabled:
                         description: 'Deprecated: no longer in use.'
                         type: boolean

--- a/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_kameletbindings.yaml
@@ -7826,6 +7826,12 @@ spec:
                               for backward compatibility.'
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                          emptyDirs:
+                            description: 'A list of EmptyDir volumes to be mounted.
+                              Syntax: [name:/container/path]'
+                            items:
+                              type: string
+                            type: array
                           enabled:
                             description: 'Deprecated: no longer in use.'
                             type: boolean

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -7824,6 +7824,12 @@ spec:
                               for backward compatibility.'
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                          emptyDirs:
+                            description: 'A list of EmptyDir volumes to be mounted.
+                              Syntax: [name:/container/path]'
+                            items:
+                              type: string
+                            type: array
                           enabled:
                             description: 'Deprecated: no longer in use.'
                             type: boolean

--- a/pkg/trait/mount.go
+++ b/pkg/trait/mount.go
@@ -149,6 +149,13 @@ func (t *mountTrait) configureVolumesAndMounts(vols *[]corev1.Volume, mnts *[]co
 			return parseErr
 		}
 	}
+	for _, v := range t.EmptyDirs {
+		if vol, parseErr := utilResource.ParseEmptyDirVolume(v); parseErr == nil {
+			t.mountResource(vols, mnts, vol)
+		} else {
+			return parseErr
+		}
+	}
 
 	return nil
 }
@@ -167,7 +174,8 @@ func (t *mountTrait) mountResource(vols *[]corev1.Volume, mnts *[]corev1.VolumeM
 	vol := getVolume(refName, string(conf.StorageType()), conf.Name(), conf.Key(), dstFile)
 	mntPath := getMountPoint(conf.Name(), dstDir, string(conf.StorageType()), string(conf.ContentType()))
 	readOnly := true
-	if conf.StorageType() == utilResource.StorageTypePVC {
+	if conf.StorageType() == utilResource.StorageTypePVC ||
+		conf.StorageType() == utilResource.StorageTypeEmptyDir {
 		readOnly = false
 	}
 	mnt := getMount(refName, mntPath, dstFile, readOnly)

--- a/pkg/trait/mount_test.go
+++ b/pkg/trait/mount_test.go
@@ -108,6 +108,52 @@ func TestMountVolumesIntegrationPhaseDeploying(t *testing.T) {
 	})
 }
 
+func TestEmptyDirVolumeIntegrationPhaseDeploying(t *testing.T) {
+	traitCatalog := NewCatalog(nil)
+
+	environment := getNominalEnv(t, traitCatalog)
+	environment.Integration.Spec.Traits.Mount = &traitv1.MountTrait{
+		EmptyDirs: []string{"my-empty-dir:/some/path"},
+	}
+	environment.Platform.ResyncStatusFullConfig()
+	conditions, err := traitCatalog.apply(environment)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, conditions)
+	assert.NotEmpty(t, environment.ExecutedTraits)
+	assert.NotNil(t, environment.GetTrait("mount"))
+
+	deployment := environment.Resources.GetDeployment(func(service *appsv1.Deployment) bool {
+		return service.Name == "hello"
+	})
+	assert.NotNil(t, deployment)
+	spec := deployment.Spec.Template.Spec
+
+	assert.Len(t, spec.Containers[0].VolumeMounts, 3)
+	assert.Len(t, spec.Volumes, 3)
+
+	assert.Condition(t, func() bool {
+		for _, v := range spec.Volumes {
+			if v.Name == "my-empty-dir" {
+				return true
+			}
+		}
+		return false
+	})
+	assert.Condition(t, func() bool {
+		for _, container := range spec.Containers {
+			if container.Name == "integration" {
+				for _, volumeMount := range container.VolumeMounts {
+					if volumeMount.Name == "my-empty-dir" {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	})
+}
+
 func TestMountVolumesIntegrationPhaseInitialization(t *testing.T) {
 	traitCatalog := NewCatalog(nil)
 

--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -57,6 +57,7 @@ const (
 	secretStorageType    = "secret"
 	configmapStorageType = "configmap"
 	pvcStorageType       = "pvc"
+	emptyDirStorageType  = "emptyDir"
 )
 
 var capabilityDynamicProperty = regexp.MustCompile(`(\$\{([^}]*)\})`)
@@ -635,6 +636,8 @@ func getVolume(volName, storageType, storageName, filterKey, filterValue string)
 		volume.VolumeSource.PersistentVolumeClaim = &corev1.PersistentVolumeClaimVolumeSource{
 			ClaimName: storageName,
 		}
+	case emptyDirStorageType:
+		volume.VolumeSource.EmptyDir = &corev1.EmptyDirVolumeSource{}
 	}
 
 	return &volume

--- a/pkg/util/resource/config.go
+++ b/pkg/util/resource/config.go
@@ -80,6 +80,8 @@ const (
 	StorageTypeSecret StorageType = "secret"
 	// StorageTypePVC --.
 	StorageTypePVC StorageType = "pvc"
+	// StorageTypeEmptyDir --.
+	StorageTypeEmptyDir StorageType = "emptyDir"
 )
 
 // ContentType represent what kind of a content is, either data or purely text configuration.
@@ -132,6 +134,21 @@ func parseCMOrSecretValue(value string) (string, string, string) {
 // ParseResource will parse a resource and return a Config.
 func ParseResource(item string) (*Config, error) {
 	return parse(item, ContentTypeData)
+}
+
+// ParseEmptyDirVolume will parse an empty dir volume and return a Config.
+func ParseEmptyDirVolume(item string) (*Config, error) {
+	configParts := strings.Split(item, ":")
+
+	if len(configParts) != 2 {
+		return nil, fmt.Errorf("could not match emptyDir volume as %s", item)
+	}
+
+	return &Config{
+		storageType:     StorageTypeEmptyDir,
+		resourceName:    configParts[0],
+		destinationPath: configParts[1],
+	}, nil
 }
 
 // ParseVolume will parse a volume and return a Config.


### PR DESCRIPTION
<!-- Description -->
Handles: https://github.com/apache/camel-k/issues/5654

Currently there is no way to add an emptyDir volume without using a pod template. This is useful but using the pod template will override any volumes mounted when using the mount trait e.g. configmaps, secrets.
This PR adds the trait field `mount.empty-dirs` which uses the same syntax as the existing `mount.volumes` trait field. To add an emptyDir volume use:
`trait=mount.empty-dirs=my-empty-dir:/var/test`
📓 Note that the trait field `empty-dirs` will be translated to `emptyDirs` in the integration yaml (if using helm or working with yaml directly)

The example above will add the following to your integration yaml
```yaml
spec:
  containers:
  - name: integration
    volumeMounts:
    - mountPath: /var/test
      name: my-empty-dir
  volumes:
  - emptyDir: {}
    name: my-empty-dir
```

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
