### PR TITLE
Let Golang testing framework clean any temporary data

### DIFF
--- a/e2e/common/cli/promote_test.go
+++ b/e2e/common/cli/promote_test.go
@@ -24,7 +24,6 @@ package common
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -47,10 +46,7 @@ func TestKamelPromoteGitOps(t *testing.T) {
 		})
 		WithNewTestNamespace(t, func(ctx context.Context, g *WithT, nsTarget string) {
 			// Export to GitOps directory structure
-			tmpDir, err := os.MkdirTemp("", "ck-promote-it-*")
-			if err != nil {
-				t.Error(err)
-			}
+			tmpDir := t.TempDir()
 			g.Expect(Kamel(t, ctx, "promote", "yaml", "-n", ns, "--to", nsTarget, "--export-gitops-dir", tmpDir).Execute()).To(Succeed())
 			// Run the exported Integration as it would be any CICD
 			ExpectExecSucceed(t, g, Kubectl("apply", "-k", tmpDir+"/yaml/overlays/"+nsTarget))

--- a/pkg/builder/common_test.go
+++ b/pkg/builder/common_test.go
@@ -28,8 +28,7 @@ import (
 )
 
 func TestProcessDependenciesSkipNested(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "ck-deps-dir")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 	tmpDirNested, err := os.MkdirTemp(tmpDir, "nested")
 	require.NoError(t, err)
 	err = util.WriteFileWithContent(path.Join(tmpDir, "deps.jar"), []byte("bogus"))
@@ -48,8 +47,7 @@ func TestProcessDependenciesSkipNested(t *testing.T) {
 }
 
 func TestProcessDependenciesIncludeNested(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "ck-deps-dir")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 	tmpDirNested, err := os.MkdirTemp(tmpDir, "nested")
 	require.NoError(t, err)
 	err = util.WriteFileWithContent(path.Join(tmpDir, "deps.jar"), []byte("bogus"))

--- a/pkg/builder/git_test.go
+++ b/pkg/builder/git_test.go
@@ -32,8 +32,7 @@ import (
 )
 
 func TestGitPublicRepo(t *testing.T) {
-	tmpGitDir, err := os.MkdirTemp("", "ck-git-dir")
-	require.NoError(t, err)
+	tmpGitDir := t.TempDir()
 
 	ctx := &builderContext{
 		C:    context.TODO(),
@@ -45,7 +44,7 @@ func TestGitPublicRepo(t *testing.T) {
 		},
 	}
 
-	err = cloneProject(ctx)
+	err := cloneProject(ctx)
 	require.NoError(t, err)
 	f, err := os.Stat(path.Join(tmpGitDir, "maven", "pom.xml"))
 	require.NoError(t, err)
@@ -75,8 +74,7 @@ func TestGitPublicRepo(t *testing.T) {
 }
 
 func TestGitPrivateRepoFail(t *testing.T) {
-	tmpGitDir, err := os.MkdirTemp("", "ck-git-dir")
-	require.NoError(t, err)
+	tmpGitDir := t.TempDir()
 
 	ctx := &builderContext{
 		Path: tmpGitDir,
@@ -87,7 +85,7 @@ func TestGitPrivateRepoFail(t *testing.T) {
 		},
 	}
 
-	err = cloneProject(ctx)
+	err := cloneProject(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication required")
 	_, err = os.Stat(path.Join(tmpGitDir, "maven", "pom.xml"))

--- a/pkg/builder/jib_test.go
+++ b/pkg/builder/jib_test.go
@@ -20,7 +20,6 @@ package builder
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -32,8 +31,7 @@ import (
 )
 
 func TestJibBuildMavenArgs(t *testing.T) {
-	tmpMvnCtxDir, err := os.MkdirTemp("", "my-build-test")
-	require.NoError(t, err)
+	tmpMvnCtxDir := t.TempDir()
 	args := buildJibMavenArgs(tmpMvnCtxDir, "my-image", "my-base-image", true, nil)
 	expectedParams := strings.Split(
 		fmt.Sprintf("jib:build -Djib.disableUpdateChecks=true -P jib -Djib.to.image=my-image "+
@@ -43,8 +41,7 @@ func TestJibBuildMavenArgs(t *testing.T) {
 }
 
 func TestJibBuildMavenArgsWithPlatforms(t *testing.T) {
-	tmpMvnCtxDir, err := os.MkdirTemp("", "my-build-test")
-	require.NoError(t, err)
+	tmpMvnCtxDir := t.TempDir()
 	args := buildJibMavenArgs(tmpMvnCtxDir, "my-image", "my-base-image", true, []string{"amd64", "arm64"})
 	expectedParams := strings.Split(
 		fmt.Sprintf("jib:build -Djib.disableUpdateChecks=true -P jib -Djib.to.image=my-image "+
@@ -55,13 +52,12 @@ func TestJibBuildMavenArgsWithPlatforms(t *testing.T) {
 }
 
 func TestInjectJibProfileMissingPom(t *testing.T) {
-	tmpMvnCtxDir, err := os.MkdirTemp("", "ck-jib-profile-test")
-	require.NoError(t, err)
+	tmpMvnCtxDir := t.TempDir()
 	builderContext := builderContext{
 		C:    context.TODO(),
 		Path: tmpMvnCtxDir,
 	}
-	err = injectJibProfile(&builderContext)
+	err := injectJibProfile(&builderContext)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no such file or directory")
 }
@@ -73,8 +69,7 @@ var poms = []string{
 }
 
 func TestInjectJibProfiles(t *testing.T) {
-	tmpMvnCtxDir, err := os.MkdirTemp("", "ck-jib-profile-test")
-	require.NoError(t, err)
+	tmpMvnCtxDir := t.TempDir()
 	builderContext := builderContext{
 		C:    context.TODO(),
 		Path: tmpMvnCtxDir,
@@ -82,7 +77,7 @@ func TestInjectJibProfiles(t *testing.T) {
 
 	for _, p := range poms {
 		pom := filepath.Join(tmpMvnCtxDir, "maven", "pom.xml")
-		err = util.WriteFileWithContent(pom, []byte(p))
+		err := util.WriteFileWithContent(pom, []byte(p))
 		require.NoError(t, err)
 		err = injectJibProfile(&builderContext)
 		require.NoError(t, err)

--- a/pkg/builder/quarkus_test.go
+++ b/pkg/builder/quarkus_test.go
@@ -104,8 +104,7 @@ func TestLoadCamelQuarkusCatalogOk(t *testing.T) {
 }
 
 func TestGenerateQuarkusProjectWithBuildTimeProperties(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "go-test-camel-k-quarkus-with-props")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 	defaultCatalog, err := camel.DefaultCatalog()
 	require.NoError(t, err)
 
@@ -167,8 +166,7 @@ func TestGenerateQuarkusProjectWithBuildTimeProperties(t *testing.T) {
 }
 
 func TestGenerateQuarkusProjectWithNativeSources(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "go-test-camel-k-quarkus-native")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 	defaultCatalog, err := camel.DefaultCatalog()
 	require.NoError(t, err)
 
@@ -227,8 +225,7 @@ func TestGenerateQuarkusProjectWithNativeSources(t *testing.T) {
 }
 
 func TestBuildQuarkusRunner(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "go-test-camel-k-quarkus")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 	defaultCatalog, err := camel.DefaultCatalog()
 	require.NoError(t, err)
 	c, err := internal.NewFakeClient(&v1.CamelCatalog{

--- a/pkg/cmd/bind_test.go
+++ b/pkg/cmd/bind_test.go
@@ -267,7 +267,8 @@ func TestBindServiceAccountName(t *testing.T) {
 }
 
 func TestBindOutputWithoutKubernetesCluster(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "camel-k-kubeconfig-*")
+	tempDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tempDir, "camel-k-kubeconfig-*")
 	require.NoError(t, err)
 
 	bindCmdOptions, bindCmd, _ := initializeBindCmdOptions(t)

--- a/pkg/cmd/promote_test.go
+++ b/pkg/cmd/promote_test.go
@@ -595,10 +595,7 @@ func TestIntegrationGitOps(t *testing.T) {
 	srcCatalog := createTestCamelCatalog(srcPlatform)
 	dstCatalog := createTestCamelCatalog(dstPlatform)
 
-	tmpDir, err := os.MkdirTemp("", "ck-promote-it-*")
-	if err != nil {
-		t.Error(err)
-	}
+	tmpDir := t.TempDir()
 
 	_, promoteCmd, _ := initializePromoteCmdOptions(t, &srcPlatform, &dstPlatform, &defaultIntegration, &defaultKit, &srcCatalog, &dstCatalog)
 	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-it-test", "--to", "prod-namespace", "--export-gitops-dir", tmpDir, "-n", "default")
@@ -702,10 +699,7 @@ func TestPipeGitOps(t *testing.T) {
 	srcCatalog := createTestCamelCatalog(srcPlatform)
 	dstCatalog := createTestCamelCatalog(dstPlatform)
 
-	tmpDir, err := os.MkdirTemp("", "ck-promote-pipe-*")
-	if err != nil {
-		t.Error(err)
-	}
+	tmpDir := t.TempDir()
 
 	_, promoteCmd, _ := initializePromoteCmdOptions(t, &srcPlatform, &dstPlatform, &defaultKB, &defaultIntegration, &defaultKit, &srcCatalog, &dstCatalog)
 	output, err := ExecuteCommand(promoteCmd, cmdPromote, "my-pipe-test", "--to", "prod-namespace", "--export-gitops-dir", tmpDir, "-n", "default")

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -300,7 +300,8 @@ func TestExtractProperties_SingleKeyValue(t *testing.T) {
 func TestExtractProperties_FromFile(t *testing.T) {
 	var tmpFile1 *os.File
 	var err error
-	if tmpFile1, err = os.CreateTemp("", "camel-k-*.properties"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile1, err = os.CreateTemp(tempDir, "camel-k-*.properties"); err != nil {
 		t.Error(err)
 	}
 
@@ -324,7 +325,8 @@ func TestExtractProperties_FromFile(t *testing.T) {
 func TestExtractPropertiesFromFileAndSingleValue(t *testing.T) {
 	var tmpFile1 *os.File
 	var err error
-	if tmpFile1, err = os.CreateTemp("", "camel-k-*.properties"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile1, err = os.CreateTemp(tempDir, "camel-k-*.properties"); err != nil {
 		t.Error(err)
 	}
 
@@ -351,7 +353,8 @@ func TestExtractPropertiesFromFileAndSingleValue(t *testing.T) {
 func TestAddPropertyFile(t *testing.T) {
 	var tmpFile *os.File
 	var err error
-	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile, err = os.CreateTemp(tempDir, "camel-k-"); err != nil {
 		t.Error(err)
 	}
 
@@ -582,7 +585,8 @@ public class Sample extends RouteBuilder {
 func TestOutputYaml(t *testing.T) {
 	var tmpFile *os.File
 	var err error
-	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile, err = os.CreateTemp(tempDir, "camel-k-"); err != nil {
 		t.Error(err)
 	}
 
@@ -616,7 +620,8 @@ status: {}
 func TestTrait(t *testing.T) {
 	var tmpFile *os.File
 	var err error
-	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile, err = os.CreateTemp(tempDir, "camel-k-"); err != nil {
 		t.Error(err)
 	}
 
@@ -653,7 +658,8 @@ status: {}
 func TestMissingTrait(t *testing.T) {
 	var tmpFile *os.File
 	var err error
-	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile, err = os.CreateTemp(tempDir, "camel-k-"); err != nil {
 		t.Error(err)
 	}
 
@@ -703,7 +709,8 @@ func TestResolveJsonPodTemplateWithSupplementalGroups(t *testing.T) {
 func TestIntegrationServiceAccountName(t *testing.T) {
 	var tmpFile *os.File
 	var err error
-	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile, err = os.CreateTemp(tempDir, "camel-k-"); err != nil {
 		t.Error(err)
 	}
 
@@ -720,7 +727,8 @@ func TestIntegrationServiceAccountName(t *testing.T) {
 func TestFileProperties(t *testing.T) {
 	var tmpFile1 *os.File
 	var err error
-	if tmpFile1, err = os.CreateTemp("", "camel-k-*.properties"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile1, err = os.CreateTemp(tempDir, "camel-k-*.properties"); err != nil {
 		t.Error(err)
 	}
 
@@ -732,7 +740,7 @@ func TestFileProperties(t *testing.T) {
 	`), 0o400))
 
 	var tmpFile *os.File
-	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+	if tmpFile, err = os.CreateTemp(tempDir, "camel-k-"); err != nil {
 		t.Error(err)
 	}
 
@@ -752,7 +760,8 @@ func TestFileProperties(t *testing.T) {
 func TestPropertyShouldNotExpand(t *testing.T) {
 	var tmpFile1 *os.File
 	var err error
-	if tmpFile1, err = os.CreateTemp("", "camel-k-*.properties"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile1, err = os.CreateTemp(tempDir, "camel-k-*.properties"); err != nil {
 		t.Error(err)
 	}
 
@@ -762,7 +771,7 @@ func TestPropertyShouldNotExpand(t *testing.T) {
 	`), 0o400))
 
 	var tmpFile *os.File
-	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+	if tmpFile, err = os.CreateTemp(tempDir, "camel-k-"); err != nil {
 		t.Error(err)
 	}
 
@@ -784,7 +793,8 @@ func TestPropertyShouldNotExpand(t *testing.T) {
 func TestRunOutput(t *testing.T) {
 	var tmpFile1 *os.File
 	var err error
-	if tmpFile1, err = os.CreateTemp("", "camel-k-*.yaml"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile1, err = os.CreateTemp(tempDir, "camel-k-*.yaml"); err != nil {
 		t.Error(err)
 	}
 	defer tmpFile1.Close()
@@ -811,10 +821,7 @@ func TestRunOutput(t *testing.T) {
 }
 
 func TestRunGlob(t *testing.T) {
-	dir, err := os.MkdirTemp("", "camel-k-TestRunGlob-*")
-	if err != nil {
-		t.Error(err)
-	}
+	dir := t.TempDir()
 
 	pattern := "camel-k-*.yaml"
 
@@ -846,10 +853,7 @@ func TestRunGlob(t *testing.T) {
 }
 
 func TestRunGlobAllFiles(t *testing.T) {
-	dir, err := os.MkdirTemp("", "camel-k-TestRunGlobAllFiles-*")
-	if err != nil {
-		t.Error(err)
-	}
+	dir := t.TempDir()
 
 	pattern := "camel-k-*.yaml"
 
@@ -881,10 +885,7 @@ func TestRunGlobAllFiles(t *testing.T) {
 }
 
 func TestRunGlobChange(t *testing.T) {
-	dir, err := os.MkdirTemp("", "camel-k-TestRunGlobChange-*")
-	if err != nil {
-		t.Error(err)
-	}
+	dir := t.TempDir()
 
 	pattern := "camel-k-*.yaml"
 
@@ -924,7 +925,8 @@ func TestRunGlobChange(t *testing.T) {
 }
 
 func TestRunOutputWithoutKubernetesCluster(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "camel-k-kubeconfig-*")
+	tempDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tempDir, "camel-k-kubeconfig-*")
 	require.NoError(t, err)
 
 	runCmdOptions, rootCmd, _ := initializeRunCmdOptions(t)

--- a/pkg/cmd/source/util_test.go
+++ b/pkg/cmd/source/util_test.go
@@ -48,8 +48,11 @@ func TestPermissionDenied(t *testing.T) {
 		t.Skip("Test not reliably producing a result on a windows OS")
 	}
 
-	dir, err := os.MkdirTemp("/tmp", "camel-k-")
+	dir := t.TempDir()
+
+	fileInfo, err := os.Stat(dir)
 	require.NoError(t, err)
+	originalDirMode := fileInfo.Mode()
 
 	filename := filepath.Join(dir, "file.txt")
 	f, err := os.Create(filename)
@@ -63,6 +66,10 @@ func TestPermissionDenied(t *testing.T) {
 	// must not panic because a permission error
 	require.Error(t, err)
 	assert.False(t, value)
+
+	// restore original directory permissions, so that the Golang test framework can delete it
+	err = os.Chmod(dir, originalDirMode)
+	require.NoError(t, err)
 }
 
 func TestSupportedScheme(t *testing.T) {

--- a/pkg/controller/integrationplatform/create_test.go
+++ b/pkg/controller/integrationplatform/create_test.go
@@ -119,8 +119,7 @@ func TestCatalogAlreadyPresent(t *testing.T) {
 
 func TestCreateNewCatalog(t *testing.T) {
 	// Set the m2 repo folder
-	m2RepoTmpDir, err := os.MkdirTemp("/tmp", "m2*")
-	assert.NoError(t, err)
+	m2RepoTmpDir := t.TempDir()
 	ip := v1.IntegrationPlatform{}
 	ip.Namespace = "ns"
 	ip.Name = "ck"
@@ -174,8 +173,7 @@ func TestCreateNewCatalog(t *testing.T) {
 	action.InjectClient(c)
 
 	// Set the folder where to install testing kamelets
-	tmpDir, err := os.MkdirTemp("/tmp", "kamelets*")
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 	defer os.Unsetenv(kameletDirEnv)
 	os.Setenv(kameletDirEnv, tmpDir)
 	answer, err := action.Handle(context.TODO(), &ip)

--- a/pkg/controller/integrationplatform/kamelets_test.go
+++ b/pkg/controller/integrationplatform/kamelets_test.go
@@ -42,7 +42,8 @@ func TestLoadKamelet(t *testing.T) {
 	itp := v1.NewIntegrationPlatform("itp-ns", "my-itp")
 	var tmpKameletFile *os.File
 	var err error
-	tmpKameletFile, err = os.CreateTemp("/tmp", "timer-source-*.kamelet.yaml")
+	tempDir := t.TempDir()
+	tmpKameletFile, err = os.CreateTemp(tempDir, "timer-source-*.kamelet.yaml")
 	require.NoError(t, err)
 	require.NoError(t, tmpKameletFile.Close())
 	require.NoError(t, os.WriteFile(tmpKameletFile.Name(), []byte(`apiVersion: camel.apache.org/v1
@@ -136,8 +137,7 @@ func TestDownloadKameletDependencyAndExtract(t *testing.T) {
 		t.Setenv("MAVEN_CMD", "mvn")
 	}
 
-	tmpDir, err := os.MkdirTemp("/tmp", "kamelets*")
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 	// Load default catalog in order to get the default Camel version
 	c, err := camel.DefaultCatalog()
 	assert.NoError(t, err)

--- a/pkg/util/digest/digest_test.go
+++ b/pkg/util/digest/digest_test.go
@@ -53,7 +53,8 @@ func TestDigestUsesAnnotations(t *testing.T) {
 func TestDigestSHA1FromTempFile(t *testing.T) {
 	var tmpFile *os.File
 	var err error
-	if tmpFile, err = os.CreateTemp("", "camel-k-"); err != nil {
+	tempDir := t.TempDir()
+	if tmpFile, err = os.CreateTemp(tempDir, "camel-k-"); err != nil {
 		t.Error(err)
 	}
 

--- a/pkg/util/maven/maven_command_test.go
+++ b/pkg/util/maven/maven_command_test.go
@@ -42,9 +42,8 @@ func TestGetMavenContext(t *testing.T) {
 }
 
 func TestGenerateMavenContext(t *testing.T) {
-	dir, err := os.MkdirTemp("", "ck-mvnconfig-*")
-	require.NoError(t, err)
-	err = generateMavenContext(dir, []string{"hello"}, nil)
+	dir := t.TempDir()
+	err := generateMavenContext(dir, []string{"hello"}, nil)
 	require.NoError(t, err)
 	f, err := os.Stat(path.Join(dir, ".mvn", "maven.config"))
 	require.NoError(t, err)
@@ -79,8 +78,7 @@ var expectPom = `<?xml version="1.0" encoding="UTF-8"?>
 </project>`
 
 func TestGenerateMavenPom(t *testing.T) {
-	dir, err := os.MkdirTemp("", "ck-mvnpom-*")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	context := NewContext(dir)
 	project := NewProject()
 	project.GroupID = "gid"
@@ -92,7 +90,7 @@ func TestGenerateMavenPom(t *testing.T) {
 		NewDependency("mgid", "maid", "1.0.0"),
 	}
 
-	err = generateProjectPom(context, project)
+	err := generateProjectPom(context, project)
 	require.NoError(t, err)
 
 	p := path.Join(dir, "pom.xml")
@@ -105,8 +103,7 @@ func TestGenerateMavenPom(t *testing.T) {
 }
 
 func TestDoSettings(t *testing.T) {
-	dir, err := os.MkdirTemp("", "ck-mvnsettings-*")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	// Required to simulate an existing maven local repo existing directory
 	localRepo, err := os.MkdirTemp(dir, "repo")
 	require.NoError(t, err)

--- a/pkg/util/sync/file_test.go
+++ b/pkg/util/sync/file_test.go
@@ -29,7 +29,8 @@ import (
 )
 
 func TestFile(t *testing.T) {
-	file, err := os.CreateTemp("", "camel-k-test-*")
+	tempDir := t.TempDir()
+	file, err := os.CreateTemp(tempDir, "camel-k-test-*")
 	require.NoError(t, err)
 	defer func() {
 		_ = os.Remove(file.Name())


### PR DESCRIPTION
Closes:

- https://github.com/apache/camel-k/issues/6192

Changes:

- temporary files created during tests are placed in a temporary directory deleted by the testing framework
- all the top-level temporary directories created for the tests are now deleted by the testing framework
- pattern in the temporary directory is lost as the testing framework does not allow to add the pattern, hence we use the default temp dir name
- test `TestPermissionDenied` changes the file permissions to the temporary directory, therefore we need to change it back so that the testing framework can delete the folder
- tests in `modeline_test.go` that use `util.WithTempDir` (from `pkg/util/util.go:465`) are untouched because I thought it was good to use this util method in tests as well, it indirectly verifies this util method and I don't see any downside

**Release Note**
```release-note
NONE
```
