### PR TITLE
fix(helm): extra environment variables

### DIFF
--- a/helm/camel-k/templates/operator-deployment.yaml
+++ b/helm/camel-k/templates/operator-deployment.yaml
@@ -73,6 +73,9 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_ID
               value: {{ .Values.operator.operatorId }}
+            {{- with .Values.operator.extraEnv }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
           image: {{ .Values.operator.image }}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/helm/camel-k/values.yaml
+++ b/helm/camel-k/values.yaml
@@ -48,3 +48,9 @@ operator:
 
   serviceAccount:
     annotations:
+
+  ## Extra environment variables.
+  ## ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+  extraEnv: []
+    # - name: MY_VAR
+      # value: my_value


### PR DESCRIPTION
<!-- Description -->

Possibility to define extra environment variables for operator deployment / pod.
Can be used for example to access private GitHub repositories for downloading custom `Kamelet`.

[Zulip thread](https://camel.zulipchat.com/#narrow/channel/257299-camel-k/topic/.E2.9C.94.20kamelet.20cataglog.20inside.20private.20git.20repository)


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(helm): extra environment variables
```
