### PR TITLE
feat(trait): use sensible timeout for Quarkus native builder

### DIFF
--- a/pkg/apis/camel/v1/integrationkit_types.go
+++ b/pkg/apis/camel/v1/integrationkit_types.go
@@ -165,6 +165,7 @@ const (
 	// IntegrationKitLayoutFastJar labels a kit using the Quarkus fast-jar packaging.
 	IntegrationKitLayoutFastJar = "fast-jar"
 	// IntegrationKitLayoutNative labels a kit using the Quarkus native packaging.
+	// Deprecated: no longer in use.
 	IntegrationKitLayoutNative = "native"
 	// IntegrationKitLayoutNativeSources labels a kit using the Quarkus native-sources packaging.
 	IntegrationKitLayoutNativeSources = "native-sources"

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -371,7 +371,6 @@ func (t *builderTrait) builderTask(e *Environment, taskConf *v1.BuildConfigurati
 	}
 
 	if t.Strategy != "" {
-		t.L.Infof("User defined build strategy %s", t.Strategy)
 		found := false
 		for _, s := range v1.BuildStrategies {
 			if string(s) == t.Strategy {
@@ -390,7 +389,6 @@ func (t *builderTrait) builderTask(e *Environment, taskConf *v1.BuildConfigurati
 	}
 
 	if t.OrderStrategy != "" {
-		t.L.Infof("User defined build order strategy %s", t.OrderStrategy)
 		found := false
 		for _, s := range v1.BuildOrderStrategies {
 			if string(s) == t.OrderStrategy {


### PR DESCRIPTION
* when this is higher than actual timeout

Closes #6061

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
