### PR TITLE
Bugfix/5758 incremental image build fix

### DIFF
--- a/pkg/apis/camel/v1/build_type_support_test.go
+++ b/pkg/apis/camel/v1/build_type_support_test.go
@@ -403,14 +403,108 @@ func TestMatchingBuildsSchedulingSameDependenciesSameRuntime(t *testing.T) {
 		Items: []Build{buildA, buildB},
 	}
 
-	// ebuilds have the same dependencies, runtime and creation timestamp
+	// builds have the same dependencies, runtime and creation timestamp
+	// buildB should wait for buildA
 
 	matches, buildMatch := buildList.HasMatchingBuild(&buildA)
 	assert.False(t, matches)
 	assert.Nil(t, buildMatch)
 	matches, buildMatch = buildList.HasMatchingBuild(&buildB)
 	assert.True(t, matches)
-	assert.True(t, buildMatch.Name == buildA.Name)
+	assert.Equal(t, buildA.Name, buildMatch.Name)
+}
+
+func TestMatchingBuildsSchedulingMutipleSubsets(t *testing.T) {
+	timestamp, _ := time.Parse("2006-01-02T15:04:05-0700", "2024-08-09T10:00:00Z")
+	creationTimestamp := v1.Time{Time: timestamp}
+	buildA := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "buildA",
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:component-a",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+	buildB := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "buildB",
+			CreationTimestamp: creationTimestamp,
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:component-a",
+							"camel:component-b",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+	buildC := Build{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "buildC",
+			CreationTimestamp: creationTimestamp,
+		},
+		Spec: BuildSpec{
+			Tasks: []Task{
+				{
+					Builder: &BuilderTask{
+						Dependencies: []string{
+							"camel:component-a",
+							"camel:component-b",
+							"camel:component-c",
+						},
+						Runtime: RuntimeSpec{
+							Version: "3.8.1",
+						},
+					},
+				},
+			},
+		},
+		Status: BuildStatus{
+			Phase: BuildPhaseScheduling,
+		},
+	}
+
+	buildList := BuildList{
+		Items: []Build{buildA, buildB, buildC},
+	}
+
+	// buildA is a subset of buildB, which is a subset of buildC
+	// buildC should wait for B, which should wait for A
+
+	matches, buildMatch := buildList.HasMatchingBuild(&buildA)
+	assert.False(t, matches)
+	assert.Nil(t, buildMatch)
+	matches, buildMatch = buildList.HasMatchingBuild(&buildB)
+	assert.True(t, matches)
+	assert.Equal(t, buildA.Name, buildMatch.Name)
+	matches, buildMatch = buildList.HasMatchingBuild(&buildC)
+	assert.True(t, matches)
+	assert.Equal(t, buildB.Name, buildMatch.Name)
 }
 
 func TestMatchingBuildsSchedulingFewCommonDependencies(t *testing.T) {
@@ -475,12 +569,12 @@ func TestMatchingBuildsSchedulingFewCommonDependencies(t *testing.T) {
 		Items: []Build{buildA, buildB},
 	}
 
-	// builds have only 1 out of 10 required dependencies. they should not match
+	// buildA is a subset of buildB. should wait for it
 
 	matches, buildMatch := buildList.HasMatchingBuild(&buildA)
 	assert.False(t, matches)
 	assert.Nil(t, buildMatch)
 	matches, buildMatch = buildList.HasMatchingBuild(&buildB)
-	assert.False(t, matches)
-	assert.Nil(t, buildMatch)
+	assert.True(t, matches)
+	assert.Equal(t, buildA.Name, buildMatch.Name)
 }

--- a/pkg/apis/camel/v1/build_types_support.go
+++ b/pkg/apis/camel/v1/build_types_support.go
@@ -282,8 +282,13 @@ func (bl BuildList) HasMatchingBuild(build *Build) (bool, *Build) {
 	if len(required) == 0 {
 		return false, nil
 	}
+	requiredMap := make(map[string]int, len(required))
+	for i, item := range required {
+		requiredMap[item] = i
+	}
 	runtimeVersion := build.RuntimeVersion()
 
+buildLoop:
 	for _, b := range bl.Items {
 		if b.Name == build.Name || b.Status.IsFinished() {
 			continue
@@ -300,12 +305,18 @@ func (bl BuildList) HasMatchingBuild(build *Build) (bool, *Build) {
 			dependencyMap[item] = i
 		}
 
-		allMatching := true
+		// check if this build has any extra dependency. If it does, we can't use it
+		for _, item := range dependencies {
+			if _, ok := requiredMap[item]; !ok {
+				continue buildLoop
+			}
+		}
+
+		// now check how many common dependencies this build has
 		missing := 0
 		commonDependencies := 0
 		for _, item := range required {
 			if _, ok := dependencyMap[item]; !ok {
-				allMatching = false
 				missing++
 			} else {
 				commonDependencies++
@@ -313,6 +324,7 @@ func (bl BuildList) HasMatchingBuild(build *Build) (bool, *Build) {
 		}
 
 		if commonDependencies < len(required)/2 {
+			// few common dependencies
 			continue
 		}
 
@@ -322,20 +334,20 @@ func (bl BuildList) HasMatchingBuild(build *Build) (bool, *Build) {
 			return true, &b
 		case BuildPhaseInitialization, BuildPhaseScheduling:
 			// handle suitable scheduled build
-			if allMatching && len(required) == len(dependencies) {
+
+			// the build has at least half the dependencies, maybe all of them
+			if compareBuilds(&b, build) < 0 {
+				return true, &b
+			}
+			if missing == 0 {
 				// seems like both builds require exactly the same list of dependencies
 				// additionally check for the creation timestamp
 				if compareBuilds(&b, build) < 0 {
 					return true, &b
 				}
-			} else if !allMatching && commonDependencies > 0 {
-				// there are common dependencies. let's compare the total number of dependencies
-				// in each build. whichever build has less dependencies should run first
-				if len(dependencies) < len(required) ||
-					len(dependencies) == len(required) && compareBuilds(&b, build) < 0 {
-					return true, &b
-				}
-				continue
+			} else {
+				// some deps are missing, but this build has at least half the deps we need and no extra dependency.
+				return true, &b
 			}
 		}
 	}

--- a/pkg/builder/image_test.go
+++ b/pkg/builder/image_test.go
@@ -99,14 +99,17 @@ func TestFindBestImageExactMatch(t *testing.T) {
 		{
 			Checksum: "1",
 			ID:       "artifact-1",
+			Target:   "dependencies/lib/main/artifact-1.jar",
 		},
 		{
 			Checksum: "2",
 			ID:       "artifact-2",
+			Target:   "dependencies/lib/main/artifact-2.jar",
 		},
 		{
 			Checksum: "3",
 			ID:       "artifact-3",
+			Target:   "dependencies/lib/main/artifact-3.jar",
 		},
 	}
 	iks := []v1.IntegrationKitStatus{
@@ -116,10 +119,12 @@ func TestFindBestImageExactMatch(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "3",
 					ID:       "artifact-3",
+					Target:   "dependencies/lib/main/artifact-3.jar",
 				},
 			},
 		},
@@ -129,14 +134,17 @@ func TestFindBestImageExactMatch(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "2",
 					ID:       "artifact-2",
+					Target:   "dependencies/lib/main/artifact-2.jar",
 				},
 				{
 					Checksum: "3",
 					ID:       "artifact-3",
+					Target:   "dependencies/lib/main/artifact-3.jar",
 				},
 			},
 		},
@@ -146,18 +154,22 @@ func TestFindBestImageExactMatch(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "2",
 					ID:       "artifact-2",
+					Target:   "dependencies/lib/main/artifact-2.jar",
 				},
 				{
 					Checksum: "3",
 					ID:       "artifact-3",
+					Target:   "dependencies/lib/main/artifact-3.jar",
 				},
 				{
 					Checksum: "4",
 					ID:       "artifact-4",
+					Target:   "dependencies/lib/main/artifact-4.jar",
 				},
 			},
 		},
@@ -167,14 +179,17 @@ func TestFindBestImageExactMatch(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "2",
 					ID:       "artifact-2",
+					Target:   "dependencies/lib/main/artifact-2.jar",
 				},
 				{
 					Checksum: "4",
 					ID:       "artifact-4",
+					Target:   "dependencies/lib/main/artifact-4.jar",
 				},
 			},
 		}}
@@ -196,14 +211,17 @@ func TestFindBestImageNoExactMatch(t *testing.T) {
 		{
 			Checksum: "1",
 			ID:       "artifact-1",
+			Target:   "dependencies/lib/main/artifact-1.jar",
 		},
 		{
 			Checksum: "2",
 			ID:       "artifact-2",
+			Target:   "dependencies/lib/main/artifact-2.jar",
 		},
 		{
 			Checksum: "3",
 			ID:       "artifact-3",
+			Target:   "dependencies/lib/main/artifact-3.jar",
 		},
 	}
 	iks := []v1.IntegrationKitStatus{
@@ -213,6 +231,7 @@ func TestFindBestImageNoExactMatch(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 			},
 		},
@@ -222,10 +241,12 @@ func TestFindBestImageNoExactMatch(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "3",
 					ID:       "artifact-3",
+					Target:   "dependencies/lib/main/artifact-3.jar",
 				},
 			},
 		},
@@ -235,18 +256,22 @@ func TestFindBestImageNoExactMatch(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "2",
 					ID:       "artifact-2",
+					Target:   "dependencies/lib/main/artifact-2.jar",
 				},
 				{
 					Checksum: "3",
 					ID:       "artifact-3",
+					Target:   "dependencies/lib/main/artifact-3.jar",
 				},
 				{
 					Checksum: "4",
 					ID:       "artifact-4",
+					Target:   "dependencies/lib/main/artifact-4.jar",
 				},
 			},
 		},
@@ -256,14 +281,17 @@ func TestFindBestImageNoExactMatch(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "2",
 					ID:       "artifact-2",
+					Target:   "dependencies/lib/main/artifact-2.jar",
 				},
 				{
 					Checksum: "4",
 					ID:       "artifact-4",
+					Target:   "dependencies/lib/main/artifact-4.jar",
 				},
 			},
 		}}
@@ -284,14 +312,17 @@ func TestFindBestImageNoExactMatchBadChecksum(t *testing.T) {
 		{
 			Checksum: "1",
 			ID:       "artifact-1",
+			Target:   "dependencies/lib/main/artifact-1.jar",
 		},
 		{
 			Checksum: "2",
 			ID:       "artifact-2",
+			Target:   "dependencies/lib/main/artifact-2.jar",
 		},
 		{
 			Checksum: "3",
 			ID:       "artifact-3",
+			Target:   "dependencies/lib/main/artifact-3.jar",
 		},
 	}
 	iks := []v1.IntegrationKitStatus{
@@ -301,6 +332,7 @@ func TestFindBestImageNoExactMatchBadChecksum(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 			},
 		},
@@ -310,10 +342,12 @@ func TestFindBestImageNoExactMatchBadChecksum(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "bad-checksum",
 					ID:       "artifact-3",
+					Target:   "dependencies/lib/main/artifact-3.jar",
 				},
 			},
 		},
@@ -323,18 +357,22 @@ func TestFindBestImageNoExactMatchBadChecksum(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "2",
 					ID:       "artifact-2",
+					Target:   "dependencies/lib/main/artifact-2.jar",
 				},
 				{
 					Checksum: "3",
 					ID:       "artifact-3",
+					Target:   "dependencies/lib/main/artifact-3.jar",
 				},
 				{
 					Checksum: "4",
 					ID:       "artifact-4",
+					Target:   "dependencies/lib/main/artifact-4.jar",
 				},
 			},
 		},
@@ -344,14 +382,17 @@ func TestFindBestImageNoExactMatchBadChecksum(t *testing.T) {
 				{
 					Checksum: "1",
 					ID:       "artifact-1",
+					Target:   "dependencies/lib/main/artifact-1.jar",
 				},
 				{
 					Checksum: "2",
 					ID:       "artifact-2",
+					Target:   "dependencies/lib/main/artifact-2.jar",
 				},
 				{
 					Checksum: "4",
 					ID:       "artifact-4",
+					Target:   "dependencies/lib/main/artifact-4.jar",
 				},
 			},
 		}}
@@ -454,4 +495,50 @@ func TestFindBestImageAllImagesWithSurplus(t *testing.T) {
 	bestImage, commonLibs := findBestImage(iks, requiredArtifacts)
 	assert.Equal(t, "", bestImage.Image)
 	assert.Empty(t, commonLibs)
+}
+
+func TestFindBestImageShouldIgnoreIntegrationArfifact(t *testing.T) {
+	requiredArtifacts := []v1.Artifact{
+		{
+			Checksum: "sha1:eMo2eeyP9wfBixeIXvWJRneAxIY=",
+			ID:       "io.github.crac.org-crac-0.1.3.jar",
+			Target:   "dependencies/lib/boot/io.github.crac.org-crac-0.1.3.jar",
+		},
+		{
+			Checksum: "sha1:bOYm5KjEIJKipCZTSMpiGReLm80=",
+			ID:       "io.quarkus.quarkus-development-mode-spi-3.8.3.jar",
+			Target:   "dependencies/lib/boot/io.quarkus.quarkus-development-mode-spi-3.8.3.jar",
+		},
+	}
+	iks := []v1.IntegrationKitStatus{
+		{
+			// the integration jar file should not be taken into account, so this should be a good match
+			Artifacts: []v1.Artifact{
+				{
+					Checksum: "sha1:Nca4e5f6WohYvjBCigLINWbigAo=",
+					ID:       "camel-k-integration-2.5.0-SNAPSHOT.jar",
+					Target:   "dependencies/app/camel-k-integration-2.5.0-SNAPSHOT.jar",
+				},
+				{
+					Checksum: "sha1:eMo2eeyP9wfBixeIXvWJRneAxIY=",
+					ID:       "io.github.crac.org-crac-0.1.3.jar",
+					Target:   "dependencies/lib/boot/io.github.crac.org-crac-0.1.3.jar",
+				},
+				{
+					Checksum: "sha1:bOYm5KjEIJKipCZTSMpiGReLm80=",
+					ID:       "io.quarkus.quarkus-development-mode-spi-3.8.3.jar",
+					Target:   "dependencies/lib/boot/io.quarkus.quarkus-development-mode-spi-3.8.3.jar",
+				},
+			},
+		},
+	}
+
+	bestImage, commonLibs := findBestImage(iks, requiredArtifacts)
+
+	assert.NotNil(t, bestImage)
+	assert.Equal(t, iks[0], bestImage)
+	assert.NotNil(t, commonLibs)
+	assert.Equal(t, 2, len(commonLibs))
+	assert.True(t, commonLibs["io.github.crac.org-crac-0.1.3.jar"])
+	assert.True(t, commonLibs["io.quarkus.quarkus-development-mode-spi-3.8.3.jar"])
 }

--- a/pkg/controller/build/build_monitor_test.go
+++ b/pkg/controller/build/build_monitor_test.go
@@ -555,14 +555,14 @@ func TestMonitorDependencyMatchingBuilds(t *testing.T) {
 				"Waiting for build (my-build-pending) to finish in order to use incremental image builds - the build (my-build) gets enqueued"),
 		},
 		{
-			name: "queueBuildWhenSuitableBuildWithSupersetDependenciesIsAlreadyRunning",
+			name: "queueBuildWhenSuitableBuildWithSubsetDependenciesIsAlreadyRunning",
 			running: []*v1.Build{
 				newBuild("some-ns", "my-build-1", deps...),
 				newBuild("other-ns", "my-build-2", deps...),
 			},
 			builds: []*v1.Build{
 				newBuildInPhase("ns", "my-build-x", v1.BuildPhaseSucceeded, deps...),
-				newBuildInPhase("ns", "my-build-running", v1.BuildPhaseRunning, append(deps, "camel:test")...),
+				newBuildInPhase("ns", "my-build-running", v1.BuildPhaseRunning, deps[0:len(deps)-1]...),
 			},
 			build:   newBuild("ns", "my-build", deps...),
 			allowed: false,


### PR DESCRIPTION
<!-- Description -->

This is a proposal for solving the bug reported in #5758.
The main idea is that the incremental image build algorithm will select the base image that has more dependencies among those required by the new image, but no extra ones.

Also, the logic in build_type_support.go has changed to be compatible with this approach. The matching build will be the one with more common dependencies, but no extra ones.

Closes #5758 

Once approved, I can backport this to release-4.x as well. 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Fixed incremental build algorithm to avoid adding unnecessary dependencies to the final image 
```
