### PR TITLE
[chore] Fix Kustomize Installation

### DIFF
--- a/pkg/resources/config/crd/kustomization.yaml
+++ b/pkg/resources/config/crd/kustomization.yaml
@@ -27,5 +27,7 @@ resources:
 - bases/camel.apache.org_kamelets.yaml
 - bases/camel.apache.org_pipes.yaml
 
-commonLabels:
-  app: camel-k
+labels:
+  - pairs:
+      app: camel-k
+    includeSelectors: true

--- a/pkg/resources/config/manifests/kustomization.yaml
+++ b/pkg/resources/config/manifests/kustomization.yaml
@@ -18,8 +18,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app: camel-k
+labels:
+  - pairs:
+      app: camel-k
+    includeSelectors: true
 
 resources:
 - ../manager


### PR DESCRIPTION
<!-- Description -->

This PR fixes the Kustomize installation by switching over deprecated `commonLabels` fields with `labels` field.

Before:

<img width="991" alt="Screenshot 2024-11-30 at 2 25 38 PM" src="https://github.com/user-attachments/assets/87be1384-5ba3-4988-b831-43aad911cd94">



After:

<img width="733" alt="Screenshot 2024-11-30 at 2 20 10 PM" src="https://github.com/user-attachments/assets/9170f31e-f717-4143-8aa7-ba8cc62bd076">


PR fixes: https://github.com/apache/camel-k/issues/5928

<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
