### PR TITLE
fix(ctrl): set ready state when reconciling back to normal

### DIFF
--- a/pkg/controller/integrationplatform/monitor.go
+++ b/pkg/controller/integrationplatform/monitor.go
@@ -77,6 +77,8 @@ func (action *monitorAction) Handle(ctx context.Context, platform *v1.Integratio
 
 		return platform, err
 	}
+	// So far the ITP is good
+	platform.Status.Phase = v1.IntegrationPlatformPhaseReady
 	platform.Status.Build.RuntimeCoreVersion = catalog.Spec.GetCamelVersion()
 	// Registry condition
 	isOpenshift, err := openshift.IsOpenShift(action.client)

--- a/pkg/controller/integrationplatform/monitor_test.go
+++ b/pkg/controller/integrationplatform/monitor_test.go
@@ -236,8 +236,29 @@ func TestMonitorMissingRegistryError(t *testing.T) {
 
 	assert.Equal(t, v1.IntegrationPlatformPhaseError, answer.Status.Phase)
 	assert.Equal(t, corev1.ConditionFalse, answer.Status.GetCondition(v1.IntegrationPlatformConditionTypeRegistryAvailable).Status)
-	assert.Equal(t, v1.IntegrationPlatformConditionTypeRegistryAvailableReason, answer.Status.GetCondition(v1.IntegrationPlatformConditionTypeRegistryAvailable).Reason)
-	assert.Equal(t, "registry address not available, you need to set one", answer.Status.GetCondition(v1.IntegrationPlatformConditionTypeRegistryAvailable).Message)
+	assert.Equal(t,
+		v1.IntegrationPlatformConditionTypeRegistryAvailableReason,
+		answer.Status.GetCondition(v1.IntegrationPlatformConditionTypeRegistryAvailable).Reason)
+	assert.Equal(t,
+		"registry address not available, you need to set one",
+		answer.Status.GetCondition(v1.IntegrationPlatformConditionTypeRegistryAvailable).Message)
+
+	// fix and see if it reconciles correctly
+	ip.Spec.Build.Registry = v1.RegistrySpec{
+		Address: "1.2.3.4",
+	}
+	answer, err = action.Handle(context.TODO(), &ip)
+	require.NoError(t, err)
+	assert.NotNil(t, answer)
+
+	assert.Equal(t, v1.IntegrationPlatformPhaseReady, answer.Status.Phase)
+	assert.Equal(t, corev1.ConditionTrue, answer.Status.GetCondition(v1.IntegrationPlatformConditionTypeRegistryAvailable).Status)
+	assert.Equal(t,
+		v1.IntegrationPlatformConditionTypeRegistryAvailableReason,
+		answer.Status.GetCondition(v1.IntegrationPlatformConditionTypeRegistryAvailable).Reason)
+	assert.Equal(t,
+		"registry available at 1.2.3.4",
+		answer.Status.GetCondition(v1.IntegrationPlatformConditionTypeRegistryAvailable).Message)
 }
 
 func TestMonitorMissingCatalogError(t *testing.T) {


### PR DESCRIPTION
Closes #6080

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(ctrl): set ready state when reconciling back to normal
```
