### PR TITLE
Issue: Set default resource for builder pod

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,7 +22,9 @@ ARG MAVEN_HOME="/usr/share/maven"
 ARG MAVEN_DIST_URL="https://archive.apache.org/dist/maven/maven-3/${MAVEN_DEFAULT_VERSION}/binaries/apache-maven-${MAVEN_DEFAULT_VERSION}-bin.zip"
 ARG MVNW_DIR="/usr/share/maven/mvnw/"
 ARG MVN_REPO="/etc/maven/m2"
-ARG MAVEN_OPTS=""
+ARG MAVEN_OPTS="-Xmx512m -Xms256m -XX:MaxRAMPercentage=75.0"
+
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
 USER 0
 


### PR DESCRIPTION
In this I have limit the heap size to use only 75% of available memory. I have also set maximun and minimum heap sizes

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
