### PR TITLE
e2e/knative service url naming tests

### DIFF
--- a/e2e/knative/files/knativeurl1.yaml
+++ b/e2e/knative/files/knativeurl1.yaml
@@ -1,0 +1,23 @@
+# camel-k: language=yaml
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- from:
+    uri: "knative:endpoint/knative"
+    steps:
+      - setBody:
+          constant: "Hello from knative"

--- a/e2e/knative/files/knativeurl2.yaml
+++ b/e2e/knative/files/knativeurl2.yaml
@@ -1,0 +1,29 @@
+# camel-k: language=yaml
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- from:
+    uri: "knative:endpoint/knative1"
+    steps:
+      - setBody:
+          constant: "knative1"
+
+- from:
+    uri: "knative:endpoint/knative2"
+    steps:
+      - setBody:
+          constant: "knative2"

--- a/e2e/knative/knative_service_test.go
+++ b/e2e/knative/knative_service_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knative
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/apache/camel-k/v2/e2e/support"
+	camelv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestKnativeServiceURL(t *testing.T) {
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+
+		t.Run("Service endpoint url check", func(t *testing.T) {
+			g.Expect(KamelRun(t, ctx, ns, "files/knativeurl1.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativeurl1"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knativeurl1", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+			ks := KnativeService(t, ctx, ns, "knativeurl1")
+			g.Eventually(ks, TestTimeoutShort).ShouldNot(BeNil())
+			url := "http://knativeurl1." + ns + ".svc.cluster.local"
+			g.Eventually(ks().Status.RouteStatusFields.URL.String(), TestTimeoutShort).Should(Equal(url))
+		})
+
+		t.Run("Service multiple endpoint url check", func(t *testing.T) {
+			g.Expect(KamelRun(t, ctx, ns, "files/knativeurl2.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "knativeurl2"), TestTimeoutLong).Should(Equal(v1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "knativeurl2", camelv1.IntegrationConditionReady), TestTimeoutMedium).Should(Equal(v1.ConditionTrue))
+			ks := KnativeService(t, ctx, ns, "knativeurl2")
+			g.Eventually(ks, TestTimeoutShort).ShouldNot(BeNil())
+			url := "http://knativeurl2." + ns + ".svc.cluster.local"
+			g.Eventually(ks().Status.RouteStatusFields.URL.String(), TestTimeoutShort).Should(Equal(url))
+		})
+		g.Expect(Kamel(t, ctx, "delete", "--all", "-n", ns).Execute()).To(Succeed())
+	})
+}


### PR DESCRIPTION
<!-- Description -->
https://github.com/apache/camel-k/issues/2249

Added knative e2e test to check the naming convention for knative service url.

Knative service url is derrived from integration name not the endpoints. Camel allows for multiple endpoints to be present in a single integration so naming services after integrations makes more sense.

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
