### PR TITLE
fix(trait): add size to emptydir

### DIFF
--- a/pkg/trait/trait_types.go
+++ b/pkg/trait/trait_types.go
@@ -29,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	serving "knative.dev/serving/pkg/apis/serving/v1"
@@ -595,7 +596,13 @@ func getVolume(volName, storageType, storageName, filterKey, filterValue string)
 			ClaimName: storageName,
 		}
 	case emptyDirStorageType:
-		volume.VolumeSource.EmptyDir = &corev1.EmptyDirVolumeSource{}
+		size, err := resource.ParseQuantity("1Gi")
+		if err != nil {
+			log.WithValues("Function", "trait.getVolume").Errorf(err, "could not parse empty dir quantity, skipping")
+		}
+		volume.VolumeSource.EmptyDir = &corev1.EmptyDirVolumeSource{
+			SizeLimit: &size,
+		}
 	}
 
 	return &volume


### PR DESCRIPTION
It is good to have a limit for security reasons and it is also a workaround for #5752

Closes #5752

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): add size to emptydir
```
