### PR TITLE
[Release 2.6.x] fix(e2e): check succeeded pods instead of running pods

### DIFF
--- a/e2e/common/traits/cron_test.go
+++ b/e2e/common/traits/cron_test.go
@@ -38,6 +38,18 @@ func TestRunCronExample(t *testing.T) {
 	t.Parallel()
 	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
 
+		t.Run("cron-fallback", func(t *testing.T) {
+			g.Expect(KamelRun(t, ctx, ns, "files/cron-fallback.yaml").Execute()).To(Succeed())
+			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-fallback"), TestTimeoutLong).Should(BeNil())
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-fallback", v1.IntegrationConditionReady), TestTimeoutShort).Should(
+				Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-fallback", v1.IntegrationConditionCronJobAvailable),
+				TestTimeoutMedium).Should(Equal(corev1.ConditionFalse))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-fallback")).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-fallback"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
+		})
+
 		t.Run("cron-timer", func(t *testing.T) {
 			g.Expect(KamelRun(t, ctx, ns, "files/cron-timer.yaml").Execute()).To(Succeed())
 			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-timer"), TestTimeoutLong).ShouldNot(BeNil())
@@ -47,8 +59,9 @@ func TestRunCronExample(t *testing.T) {
 				Equal(corev1.ConditionTrue))
 			// As it's a cron, we expect it's triggered, executed and turned off
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-timer"), TestTimeoutMedium).Should(Equal(ptr.To(int32(1))))
-			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-timer")).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-timer")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-timer")).Should(Equal(ptr.To(int32(0))))
+			g.Eventually(LastIntegrationCronLogs(t, ctx, ns, "cron-timer")).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
 		})
 
@@ -61,8 +74,9 @@ func TestRunCronExample(t *testing.T) {
 				Equal(corev1.ConditionTrue))
 			// As it's a cron, we expect it's triggered, executed and turned off
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-java"), TestTimeoutMedium).Should(Equal(ptr.To(int32(1))))
-			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-java")).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-java")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-java")).Should(Equal(ptr.To(int32(0))))
+			g.Eventually(LastIntegrationCronLogs(t, ctx, ns, "cron-java")).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
 		})
 
@@ -75,8 +89,9 @@ func TestRunCronExample(t *testing.T) {
 				Equal(corev1.ConditionTrue))
 			// As it's a cron, we expect it's triggered, executed and turned off
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-tab"), TestTimeoutMedium).Should(Equal(ptr.To(int32(1))))
-			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-tab")).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-tab")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-tab")).Should(Equal(ptr.To(int32(0))))
+			g.Eventually(LastIntegrationCronLogs(t, ctx, ns, "cron-tab")).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
 		})
 
@@ -89,20 +104,9 @@ func TestRunCronExample(t *testing.T) {
 				Equal(corev1.ConditionTrue))
 			// As it's a cron, we expect it's triggered, executed and turned off
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-quartz"), TestTimeoutMedium).Should(Equal(ptr.To(int32(1))))
-			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-quartz")).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-quartz")).Should(Equal(corev1.PodRunning))
 			g.Eventually(IntegrationStatusReplicas(t, ctx, ns, "cron-quartz")).Should(Equal(ptr.To(int32(0))))
-			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
-		})
-
-		t.Run("cron-fallback", func(t *testing.T) {
-			g.Expect(KamelRun(t, ctx, ns, "files/cron-fallback.yaml").Execute()).To(Succeed())
-			g.Eventually(IntegrationCronJob(t, ctx, ns, "cron-fallback"), TestTimeoutLong).Should(BeNil())
-			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-fallback", v1.IntegrationConditionReady), TestTimeoutShort).Should(
-				Equal(corev1.ConditionTrue))
-			g.Eventually(IntegrationConditionStatus(t, ctx, ns, "cron-fallback", v1.IntegrationConditionCronJobAvailable), TestTimeoutMedium).Should(
-				Equal(corev1.ConditionFalse))
-			g.Eventually(IntegrationPodPhase(t, ctx, ns, "cron-fallback")).Should(Equal(corev1.PodRunning))
-			g.Eventually(IntegrationLogs(t, ctx, ns, "cron-fallback"), TestTimeoutShort).Should(ContainSubstring("Magicstring!"))
+			g.Eventually(LastIntegrationCronLogs(t, ctx, ns, "cron-quartz")).Should(ContainSubstring("Magicstring!"))
 			g.Eventually(DeleteIntegrations(t, ctx, ns)).Should(Equal(0))
 		})
 

--- a/e2e/common/traits/files/cron-fallback.yaml
+++ b/e2e/common/traits/files/cron-fallback.yaml
@@ -18,6 +18,8 @@
 - from:
     uri: "cron:tab"
     parameters:
+      # as it runs every second, won't be creating a
+      # Kubernetes CronJob
       schedule: "0/1 * * * * ?"
     steps:
       - setHeader:


### PR DESCRIPTION
Closes #5912

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
