### PR TITLE
fix(api): count all sources only once

### DIFF
--- a/pkg/apis/camel/v1/integration_types_support.go
+++ b/pkg/apis/camel/v1/integration_types_support.go
@@ -90,10 +90,15 @@ func (in *Integration) AllSources() []SourceSpec {
 		if len(in.Status.GeneratedSources) == 0 {
 			sources = append(sources, src)
 		} else {
+			found := false
 			for _, genSrc := range in.Status.GeneratedSources {
-				if src.Name != genSrc.Name {
-					sources = append(sources, src)
+				if src.Name == genSrc.Name {
+					found = true
+					break
 				}
+			}
+			if !found {
+				sources = append(sources, src)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #6098

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix(api): count all sources only once
```
