### PR TITLE
feat: explicit IntegrationPlatform installation

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * xref:installation/installation.adoc[Installation]
+** xref:installation/integrationplatform.adoc[Configure IntegrationPlatform]
 ** xref:installation/registry/registry.adoc[Configure Registry]
 ** xref:installation/advanced/maven.adoc[Configure Maven]
 ** xref:installation/knative.adoc[Configure Knative]

--- a/docs/modules/ROOT/pages/cli/cli.adoc
+++ b/docs/modules/ROOT/pages/cli/cli.adoc
@@ -59,10 +59,6 @@ Some of the most used commands are:
 |Bind Kubernetes resources, such as Kamelets, in an integration flow.
 |kamel bind timer-source -p "source.message=hello world" channel:mychannel
 
-|install
-|Install Camel K on a Kubernetes cluster
-|kamel install
-
 |rebuild
 |Clear the state of integrations to rebuild them.
 |kamel rebuild --all
@@ -71,19 +67,13 @@ Some of the most used commands are:
 |Reset the Camel K installation
 |kamel reset
 
-|uninstall
-|Uninstall Camel K from a Kubernetes cluster
-|kamel uninstall
-
 |version
 |Display client version
 |kamel version
 
 |===
 
-The list above is not the full list of available commands.
-You can run `kamel help` to obtain the full list.
-Each command also takes the `--help` as option to output more information, e.g.:
+The list above is not the full list of available commands. You can run `kamel help` to obtain the full list. Each command also takes the `--help` as option to output more information, e.g.:
 
 [source,console]
 ----
@@ -101,7 +91,7 @@ While each command has a dedicated set of flags, there are global flags that are
 
 |`--kube-config PATH`
 |Path to the config file to use for CLI requests
-|kamel install --kube-config ~/.kube/config
+|kamel run my-route.yaml --kube-config ~/.kube/config
 
 |`-h` or `--help`
 |Help for `kamel`, or the command
@@ -122,5 +112,4 @@ $ kamel <command> --help
 
 == Modeline
 
-Some command options in the CLI can be also specified as modeline in the source file, take a look at the xref:cli/modeline.adoc[Modeline] section
-for more information.
+Some command options in the CLI can be also specified as modeline in the source file, take a look at the xref:cli/modeline.adoc[Modeline] section for more information.

--- a/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
@@ -1,125 +1,33 @@
 [[fine-tuning]]
 = Camel K Operator fine tuning
 
-Camel K Operators offers several possibility of customization. The default installation could be good in the most of the cases, but, we have a series of configuration that can be applied when you want to fine tune your Camel K operator and get the very best of it. The following settings will work for an installation via `kamel` CLI, but the same configuration could be done with the other xref:installation/installation.adoc[installation procedures] by applying the required changes on the related configuration files.
+Camel K Operators offers several possibility of customization. The default installation could be good in the most of the cases, but, we have a series of configuration that can be applied when you want to fine tune your Camel K operator and get the very best of it.
 
-NOTE: changing some of the following configuration may affect the behavior of your Camel K Operator. Make sure to understand how to properly tune each configuration.
+Some of the configuration can be defined after the operator is installed using the proper xref:installation/integrationplatform.adoc[IntegrationPlatform specifications]. Other fine tunings require to change the operator Deployment, so they either need to be provided before the installation procedure start, or after, with the subsequent operator restart.
 
-[[operator-customization]]
-== Operator configuration
-The operator installation can be customized by using the following parameters:
-```
---operator-env-vars stringArray               Add an environment variable to set in the operator Pod(s), as <name=value>
--x, --operator-id string                      Set the operator id that is used to select the resources this operator should manage (default "camel-k")
---operator-image string                       Set the operator Image used for the operator deployment
---operator-image-pull-policy string           Set the operator ImagePullPolicy used for the operator deployment
---skip-cluster-setup                          Skip the cluster-setup phase
---skip-default-kamelets-setup                 Skip installation of the default Kamelets from catalog
---skip-operator-setup                         Do not install the operator in the namespace (in case there's a global one)
---skip-registry-setup                         Skip the registry-setup phase (may negatively impact building of integrations)
-```
+NOTE: changing some of the default configuration may affect the behavior of your Camel K Operator. Make sure to understand how to properly tune each configuration.
 
-The above parameters are helpful to change the default Camel K operator configuration or to partially skip certain advanced configuration resources.
+Most of these settings will require changing either an environment variable or other configuration of the operator Deployment. You need to verify how to apply those changes according the installation methodology chosen.
+
+== Installation name
+
+You can install one or more Camel K operators (which must share CRDs). In such case you need to specify a unique operator name which will be used by each resource to know who is in charge to reconcile it. This behavior is controlled by the OPERATOR_ID environment variable (default value, _camel-k_).
 
 [[resources]]
 == Resource management
 
-We provide certain configuration to better "operationalize" the Camel K Operator:
-```
---node-selector stringArray                   Add a NodeSelector to the operator Pod
---operator-resources stringArray              Define the resources requests and limits assigned to the operator Pod as <requestType.requestResource=value> (i.e., limits.memory=256Mi)
---toleration stringArray                      Add a Toleration to the operator Pod
-```
-
-More detailed information on the xref:installation/advanced/resources.adoc[resource management] page.
-
-[[build-configuration]]
-== Build configuration
-
-We have several configuration used to influence the building of an integration:
-
-```
---base-image string                           Set the base Image used to run integrations
---build-publish-strategy string               Set the build publish strategy
---build-publish-strategy-option stringArray   Add a build publish strategy option, as <name=value>
---build-strategy string                       Set the build strategy
---build-order-strategy string                 Set the build order strategy
---build-timeout string                        Set how long the build process can last
---max-running-pipelines int                   Maximum number of parallel running pipelines
-```
-A very important set of configuration you can provide is related to Maven:
-```
---maven-ca-secret string                      Configure the secret key containing the Maven CA certificates (secret/key)
---maven-cli-option stringArray                Add a default Maven CLI option to the list of arguments for Maven commands
---maven-extension stringArray                 Add a Maven build extension
---maven-local-repository string               Path of the local Maven repository
---maven-property stringArray                  Add a Maven property
---maven-repository stringArray                Add a Maven repository
---maven-settings string                       Configure the source of the Maven settings (configmap|secret:name[/key])
-```
-You can learn more in details in the xref:installation/advanced/maven.adoc[Maven configuration] page.
-
-[[publish-configuration]]
-== Publish configuration
-
-Camel K requires a container registry where to store the applications built. These are the main configurations:
-
-```
---organization string                         A organization on the Docker Hub that can be used to publish images
---registry string                             A container registry that can be used to publish images
---registry-auth-file string                   A container registry configuration file containing authorization tokens for pushing and pulling images
---registry-auth-password string               The container registry authentication password
---registry-auth-server string                 The container registry authentication server
---registry-auth-username string               The container registry authentication username
---registry-insecure                           Configure registry access in insecure mode or not (`http` vs `https`)
---registry-secret string                      A secret used to push/pull images to the container registry
-```
-We have a dedicated section to explain more in details xref:installation/registry/registry.adoc[how to configure a registry].
+We provide certain configuration to better "operationalize" the Camel K Operator. More detailed information on the xref:installation/advanced/resources.adoc[resource management] page.
 
 == Monitoring
 
-Camel K Operator provides certain monitoring capabilities. You can change the default settings:
+Camel K Operator provides certain parameters that would let you enable monitoring capabilities.
 
-```
---health-port int                             The port of the health endpoint (default 8081)
---monitoring                                  To enable or disable the operator monitoring
---monitoring-port int                         The port of the metrics endpoint (default 8080)
---log-level string                            The level of operator logging (default - info): info or 0, debug or 1 (default "info")
-```
-You can learn more about xref:observability/monitoring/operator.adoc[how to monitor Camel K Operator].
+There is a default liveness service that is available at the operator Pod _/healtz_ endpoint on port _8081_. You can change the port parameter if you need to expose under a different port making sure to start the operator with the _--health-port_ to the same value. You also need to change the Deployment template spec to reflect the change on the operator container liveness check.
 
-== Debugging
+There is a default metrics service as well available at the operator Pod _/metrics_ endpoint on port _8080_. The port can be also changed. In this case you only need to change the Deployment container operator, changing the _--monitoring-port_ value to the port you want the operator to expose.
 
-Camel K offers the possibility to execute debugging on the same operator program. Here is the list of settings available:
+The service exposed on the _/metrics_ endpoint is compatible with Prometheus. You can learn more about xref:observability/monitoring/operator.adoc[how to monitor Camel K Operator].
 
-```
---debugging                                   To enable or disable the operator debugging
---debugging-path string                       The path to the kamel executable file (default "/usr/local/bin/kamel")
---debugging-port int                          The port of the debugger (default 4040)
-```
+== Logging
 
-== Installation topology
-
-We have also certain configuration that let you control how to deploy your Camel K Operator(s):
-```
---global                                      Configure the operator to watch all namespaces. No integration platform is created. You can run integrations in a namespace by installing an integration platform: 'kamel install --skip-operator-setup -n my-namespace'
---operator-id string                          Set the operator id that is used to select the resources this operator should manage (default "camel-k")
-```
-Learn more about xref:installation/advanced/multi.adoc[Camel K multi-tenancy].
-
-== OLM Specific parameters
-
-OLM is one of the methodology and we have a few handy parameters to customize it:
-
-```
---olm                                         Try to install everything via OLM (Operator Lifecycle Manager) if available (default true)
---olm-channel string                          Name of the Camel K channel in the OLM source or marketplace
---olm-global-namespace string                 A namespace containing an OperatorGroup that defines global scope for the operator (used in combination with the --global flag)
---olm-operator-name string                    Name of the Camel K operator in the OLM source or marketplace
---olm-package string                          Name of the Camel K package in the OLM source or marketplace
---olm-source string                           Name of the OLM source providing the Camel K package (defaults to the standard Operator Hub source)
---olm-source-namespace string                 Namespace where the OLM source is available
---olm-starting-csv string                     Allow to install a specific version from the operator source instead of latest available from the channel
-```
-
-Have a look at xref:installation/installation.adoc#olm[OLM installation procedure].
+By default, the operator Pod logging level is set to INFO. You may require to change this value to log also DEBUG. In this case you need to provide an environment variable to the operator Deployment, _LOG_LEVEL_ which can be set to `debug`. You can also lower the number of logging tracing by setting this value to `error` (advisable for production environments).

--- a/docs/modules/ROOT/pages/installation/advanced/build-config.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/build-config.adoc
@@ -1,6 +1,6 @@
 = Build configuration
 
-The default installation provides some default configuration in order to perform a build and the publishing of the application in the container registry. In order to provide a more customized user experience, we provide two build configuration which you can use: **Build Strategy** and **Publish Strategy**.
+The Camel K operator installation provides some default configuration in order to perform a build and the publishing of the application in a container registry. The configuration can be defined at a global scope in the IntegrationPlatform custom resource, or during each Integration execution via the options available in the builder trait.
 
 [[build-strategy]]
 == Build strategy
@@ -20,12 +20,10 @@ The most relevant are the `resource` and `limit` parameters which can be used to
 
 The publish strategy is used to control the behavior of the creation of the container after a build. Basically it create a container image from the application built in the previous step and store as a container in the xref:installation/registry/registry.adoc[registry] configured.
 
-The operator has 3 different strategy which you can adopt: Spectrum (default in plain Kubernetes profile), S2I (default in Openshift profile) and Jib.
-
-Each configuration provides a set of technologies which are supporting the creation of a container image and the storage into a container registry. https://github.com/container-tools/spectrum[Spectrum] is a lightweight technology based on https://github.com/google/go-containerregistry[go-containerregistry]. It creates a raw image on top of a base image and push very quickly to a registry.
-
-https://access.redhat.com/documentation/es-es/openshift_container_platform/4.2/html/builds/understanding-image-builds#build-strategy-s2i_understanding-image-builds[S2I] is an efficient technology integrated in Openshift, reason why it is enabled by default in such a profile.
+The operator has 2 different strategy which you can adopt: Jib (default in plain Kubernetes profile) and S2I (default in Openshift profile).
 
 https://cloud.google.com/java/getting-started/jib[Jib] is a technology that transform a Java project into a container image and is configurable directly in Maven.
+
+https://access.redhat.com/documentation/es-es/openshift_container_platform/4.2/html/builds/understanding-image-builds#build-strategy-s2i_understanding-image-builds[S2I] is an efficient technology integrated in Openshift, reason why it is enabled by default in such a profile.
 
 NOTE: you may define your own publishing technology by using xref:pipeline/pipeline.adoc[pipelines].

--- a/docs/modules/ROOT/pages/installation/advanced/resources.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/resources.adoc
@@ -1,25 +1,23 @@
 [[scheduling-infra-pod]]
 = Infrastructure Pods and Resource Management
 
-During the installation procedure you will be able to provide information on how to best "operationalize" your infrastructure. Through the configuration of `--node-selector`, `--toleration` and `--operator-resources` you will be able to drive the operator `Pods` scheduling and to be able to assign resources.
+During the installation procedure you will be able to provide information on how to best "operationalize" your infrastructure. Here we give you some Kubernetes best practices you can use in order to configure a production ready environment.
 
-The usage of these advanced properties assumes you're familiar with the https://kubernetes.io/docs/concepts/scheduling-eviction/[Kubernetes Scheduling] concepts and configurations.
+The usage of these advanced configuration assumes you're familiar with the https://kubernetes.io/docs/concepts/scheduling-eviction/[Kubernetes Scheduling] concepts and configurations.
 
-NOTE: The aforementioned flags setting will work both with `OLM` installation and regular installation.
+Depending on the installation methodology (ie, Helm) provided you may have certain configuration parameters out of the box. Otherwise you should be able to fine tune those parameters altering directly the Camel K operator Deployment.
 
 [[scheduling-infra-pod-scheduling]]
 == Scheduling
 
-=== Node Selectors
-The most basic operation we provide is to let you assign Camel K operator `Pods` to a specific cluster `Node`. The functionality is based on https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[`NodeSelector` Kubernetes feature]. As an example, you can schedule Camel K infra `Pods` to a specific `Node` of your cluster. See how to configure according the installation methodology selected.
+=== Node Selectors and tolerations
 
-=== Tolerations
-The `--toleration` option will let you tolerate a Camel K infra `Pod` to support any matching `Taint` according the https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[`Taint` and `Toleration` Kubernetes feature]. As an example, let's suppose we have a node tainted as "dedicated=camel-k:NoSchedule". In order to allow the infra `Pods` to be scheduled on that `Node` we can provide the following option during installation procedure. See how to configure according the installation methodology selected.
+We suggest to edit the Deployment to configure the https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[`NodeSelector` Kubernetes feature] and the https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[`Taint` and `Toleration` Kubernetes feature].
 
 [[scheduling-infra-pod-resources]]
 == Resources
 
-While installing the Camel K operator, you can also specify the resources requests and limits to assign to the operator `Pod` with `--operator-resources` option. The option will expect the configuration as required by https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes Resource Management]. See how to configure according the installation methodology selected.
+While installing the Camel K operator, you can also specify the resources requests and limits to assign to the operator `Pod`. This configuration will expect the setting as required by https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes Resource Management].
 
 NOTE: if you specify a limit, but does not specify a request, Kubernetes automatically assigns a request that matches the limit.
 

--- a/docs/modules/ROOT/pages/installation/installation.adoc
+++ b/docs/modules/ROOT/pages/installation/installation.adoc
@@ -1,29 +1,27 @@
 [[installation]]
 = Installation
 
-Camel K allows us to run Camel integrations directly on a Kubernetes or OpenShift cluster. To use it, you need to be connected to a cloud environment or to a local cluster created for development purposes (ie, Minikube or Kind).
+Camel K allows us to run Camel integrations directly on a Kubernetes cluster. To use it, you need to be connected to a cloud environment or to a local cluster created for development purposes (ie, Minikube or Kind).
 
-[[registry]]
-== Registry requirements
+[[operator]]
+== Camel K operator installation
 
-Camel K may require a container registry which is used to store the images built for your applications. Certain clusters may use their internal container registry (ie, Openshift, Minikube or https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry[KEP-1755 compatible] clusters). If it's not the case for your cluster make sure to have a xref:installation/registry/registry.adoc#configuring-registry-install-time[container registry] available and set it according the specific installation methodology chosen.
+The first step is to install and run the Camel K operator. You can do it via any of the following methodologies:
 
 [[helm]]
-== Installation via Helm Hub
+=== Installation via Helm Hub
 
-Camel K is also available in Helm Hub:
+Camel K is available in Helm Hub:
 
 ```
 $ helm repo add camel-k https://apache.github.io/camel-k/charts/
-$ helm install camel-k [--set platform.build.registry.address=<my-registry>] camel-k/camel-k --force
+$ helm install camel-k camel-k/camel-k
 ```
-
-NOTE: the `--force` option may be required to override the platform configuration with the registry values provided.
 
 More instructions on the https://hub.helm.sh/charts/camel-k/camel-k[Camel K Helm] page.
 
 [[olm]]
-== Installation via Operator Hub
+=== Installation via Operator Hub
 
 Camel K is also available in Operator Hub. You will need the OLM framework to be properly installed in your cluster. More instructions on the https://operatorhub.io/operator/camel-k[Camel K Operator Hub] page.
 
@@ -36,52 +34,74 @@ You can edit the `Subscription` custom resource, setting the channel you want to
 NOTE: Some Kubernetes clusters such as Openshift may let you to perform the same operation from a GUI as well. Refer to the cluster instruction to learn how to perform such action from user interface.
 
 [[kustomize]]
-== Installation via Kustomize
+=== Installation via Kustomize
 
 https://kustomize.io[Kustomize] provides a declarative approach to the configuration customization of a Camel-K installation. Kustomize works either with a standalone executable or as a built-in to `kubectl`. The https://github.com/apache/camel-k/tree/main/install[/install] directory provides a series of base and overlays configuration that you can use. You can create your own overlays or customize the one available in the repository to accommodate your need.
 
-=== One liner operator installation procedure
-
-If you don't need to provide any configuration nor the registry (ie, in Openshift), you can apply this simple one liner:
-
 ```
-$ kubectl apply -k github.com/apache/camel-k/install/overlays/openshift/descoped?ref=v2.4.0 --server-side
+$ kubectl apply -k github.com/apache/camel-k/install/overlays/kubernetes/descoped?ref=v2.4.0 --server-side
 ```
 
 You can specify as `ref` parameter the version you're willing to install (ie, `v2.4.0`). The command above will install a descoped (global) operator in the camel-k namespace.
 
-NOTE: if you're not installing in Openshift you will need to manually change the IntegrationPlatform registry configuration as the operator won't be able to find any valid registry address (see section below).
+[[verify]]
+=== Verify that the operator is up and running
 
-=== Custom configuration procedure
-
-Most often you want to specify different parameters to configure the registry and other platform behaviors. In such case you can clone the project repository and use any of the overlays available, customizing to your needs.
-
-```
-# Clone the project repository
-$ https://github.com/apache/camel-k.git
-$ cd camel-k
-# You can use any release tag (recommended as it is immutable) or branch
-$ git checkout v2.4.0
-$ cd install/overlays
-```
-
-In this directory you may find a series of default configuration for Kubernetes, Openshift and any other sensible profile. For Kubernetes, you can see we have prepared a `descoped` configuration and a `namespaced` which are installing the operator globally or in a specific namespace.
+In order to verify that the operator is up and running, you should be able to see a Camel K operator `Pod` running in the namespace used, for example:
 
 ```
-# Default, use this namespace (edit `kustomize.yaml` to change it)
-$ kubectl create ns camel-k
-$ kubectl apply -k kubernetes/descoped --server-side
-# Change the registry address (edit the file for more configuration if required)
-$ sed -i 's/address: .*/address: my-registry-host.io/' kubernetes/descoped/integration-platform.yaml
-$ kubectl apply -k platform
+kubectl get pods -n camel-k
+NAME                                READY   STATUS    RESTARTS   AGE
+camel-k-operator-5b686db99f-c2k2s   1/1     Running   0          3m46s
 ```
 
-NOTE: you don't need to set the platform if running on Openshift.
+[[integration-platform]]
+== IntegrationPlatform and container registry
 
-The above command will install a global Camel K operator in the `camel-k` namespace using the container registry you've provided. The `server-side` option is required in order to prevent some error while installing CRDs. We need to apply a separate platform configuration as Kustomize may not be yet aware of the CRDs if done in the same step.
+The operator is now up and running. However, there is a second step you need to perform in order to be able to properly use it.
+
+The majority of configuration required to tune the operator are stored in an `IntegrationPlatform` custom resource. This is mainly required to provide configuration for the container registry, build time configuration or common profile you want to apply to all your `Integrations`.
+
+Camel K requires a container registry which is used to store the images built for your applications. Certain clusters may use their internal container registry (ie, Openshift, Minikube or https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry[KEP-1755 compatible] clusters).
+
+You need to create an `IntegrationPlatform` with the following configuration in the namespace where the operator is running:
+
+```yaml
+apiVersion: camel.apache.org/v1
+kind: IntegrationPlatform
+metadata:
+labels:
+    app: camel-k
+name: camel-k
+namespace: camel-k
+spec:
+build:
+    registry:
+    address: registry.io
+    insecure: true
+```
+
+The minimum configuration required is the container registry. Just change the example value with the configuration available for your installation and write as a file as `itp.yaml`.
+
+NOTE: a local minikube registry can be enabled via `minikube addons enable registry` and the IP to use running `kubectl -n kube-system get service registry -o jsonpath='{.spec.clusterIP}'`.
+
+```
+kubectl apply -f itp.yaml -n camel-k
+```
+
+Wait now for the`IntegrationPlatform` to turn into ready state:
+
+```
+$ kubectl wait --for jsonpath='{.status.phase}'=Ready IntegrationPlatform camel-k -n camel-k --timeout 30s
+integrationplatform.camel.apache.org/camel-k condition met
+```
+
+Your operator is now ready to run some Camel `Integration`.
+
+NOTE: a xref:installation/registry/registry.adoc#configuring-registry-install-time[container registry] configuration may require other parameters and secret management.
 
 [[test]]
-== Test your installation
+== Run some integration
 
 Once you've completed any of the above installation procedure, you'll be ready to xref:running/running.adoc[run some integrations].
 

--- a/docs/modules/ROOT/pages/installation/integrationplatform.adoc
+++ b/docs/modules/ROOT/pages/installation/integrationplatform.adoc
@@ -1,0 +1,40 @@
+= Configure an IntegrationPlatform
+
+The IntegrationPlatform custom resource is used to configure your operator and the components required to build, publish and run your Camel applications. This custom resource may be provided at installation time (above all when using Helm or Kustomize methodology) or after the Camel K operator is running. The same operator will be in charge to reconcile the configuration provided and run any following Integration with the new values provided.
+
+The operator is using default values for most of the configuration. The only mandatory configuration you need to provide is the container registry (1) where you want to push and pull the container images.
+
+```
+apiVersion: camel.apache.org/v1
+kind: IntegrationPlatform
+metadata:
+  name: camel-k
+spec:
+   build:
+     registry: (1)
+...
+status:
+  build:
+    baseImage: eclipse-temurin:17
+    buildConfiguration:
+      orderStrategy: dependencies
+      strategy: routine
+    maven:
+      cliOptions:
+      - -V
+      - --no-transfer-progress
+      - -Dstyle.color=never
+      localRepository: /etc/maven/m2
+    maxRunningBuilds: 3
+    publishStrategy: Jib
+    registry: (1)
+    runtimeVersion: 3.8.1
+    timeout: 5m0s
+  cluster: Kubernetes
+```
+
+NOTE: the above are the default values coming from version 2.5.0, they may slightly change in future versions.
+
+There are many more configuration available in the IntegrationPlatform specification. Have a look at the xref:apis/camel-k.adoc#_camel_apache_org_v1_IntegrationPlatformSpec[IntegrationPlatform API specification] to learn more about each of its usage.
+
+Have also a look at the specific sections to learn more about xref:registry/registry.adoc[how to configure a container registry], xref:advanced/build-config.adoc[how to choose the right build and publishing strategy] or xref:advanced/maven.adoc[how to configure Maven].

--- a/docs/modules/ROOT/pages/installation/registry/registry.adoc
+++ b/docs/modules/ROOT/pages/installation/registry/registry.adoc
@@ -10,23 +10,14 @@ For the reason above it's important that you provide a container registry which 
 
 For any other platform that do not provide a default container registry, then, a registry must be provided accordingly.
 
-[[configuring-registry-install-time]]
-== Configure the registry at installation time
+[[how-to-configure]]
+== How to configure Camel K container registry
 
-Registry configuration can be set upon installation using command:
+When running a production grade installation, you'll be probably using a private container registry which is accessible via authenticated method. The secret is something that will be https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret[included at deployment time] as `imagePullSecret` configuration.
 
-[source,bash]
-----
-$ kamel install --registry registry-host.io [--organization your-user-id-or-org] [--registry-secret my-secret-registry-conf]
-----
+As each registry may have a slightly different way of securing the access you can use the generic guidelines provided in xref:installation/registry/dockerhub.adoc[Docker Hub] registry configuration and adjust accordingly. We expect that at the end of the process you have a public address (1) an _organization_ (2) and a _secret_ (3) values that will be used to configure the registry.
 
-Although optionals, the `organization` and `registry-secret` parameters are strongly suggested in order to secure the pull/push operations on a registry that is private, although accessible through the Internet. The secret is something that will https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret[included at deployment time] as `imagePullSecret` configuration.
-
-As each registry may have a slightly different way of securing the access you can use the guidelines provided in xref:installation/registry/dockerhub.adoc[Docker Hub] registry configuration and adjust accordingly.
-
-[[configuring-registry-after-install]]
-== Configure the registry after installation
-The settings you've provided in the chapter above are applied to the `IntegrationPlatform` custom resource. In particular you can find them in the `.spec.pipeline.registry`.
+You will need to create or edit any existing `IntegrationPlatform` custom resource with the values as expected in the `.spec.build.registry`.
 
 [source,yaml]
 ----
@@ -39,12 +30,12 @@ metadata:
 spec:
   build:
     registry:
-      address: registry-host.io
-      organization: your-user-id-or-org
-      secret: my-secret-registry-conf
+      address: <my-registry-address> (1)
+      organization: <my-organization> (2)
+      secret: <my-secret-credentials> (3)
 ----
 
-You can therefore update the values in the `IntegrationPlatform` in order to perform any change to the registry configuration after the Camel K operator is installed. The changes will be immediately reconciled and ready to use.
+The changes will be immediately reconciled and the operator will be able to push and pull resources in a secure manner.
 
 [[configuring-registry]]
 == Container registry requirements

--- a/docs/modules/ROOT/pages/observability/logging/operator.adoc
+++ b/docs/modules/ROOT/pages/observability/logging/operator.adoc
@@ -1,7 +1,7 @@
 [[logging]]
 = Camel K Operator Logging
 
-The operator provides https://kubernetes.io/blog/2020/09/04/kubernetes-1-19-introducing-structured-logs/[structured logging], so that the logs are more easily parseable.
+The operator provides https://kubernetes.io/blog/2020/09/04/kubernetes-1-19-introducing-structured-logs/[structured logging], so that the logs are more easily parsable.
 
 This includes the output of components managed by the operator, such as the Maven build, and the Integration container image build.
 
@@ -19,6 +19,4 @@ This may differ when running the operator locally, for development purposes, in 
 
 The operator log level is controlled by an environment setting (`LOG_LEVEL`) on the operator deployment. You can set the log level during installation procedure (see details in installation section). The default level is `info`.
 
-In general log levels are represented by numeric verbosity levels where `0` is the standard
-info log level and `1` is debug level. All values `2-10` represent different trace levels.
-You can set numeric values or one of the preset values `info`, `debug`, `error`.
+In general log levels are represented by numeric verbosity levels where `0` is the standard info log level and `1` is debug level. All values `2-10` represent different trace levels. You can set numeric values or one of the preset values `info`, `debug`, `error`.

--- a/docs/modules/ROOT/pages/observability/monitoring/operator.adoc
+++ b/docs/modules/ROOT/pages/observability/monitoring/operator.adoc
@@ -6,26 +6,17 @@ NOTE: The Camel K monitoring architecture relies on https://prometheus.io[Promet
 [[installation]]
 == Installation
 
-The `kamel install` command provides the `--monitoring` option flag, that can be used to automatically create the default resources required to monitor the Camel K operator, e.g.:
+You need to create the resources required to let Prometheus to interact with the metrics exposed by the operator. There is a Kustomization based configuration you can find under `/install/base/config/prometheus`.
 
-[source,console]
-----
-$ kamel install --monitoring=true
-----
+We have prepared a base configuration you can quickly apply executing:
 
-This creates:
+```
+kubectl apply -k github.com/apache/camel-k/install/base/config/prometheus?ref=v2.4.0
+```
 
-* a `PodMonitor` resource targeting the operator _metrics_ endpoint, so that the Prometheus server can scrape the <<metrics>> exposed by the operator;
-* a `PrometheusRule` resource with default alerting rules based on the exposed metrics. The <<alerting>> provides more details about these default rules.
+NOTE: change the ref value with the installation version tag you want to install.
 
-The `kamel install` command also provides the `--monitoring-port` option, that can be used to change the port of the operator monitoring endpoint, e.g.:
-
-[source,console]
-----
-$ kamel install --monitoring=true --monitoring-port=8888
-----
-
-You can refer to the <<discovery>> and <<alerting>> sections in case you don't want to rely on the default monitoring configuration.
+However, most of the time you want to probably configure and add different thresholds and KPIs in order to monitor in a properly manner your installation.
 
 [[metrics]]
 == Metrics
@@ -73,7 +64,7 @@ The Camel K operator monitoring endpoint exposes the following metrics:
 
 A `PodMonitor` resource must be created for the Prometheus Operator to reconcile, so that the managed Prometheus instance can scrape the Camel K operator _metrics_ endpoint.
 
-As an example, hereafter is the `PodMonitor` resource that is created when executing the `kamel install --monitoring=true` command:
+As an example, hereafter is the `PodMonitor` resource that is created when executing the default Prometheus configuration provided above:
 
 .operator-pod-monitor.yaml
 [source,yaml]
@@ -106,7 +97,7 @@ NOTE: The Prometheus Operator declares the `AlertManager` resource that can be u
 
 A `PrometheusRule` resource can be created for the Prometheus Operator to reconcile, so that the managed AlertManager instance can trigger alerts, based on the metrics exposed by the Camel K operator.
 
-As an example, hereafter is the alerting rules that are defined in `PrometheusRule` resource that is created when executing the `kamel install --monitoring=true` command:
+As an example, hereafter is the alerting rules that are defined in `PrometheusRule` resource that is created when executing the default Prometheus configuration provided above:
 
 .Camel K operator alerts
 |===

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -38,7 +38,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -222,7 +221,6 @@ func Run(healthPort, monitoringPort int32, leaderElection bool, leaderElectionID
 	installCtx, installCancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer installCancel()
 	install.OperatorStartupOptionalTools(installCtx, bootstrapClient, watchNamespace, operatorNamespace, log)
-	exitOnError(findOrCreateIntegrationPlatform(installCtx, bootstrapClient, operatorNamespace), "failed to create integration platform")
 
 	synthEnvVal, synth := os.LookupEnv("CAMEL_K_SYNTHETIC_INTEGRATIONS")
 	if synth && synthEnvVal == "true" {
@@ -243,45 +241,6 @@ func getNamespacesSelector(operatorNamespace string, watchNamespace string) map[
 		namespacesSelector[watchNamespace] = cache.Config{}
 	}
 	return namespacesSelector
-}
-
-// findOrCreateIntegrationPlatform create default integration platform in operator namespace if not already exists.
-func findOrCreateIntegrationPlatform(ctx context.Context, c client.Client, operatorNamespace string) error {
-	operatorID := defaults.OperatorID()
-	var platformName string
-	if operatorID != "" {
-		platformName = operatorID
-	} else {
-		platformName = platform.DefaultPlatformName
-	}
-
-	if pl, err := kubernetes.GetIntegrationPlatform(ctx, c, platformName, operatorNamespace); pl == nil || k8serrors.IsNotFound(err) {
-		log.Info("No IntegrationPlatform provided. Creating one with default values.")
-		defaultPlatform := v1.NewIntegrationPlatform(operatorNamespace, platformName)
-
-		if defaultPlatform.Labels == nil {
-			defaultPlatform.Labels = make(map[string]string)
-		}
-		defaultPlatform.Labels["app"] = "camel-k"
-		defaultPlatform.Labels["camel.apache.org/platform.generated"] = "true"
-
-		if operatorID != "" {
-			defaultPlatform.SetOperatorID(operatorID)
-		}
-
-		if _, err := c.CamelV1().IntegrationPlatforms(operatorNamespace).Create(ctx, &defaultPlatform, metav1.CreateOptions{}); err != nil {
-			return err
-		}
-
-		// Make sure that IntegrationPlatform installed in operator namespace can be seen by others
-		if err := install.IntegrationPlatformViewerRole(ctx, c, operatorNamespace); err != nil && !k8serrors.IsAlreadyExists(err) {
-			return fmt.Errorf("error while installing global IntegrationPlatform viewer role: %w", err)
-		}
-	} else {
-		return err
-	}
-
-	return nil
 }
 
 // getWatchNamespace returns the Namespace the operator should be watching for changes.


### PR DESCRIPTION
<!-- Description -->

With this PR we make sure that the user provide a configuration for the IntegrationPlatform custom resource. This is required as the generation of the platform is making unstable the installation procedure (where the platform is provided beside the operator configuration). We also make sure to "educate" the user about the presence and the need of this custom resource that drives the behavior of the operator. Above all, we make sure the user to understand they require a container registry in order to properly use the operator.


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat: explicit IntegrationPlatform installation
```
