### PR TITLE
feat(runtime): enable plain Quarkus runtime

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -73,11 +73,6 @@ jobs:
     - name: Infra setting
       uses: ./.github/actions/infra-setting
 
-    - name: Install Knative
-      shell: bash
-      run: |
-        ./e2e/knative/files/setup.sh
-
     - name: Install operator
       shell: bash
       run: |

--- a/.github/workflows/nightly-latest-runtime.yml
+++ b/.github/workflows/nightly-latest-runtime.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  smoke-tests:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-quarkus-plain-runtime.yml
+++ b/.github/workflows/nightly-quarkus-plain-runtime.yml
@@ -1,0 +1,140 @@
+--- # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: Nightly check against plain Quarkus runtime
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  CAMEL_K_TEST_TIMEOUT_SHORT: 2m
+  CAMEL_K_TEST_TIMEOUT_MEDIUM: 5m
+  CAMEL_K_TEST_TIMEOUT_LONG: 10m
+  CAMEL_K_TEST_TIMEOUT_VERY_LONG: 30m
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  common:
+    strategy:
+      matrix:
+        # We want to check this on latest development branch only
+        ref-branch: [main]
+
+    if: github.repository == 'apache/camel-k'
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: "Checkout code"
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.ref-branch }}
+        persist-credentials: false
+        submodules: recursive
+
+    - name: Infra setting
+      uses: ./.github/actions/infra-setting
+
+    - name: Install operator
+      shell: bash
+      run: |
+        kubectl create ns camel-k
+        make install-k8s-global
+        kubectl wait --for=jsonpath='{.status.phase}'=Ready itp camel-k -n camel-k --timeout=60s
+        kubectl patch itp camel-k -n camel-k -p '{"spec":{"traits":{"camel":{"runtimeProvider":"plain-quarkus"}}}}' --type=merge
+        kubectl wait --for=jsonpath='{.status.phase}'=Ready itp camel-k -n camel-k --timeout=60s
+
+    - name: Run test
+      shell: bash
+      run: |
+        DO_TEST_PREBUILD=false GOTESTFMT="-json 2>&1 | gotestfmt" make test-common
+
+  quarkus-native:
+    strategy:
+      matrix:
+        # We want to check this on latest development branch only
+        ref-branch: [main]
+
+    if: github.repository == 'apache/camel-k'
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: "Checkout code"
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.ref-branch }}
+        persist-credentials: false
+        submodules: recursive
+
+    - name: Infra setting
+      uses: ./.github/actions/infra-setting
+
+    - name: Install operator
+      shell: bash
+      run: |
+        kubectl create ns camel-k
+        make install-k8s-global
+        kubectl wait --for=jsonpath='{.status.phase}'=Ready itp camel-k -n camel-k --timeout=60s
+        kubectl patch itp camel-k -n camel-k -p '{"spec":{"traits":{"camel":{"runtimeProvider":"plain-quarkus"}}}}' --type=merge
+        kubectl wait --for=jsonpath='{.status.phase}'=Ready itp camel-k -n camel-k --timeout=60s
+
+    - name: Run test
+      shell: bash
+      run: |
+        DO_TEST_PREBUILD=false GOTESTFMT="-json 2>&1 | gotestfmt" make test-quarkus-native
+
+  knative:
+    strategy:
+      matrix:
+        # We want to check this on latest development branch only
+        ref-branch: [main]
+
+    if: github.repository == 'apache/camel-k'
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: "Checkout code"
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.ref-branch }}
+        persist-credentials: false
+        submodules: recursive
+
+    - name: Infra setting
+      uses: ./.github/actions/infra-setting
+
+    - name: Install Knative
+      shell: bash
+      run: |
+        ./e2e/knative/files/setup.sh
+
+    - name: Install operator
+      shell: bash
+      run: |
+        kubectl create ns camel-k
+        make install-k8s-global
+        kubectl wait --for=jsonpath='{.status.phase}'=Ready itp camel-k -n camel-k --timeout=60s
+        kubectl patch itp camel-k -n camel-k -p '{"spec":{"traits":{"camel":{"runtimeProvider":"plain-quarkus"}}}}' --type=merge
+        kubectl wait --for=jsonpath='{.status.phase}'=Ready itp camel-k -n camel-k --timeout=60s
+
+    - name: Run test
+      shell: bash
+      run: |
+        DO_TEST_PREBUILD=false GOTESTFMT="-json 2>&1 | gotestfmt" make test-knative

--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -6497,14 +6497,21 @@ The Camel trait can be used to configure versions of Apache Camel K runtime and 
 
 
 
+|`runtimeProvider` +
+string
+|
+
+
+The runtime provider to use for the integration. (Default, Camel K Runtime).
+
 |`runtimeVersion` +
 string
 |
 
 
-The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
 You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-to the best matching Catalog existing on the cluster.
+to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
 
 |`properties` +
 []string

--- a/docs/modules/traits/pages/camel.adoc
+++ b/docs/modules/traits/pages/camel.adoc
@@ -29,11 +29,15 @@ The following configuration options are available:
 | bool
 | Deprecated: no longer in use.
 
+| camel.runtime-provider
+| string
+| The runtime provider to use for the integration. (Default, Camel K Runtime).
+
 | camel.runtime-version
 | string
-| The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+| The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
 You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-to the best matching Catalog existing on the cluster.
+to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
 
 | camel.properties
 | []string

--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -3023,11 +3023,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   quarkus:
@@ -3965,11 +3972,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -6154,11 +6168,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -8246,11 +8267,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -10314,11 +10342,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -18763,11 +18798,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -20758,11 +20800,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -30582,11 +30631,18 @@ spec:
                             items:
                               type: string
                             type: array
+                          runtimeProvider:
+                            description: The runtime provider to use for the integration.
+                              (Default, Camel K Runtime).
+                            enum:
+                            - quarkus
+                            - plain-quarkus
+                            type: string
                           runtimeVersion:
                             description: |-
-                              The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                              The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                               You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                              to the best matching Catalog existing on the cluster.
+                              to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                             type: string
                         type: object
                       container:

--- a/pkg/apis/camel/v1/camelcatalog_types_support.go
+++ b/pkg/apis/camel/v1/camelcatalog_types_support.go
@@ -182,6 +182,11 @@ func (c *CamelCatalogSpec) GetRuntimeVersion() string {
 	return c.Runtime.Version
 }
 
+// GetRuntimeVersion returns the Camel K runtime version of the catalog.
+func (c *CamelCatalogSpec) GetRuntimeProvider() RuntimeProvider {
+	return c.Runtime.Provider
+}
+
 // GetCamelVersion returns the Camel version the runtime is based on.
 func (c *CamelCatalogSpec) GetCamelVersion() string {
 	return c.Runtime.Metadata["camel.version"]

--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -18,10 +18,9 @@ limitations under the License.
 package v1
 
 import (
+	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 )
 
 const (
@@ -433,9 +432,15 @@ type Flow struct {
 type RuntimeProvider string
 
 const (
-	// RuntimeProviderQuarkus Camel Quarkus runtime.
+	// RuntimeProviderQuarkus Camel K runtime (Quarkus based).
 	RuntimeProviderQuarkus RuntimeProvider = "quarkus"
+	// RuntimeProviderPlainQuarkus Camel Quarkus plain runtime.
+	RuntimeProviderPlainQuarkus RuntimeProvider = "plain-quarkus"
 )
+
+func (rt RuntimeProvider) IsQuarkusBased() bool {
+	return rt == RuntimeProviderQuarkus || rt == RuntimeProviderPlainQuarkus
+}
 
 // SourceSpec defines the configuration for one or more routes to be executed in a certain Camel DSL language.
 type SourceSpec struct {

--- a/pkg/apis/camel/v1/trait/camel.go
+++ b/pkg/apis/camel/v1/trait/camel.go
@@ -22,9 +22,12 @@ package trait
 // +camel-k:trait=camel.
 type CamelTrait struct {
 	PlatformBaseTrait `property:",squash" json:",inline"`
-	// The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+	// The runtime provider to use for the integration. (Default, Camel K Runtime).
+	// +kubebuilder:validation:Enum=quarkus;plain-quarkus
+	RuntimeProvider string `property:"runtime-provider" json:"runtimeProvider,omitempty"`
+	// The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
 	// You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-	// to the best matching Catalog existing on the cluster.
+	// to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
 	RuntimeVersion string `property:"runtime-version" json:"runtimeVersion,omitempty"`
 	// A list of properties to be provided to the Integration runtime
 	Properties []string `property:"properties" json:"properties,omitempty"`

--- a/pkg/builder/quarkus_test.go
+++ b/pkg/builder/quarkus_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestGenerateQuarkusProjectCommon(t *testing.T) {
-	p := generateQuarkusProjectCommon("1.2.3", "4.5.6")
+	p := generateQuarkusProjectCommon(v1.RuntimeProviderQuarkus, "1.2.3", "4.5.6")
 	assert.Equal(t, "org.apache.camel.k.integration", p.GroupID)
 	assert.Equal(t, "camel-k-integration", p.ArtifactID)
 	assert.Equal(t, defaults.Version, p.Version)

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationkits.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationkits.yaml
@@ -360,11 +360,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   quarkus:

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -735,11 +735,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -2924,11 +2931,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -604,11 +604,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -2672,11 +2679,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -6964,11 +6964,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:
@@ -8959,11 +8966,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      runtimeProvider:
+                        description: The runtime provider to use for the integration.
+                          (Default, Camel K Runtime).
+                        enum:
+                        - quarkus
+                        - plain-quarkus
+                        type: string
                       runtimeVersion:
                         description: |-
-                          The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                          The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                           You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                          to the best matching Catalog existing on the cluster.
+                          to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                         type: string
                     type: object
                   container:

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -7027,11 +7027,18 @@ spec:
                             items:
                               type: string
                             type: array
+                          runtimeProvider:
+                            description: The runtime provider to use for the integration.
+                              (Default, Camel K Runtime).
+                            enum:
+                            - quarkus
+                            - plain-quarkus
+                            type: string
                           runtimeVersion:
                             description: |-
-                              The camel-k-runtime version to use for the integration. It overrides the default version set in the Integration Platform.
+                              The runtime version to use for the integration. It overrides the default version set in the Integration Platform.
                               You can use a fixed version (for example "3.2.3") or a semantic version (for example "3.x") which will try to resolve
-                              to the best matching Catalog existing on the cluster.
+                              to the best matching Catalog existing on the cluster (Default, the one provided by the operator version).
                             type: string
                         type: object
                       container:

--- a/pkg/trait/environment.go
+++ b/pkg/trait/environment.go
@@ -18,6 +18,7 @@ limitations under the License.
 package trait
 
 import (
+	"fmt"
 	"os"
 
 	"k8s.io/utils/ptr"
@@ -79,6 +80,10 @@ func (t *environmentTrait) Apply(e *Environment) error {
 	envvar.SetVal(&e.EnvVars, envVarCamelKRuntimeVersion, e.Integration.Status.RuntimeVersion)
 	envvar.SetVal(&e.EnvVars, envVarMountPathConfigMaps, camel.ConfigConfigmapsMountPath)
 	envvar.SetVal(&e.EnvVars, envVarMountPathSecrets, camel.ConfigSecretsMountPath)
+	if e.CamelCatalog.GetRuntimeProvider() == v1.RuntimeProviderPlainQuarkus {
+		envvar.SetVal(&e.EnvVars, "QUARKUS_CONFIG_LOCATIONS",
+			fmt.Sprintf("%s/application.properties,%s/user.properties", camel.BasePath, camel.ConfDPath))
+	}
 
 	if ptr.Deref(t.ContainerMeta, true) {
 		envvar.SetValFrom(&e.EnvVars, envVarNamespace, "metadata.namespace")

--- a/pkg/trait/telemetry.go
+++ b/pkg/trait/telemetry.go
@@ -52,6 +52,13 @@ var (
 			propSamplerRatio:       "quarkus.opentelemetry.tracer.sampler.ratio",
 			propSamplerParentBased: "quarkus.opentelemetry.tracer.sampler.parent-based",
 		},
+		v1.RuntimeProviderPlainQuarkus: {
+			propEndpoint:           "quarkus.opentelemetry.tracer.exporter.otlp.endpoint",
+			propServiceName:        "quarkus.opentelemetry.tracer.resource-attributes",
+			propSampler:            "quarkus.opentelemetry.tracer.sampler",
+			propSamplerRatio:       "quarkus.opentelemetry.tracer.sampler.ratio",
+			propSamplerParentBased: "quarkus.opentelemetry.tracer.sampler.parent-based",
+		},
 	}
 )
 
@@ -124,7 +131,7 @@ func (t *telemetryTrait) Apply(e *Environment) error {
 	util.StringSliceUniqueAdd(&e.Integration.Status.Capabilities, v1.CapabilityTelemetry)
 
 	// Hack for camel-k-runtime 3.15.0
-	if e.CamelCatalog.CamelCatalogSpec.Runtime.Provider == v1.RuntimeProviderQuarkus &&
+	if e.CamelCatalog.CamelCatalogSpec.Runtime.Provider.IsQuarkusBased() &&
 		e.CamelCatalog.CamelCatalogSpec.Runtime.Version == "3.15.0" {
 		t.setRuntimeProviderQuarkus315Properties(e)
 		return nil

--- a/pkg/util/camel/camel_dependencies.go
+++ b/pkg/util/camel/camel_dependencies.go
@@ -169,7 +169,7 @@ func addBOM(project *maven.Project, dependency string) error {
 
 func addCamelComponent(project *maven.Project, catalog *RuntimeCatalog, dependency string) {
 	artifactID := strings.TrimPrefix(dependency, "camel:")
-	if catalog != nil && catalog.Runtime.Provider == v1.RuntimeProviderQuarkus {
+	if catalog != nil && catalog.Runtime.Provider.IsQuarkusBased() {
 		if !strings.HasPrefix(artifactID, "camel-") {
 			artifactID = "camel-quarkus-" + artifactID
 		}

--- a/pkg/util/camel/camel_runtime_catalog.go
+++ b/pkg/util/camel/camel_runtime_catalog.go
@@ -89,7 +89,7 @@ type RuntimeCatalog struct {
 func (c *RuntimeCatalog) HasArtifact(artifact string) bool {
 	a := artifact
 	if !strings.HasPrefix(a, "camel-") {
-		if c.Runtime.Provider == v1.RuntimeProviderQuarkus {
+		if c.Runtime.Provider.IsQuarkusBased() {
 			a = "camel-quarkus-" + a
 		} else {
 			a = "camel-" + a
@@ -105,7 +105,7 @@ func (c *RuntimeCatalog) HasArtifact(artifact string) bool {
 func (c *RuntimeCatalog) HasLoaderByArtifact(artifact string) bool {
 	a := artifact
 	if !strings.HasPrefix(a, "camel-") {
-		if c.Runtime.Provider == v1.RuntimeProviderQuarkus {
+		if c.Runtime.Provider.IsQuarkusBased() {
 			a = "camel-quarkus-" + a
 		} else {
 			a = "camel-" + a

--- a/pkg/util/camel/camel_util.go
+++ b/pkg/util/camel/camel_util.go
@@ -105,7 +105,7 @@ func newCatalogVersionCollection(catalogs []v1.CamelCatalog) CatalogVersionColle
 }
 
 func getDependency(artifact v1.CamelArtifact, runtimeProvider v1.RuntimeProvider) string {
-	if runtimeProvider == v1.RuntimeProviderQuarkus {
+	if runtimeProvider.IsQuarkusBased() {
 		return strings.Replace(artifact.ArtifactID, "camel-quarkus-", "camel:", 1)
 	}
 	return strings.Replace(artifact.ArtifactID, "camel-", "camel:", 1)


### PR DESCRIPTION
Added the support for plain Quarkus runtime. Trait `camel.runtime-provider` is in charge to control the possibility to use `plain-quarkus`.

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(runtime): enable plain Quarkus runtime
```
