### PR TITLE
fix(e2e): wait for Pod readiness

### DIFF
--- a/e2e/common/traits/cron_test.go
+++ b/e2e/common/traits/cron_test.go
@@ -43,10 +43,11 @@ func TestRunCronExample(t *testing.T) {
 			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-timer"), TestTimeoutLong).ShouldNot(BeNil())
 			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-timer", v1.IntegrationConditionReady), TestTimeoutMedium).Should(
 				Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-timer", v1.IntegrationConditionCronJobAvailable), TestTimeoutMedium).Should(
-				Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-timer", v1.IntegrationConditionCronJobAvailable),
+				TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 			// As it's a cron, we expect it's triggered, executed and turned off
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-timer"), TestTimeoutMedium).Should(Equal(ptr.To(int32(1))))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-timer")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-timer")).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-timer")).Should(Equal(ptr.To(int32(0))))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
@@ -57,10 +58,11 @@ func TestRunCronExample(t *testing.T) {
 			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-java"), TestTimeoutLong).ShouldNot(BeNil())
 			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-java", v1.IntegrationConditionReady), TestTimeoutMedium).Should(
 				Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-java", v1.IntegrationConditionCronJobAvailable), TestTimeoutMedium).Should(
-				Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-java", v1.IntegrationConditionCronJobAvailable),
+				TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 			// As it's a cron, we expect it's triggered, executed and turned off
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-java"), TestTimeoutMedium).Should(Equal(ptr.To(int32(1))))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-java")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-java")).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-java")).Should(Equal(ptr.To(int32(0))))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
@@ -71,10 +73,11 @@ func TestRunCronExample(t *testing.T) {
 			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-tab"), TestTimeoutLong).ShouldNot(BeNil())
 			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-tab", v1.IntegrationConditionReady), TestTimeoutMedium).Should(
 				Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-tab", v1.IntegrationConditionCronJobAvailable), TestTimeoutMedium).Should(
-				Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-tab", v1.IntegrationConditionCronJobAvailable),
+				TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 			// As it's a cron, we expect it's triggered, executed and turned off
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-tab"), TestTimeoutMedium).Should(Equal(ptr.To(int32(1))))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-tab")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-tab")).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-tab")).Should(Equal(ptr.To(int32(0))))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
@@ -85,10 +88,11 @@ func TestRunCronExample(t *testing.T) {
 			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-quartz"), TestTimeoutLong).ShouldNot(BeNil())
 			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-quartz", v1.IntegrationConditionReady), TestTimeoutShort).Should(
 				Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-quartz", v1.IntegrationConditionCronJobAvailable), TestTimeoutMedium).Should(
-				Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-quartz", v1.IntegrationConditionCronJobAvailable),
+				TestTimeoutMedium).Should(Equal(corev1.ConditionTrue))
 			// As it's a cron, we expect it's triggered, executed and turned off
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-quartz"), TestTimeoutMedium).Should(Equal(ptr.To(int32(1))))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-quartz")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-quartz")).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-quartz")).Should(Equal(ptr.To(int32(0))))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
@@ -99,8 +103,8 @@ func TestRunCronExample(t *testing.T) {
 			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-fallback"), TestTimeoutLong).Should(BeNil())
 			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-fallback", v1.IntegrationConditionReady), TestTimeoutShort).Should(
 				Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-fallback", v1.IntegrationConditionCronJobAvailable), TestTimeoutMedium).Should(
-				Equal(corev1.ConditionFalse))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-fallback", v1.IntegrationConditionCronJobAvailable),
+				TestTimeoutMedium).Should(Equal(corev1.ConditionFalse))
 			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-fallback")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-fallback"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))


### PR DESCRIPTION
Closes #5912

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(e2e): wait for Pod readiness
```
