### PR TITLE
[Backport 2.4.x]: fix(e2e): Get the most recent pod in e2e tests and add logs

### DIFF
--- a/e2e/common/misc/files/cron-yaml.yaml
+++ b/e2e/common/misc/files/cron-yaml.yaml
@@ -18,7 +18,7 @@
 - from:
     uri: "cron:tab"
     parameters:
-      schedule: "* * * * ?"
+      schedule: "*/2 * * * ?"
     steps:
       - setHeader:
           name: "m"

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -36,6 +36,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -546,6 +547,10 @@ func IntegrationPod(t *testing.T, ctx context.Context, ns string, name string) f
 		if len(pods) == 0 {
 			return nil
 		}
+
+		sort.SliceStable(pods, func(i, j int) bool {
+			return pods[i].GetCreationTimestamp().Time.After(pods[j].GetCreationTimestamp().Time)
+		})
 		return &pods[0]
 	}
 }

--- a/e2e/support/util/dump.go
+++ b/e2e/support/util/dump.go
@@ -320,6 +320,21 @@ func Dump(ctx context.Context, c client.Client, ns string, t *testing.T) error {
 		}
 	}
 
+	// Cronjobs
+	cronjobs, err := c.BatchV1().CronJobs(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	t.Logf("\nFound %d cronjobs:\n", len(cronjobs.Items))
+	for _, cronjobs := range cronjobs.Items {
+		ref := cronjobs
+		data, err := kubernetes.ToYAMLNoManagedFields(&ref)
+		if err != nil {
+			return err
+		}
+		t.Logf("---\n%s\n---\n", string(data))
+	}
+
 	// OLM CSV
 	csvs := olm.ClusterServiceVersionList{}
 	err = c.List(ctx, &csvs, ctrl.InNamespace(ns))


### PR DESCRIPTION
Backport fix https://github.com/apache/camel-k/pull/5808
Backport fix https://github.com/apache/camel-k/pull/5790

Ref #5533 


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): Get the most recent pod in e2e tests and add logs
```
