### PR TITLE
bugfix(#5755): avoiding deadlock between builds with dependencies build order strategy

### DIFF
--- a/pkg/apis/camel/v1/build_type_support_test.go
+++ b/pkg/apis/camel/v1/build_type_support_test.go
@@ -19,6 +19,7 @@ package v1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,9 @@ func TestMatchingBuildsPending(t *testing.T) {
 						Dependencies: []string{
 							"camel:timer",
 							"camel:log",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
 						},
 					},
 				},
@@ -57,6 +61,9 @@ func TestMatchingBuildsPending(t *testing.T) {
 							"camel:timer",
 							"camel:log",
 							"camel:bean",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
 						},
 					},
 				},
@@ -80,6 +87,9 @@ func TestMatchingBuildsPending(t *testing.T) {
 							"camel:bean",
 							"camel:zipfile",
 						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
 					},
 				},
 			},
@@ -100,6 +110,9 @@ func TestMatchingBuildsPending(t *testing.T) {
 							"camel:mongodb",
 							"camel:component-a",
 							"camel:component-b",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
 						},
 					},
 				},
@@ -123,6 +136,294 @@ func TestMatchingBuildsPending(t *testing.T) {
 	// The matching logic is returning the first matching build found
 	assert.True(t, buildMatch.Name == buildA.Name || buildMatch.Name == buildB.Name)
 	matches, buildMatch = buildList.HasMatchingBuild(&buildZ)
+	assert.False(t, matches)
+	assert.Nil(t, buildMatch)
+}
+
+func TestMatchingBuildsSchedulingSharedDependencies(t *testing.T) {
+	timestamp, _ := time.Parse("2006-01-02T15:04:05-0700", "2024-08-09T10:00:00Z")
+	creationTimestamp := v1.Time{Time: timestamp}
+	buildA := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "buildA",
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:core",
+							"camel:rest",
+							"mvn:org.apache.camel.k:camel-k-runtime",
+							"mvn:org.apache.camel.quarkus:camel-quarkus-yaml-dsl",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+	buildB := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "buildB",
+			CreationTimestamp: creationTimestamp,
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:quartz",
+							"mvn:org.apache.camel.k:camel-k-cron",
+							"mvn:org.apache.camel.k:camel-k-runtime",
+							"mvn:org.apache.camel.quarkus:camel-quarkus-yaml-dsl",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						}},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+
+	buildList := BuildList{
+		Items: []Build{buildA, buildB},
+	}
+
+	// both builds share dependencies and have the same creationTimestamp
+	// buildA should be prioritized so there should be not matching build for it
+
+	matches, buildMatch := buildList.HasMatchingBuild(&buildA)
+	assert.False(t, matches)
+	assert.Nil(t, buildMatch)
+	matches, buildMatch = buildList.HasMatchingBuild(&buildB)
+	assert.True(t, matches)
+	assert.True(t, buildMatch.Name == buildA.Name)
+}
+
+func TestMatchingBuildsSchedulingSameDependenciesDIfferentRuntimes(t *testing.T) {
+	timestamp, _ := time.Parse("2006-01-02T15:04:05-0700", "2024-08-09T10:00:00Z")
+	creationTimestamp := v1.Time{Time: timestamp}
+	buildA := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "buildA",
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:quartz",
+							"mvn:org.apache.camel.k:camel-k-cron",
+							"mvn:org.apache.camel.k:camel-k-runtime",
+							"mvn:org.apache.camel.quarkus:camel-quarkus-yaml-dsl",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+	buildB := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "buildB",
+			CreationTimestamp: creationTimestamp,
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:quartz",
+							"mvn:org.apache.camel.k:camel-k-cron",
+							"mvn:org.apache.camel.k:camel-k-runtime",
+							"mvn:org.apache.camel.quarkus:camel-quarkus-yaml-dsl",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.2.3",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+
+	buildList := BuildList{
+		Items: []Build{buildA, buildB},
+	}
+
+	// each build uses a different runtime, so they should not match
+
+	matches, buildMatch := buildList.HasMatchingBuild(&buildA)
+	assert.False(t, matches)
+	assert.Nil(t, buildMatch)
+	matches, buildMatch = buildList.HasMatchingBuild(&buildB)
+	assert.False(t, matches)
+	assert.Nil(t, buildMatch)
+}
+
+func TestMatchingBuildsSchedulingSameDependenciesSameRuntime(t *testing.T) {
+	timestamp, _ := time.Parse("2006-01-02T15:04:05-0700", "2024-08-09T10:00:00Z")
+	creationTimestamp := v1.Time{Time: timestamp}
+	buildA := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "buildA",
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:quartz",
+							"mvn:org.apache.camel.k:camel-k-cron",
+							"mvn:org.apache.camel.k:camel-k-runtime",
+							"mvn:org.apache.camel.quarkus:camel-quarkus-yaml-dsl",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+	buildB := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "buildB",
+			CreationTimestamp: creationTimestamp,
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:quartz",
+							"mvn:org.apache.camel.k:camel-k-cron",
+							"mvn:org.apache.camel.k:camel-k-runtime",
+							"mvn:org.apache.camel.quarkus:camel-quarkus-yaml-dsl",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+
+	buildList := BuildList{
+		Items: []Build{buildA, buildB},
+	}
+
+	// ebuilds have the same dependencies, runtime and creation timestamp
+
+	matches, buildMatch := buildList.HasMatchingBuild(&buildA)
+	assert.False(t, matches)
+	assert.Nil(t, buildMatch)
+	matches, buildMatch = buildList.HasMatchingBuild(&buildB)
+	assert.True(t, matches)
+	assert.True(t, buildMatch.Name == buildA.Name)
+}
+
+func TestMatchingBuildsSchedulingFewCommonDependencies(t *testing.T) {
+	timestamp, _ := time.Parse("2006-01-02T15:04:05-0700", "2024-08-09T10:00:00Z")
+	creationTimestamp := v1.Time{Time: timestamp}
+	buildA := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "buildA",
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:quartz",
+							"camel:componenta1",
+							"camel:componentb1",
+							"camel:componentc1",
+							"camel:componentd1",
+							"camel:componente1",
+							"camel:componentf1",
+							"camel:componentg1",
+							"camel:componenth1",
+							"camel:componenti1",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+	buildB := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "buildB",
+			CreationTimestamp: creationTimestamp,
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:quartz",
+							"camel:componenta2",
+							"camel:componentb2",
+							"camel:componentc2",
+							"camel:componentd2",
+							"camel:componente2",
+							"camel:componentf2",
+							"camel:componentg2",
+							"camel:componenth2",
+							"camel:componenti2",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+
+	buildList := BuildList{
+		Items: []Build{buildA, buildB},
+	}
+
+	// builds have only 1 out of 10 shared dependencies. they should not match
+
+	matches, buildMatch := buildList.HasMatchingBuild(&buildA)
+	assert.False(t, matches)
+	assert.Nil(t, buildMatch)
+	matches, buildMatch = buildList.HasMatchingBuild(&buildB)
 	assert.False(t, matches)
 	assert.Nil(t, buildMatch)
 }

--- a/pkg/apis/camel/v1/build_types_support.go
+++ b/pkg/apis/camel/v1/build_types_support.go
@@ -326,14 +326,9 @@ func (bl BuildList) HasMatchingBuild(build *Build) (bool, *Build) {
 			if allMatching && len(required) == len(dependencies) {
 				// seems like both builds require exactly the same list of dependencies
 				// additionally check for the creation timestamp
-				if b.CreationTimestamp.Before(&build.CreationTimestamp) {
+				if compareBuilds(&b, build) < 0 {
 					return true, &b
-				} else if b.CreationTimestamp.Equal(&build.CreationTimestamp) {
-					if strings.Compare(b.Name, build.Name) < 0 {
-						return true, &b
-					}
 				}
-
 			} else if !allMatching && commonDependencies > 0 {
 				// there are common dependencies. let's compare the total number of dependencies
 				// in each build. whichever build has less dependencies should run first
@@ -341,10 +336,7 @@ func (bl BuildList) HasMatchingBuild(build *Build) (bool, *Build) {
 					return true, &b
 				} else if len(dependencies) == len(required) {
 					// same number of total dependencies.
-					if b.CreationTimestamp.Before(&build.CreationTimestamp) {
-						return true, &b
-					} else if b.CreationTimestamp.Equal(&build.CreationTimestamp) &&
-						strings.Compare(b.Name, build.Name) < 0 {
+					if compareBuilds(&b, build) < 0 {
 						return true, &b
 					}
 				}
@@ -354,4 +346,14 @@ func (bl BuildList) HasMatchingBuild(build *Build) (bool, *Build) {
 	}
 
 	return false, nil
+}
+
+func compareBuilds(b1 *Build, b2 *Build) int {
+	if b1.CreationTimestamp.Before(&b2.CreationTimestamp) {
+		return -1
+	} else if b2.CreationTimestamp.Before(&b1.CreationTimestamp) {
+		return 1
+	} else {
+		return strings.Compare(b1.Name, b2.Name)
+	}
 }


### PR DESCRIPTION
Closes #5755 

<!-- Description -->



<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fixed dependencies build order strategy to avoid deadlocks
```
