### PR TITLE
chore(cmd): deprecate CLIs subcommands

### DIFF
--- a/docs/modules/ROOT/pages/cli/cli.adoc
+++ b/docs/modules/ROOT/pages/cli/cli.adoc
@@ -43,10 +43,6 @@ Some of the most used commands are:
 |Get integrations deployed on Kubernetes
 |kamel get
 
-|describe
-|Get detailed information on a resource
-|kamel describe integration routes
-
 |log
 |Print the logs of a running integration
 |kamel log routes
@@ -59,10 +55,6 @@ Some of the most used commands are:
 |Bind Kubernetes resources, such as Kamelets, in an integration flow.
 |kamel bind timer-source -p "source.message=hello world" channel:mychannel
 
-|install
-|Install Camel K on a Kubernetes cluster
-|kamel install
-
 |rebuild
 |Clear the state of integrations to rebuild them.
 |kamel rebuild --all
@@ -70,10 +62,6 @@ Some of the most used commands are:
 |reset
 |Reset the Camel K installation
 |kamel reset
-
-|uninstall
-|Uninstall Camel K from a Kubernetes cluster
-|kamel uninstall
 
 |version
 |Display client version
@@ -101,7 +89,7 @@ While each command has a dedicated set of flags, there are global flags that are
 
 |`--kube-config PATH`
 |Path to the config file to use for CLI requests
-|kamel install --kube-config ~/.kube/config
+|kamel run my-route.yaml --kube-config ~/.kube/config
 
 |`-h` or `--help`
 |Help for `kamel`, or the command

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -23,8 +23,9 @@ import (
 
 func newCmdCompletion(root *cobra.Command) *cobra.Command {
 	completion := cobra.Command{
-		Use:   "completion",
-		Short: "Generate completion scripts",
+		Use:        "completion",
+		Short:      "Generate completion scripts",
+		Deprecated: "no longer supported.",
 	}
 
 	completion.AddCommand(newCmdCompletionBash(root))

--- a/pkg/cmd/completion_bash.go
+++ b/pkg/cmd/completion_bash.go
@@ -341,9 +341,10 @@ __custom_func() {
 
 func newCmdCompletionBash(root *cobra.Command) *cobra.Command {
 	return &cobra.Command{
-		Use:   "bash",
-		Short: "Generates bash completion scripts",
-		Long:  bashCompletionCmdLongDescription,
+		Use:        "bash",
+		Short:      "Generates bash completion scripts",
+		Long:       bashCompletionCmdLongDescription,
+		Deprecated: "no longer supported.",
 		Run: func(_ *cobra.Command, _ []string) {
 			err := root.GenBashCompletion(root.OutOrStdout())
 			if err != nil {

--- a/pkg/cmd/completion_zsh.go
+++ b/pkg/cmd/completion_zsh.go
@@ -45,9 +45,10 @@ fi
 
 func newCmdCompletionZsh(root *cobra.Command) *cobra.Command {
 	return &cobra.Command{
-		Use:   "zsh",
-		Short: "Generates zsh completion scripts",
-		Long:  zshCompletionCmdLongDescription,
+		Use:        "zsh",
+		Short:      "Generates zsh completion scripts",
+		Long:       zshCompletionCmdLongDescription,
+		Deprecated: "no longer supported.",
 		Run: func(_ *cobra.Command, _ []string) {
 			err := root.GenZshCompletion(root.OutOrStdout())
 			if err != nil {

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -48,11 +48,12 @@ const (
 func newCmdConfig(rootCmdOptions *RootCmdOptions) (*cobra.Command, *configCmdOptions) {
 	options := configCmdOptions{}
 	cmd := cobra.Command{
-		Use:     "config",
-		Short:   "Configure the default settings",
-		PreRunE: decode(&options, rootCmdOptions.Flags),
-		Args:    options.validateArgs,
-		RunE:    options.run,
+		Use:        "config",
+		Short:      "Configure the default settings",
+		Deprecated: "no longer supported.",
+		PreRunE:    decode(&options, rootCmdOptions.Flags),
+		Args:       options.validateArgs,
+		RunE:       options.run,
 	}
 
 	cmd.Flags().String("folder", "used", "The type of folder containing the configuration file to read/write. The supported values are 'env', 'home', 'sub', 'working' and 'used' for respectively $KAMEL_CONFIG_PATH, $HOME/.kamel, .kamel, . and the folder used by kamel")

--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -75,9 +75,10 @@ func describeTraits(w *indentedwriter.Writer, traits interface{}) error {
 
 func newCmdDescribe(rootCmdOptions *RootCmdOptions) *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "describe",
-		Short: "Describe a resource",
-		Long:  `Describe a Camel K resource.`,
+		Use:        "describe",
+		Deprecated: "consider using kubectl (or oc) custom resource describe command instead.",
+		Short:      "Describe a resource",
+		Long:       `Describe a Camel K resource.`,
 	}
 
 	cmd.AddCommand(cmdOnly(newDescribeKitCmd(rootCmdOptions)))

--- a/pkg/cmd/describe_integration.go
+++ b/pkg/cmd/describe_integration.go
@@ -37,11 +37,12 @@ func newDescribeIntegrationCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, 
 	}
 
 	cmd := cobra.Command{
-		Use:     "integration",
-		Aliases: []string{"it"},
-		Short:   "Describe an Integration",
-		Long:    `Describe an Integration.`,
-		PreRunE: decode(&options, options.Flags),
+		Use:        "integration",
+		Aliases:    []string{"it"},
+		Short:      "Describe an Integration",
+		Long:       `Describe an Integration.`,
+		Deprecated: "consider using kubectl (or oc) custom resource describe command instead.",
+		PreRunE:    decode(&options, options.Flags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(cmd, args); err != nil {
 				return err

--- a/pkg/cmd/describe_kamelet.go
+++ b/pkg/cmd/describe_kamelet.go
@@ -38,11 +38,12 @@ func newDescribeKameletCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *des
 	}
 
 	cmd := cobra.Command{
-		Use:     "kamelet",
-		Aliases: []string{"kl"},
-		Short:   "Describe a Kamelet",
-		Long:    `Describe a Kamelet.`,
-		PreRunE: decode(&options, options.Flags),
+		Use:        "kamelet",
+		Aliases:    []string{"kl"},
+		Short:      "Describe a Kamelet",
+		Long:       `Describe a Kamelet.`,
+		Deprecated: "consider using kubectl (or oc) custom resource describe command instead.",
+		PreRunE:    decode(&options, options.Flags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(cmd, args); err != nil {
 				return err

--- a/pkg/cmd/describe_kit.go
+++ b/pkg/cmd/describe_kit.go
@@ -36,11 +36,12 @@ func newDescribeKitCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *describ
 	}
 
 	cmd := cobra.Command{
-		Use:     "kit",
-		Aliases: []string{"ik"},
-		Short:   "Describe an Integration Kit",
-		Long:    `Describe an Integration Kit.`,
-		PreRunE: decode(&options, options.Flags),
+		Use:        "kit",
+		Aliases:    []string{"ik"},
+		Short:      "Describe an Integration Kit",
+		Long:       `Describe an Integration Kit.`,
+		Deprecated: "consider using kubectl (or oc) custom resource describe command instead.",
+		PreRunE:    decode(&options, options.Flags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(cmd, args); err != nil {
 				return err

--- a/pkg/cmd/describe_platform.go
+++ b/pkg/cmd/describe_platform.go
@@ -36,11 +36,12 @@ func newDescribePlatformCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *de
 	}
 
 	cmd := cobra.Command{
-		Use:     "platform",
-		Aliases: []string{"ip"},
-		Short:   "Describe an Integration Platform",
-		Long:    `Describe an Integration Platform.`,
-		PreRunE: decode(&options, options.Flags),
+		Use:        "platform",
+		Aliases:    []string{"ip"},
+		Short:      "Describe an Integration Platform",
+		Long:       `Describe an Integration Platform.`,
+		Deprecated: "consider using kubectl (or oc) custom resource describe command instead.",
+		PreRunE:    decode(&options, options.Flags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(cmd, args); err != nil {
 				return err

--- a/pkg/cmd/dump.go
+++ b/pkg/cmd/dump.go
@@ -47,6 +47,9 @@ func newCmdDump(rootCmdOptions *RootCmdOptions) (*cobra.Command, *dumpCmdOptions
 		Long:    `Dump the state of currently used namespace. If no filename will be specified, the output will be on stdout`,
 		PreRunE: decode(&options, options.Flags),
 		RunE:    options.dump,
+		// Once we moved from the deprecation this should be hidden and only used internally for E2E test execution.
+		Deprecated: "no longer supported.",
+		// Hidden: true,
 	}
 
 	cmd.Flags().Int("logLines", 100, "Number of log lines to dump")

--- a/pkg/cmd/kamelet.go
+++ b/pkg/cmd/kamelet.go
@@ -23,9 +23,10 @@ import (
 
 func newCmdKamelet(rootCmdOptions *RootCmdOptions) *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "kamelet",
-		Short: "Configure a Kamelet",
-		Long:  `Configure a Kamelet.`,
+		Use:        "kamelet",
+		Short:      "Configure a Kamelet",
+		Long:       `Configure a Kamelet.`,
+		Deprecated: "consider using kubectl (or oc) command instead.",
 	}
 
 	cmd.AddCommand(cmdOnly(newKameletGetCmd(rootCmdOptions)))

--- a/pkg/cmd/kamelet_add_repo.go
+++ b/pkg/cmd/kamelet_add_repo.go
@@ -40,10 +40,11 @@ func newKameletAddRepoCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kame
 	}
 
 	cmd := cobra.Command{
-		Use:     "add-repo github:owner/repo[/path_to_kamelets_folder][@version] ...",
-		Short:   "Add a Kamelet repository",
-		Long:    `Add a Kamelet repository.`,
-		PreRunE: decode(&options, options.Flags),
+		Use:        "add-repo github:owner/repo[/path_to_kamelets_folder][@version] ...",
+		Short:      "Add a Kamelet repository",
+		Long:       `Add a Kamelet repository.`,
+		Deprecated: "consider using kubectl (or oc) command instead.",
+		PreRunE:    decode(&options, options.Flags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(args); err != nil {
 				return err

--- a/pkg/cmd/kamelet_delete.go
+++ b/pkg/cmd/kamelet_delete.go
@@ -35,9 +35,10 @@ func newKameletDeleteCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kamel
 	}
 
 	cmd := cobra.Command{
-		Use:     "delete [Kamelet1] [Kamelet2] ...",
-		Short:   "Delete Kamelets deployed on Kubernetes",
-		PreRunE: decode(&options, options.Flags),
+		Use:        "delete [Kamelet1] [Kamelet2] ...",
+		Short:      "Delete Kamelets deployed on Kubernetes",
+		Deprecated: "consider using kubectl (or oc) command instead.",
+		PreRunE:    decode(&options, options.Flags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(args); err != nil {
 				return err

--- a/pkg/cmd/kamelet_get.go
+++ b/pkg/cmd/kamelet_get.go
@@ -36,10 +36,11 @@ func newKameletGetCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *kameletG
 	}
 
 	cmd := cobra.Command{
-		Use:     "get",
-		Short:   "Get defined Kamelet",
-		Long:    `Get defined Kamelet.`,
-		PreRunE: decode(&options, options.Flags),
+		Use:        "get",
+		Short:      "Get defined Kamelet",
+		Long:       `Get defined Kamelet.`,
+		Deprecated: "consider using kubectl (or oc) command instead.",
+		PreRunE:    decode(&options, options.Flags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(); err != nil {
 				return err

--- a/pkg/cmd/kamelet_remove_repo.go
+++ b/pkg/cmd/kamelet_remove_repo.go
@@ -33,10 +33,11 @@ func newKameletRemoveRepoCmd(rootCmdOptions *RootCmdOptions) (*cobra.Command, *k
 	}
 
 	cmd := cobra.Command{
-		Use:     "remove-repo github:owner/repo[/path_to_kamelets_folder][@version] ...",
-		Short:   "Remove a Kamelet repository",
-		Long:    `Remove a Kamelet repository.`,
-		PreRunE: decode(&options, options.Flags),
+		Use:        "remove-repo github:owner/repo[/path_to_kamelets_folder][@version] ...",
+		Short:      "Remove a Kamelet repository",
+		Long:       `Remove a Kamelet repository.`,
+		Deprecated: "consider using kubectl (or oc) command instead.",
+		PreRunE:    decode(&options, options.Flags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.validate(args); err != nil {
 				return err


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(cmd): deprecate CLIs subcommands
```
