### PR TITLE
feat(cmd): kamel promote --export-gitops-dir

### DIFF
--- a/e2e/common/cli/promote_test.go
+++ b/e2e/common/cli/promote_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/apache/camel-k/v2/e2e/support"
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+)
+
+func TestKamelPromoteGitOps(t *testing.T) {
+	t.Parallel()
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		t.Run("build and run gitops", func(t *testing.T) {
+			g.Expect(KamelRun(t, ctx, ns, "files/yaml.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "yaml", v1.IntegrationConditionReady)).
+				Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "yaml"), TestTimeoutShort).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+		})
+		WithNewTestNamespace(t, func(ctx context.Context, g *WithT, nsTarget string) {
+			// Export to GitOps directory structure
+			tmpDir, err := os.MkdirTemp("", "ck-promote-it-*")
+			if err != nil {
+				t.Error(err)
+			}
+			g.Expect(Kamel(t, ctx, "promote", "yaml", "-n", ns, "--to", nsTarget, "--export-gitops-dir", tmpDir).Execute()).To(Succeed())
+			// Run the exported Integration as it would be any CICD
+			ExpectExecSucceed(t, g, Kubectl("apply", "-k", tmpDir+"/yaml/overlays/"+nsTarget))
+			g.Eventually(IntegrationPodPhase(t, ctx, nsTarget, "yaml"), TestTimeoutShort).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, nsTarget, "yaml", v1.IntegrationConditionReady), TestTimeoutShort).
+				Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, nsTarget, "yaml"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			// Make sure that no IntegrationKit was ever built for this Integration
+			g.Eventually(IntegrationKit(t, ctx, nsTarget, "yaml")).Should(Equal(""))
+		})
+	})
+}

--- a/pkg/cmd/bind.go
+++ b/pkg/cmd/bind.go
@@ -281,7 +281,6 @@ func (o *bindCmdOptions) run(cmd *cobra.Command, args []string) error {
 // for example, `-t camel.properties=a=1 -t camel.properties=b=2` would convert into annotation
 // `camel.properties=[a=1,b=2]“.
 func maybeBuildArrayNotation(array, value string) string {
-	fmt.Println(array, value)
 	if array == "" {
 		return value
 	}

--- a/pkg/cmd/promote_test.go
+++ b/pkg/cmd/promote_test.go
@@ -19,6 +19,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -142,13 +144,13 @@ func TestPipeDryRun(t *testing.T) {
 	dstPlatform.Status.Version = defaults.Version
 	dstPlatform.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
 	dstPlatform.Status.Phase = v1.IntegrationPlatformPhaseReady
-	defaultKB := nominalPipe("my-kb-test")
-	defaultIntegration, defaultKit := nominalIntegration("my-kb-test")
+	defaultKB := nominalPipe("my-pipe-test")
+	defaultIntegration, defaultKit := nominalIntegration("my-pipe-test")
 	srcCatalog := createTestCamelCatalog(srcPlatform)
 	dstCatalog := createTestCamelCatalog(dstPlatform)
 
 	promoteCmdOptions, promoteCmd, _ := initializePromoteCmdOptions(t, &srcPlatform, &dstPlatform, &defaultKB, &defaultIntegration, &defaultKit, &srcCatalog, &dstCatalog)
-	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-kb-test", "--to", "prod-namespace", "-o", "yaml", "-n", "default")
+	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-pipe-test", "--to", "prod-namespace", "-o", "yaml", "-n", "default")
 	assert.Equal(t, "yaml", promoteCmdOptions.OutputFormat)
 	require.NoError(t, err)
 	assert.Equal(t, `apiVersion: camel.apache.org/v1
@@ -159,7 +161,7 @@ metadata:
     trait.camel.apache.org/container.image: my-special-image
     trait.camel.apache.org/jvm.classpath: /path/to/artifact-1/*:/path/to/artifact-2/*
   creationTimestamp: null
-  name: my-kb-test
+  name: my-pipe-test
   namespace: prod-namespace
 spec:
   sink: {}
@@ -235,7 +237,7 @@ func TestPipeWithMetadataDryRun(t *testing.T) {
 	dstPlatform.Status.Version = defaults.Version
 	dstPlatform.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
 	dstPlatform.Status.Phase = v1.IntegrationPlatformPhaseReady
-	defaultKB := nominalPipe("my-kb-test")
+	defaultKB := nominalPipe("my-pipe-test")
 	defaultKB.Annotations = map[string]string{
 		"camel.apache.org/operator.id": "camel-k",
 		"my-annotation":                "my-value",
@@ -243,12 +245,12 @@ func TestPipeWithMetadataDryRun(t *testing.T) {
 	defaultKB.Labels = map[string]string{
 		"my-label": "my-value",
 	}
-	defaultIntegration, defaultKit := nominalIntegration("my-kb-test")
+	defaultIntegration, defaultKit := nominalIntegration("my-pipe-test")
 	srcCatalog := createTestCamelCatalog(srcPlatform)
 	dstCatalog := createTestCamelCatalog(dstPlatform)
 
 	promoteCmdOptions, promoteCmd, _ := initializePromoteCmdOptions(t, &srcPlatform, &dstPlatform, &defaultKB, &defaultIntegration, &defaultKit, &srcCatalog, &dstCatalog)
-	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-kb-test", "--to", "prod-namespace", "-o", "yaml", "-n", "default")
+	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-pipe-test", "--to", "prod-namespace", "-o", "yaml", "-n", "default")
 	assert.Equal(t, "yaml", promoteCmdOptions.OutputFormat)
 	require.NoError(t, err)
 	assert.Equal(t, `apiVersion: camel.apache.org/v1
@@ -262,7 +264,7 @@ metadata:
   creationTimestamp: null
   labels:
     my-label: my-value
-  name: my-kb-test
+  name: my-pipe-test
   namespace: prod-namespace
 spec:
   sink: {}
@@ -299,13 +301,13 @@ func TestPipeImageOnly(t *testing.T) {
 	dstPlatform.Status.Version = defaults.Version
 	dstPlatform.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
 	dstPlatform.Status.Phase = v1.IntegrationPlatformPhaseReady
-	defaultKB := nominalPipe("my-kb-test")
-	defaultIntegration, defaultKit := nominalIntegration("my-kb-test")
+	defaultKB := nominalPipe("my-pipe-test")
+	defaultIntegration, defaultKit := nominalIntegration("my-pipe-test")
 	srcCatalog := createTestCamelCatalog(srcPlatform)
 	dstCatalog := createTestCamelCatalog(dstPlatform)
 
 	_, promoteCmd, _ := initializePromoteCmdOptions(t, &srcPlatform, &dstPlatform, &defaultKB, &defaultIntegration, &defaultKit, &srcCatalog, &dstCatalog)
-	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-kb-test", "--to", "prod-namespace", "-i", "-n", "default")
+	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-pipe-test", "--to", "prod-namespace", "-i", "-n", "default")
 	require.NoError(t, err)
 	assert.Equal(t, "my-special-image\n", output)
 }
@@ -427,7 +429,7 @@ func TestPipeWithSavedTraitsDryRun(t *testing.T) {
 	dstPlatform.Status.Version = defaults.Version
 	dstPlatform.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
 	dstPlatform.Status.Phase = v1.IntegrationPlatformPhaseReady
-	defaultKB := nominalPipe("my-kb-test")
+	defaultKB := nominalPipe("my-pipe-test")
 	defaultKB.Annotations = map[string]string{
 		"camel.apache.org/operator.id": "camel-k",
 		"my-annotation":                "my-value",
@@ -435,12 +437,12 @@ func TestPipeWithSavedTraitsDryRun(t *testing.T) {
 	defaultKB.Labels = map[string]string{
 		"my-label": "my-value",
 	}
-	defaultIntegration, defaultKit := nominalIntegration("my-kb-test")
+	defaultIntegration, defaultKit := nominalIntegration("my-pipe-test")
 	srcCatalog := createTestCamelCatalog(srcPlatform)
 	dstCatalog := createTestCamelCatalog(dstPlatform)
 
 	promoteCmdOptions, promoteCmd, _ := initializePromoteCmdOptions(t, &srcPlatform, &dstPlatform, &defaultKB, &defaultIntegration, &defaultKit, &srcCatalog, &dstCatalog)
-	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-kb-test", "--to", "prod-namespace", "-o", "yaml", "-n", "default")
+	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-pipe-test", "--to", "prod-namespace", "-o", "yaml", "-n", "default")
 	assert.Equal(t, "yaml", promoteCmdOptions.OutputFormat)
 	require.NoError(t, err)
 	assert.Equal(t, `apiVersion: camel.apache.org/v1
@@ -454,11 +456,267 @@ metadata:
   creationTimestamp: null
   labels:
     my-label: my-value
-  name: my-kb-test
+  name: my-pipe-test
   namespace: prod-namespace
 spec:
   sink: {}
   source: {}
 status: {}
 `, output)
+}
+
+const expectedGitOpsIt = `apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  creationTimestamp: null
+  name: my-it-test
+spec:
+  traits:
+    affinity:
+      nodeAffinityLabels:
+      - my-node
+    camel:
+      properties:
+      - my.property=val
+      runtimeVersion: 1.2.3
+    container:
+      image: my-special-image
+      imagePullPolicy: Always
+      limitCPU: "1"
+      limitMemory: 1024Mi
+      port: 2000
+      requestCPU: "0.5"
+      requestMemory: 512Mi
+    environment:
+      vars:
+      - MY_VAR=val
+    jvm:
+      classpath: /path/to/artifact-1/*:/path/to/artifact-2/*
+      jar: my.jar
+      options:
+      - -XMX 123
+    mount:
+      configs:
+      - configmap:my-cm
+      - secret:my-sec
+    service:
+      annotations:
+        my-annotation: "123"
+      auto: false
+      enabled: true
+    toleration:
+      taints:
+      - taint1:true
+status: {}
+`
+
+const expectedGitOpsItPatch = `apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  creationTimestamp: null
+  name: my-it-test
+spec:
+  traits:
+    affinity:
+      nodeAffinityLabels:
+      - my-node
+    camel:
+      properties:
+      - my.property=val
+    container:
+      limitCPU: "1"
+      limitMemory: 1024Mi
+      requestCPU: "0.5"
+      requestMemory: 512Mi
+    environment:
+      vars:
+      - MY_VAR=val
+    jvm:
+      options:
+      - -XMX 123
+    mount:
+      configs:
+      - configmap:my-cm
+      - secret:my-sec
+    toleration:
+      taints:
+      - taint1:true
+status: {}
+`
+
+func TestIntegrationGitOps(t *testing.T) {
+	srcPlatform := v1.NewIntegrationPlatform("default", platform.DefaultPlatformName)
+	srcPlatform.Status.Version = defaults.Version
+	srcPlatform.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
+	srcPlatform.Status.Phase = v1.IntegrationPlatformPhaseReady
+	dstPlatform := v1.NewIntegrationPlatform("prod-namespace", platform.DefaultPlatformName)
+	dstPlatform.Status.Version = defaults.Version
+	dstPlatform.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
+	dstPlatform.Status.Phase = v1.IntegrationPlatformPhaseReady
+	defaultIntegration, defaultKit := nominalIntegration("my-it-test")
+	defaultIntegration.Status.Traits = &v1.Traits{
+		Affinity: &trait.AffinityTrait{
+			NodeAffinityLabels: []string{"my-node"},
+		},
+		Camel: &trait.CamelTrait{
+			Properties: []string{"my.property=val"},
+		},
+		Container: &trait.ContainerTrait{
+			LimitCPU:        "1",
+			LimitMemory:     "1024Mi",
+			RequestCPU:      "0.5",
+			RequestMemory:   "512Mi",
+			Port:            2000,
+			ImagePullPolicy: corev1.PullAlways,
+		},
+		Environment: &trait.EnvironmentTrait{
+			Vars: []string{"MY_VAR=val"},
+		},
+		JVM: &trait.JVMTrait{
+			Jar:     "my.jar",
+			Options: []string{"-XMX 123"},
+		},
+		Mount: &trait.MountTrait{
+			Configs: []string{"configmap:my-cm", "secret:my-sec"},
+		},
+		Service: &trait.ServiceTrait{
+			Trait: trait.Trait{
+				Enabled: ptr.To(true),
+			},
+			Auto: ptr.To(false),
+			Annotations: map[string]string{
+				"my-annotation": "123",
+			},
+		},
+		Toleration: &trait.TolerationTrait{
+			Taints: []string{"taint1:true"},
+		},
+	}
+	srcCatalog := createTestCamelCatalog(srcPlatform)
+	dstCatalog := createTestCamelCatalog(dstPlatform)
+
+	tmpDir, err := os.MkdirTemp("", "ck-promote-it-*")
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, promoteCmd, _ := initializePromoteCmdOptions(t, &srcPlatform, &dstPlatform, &defaultIntegration, &defaultKit, &srcCatalog, &dstCatalog)
+	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-it-test", "--to", "prod-namespace", "--export-gitops-dir", tmpDir, "-n", "default")
+	require.NoError(t, err)
+	assert.Contains(t, output, `Exported a Kustomize based Gitops directory`)
+
+	baseIt, err := os.ReadFile(filepath.Join(tmpDir, "my-it-test", "base", "integration.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedGitOpsIt, string(baseIt))
+
+	patchIt, err := os.ReadFile(filepath.Join(tmpDir, "my-it-test", "overlays", "prod-namespace", "patch-integration.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedGitOpsItPatch, string(patchIt))
+}
+
+const expectedGitOpsPipe = `apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  annotations:
+    my-annotation: my-value
+    trait.camel.apache.org/affinity.node-affinity-labels: '[node1,node2]'
+    trait.camel.apache.org/camel.properties: '[a=1]'
+    trait.camel.apache.org/camel.runtime-version: 1.2.3
+    trait.camel.apache.org/container.image: my-special-image
+    trait.camel.apache.org/container.image-pull-policy: Always
+    trait.camel.apache.org/container.limit-cpu: "2"
+    trait.camel.apache.org/container.limit-memory: 1024Mi
+    trait.camel.apache.org/container.request-cpu: "1"
+    trait.camel.apache.org/container.request-memory: 2048Mi
+    trait.camel.apache.org/environment.vars: '[MYVAR=1]'
+    trait.camel.apache.org/jvm.classpath: /path/to/artifact-1/*:/path/to/artifact-2/*
+    trait.camel.apache.org/jvm.jar: my.jar
+    trait.camel.apache.org/jvm.options: '[-XMX 123]'
+    trait.camel.apache.org/mount.resources: '[configmap:my-cm,secret:my-sec/my-key@/tmp/file.txt]'
+    trait.camel.apache.org/service.auto: "false"
+    trait.camel.apache.org/toleration.taints: '[mytaints:true]'
+  creationTimestamp: null
+  labels:
+    my-label: my-value
+  name: my-pipe-test
+spec:
+  sink: {}
+  source: {}
+status: {}
+`
+
+const expectedGitOpsPipePatch = `apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  annotations:
+    my-annotation: my-value
+    trait.camel.apache.org/affinity.node-affinity-labels: '[node1,node2]'
+    trait.camel.apache.org/camel.properties: '[a=1]'
+    trait.camel.apache.org/container.limit-cpu: "2"
+    trait.camel.apache.org/container.limit-memory: 1024Mi
+    trait.camel.apache.org/container.request-cpu: "1"
+    trait.camel.apache.org/container.request-memory: 2048Mi
+    trait.camel.apache.org/environment.vars: '[MYVAR=1]'
+    trait.camel.apache.org/jvm.options: '[-XMX 123]'
+    trait.camel.apache.org/mount.resources: '[configmap:my-cm,secret:my-sec/my-key@/tmp/file.txt]'
+    trait.camel.apache.org/toleration.taints: '[mytaints:true]'
+  creationTimestamp: null
+  name: my-pipe-test
+spec:
+  sink: {}
+  source: {}
+status: {}
+`
+
+func TestPipeGitOps(t *testing.T) {
+	srcPlatform := v1.NewIntegrationPlatform("default", platform.DefaultPlatformName)
+	srcPlatform.Status.Version = defaults.Version
+	srcPlatform.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
+	srcPlatform.Status.Phase = v1.IntegrationPlatformPhaseReady
+	dstPlatform := v1.NewIntegrationPlatform("prod-namespace", platform.DefaultPlatformName)
+	dstPlatform.Status.Version = defaults.Version
+	dstPlatform.Status.Build.RuntimeVersion = defaults.DefaultRuntimeVersion
+	dstPlatform.Status.Phase = v1.IntegrationPlatformPhaseReady
+	defaultKB := nominalPipe("my-pipe-test")
+	defaultKB.Annotations = map[string]string{
+		"camel.apache.org/operator.id": "camel-k",
+		"my-annotation":                "my-value",
+		v1.TraitAnnotationPrefix + "affinity.node-affinity-labels": "[node1,node2]",
+		v1.TraitAnnotationPrefix + "camel.properties":              "[a=1]",
+		v1.TraitAnnotationPrefix + "container.limit-cpu":           "2",
+		v1.TraitAnnotationPrefix + "container.limit-memory":        "1024Mi",
+		v1.TraitAnnotationPrefix + "container.request-cpu":         "1",
+		v1.TraitAnnotationPrefix + "container.request-memory":      "2048Mi",
+		v1.TraitAnnotationPrefix + "container.image-pull-policy":   "Always",
+		v1.TraitAnnotationPrefix + "environment.vars":              "[MYVAR=1]",
+		v1.TraitAnnotationPrefix + "jvm.options":                   "[-XMX 123]",
+		v1.TraitAnnotationPrefix + "jvm.jar":                       "my.jar",
+		v1.TraitAnnotationPrefix + "mount.resources":               "[configmap:my-cm,secret:my-sec/my-key@/tmp/file.txt]",
+		v1.TraitAnnotationPrefix + "service.auto":                  "false",
+		v1.TraitAnnotationPrefix + "toleration.taints":             "[mytaints:true]",
+	}
+	defaultKB.Labels = map[string]string{
+		"my-label": "my-value",
+	}
+	defaultIntegration, defaultKit := nominalIntegration("my-pipe-test")
+	srcCatalog := createTestCamelCatalog(srcPlatform)
+	dstCatalog := createTestCamelCatalog(dstPlatform)
+
+	tmpDir, err := os.MkdirTemp("", "ck-promote-pipe-*")
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, promoteCmd, _ := initializePromoteCmdOptions(t, &srcPlatform, &dstPlatform, &defaultKB, &defaultIntegration, &defaultKit, &srcCatalog, &dstCatalog)
+	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-pipe-test", "--to", "prod-namespace", "--export-gitops-dir", tmpDir, "-n", "default")
+	require.NoError(t, err)
+	assert.Contains(t, output, `Exported a Kustomize based Gitops directory`)
+
+	baseIt, err := os.ReadFile(filepath.Join(tmpDir, "my-pipe-test", "base", "pipe.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedGitOpsPipe, string(baseIt))
+
+	patchPipe, err := os.ReadFile(filepath.Join(tmpDir, "my-pipe-test", "overlays", "prod-namespace", "patch-pipe.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedGitOpsPipePatch, string(patchPipe))
 }


### PR DESCRIPTION
<!-- Description -->

Introduced a `--export-gitops-dir` flag that will create a simple opinionated Kustomize based GitOps overlay directory. The result can be used to be stored in Git and be used as a source for any GitOps pipeline.

```
kamel promote my-it --to my-dest-namespace --export-gitops-dir /path/to/export/dir
```

Closes https://github.com/apache/camel-k/issues/5456


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
feat(cmd): kamel promote --export-gitops-dir
```
