### PR TITLE
chore(lint): Fix warnings when running linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,7 +98,6 @@ linters:
     - gocyclo
     - godox
     - err113
-    - gomnd
     - ireturn
     - nilnil
     - nlreturn
@@ -112,3 +111,4 @@ linters:
     # TODO: too much work at this stage as many files are impacted by the lint suggestions, however the reported
     #       lint violation make a lot of sense so we should re-enable the lints below and work to fix the findings
     - perfsprint
+    - tenv  # the functionality provided by 'usetesting'


### PR DESCRIPTION
- closes: https://github.com/apache/camel-k/pull/6125

Changes:

- drop `gomnd` as it has been replaced by `mnd` (see https://github.com/golangci/golangci-lint/pull/4572) and then removed (see https://github.com/golangci/golangci-lint/pull/5110)
  - addresses warning: `WARN [lintersdb] The linter "gomnd" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle`
- disable `tenv` as the same functionality is provided by `usetesting` and we enable it with `enable-all: true`
  - addresses warning: `WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting.`

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
