### PR TITLE
fix(e2e): Get the most recent pod in e2e tests

### DIFF
--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -36,6 +36,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -546,6 +547,10 @@ func IntegrationPod(t *testing.T, ctx context.Context, ns string, name string) f
 		if len(pods) == 0 {
 			return nil
 		}
+
+		sort.SliceStable(pods, func(i, j int) bool {
+			return pods[i].GetCreationTimestamp().Time.After(pods[j].GetCreationTimestamp().Time)
+		})
 		return &pods[0]
 	}
 }


### PR DESCRIPTION
Ref #5533 

Ensure we get the most recently created pod in tests




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): Get the most recent pod in e2e tests
```
