### PR TITLE
feat(trait): add support for multiple ingress paths

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -7331,6 +7331,14 @@ string
 
 
 To configure the path exposed by the ingress (default `/`).
+Deprecated: In favor of `paths` - left for backward compatibility.
+
+|`paths` +
+[]string
+|
+
+
+To configure the paths exposed by the ingress (default `['/']`).
 
 |`pathType` +
 *https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#pathtype-v1-networking[Kubernetes networking/v1.PathType]*

--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -4467,9 +4467,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -6656,9 +6662,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -8748,9 +8760,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -10816,9 +10834,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -19265,9 +19289,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -21260,9 +21290,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -31089,6 +31125,16 @@ spec:
                             description: To configure the path exposed by the ingress
                               (default `/`).
                             type: string
+                          path:
+                            description: |-
+                              To configure the path exposed by the ingress (default `/`).
+                              Deprecated: In favor of `paths` - left for backward compatibility.
+                            type: string
+                          paths:
+                            description: To configure the paths exposed by the ingress (default `['/']`).
+                            items:
+                              type: string
+                            type: array
                           pathType:
                             description: |-
                               To configure the path type exposed by the ingress.

--- a/pkg/apis/camel/v1/trait/ingress.go
+++ b/pkg/apis/camel/v1/trait/ingress.go
@@ -38,6 +38,9 @@ type IngressTrait struct {
 	Host string `property:"host" json:"host,omitempty"`
 	// To configure the path exposed by the ingress (default `/`).
 	Path string `property:"path" json:"path,omitempty"`
+	// To configure the paths exposed by the ingress (default `['/']`).
+	// Deprecated: In favor of `paths` - left for backward compatibility.
+	Paths []string `property:"paths" json:"paths,omitempty"`
 	// To configure the path type exposed by the ingress.
 	// One of `Exact`, `Prefix`, `ImplementationSpecific` (default to `Prefix`).
 	// +kubebuilder:validation:Enum=Exact;Prefix;ImplementationSpecific

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -1237,9 +1237,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -3426,9 +3432,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -1106,9 +1106,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -3174,9 +3180,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -7466,9 +7466,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.
@@ -9461,9 +9467,15 @@ spec:
                           See https://kubernetes.io/docs/concepts/services-networking/ingress/
                         type: string
                       path:
-                        description: To configure the path exposed by the ingress
-                          (default `/`).
+                        description: |-
+                          To configure the path exposed by the ingress (default `/`).
+                          Deprecated: In favor of `paths` - left for backward compatibility.
                         type: string
+                      paths:
+                        description: To configure the paths exposed by the ingress (default `['/']`).
+                        items:
+                          type: string
+                        type: array
                       pathType:
                         description: |-
                           To configure the path type exposed by the ingress.

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -7531,9 +7531,15 @@ spec:
                               See https://kubernetes.io/docs/concepts/services-networking/ingress/
                             type: string
                           path:
-                            description: To configure the path exposed by the ingress
-                              (default `/`).
+                            description: |-
+                              To configure the path exposed by the ingress (default `/`).
+                              Deprecated: In favor of `paths` - left for backward compatibility.
                             type: string
+                          paths:
+                            description: To configure the paths exposed by the ingress (default `['/']`).
+                            items:
+                              type: string
+                            type: array
                           pathType:
                             description: |-
                               To configure the path type exposed by the ingress.

--- a/pkg/trait/ingress.go
+++ b/pkg/trait/ingress.go
@@ -154,9 +154,10 @@ func (t *ingressTrait) getPaths(service *corev1.Service) []networkingv1.HTTPIngr
 	paths := []networkingv1.HTTPIngressPath{}
 	if t.Path == "" && len(t.Paths) == 0 {
 		paths = append(paths, createIngressPath(defaultPath))
-	} else if t.Path != "" {
-		paths = append(paths, createIngressPath(t.Path))
 	} else {
+		if t.Path != "" {
+			paths = append(paths, createIngressPath(t.Path))
+		}
 		for _, p := range t.Paths {
 			paths = append(paths, createIngressPath(p))
 		}

--- a/pkg/trait/ingress.go
+++ b/pkg/trait/ingress.go
@@ -57,9 +57,11 @@ func (t *ingressTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 	if e.Integration == nil {
 		return false, nil, nil
 	}
+
 	if !e.IntegrationInRunningPhases() {
 		return false, nil, nil
 	}
+
 	if !ptr.Deref(t.Enabled, true) {
 		return false, NewIntegrationCondition(
 			"Ingress",
@@ -74,6 +76,18 @@ func (t *ingressTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 		if e.Resources.GetUserServiceForIntegration(e.Integration) == nil {
 			return false, nil, nil
 		}
+	}
+
+	if t.Path != "" {
+		condition := NewIntegrationCondition(
+			"Ingress",
+			v1.IntegrationConditionTraitInfo,
+			corev1.ConditionTrue,
+			TraitConfigurationReason,
+			"The path parameter is deprecated and may be removed in future releases. Use the paths parameter instead.",
+		)
+
+		return true, condition, nil
 	}
 
 	return true, nil, nil

--- a/pkg/trait/ingress.go
+++ b/pkg/trait/ingress.go
@@ -79,12 +79,14 @@ func (t *ingressTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 	}
 
 	if t.Path != "" {
+		m := "The path parameter is deprecated and may be removed in a future release. Use the paths parameter instead."
+		t.L.Info(m)
 		condition := NewIntegrationCondition(
 			"Ingress",
 			v1.IntegrationConditionTraitInfo,
 			corev1.ConditionTrue,
 			TraitConfigurationReason,
-			"The path parameter is deprecated and may be removed in future releases. Use the paths parameter instead.",
+			m,
 		)
 
 		return true, condition, nil

--- a/pkg/trait/ingress.go
+++ b/pkg/trait/ingress.go
@@ -101,20 +101,7 @@ func (t *ingressTrait) Apply(e *Environment) error {
 					Host: t.Host,
 					IngressRuleValue: networkingv1.IngressRuleValue{
 						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Path:     t.getPath(),
-									PathType: t.getPathType(),
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: service.Name,
-											Port: networkingv1.ServiceBackendPort{
-												Name: "http",
-											},
-										},
-									},
-								},
-							},
+							Paths: t.getPaths(service),
 						},
 					},
 				},
@@ -148,12 +135,34 @@ func (t *ingressTrait) Apply(e *Environment) error {
 	return nil
 }
 
-func (t *ingressTrait) getPath() string {
-	if t.Path == "" {
-		return defaultPath
+func (t *ingressTrait) getPaths(service *corev1.Service) []networkingv1.HTTPIngressPath {
+	createIngressPath := func(path string) networkingv1.HTTPIngressPath {
+		return networkingv1.HTTPIngressPath{
+			Path:     path,
+			PathType: t.getPathType(),
+			Backend: networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: service.Name,
+					Port: networkingv1.ServiceBackendPort{
+						Name: "http",
+					},
+				},
+			},
+		}
 	}
 
-	return t.Path
+	paths := []networkingv1.HTTPIngressPath{}
+	if t.Path == "" && len(t.Paths) == 0 {
+		paths = append(paths, createIngressPath(defaultPath))
+	} else if t.Path != "" {
+		paths = append(paths, createIngressPath(t.Path))
+	} else {
+		for _, p := range t.Paths {
+			paths = append(paths, createIngressPath(p))
+		}
+	}
+
+	return paths
 }
 
 func (t *ingressTrait) getPathType() *networkingv1.PathType {

--- a/pkg/trait/ingress_test.go
+++ b/pkg/trait/ingress_test.go
@@ -188,6 +188,21 @@ func TestApplyIngressTraitWithPathsDoesSucceed(t *testing.T) {
 	assert.Equal(t, "service-name(hostname) -> service-name(http)", conditions[0].Message)
 }
 
+func TestApplyIngressTraitWithPathAndPathsDoesSucceed(t *testing.T) {
+	ingressTrait, environment := createNominalIngressTest()
+	ingressTrait.Path = string("/path")
+	ingressTrait.Paths = []string{"/path-a", "/path-b"}
+
+	err := ingressTrait.Apply(environment)
+
+	require.NoError(t, err)
+	environment.Resources.Visit(func(resource runtime.Object) {
+		if ingress, ok := resource.(*networkingv1.Ingress); ok {
+			assert.Len(t, ingress.Spec.Rules[0].HTTP.Paths, 3)
+		}
+	})
+}
+
 func TestApplyIngressTraitWithIngressClassNameDoesSucceed(t *testing.T) {
 	ingressTrait, environment := createNominalIngressTestWithIngressClassName("someIngressClass")
 

--- a/pkg/trait/ingress_test.go
+++ b/pkg/trait/ingress_test.go
@@ -156,6 +156,15 @@ func TestApplyIngressTraitWithPathDoesSucceed(t *testing.T) {
 	conditions := environment.Integration.Status.Conditions
 	assert.Len(t, conditions, 1)
 	assert.Equal(t, "service-name(hostname) -> service-name(http)", conditions[0].Message)
+
+	// ensure a condition exists with the depreciation notice
+	enabled, condition, err := ingressTrait.Configure(environment)
+	require.NoError(t, err)
+	assert.True(t, enabled)
+	assert.NotNil(t, condition)
+	assert.Equal(t, "The path parameter is deprecated and may be removed in a future release. Use the paths parameter instead.",
+		condition.message,
+	)
 }
 
 func TestApplyIngressTraitWithPathsDoesSucceed(t *testing.T) {


### PR DESCRIPTION
Related to issue #5981.

- [x] Allow multiple paths to be set within an ingress.
- [x] Implement a workaround to allow backward compatibility for `ingress.path`.
- [x] ~~Determine if the IngressTrait should be migrated towards adopting K8s API [IngressSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#ingressspec-v1-networking-k8s-io) hierarchy.~~
_Can be reviewed again at a later point in time/in a separate PR._
- [x] Implement a depreciation message for `ingress.path`.
- [x] Output the depreciation message where applicable.

Example usage:
```bash
build/_output/bin/kamel-amd64 run test/src/multi-path.yml -o yaml --trait ingress.paths="/api/v1/multi" --trait ingress.paths="/api/v1/path" > test/base/multi-path.yml
```

... generates:
```yaml
apiVersion: camel.apache.org/v1
kind: Integration
metadata:
  annotations:
    camel.apache.org/operator.id: camel-k
  creationTimestamp: null
  name: multi-path
spec:
  flows:
  - from:
      steps:
      - set-header:
          name: Content-Type
          simple: application/json
      - set-body:
          constant: '{"welcome": "multi"}'
      uri: rest:get:/api/v1/multi
  - from:
      steps:
      - set-header:
          name: Content-Type
          simple: application/json
      - set-body:
          constant: '{"welcome": "path"}'
      uri: rest:get:/api/v1/path
  traits:
    ingress:
      paths: 
        - /api/v1/multi
        - /api/v1/path
status: {}
```

Output of ingress (`kubectl get ingress multi-path -o yaml`):
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  creationTimestamp: "2024-12-13T15:21:34Z"
  generation: 1
  labels:
    camel.apache.org/generation: "1"
    camel.apache.org/integration: multi-path
  name: multi-path
  namespace: default
  ownerReferences:
  - apiVersion: camel.apache.org/v1
    blockOwnerDeletion: true
    controller: true
    kind: Integration
    name: multi-path
    uid: eb44c65f-3dca-49e5-a368-1ba8946fc3ee
  resourceVersion: "97865"
  uid: bc5651de-87a5-40d7-be30-9375c98dfb61
spec:
  ingressClassName: nginx
  rules:
  - http:
      paths:
      - backend:
          service:
            name: multi-path
            port:
              name: http
        path: /api/v1/multi
        pathType: Prefix
      - backend:
          service:
            name: multi-path
            port:
              name: http
        path: /api/v1/path
        pathType: Prefix
status:
  loadBalancer:
    ingress:
    - ip: 192.168.49.2
```

Curl Output:
```curl
curl 192.168.49.2/api/v1/multi
{"welcome": "multi"}

curl 192.168.49.2/api/v1/path
{"welcome": "path"}
```
