### PR TITLE
fix(builder): allow any plain Quarkus runtime

### DIFF
--- a/pkg/controller/integration/kits.go
+++ b/pkg/controller/integration/kits.go
@@ -31,7 +31,6 @@ import (
 	"github.com/apache/camel-k/v2/pkg/platform"
 	"github.com/apache/camel-k/v2/pkg/trait"
 	"github.com/apache/camel-k/v2/pkg/util"
-	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/log"
 )
@@ -169,11 +168,7 @@ func statusMatches(integration *v1.Integration, kit *v1.IntegrationKit, ilog *lo
 
 // kitMatches returns whether the kit matches with the existing target kit.
 func kitMatches(c client.Client, kit *v1.IntegrationKit, target *v1.IntegrationKit) (bool, error) {
-	version := kit.Status.RuntimeVersion
-	if version == "" {
-		// Defaults with the version that is going to be set during the kit initialization
-		version = defaults.DefaultRuntimeVersion
-	}
+	version := kit.Labels[kubernetes.CamelLabelRuntimeVersion]
 	if version != target.Status.RuntimeVersion {
 		return false, nil
 	}

--- a/pkg/controller/integrationkit/initialize.go
+++ b/pkg/controller/integrationkit/initialize.go
@@ -79,11 +79,17 @@ func (action *initializeAction) Handle(ctx context.Context, kit *v1.IntegrationK
 }
 
 func (action *initializeAction) image(ctx context.Context, env *trait.Environment, kit *v1.IntegrationKit) error {
+	catalogName := fmt.Sprintf("camel-catalog-%s", strings.ToLower(env.CamelCatalog.GetRuntimeVersion()))
+	if env.CamelCatalog.GetRuntimeProvider() == v1.RuntimeProviderPlainQuarkus {
+		// We need this workaround to load the last existing catalog
+		// TODO: this part will be subject to future refactoring
+		catalogName = fmt.Sprintf("camel-catalog-quarkus-%s", strings.ToLower(defaults.DefaultRuntimeVersion))
+	}
 	// Wait for CamelCatalog to be ready
 	catalog, err := kubernetes.GetCamelCatalog(
 		ctx,
 		action.client,
-		fmt.Sprintf("camel-catalog-%s", strings.ToLower(env.CamelCatalog.GetRuntimeVersion())),
+		catalogName,
 		kit.Namespace,
 	)
 

--- a/pkg/trait/camel.go
+++ b/pkg/trait/camel.go
@@ -29,6 +29,7 @@ import (
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/util/camel"
+	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/property"
 )
@@ -157,6 +158,11 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment) error {
 		Version:  t.runtimeVersion,
 		Provider: v1.RuntimeProvider(t.runtimeProvider),
 	}
+	if runtime.Provider == v1.RuntimeProviderPlainQuarkus {
+		// We need this workaround to load the last existing catalog
+		// TODO: this part will be subject to future refactoring
+		runtime.Version = defaults.DefaultRuntimeVersion
+	}
 
 	catalog, err := camel.LoadCatalog(e.Ctx, e.Client, catalogNamespace, runtime)
 	if err != nil {
@@ -179,6 +185,11 @@ func (t *camelTrait) loadOrCreateCatalog(e *Environment) error {
 		return fmt.Errorf("unable to find catalog matching version requirement: runtime=%s, provider=%s",
 			runtime.Version,
 			runtime.Provider)
+	}
+	if runtime.Provider == v1.RuntimeProviderPlainQuarkus {
+		// We need this workaround to load the last existing catalog
+		// TODO: this part will be subject to future refactoring
+		catalog.Runtime.Version = t.runtimeVersion
 	}
 
 	e.CamelCatalog = catalog


### PR DESCRIPTION
We were previously forced to use only the same version available through Camel K runtime catalog

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
