### PR TITLE
fix(cli): allow specifying integration run sources exclusively via config file

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -337,7 +337,7 @@ func (o *runCmdOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// We need to make this check at this point, in order to have sources filled during decoding
-	if len(args) < 1 && o.ContainerImage == "" {
+	if (len(args) < 1 && len(o.Sources) < 0) && o.ContainerImage == "" {
 		return errors.New("run command expects either an Integration source or the container image (via --image argument)")
 	}
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -337,7 +337,7 @@ func (o *runCmdOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// We need to make this check at this point, in order to have sources filled during decoding
-	if (len(args) < 1 && len(o.Sources) < 0) && o.ContainerImage == "" {
+	if (len(args) < 1 && len(o.Sources) < 1) && o.ContainerImage == "" {
 		return errors.New("run command expects either an Integration source or the container image (via --image argument)")
 	}
 


### PR DESCRIPTION
Hey there!

Thank you for doing such awesome work with that project.

While using the `kamel` tool, I tried to exclusively configure my deployment via the `kamel-config.yaml` file. Due to there is a `sources` array in that config file, I think specifying the sources there should be enough to run an integration rather than needing to define at least one source at `kamel run [file to run]`.

My patch skips the error if no source file is provided via arguments and at least one source is provided in the configuration file. Otherwise, there will be an error if the sources are only provided in config file.