### PR TITLE
fix(#6182): fixing integration x kit matching algorithm for runtime version

### DIFF
--- a/pkg/controller/integration/kits.go
+++ b/pkg/controller/integration/kits.go
@@ -31,7 +31,6 @@ import (
 	"github.com/apache/camel-k/v2/pkg/platform"
 	"github.com/apache/camel-k/v2/pkg/trait"
 	"github.com/apache/camel-k/v2/pkg/util"
-	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/log"
 )
@@ -169,11 +168,8 @@ func statusMatches(integration *v1.Integration, kit *v1.IntegrationKit, ilog *lo
 
 // kitMatches returns whether the kit matches with the existing target kit.
 func kitMatches(c client.Client, kit *v1.IntegrationKit, target *v1.IntegrationKit) (bool, error) {
-	version := kit.Status.RuntimeVersion
-	if version == "" {
-		// Defaults with the version that is going to be set during the kit initialization
-		version = defaults.DefaultRuntimeVersion
-	}
+	version := kit.Labels[kubernetes.CamelLabelRuntimeVersion]
+
 	if version != target.Status.RuntimeVersion {
 		return false, nil
 	}

--- a/pkg/controller/integration/kits_test.go
+++ b/pkg/controller/integration/kits_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/client"
 
 	"github.com/apache/camel-k/v2/pkg/trait"
+	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 
 	"github.com/apache/camel-k/v2/pkg/internal"
 	"github.com/stretchr/testify/assert"
@@ -445,4 +446,97 @@ func integrationAndKitHaveSameTraits(c client.Client, i1 *v1.Integration, i2 *v1
 	}
 
 	return trait.Equals(ikOpts, itOpts), nil
+}
+
+func TestLookupKitForIntegration_GetCorrectKitForRuntime(t *testing.T) {
+	c, err := internal.NewFakeClient(
+		&v1.IntegrationPlatform{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       v1.IntegrationPlatformKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "camel-k",
+			},
+		},
+		&v1.IntegrationKit{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       v1.IntegrationKitKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "my-kit-1",
+				Labels: map[string]string{
+					v1.IntegrationKitTypeLabel:           v1.IntegrationKitTypePlatform,
+					kubernetes.CamelLabelRuntimeVersion:  "3.2.3",
+					kubernetes.CamelLabelRuntimeProvider: "quarkus",
+				},
+			},
+			Spec: v1.IntegrationKitSpec{
+				Dependencies: []string{
+					"camel-core",
+					"camel-irc",
+				},
+			},
+			Status: v1.IntegrationKitStatus{
+				Phase:           v1.IntegrationKitPhaseReady,
+				RuntimeVersion:  "3.2.3",
+				RuntimeProvider: "quarkus",
+			},
+		},
+		&v1.IntegrationKit{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       v1.IntegrationKitKind,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "my-kit-2",
+				Labels: map[string]string{
+					v1.IntegrationKitTypeLabel:           v1.IntegrationKitTypePlatform,
+					kubernetes.CamelLabelRuntimeVersion:  "3.15.3",
+					kubernetes.CamelLabelRuntimeProvider: "quarkus",
+				},
+			},
+			Spec: v1.IntegrationKitSpec{
+				Dependencies: []string{
+					"camel-core",
+					"camel-irc",
+				},
+			},
+			Status: v1.IntegrationKitStatus{
+				Phase:           v1.IntegrationKitPhaseReady,
+				RuntimeVersion:  "3.15.3",
+				RuntimeProvider: "quarkus",
+			},
+		},
+	)
+
+	require.NoError(t, err)
+
+	kits, err := lookupKitsForIntegration(context.TODO(), c, &v1.Integration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       v1.IntegrationKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "my-integration",
+		},
+		Status: v1.IntegrationStatus{
+			Dependencies: []string{
+				"camel-core",
+				"camel-irc",
+			},
+			RuntimeVersion:  "3.15.3",
+			RuntimeProvider: "quarkus",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, kits)
+	assert.Len(t, kits, 1)
+	assert.Equal(t, "my-kit-2", kits[0].Name)
 }


### PR DESCRIPTION
<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
fix: Correctly matching runtime versions when searching for an Integration Kit
```
