### PR TITLE
fix(e2e): olm needs to create an Integration Platform

### DIFF
--- a/e2e/install/olm/olm_install_test.go
+++ b/e2e/install/olm/olm_install_test.go
@@ -75,12 +75,12 @@ func TestOLMInstallation(t *testing.T) {
 		g.Eventually(OperatorPodPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(corev1.PodRunning))
 		g.Eventually(OperatorImage(t, ctx, ns), TestTimeoutShort).Should(Equal(defaults.OperatorImage()))
 
-		// Check the IntegrationPlatform has been reconciled after setting the expected container registry
-		g.Eventually(Platform(t, ctx, ns)).ShouldNot(BeNil())
-		g.Expect(UpdatePlatform(t, ctx, ns, func(ip *v1.IntegrationPlatform) {
-			ip.Spec.Build.Registry.Address = containerRegistry
-			ip.Spec.Build.Registry.Insecure = true
-		})).To(Succeed())
+		integrationPlatform := v1.NewIntegrationPlatform(ns, "camel-k")
+		integrationPlatform.Spec.Build.Registry = v1.RegistrySpec{
+			Address:  containerRegistry,
+			Insecure: true,
+		}
+		g.Expect(CreateIntegrationPlatform(t, ctx, &integrationPlatform)).To(Succeed())
 		g.Eventually(PlatformPhase(t, ctx, ns), TestTimeoutMedium).Should(Equal(v1.IntegrationPlatformPhaseReady))
 		g.Eventually(PlatformVersion(t, ctx, ns), TestTimeoutMedium).Should(Equal(defaults.Version))
 

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -2110,6 +2110,10 @@ func UpdatePlatform(t *testing.T, ctx context.Context, ns string, upd func(ip *v
 	return TestClient(t).Patch(ctx, target, ctrl.RawPatch(types.MergePatchType, p))
 }
 
+func CreateIntegrationPlatform(t *testing.T, ctx context.Context, ip *v1.IntegrationPlatform) error {
+	return TestClient(t).Create(ctx, ip)
+}
+
 func PlatformVersion(t *testing.T, ctx context.Context, ns string) func() string {
 	return func() string {
 		p := Platform(t, ctx, ns)()


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): olm needs to create an Integration Platform
```
