### PR TITLE
fix(#6182): fixing integration x kit matching algorithm for runtime version

### DIFF
--- a/pkg/controller/integration/kits.go
+++ b/pkg/controller/integration/kits.go
@@ -31,7 +31,6 @@ import (
 	"github.com/apache/camel-k/v2/pkg/platform"
 	"github.com/apache/camel-k/v2/pkg/trait"
 	"github.com/apache/camel-k/v2/pkg/util"
-	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/log"
 )
@@ -169,11 +168,8 @@ func statusMatches(integration *v1.Integration, kit *v1.IntegrationKit, ilog *lo
 
 // kitMatches returns whether the kit matches with the existing target kit.
 func kitMatches(c client.Client, kit *v1.IntegrationKit, target *v1.IntegrationKit) (bool, error) {
-	version := kit.Status.RuntimeVersion
-	if version == "" {
-		// Defaults with the version that is going to be set during the kit initialization
-		version = defaults.DefaultRuntimeVersion
-	}
+	version := kit.Labels[kubernetes.CamelLabelRuntimeVersion]
+
 	if version != target.Status.RuntimeVersion {
 		return false, nil
 	}


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix: Correctly matching runtime versions when searching for an Integration Kit
```
