### PR TITLE
fix(e2e): Kamelet in route logs

### DIFF
--- a/e2e/common/traits/kamelet_test.go
+++ b/e2e/common/traits/kamelet_test.go
@@ -54,7 +54,7 @@ func TestKameletTrait(t *testing.T) {
 			g.Expect(KamelRun(t, ctx, ns, "files/webhook.yaml", "--name", name).Execute()).To(Succeed())
 			g.Eventually(IntegrationPodPhase(t, ctx, ns, name), TestTimeoutLong).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady), TestTimeoutShort).Should(Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Started capabilities-webhook-source-1 (platform-http:///webhook)"))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name), TestTimeoutShort).Should(ContainSubstring("Started route1 (kamelet://capabilities-webhook-source)"))
 			// Verify Integration capabilities
 			g.Eventually(IntegrationStatusCapabilities(t, ctx, ns, name), TestTimeoutShort).Should(ContainElements("platform-http"))
 			// Verify expected resources from Kamelet (Service in this case)


### PR DESCRIPTION
Closes #5746 

The change is from this CAMEL issue [CAMEL-18858](https://issues.apache.org/jira/browse/CAMEL-18858).
The logs changed from:
```
2024-08-20 09:01:18,136 INFO  [org.apa.cam.k.sup.SourcesSupport] (main) Loading routes from: SourceDefinition{name='camel-k-embedded-flow', language='yaml', type='source', location='file:/etc/camel/sources/camel-k-embedded-flow.yaml', }
2024-08-20 09:01:19,432 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main) Apache Camel 4.4.1 (camel-1) is starting
2024-08-20 09:01:19,532 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main) Routes startup (started:2)
2024-08-20 09:01:19,533 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main)     Started route1 (kamelet://capabilities-webhook-source)
2024-08-20 09:01:19,533 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main)     Started capabilities-webhook-source-1 (platform-http:///webhook)
2024-08-20 09:01:19,533 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main) Apache Camel 4.4.1 (camel-1) started in 100ms (build:0ms init:0ms start:100ms)
```
to
```
2024-08-20 09:39:22,847 INFO  [org.apa.cam.k.sup.SourcesSupport] (main) Loading routes from: SourceDefinition{name='camel-k-embedded-flow', language='yaml', type='source', location='file:/etc/camel/sources/camel-k-embedded-flow.yaml', }
2024-08-20 09:39:24,351 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main) Apache Camel 4.7.0 (camel-1) is starting
2024-08-20 09:39:24,440 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main) Routes startup (total:1 started:1 kamelets:1)
2024-08-20 09:39:24,441 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main)     Started route1 (kamelet://capabilities-webhook-source)
2024-08-20 09:39:24,441 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main) Apache Camel 4.7.0 (camel-1) started in 89ms (build:0ms init:0ms start:89ms)

```
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): Kamelet in route logs
```
