### PR TITLE
chore(api): deprecate PublishStrategyOptions

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -2833,7 +2833,7 @@ map[string]string
 |
 
 
-Generic options that can used by any publish strategy
+Deprecated: no longer in use
 
 |`maxRunningBuilds` +
 int32

--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -3238,7 +3238,7 @@ spec:
                   PublishStrategyOptions:
                     additionalProperties:
                       type: string
-                    description: Generic options that can used by any publish strategy
+                    description: 'Deprecated: no longer in use'
                     type: object
                   baseImage:
                     description: |-
@@ -5286,7 +5286,7 @@ spec:
                   PublishStrategyOptions:
                     additionalProperties:
                       type: string
-                    description: Generic options that can used by any publish strategy
+                    description: 'Deprecated: no longer in use'
                     type: object
                   baseImage:
                     description: |-

--- a/pkg/apis/camel/v1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1/integrationplatform_types.go
@@ -131,7 +131,7 @@ type IntegrationPlatformBuildSpec struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// Maven configuration used to build the Camel/Camel-Quarkus applications
 	Maven MavenSpec `json:"maven,omitempty"`
-	// Generic options that can used by any publish strategy
+	// Deprecated: no longer in use
 	PublishStrategyOptions map[string]string `json:"PublishStrategyOptions,omitempty"`
 	// the maximum amount of parallel running pipelines started by this operator instance
 	MaxRunningBuilds int32 `json:"maxRunningBuilds,omitempty"`

--- a/pkg/apis/camel/v1/integrationplatform_types_support.go
+++ b/pkg/apis/camel/v1/integrationplatform_types_support.go
@@ -171,16 +171,6 @@ func (in *IntegrationPlatformStatus) RemoveCondition(condType IntegrationPlatfor
 	in.Conditions = newConditions
 }
 
-// AddOption add a publish strategy option.
-func (b *IntegrationPlatformBuildSpec) AddOption(option string, value string) {
-	options := b.PublishStrategyOptions
-	if options == nil {
-		options = make(map[string]string)
-		b.PublishStrategyOptions = options
-	}
-	options[option] = value
-}
-
 // GetTimeout returns the specified duration or a default one.
 func (b IntegrationPlatformBuildSpec) GetTimeout() metav1.Duration {
 	if b.Timeout == nil {

--- a/pkg/platform/defaults.go
+++ b/pkg/platform/defaults.go
@@ -230,10 +230,7 @@ func applyPlatformSpec(source *v1.IntegrationPlatform, target *v1.IntegrationPla
 	if target.Status.Build.PublishStrategy == "" {
 		target.Status.Build.PublishStrategy = source.Status.Build.PublishStrategy
 	}
-	if target.Status.Build.PublishStrategyOptions == nil {
-		log.Debugf("Integration Platform %s [%s]: setting publish strategy options", target.Name, target.Namespace)
-		target.Status.Build.PublishStrategyOptions = source.Status.Build.PublishStrategyOptions
-	}
+
 	if target.Status.Build.BuildConfiguration.Strategy == "" {
 		target.Status.Build.BuildConfiguration.Strategy = source.Status.Build.BuildConfiguration.Strategy
 	}
@@ -311,10 +308,6 @@ func applyPlatformSpec(source *v1.IntegrationPlatform, target *v1.IntegrationPla
 }
 
 func setPlatformDefaults(p *v1.IntegrationPlatform, verbose bool) error {
-	if p.Status.Build.PublishStrategyOptions == nil {
-		log.Debugf("Integration Platform %s [%s]: setting publish strategy options", p.Name, p.Namespace)
-		p.Status.Build.PublishStrategyOptions = map[string]string{}
-	}
 	if p.Status.Build.RuntimeVersion == "" {
 		log.Debugf("Integration Platform %s [%s]: setting runtime version", p.Name, p.Namespace)
 		p.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -92,7 +92,7 @@ spec:
                   PublishStrategyOptions:
                     additionalProperties:
                       type: string
-                    description: Generic options that can used by any publish strategy
+                    description: 'Deprecated: no longer in use'
                     type: object
                   baseImage:
                     description: |-
@@ -2140,7 +2140,7 @@ spec:
                   PublishStrategyOptions:
                     additionalProperties:
                       type: string
-                    description: Generic options that can used by any publish strategy
+                    description: 'Deprecated: no longer in use'
                     type: object
                   baseImage:
                     description: |-

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -145,11 +145,10 @@ func createBuilderTestEnv(cluster v1.IntegrationPlatformCluster, strategy v1.Int
 			Spec: v1.IntegrationPlatformSpec{
 				Cluster: cluster,
 				Build: v1.IntegrationPlatformBuildSpec{
-					PublishStrategy:        strategy,
-					Registry:               v1.RegistrySpec{Address: "registry"},
-					RuntimeVersion:         defaults.DefaultRuntimeVersion,
-					RuntimeProvider:        v1.RuntimeProviderQuarkus,
-					PublishStrategyOptions: map[string]string{},
+					PublishStrategy: strategy,
+					Registry:        v1.RegistrySpec{Address: "registry"},
+					RuntimeVersion:  defaults.DefaultRuntimeVersion,
+					RuntimeProvider: v1.RuntimeProviderQuarkus,
 					BuildConfiguration: v1.BuildConfiguration{
 						Strategy: buildStrategy,
 					},


### PR DESCRIPTION
It's no longer in use for some time now.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
chore(api): deprecate PublishStrategyOptions
```
