### PR TITLE
Allow to specify annotations for operator Kubernetes Service Account

### DIFF
--- a/helm/camel-k/templates/operator-service-account.yaml
+++ b/helm/camel-k/templates/operator-service-account.yaml
@@ -22,3 +22,7 @@ metadata:
   labels:
     app: "camel-k"
     {{- include "camel-k.labels" . | nindent 4 }}
+  {{- with .Values.operator.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -45,3 +45,6 @@ operator:
 
   # Default operator name
   operatorId: camel-k
+
+  serviceAccount:
+    annotations:


### PR DESCRIPTION
We'd like to allow the operator to push images to Google Artifact Registry using the workload identity feature in the GCP. This requires to specify the Google Service Account in an annotation to the Kubernetes service account the `camel-k-operator` deployment is using:

```
annotations:
   iam.gke.io/gcp-service-account: ACCOUNT@PROJECT.iam.gserviceaccount.com
```
