### PR TITLE
fix(trait): workaround Knative h2c port name

### DIFF
--- a/pkg/trait/prometheus.go
+++ b/pkg/trait/prometheus.go
@@ -87,7 +87,7 @@ func (t *prometheusTrait) Apply(e *Environment) error {
 
 	// Add the PodMonitor resource
 	if ptr.Deref(t.PodMonitor, true) {
-		portName := containerPort.Name
+		portName := getPortName(containerPort.Name)
 		podMonitor, err := t.getPodMonitorFor(e, portName)
 		if err != nil {
 			return err
@@ -101,6 +101,15 @@ func (t *prometheusTrait) Apply(e *Environment) error {
 	e.Integration.Status.SetConditions(condition)
 
 	return nil
+}
+
+func getPortName(portName string) string {
+	// This is a workaround to fix Knative behavior
+	// as described in https://github.com/apache/camel-k/issues/6014
+	if portName == defaultKnativeContainerPortName {
+		return "user-port"
+	}
+	return portName
 }
 
 func (t *prometheusTrait) getPodMonitorFor(e *Environment, portName string) (*monitoringv1.PodMonitor, error) {


### PR DESCRIPTION
Closes #6014

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(trait): workaround Knative h2c port name
```
