### PR TITLE
feat(api): expose Camel core version

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -2830,6 +2830,13 @@ the Camel K Runtime dependency version
 
 the runtime used. Likely Camel Quarkus (we used to have main runtime which has been discontinued since version 1.5)
 
+|`runtimeCoreVersion` +
+string
+|
+
+
+the Camel core version used by this IntegrationPlatform
+
 |`baseImage` +
 string
 |

--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -3212,6 +3212,10 @@ spec:
       jsonPath: .status.build.runtimeVersion
       name: Default runtime
       type: string
+    - description: The default Camel core version
+      jsonPath: .status.build.runtimeCoreVersion
+      name: Camel version
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -3571,6 +3575,9 @@ spec:
                         description: the secret where credentials are stored
                         type: string
                     type: object
+                  runtimeCoreVersion:
+                    description: the Camel core version used by this IntegrationPlatform
+                    type: string
                   runtimeProvider:
                     description: the runtime used. Likely Camel Quarkus (we used to
                       have main runtime which has been discontinued since version
@@ -5624,6 +5631,9 @@ spec:
                         description: the secret where credentials are stored
                         type: string
                     type: object
+                  runtimeCoreVersion:
+                    description: the Camel core version used by this IntegrationPlatform
+                    type: string
                   runtimeProvider:
                     description: the runtime used. Likely Camel Quarkus (we used to
                       have main runtime which has been discontinued since version

--- a/pkg/apis/camel/v1/integrationplatform_types.go
+++ b/pkg/apis/camel/v1/integrationplatform_types.go
@@ -72,6 +72,7 @@ type IntegrationPlatformStatus struct {
 // +kubebuilder:printcolumn:name="Publish strategy",type=string,JSONPath=`.status.build.publishStrategy`,description="The default publish strategy"
 // +kubebuilder:printcolumn:name="Registry address",type=string,JSONPath=`.status.build.registry.address`,description="The container registry address"
 // +kubebuilder:printcolumn:name="Default runtime",type=string,JSONPath=`.status.build.runtimeVersion`,description="The default runtime version"
+// +kubebuilder:printcolumn:name="Camel version",type=string,JSONPath=`.status.build.runtimeCoreVersion`,description="The default Camel core version"
 
 // IntegrationPlatform is the resource used to drive the Camel K operator behavior.
 // It defines the behavior of all Custom Resources (`IntegrationKit`, `Integration`, `Kamelet`) in the given namespace.
@@ -119,6 +120,8 @@ type IntegrationPlatformBuildSpec struct {
 	RuntimeVersion string `json:"runtimeVersion,omitempty"`
 	// the runtime used. Likely Camel Quarkus (we used to have main runtime which has been discontinued since version 1.5)
 	RuntimeProvider RuntimeProvider `json:"runtimeProvider,omitempty"`
+	// the Camel core version used by this IntegrationPlatform
+	RuntimeCoreVersion string `json:"runtimeCoreVersion,omitempty"`
 	// a base image that can be used as base layer for all images.
 	// It can be useful if you want to provide some custom base image with further utility software
 	BaseImage string `json:"baseImage,omitempty"`

--- a/pkg/client/camel/applyconfiguration/camel/v1/integrationplatformbuildspec.go
+++ b/pkg/client/camel/applyconfiguration/camel/v1/integrationplatformbuildspec.go
@@ -31,6 +31,7 @@ type IntegrationPlatformBuildSpecApplyConfiguration struct {
 	PublishStrategy         *camelv1.IntegrationPlatformBuildPublishStrategy `json:"publishStrategy,omitempty"`
 	RuntimeVersion          *string                                          `json:"runtimeVersion,omitempty"`
 	RuntimeProvider         *camelv1.RuntimeProvider                         `json:"runtimeProvider,omitempty"`
+	RuntimeCoreVersion      *string                                          `json:"runtimeCoreVersion,omitempty"`
 	BaseImage               *string                                          `json:"baseImage,omitempty"`
 	Registry                *RegistrySpecApplyConfiguration                  `json:"registry,omitempty"`
 	BuildCatalogToolTimeout *metav1.Duration                                 `json:"buildCatalogToolTimeout,omitempty"`
@@ -75,6 +76,14 @@ func (b *IntegrationPlatformBuildSpecApplyConfiguration) WithRuntimeVersion(valu
 // If called multiple times, the RuntimeProvider field is set to the value of the last call.
 func (b *IntegrationPlatformBuildSpecApplyConfiguration) WithRuntimeProvider(value camelv1.RuntimeProvider) *IntegrationPlatformBuildSpecApplyConfiguration {
 	b.RuntimeProvider = &value
+	return b
+}
+
+// WithRuntimeCoreVersion sets the RuntimeCoreVersion field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RuntimeCoreVersion field is set to the value of the last call.
+func (b *IntegrationPlatformBuildSpecApplyConfiguration) WithRuntimeCoreVersion(value string) *IntegrationPlatformBuildSpecApplyConfiguration {
+	b.RuntimeCoreVersion = &value
 	return b
 }
 

--- a/pkg/controller/integrationplatform/catalog_test.go
+++ b/pkg/controller/integrationplatform/catalog_test.go
@@ -121,6 +121,8 @@ func TestCreateCatalog(t *testing.T) {
 
 	assert.Equal(t, v1.IntegrationPlatformPhaseReady, answer.Status.Phase, "Error", answer.Status.Conditions[0].Message)
 	assert.Equal(t, corev1.ConditionTrue, answer.Status.GetCondition(v1.IntegrationPlatformConditionCamelCatalogAvailable).Status)
+	// We don't know exactly which is the core version, it is enough to check is not empty in the test
+	assert.NotEqual(t, "", answer.Status.Build.RuntimeCoreVersion)
 
 	list := v1.NewCamelCatalogList()
 	err = c.List(context.TODO(), &list, k8sclient.InNamespace(ip.Namespace))
@@ -160,6 +162,9 @@ func TestCatalogAlreadyPresent(t *testing.T) {
 	catalog := v1.NewCamelCatalog("ns", fmt.Sprintf("camel-catalog-%s", defaults.DefaultRuntimeVersion))
 	catalog.Spec.Runtime.Version = defaults.DefaultRuntimeVersion
 	catalog.Spec.Runtime.Provider = v1.RuntimeProviderQuarkus
+	catalog.Spec.Runtime.Metadata = map[string]string{
+		"camel.version": "4.4.0",
+	}
 
 	c, err := test.NewFakeClient(&ip, &catalog)
 	require.NoError(t, err)
@@ -176,6 +181,7 @@ func TestCatalogAlreadyPresent(t *testing.T) {
 	assert.NotNil(t, answer)
 
 	assert.Equal(t, v1.IntegrationPlatformPhaseReady, answer.Status.Phase)
+	assert.Equal(t, "4.4.0", answer.Status.Build.RuntimeCoreVersion)
 	assert.Equal(t, corev1.ConditionTrue, answer.Status.GetCondition(v1.IntegrationPlatformConditionCamelCatalogAvailable).Status)
 }
 

--- a/pkg/controller/integrationplatform/monitor.go
+++ b/pkg/controller/integrationplatform/monitor.go
@@ -121,6 +121,7 @@ func (action *monitorAction) Handle(ctx context.Context, platform *v1.Integratio
 				corev1.ConditionTrue,
 				v1.IntegrationPlatformConditionCamelCatalogAvailableReason,
 				fmt.Sprintf("camel catalog %s available", runtimeSpec.Version))
+			platform.Status.Build.RuntimeCoreVersion = catalog.Runtime.Metadata["camel.version"]
 		}
 	}
 

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -57,6 +57,10 @@ spec:
       jsonPath: .status.build.runtimeVersion
       name: Default runtime
       type: string
+    - description: The default Camel core version
+      jsonPath: .status.build.runtimeCoreVersion
+      name: Camel version
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -416,6 +420,9 @@ spec:
                         description: the secret where credentials are stored
                         type: string
                     type: object
+                  runtimeCoreVersion:
+                    description: the Camel core version used by this IntegrationPlatform
+                    type: string
                   runtimeProvider:
                     description: the runtime used. Likely Camel Quarkus (we used to
                       have main runtime which has been discontinued since version
@@ -2469,6 +2476,9 @@ spec:
                         description: the secret where credentials are stored
                         type: string
                     type: object
+                  runtimeCoreVersion:
+                    description: the Camel core version used by this IntegrationPlatform
+                    type: string
                   runtimeProvider:
                     description: the runtime used. Likely Camel Quarkus (we used to
                       have main runtime which has been discontinued since version


### PR DESCRIPTION
It is useful to know what core version of Camel the runtime is running

```
$ k get itp --all-namespaces
NAMESPACE   NAME      PHASE   BUILD STRATEGY   PUBLISH STRATEGY   REGISTRY ADDRESS   DEFAULT RUNTIME   CAMEL VERSION
camel-k     camel-k   Ready   routine          Jib                10.100.107.57      3.8.1             4.4.1
```

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(api): expose Camel core version
```
