### PR TITLE
update registry location

### DIFF
--- a/docs/modules/ROOT/pages/installation/registry/registry.adoc
+++ b/docs/modules/ROOT/pages/installation/registry/registry.adoc
@@ -41,7 +41,7 @@ The changes will be immediately reconciled and the operator will be able to push
 == Container registry requirements
 Each platform may have its default registry of choice. And each container registry may have a slight different configuration. Please, be aware that we won't be able to support all the available solutions.
 
-The only requirement we have is that the registry must be able to produce/consume images with the following tagging convention: `<registry-host>[:<registry-port>]/<k8s-namespace>/kit-<hash-code>@sha256:<sha256-code>`, ie `10.110.251.124/default/kit-ck0612dahvgs73ffe5g0@sha256:3c9589dd093b689aee6bf5c2d35aa1fce9d0e76d5bb7da8b61d87e7a1ed6f36a`.
+The only requirement we have is that the registry must be able to produce/consume images with the following tagging convention: `<registry-host>[:<registry-port>]/<k8s-namespace>/camel-k-kit-<hash-code>@sha256:<sha256-code>`, ie `10.110.251.124/default/kit-ck0612dahvgs73ffe5g0@sha256:3c9589dd093b689aee6bf5c2d35aa1fce9d0e76d5bb7da8b61d87e7a1ed6f36a`.
 
 This should be within the standard convention adopted by https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier[pulling a Docker image by digest] (immutable).
 


### PR DESCRIPTION
This is to conform with how the images are being populated into the registry (as well as how it relates to the IntegrationPlatform specs).

Of note, it uses the registry.organization vs. namespace. It also uses '/camel-k-kit-...' vs. just '/kit-...'.
