### PR TITLE
fix(#5706): removing trait prefix from condition type (release 2.3.x)

### DIFF
--- a/pkg/trait/trait_condition_types.go
+++ b/pkg/trait/trait_condition_types.go
@@ -76,15 +76,23 @@ func NewIntegrationConditionPlatformDisabledCatalogMissing() *TraitCondition {
 }
 
 func (tc *TraitCondition) integrationCondition() (v1.IntegrationConditionType, corev1.ConditionStatus, string, string) {
-	return v1.IntegrationConditionType(fmt.Sprintf("%s%s", tc.traitID, tc.integrationConditionType)),
+	return v1.IntegrationConditionType(tc.typeForCondition()),
 		tc.conditionStatus,
 		tc.reason,
 		tc.message
 }
 
 func (tc *TraitCondition) integrationKitCondition() (v1.IntegrationKitConditionType, corev1.ConditionStatus, string, string) {
-	return v1.IntegrationKitConditionType(fmt.Sprintf("%s%s", tc.traitID, tc.integrationConditionType)),
+	return v1.IntegrationKitConditionType(tc.typeForCondition()),
 		tc.conditionStatus,
 		tc.reason,
 		tc.message
+}
+
+func (tc *TraitCondition) typeForCondition() string {
+	conditionType := string(tc.integrationConditionType)
+	if conditionType == "TraitInfo" {
+		conditionType = fmt.Sprintf("%s%s", tc.traitID, tc.integrationConditionType)
+	}
+	return conditionType
 }


### PR DESCRIPTION
<!-- Description -->

Fixing #5706 for release-2.3.x branch.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fixed Integration and IntegrationKit condition type values.
```
