### PR TITLE
fix(e2e): check succeeded pods instead of running pods

### DIFF
--- a/e2e/common/traits/files/cron-fallback.yaml
+++ b/e2e/common/traits/files/cron-fallback.yaml
@@ -18,6 +18,8 @@
 - from:
     uri: "cron:tab"
     parameters:
+      # as it runs every second, won't be creating a
+      # Kubernetes CronJob
       schedule: "0/1 * * * * ?"
     steps:
       - setHeader:

--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -431,6 +431,25 @@ func IntegrationLogs(t *testing.T, ctx context.Context, ns, name string) func() 
 	}
 }
 
+func LastIntegrationCronLogs(t *testing.T, ctx context.Context, ns, name string) func() string {
+	return func() string {
+		pod := LastIntegrationCronPod(t, ctx, ns, name)()
+		if pod == nil {
+			return ""
+		}
+
+		options := corev1.PodLogOptions{
+			TailLines: ptr.To(int64(100)),
+		}
+
+		if len(pod.Spec.Containers) > 1 {
+			options.Container = pod.Spec.Containers[0].Name
+		}
+
+		return Logs(t, ctx, ns, pod.Name, options)()
+	}
+}
+
 func OperatorLogs(t *testing.T, ctx context.Context, ns string) func() string {
 	return func() string {
 		pod := OperatorPod(t, ctx, ns)()
@@ -572,6 +591,20 @@ func IntegrationPod(t *testing.T, ctx context.Context, ns string, name string) f
 	}
 }
 
+func LastIntegrationCronPod(t *testing.T, ctx context.Context, ns string, name string) func() *corev1.Pod {
+	return func() *corev1.Pod {
+		pods := IntegrationPodsSucceeded(t, ctx, ns, name)()
+		if len(pods) == 0 {
+			return nil
+		}
+
+		sort.SliceStable(pods, func(i, j int) bool {
+			return pods[i].GetCreationTimestamp().Time.After(pods[j].GetCreationTimestamp().Time)
+		})
+		return &pods[0]
+	}
+}
+
 func IntegrationPodHas(t *testing.T, ctx context.Context, ns string, name string, predicate func(pod *corev1.Pod) bool) func() bool {
 	return func() bool {
 		pod := IntegrationPod(t, ctx, ns, name)()
@@ -599,6 +632,21 @@ func IntegrationPods(t *testing.T, ctx context.Context, ns string, name string) 
 			failTest(t, err)
 		}
 		return lst.Items
+	}
+}
+
+func IntegrationPodsSucceeded(t *testing.T, ctx context.Context, ns string, name string) func() []corev1.Pod {
+	return func() []corev1.Pod {
+		pods := IntegrationPods(t, ctx, ns, name)
+
+		completedPods := []corev1.Pod{}
+		for _, pod := range pods() {
+			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+				completedPods = append(completedPods, pod)
+			}
+		}
+
+		return completedPods
 	}
 }
 


### PR DESCRIPTION
Closes #5912

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
