### PR TITLE
feat(6276: Support for specifying pod template labels on the integration spec

### DIFF
--- a/pkg/apis/camel/v1/integration_types.go
+++ b/pkg/apis/camel/v1/integration_types.go
@@ -70,9 +70,10 @@ type IntegrationSpec struct {
 	// the profile needed to run this Integration
 	Profile TraitProfile `json:"profile,omitempty"`
 	// the traits needed to run this Integration
-	Traits Traits `json:"traits,omitempty"`
-	// Pod template customization
+	Traits      Traits           `json:"traits,omitempty"`
 	PodTemplate *PodSpecTemplate `json:"template,omitempty"`
+
+	//PodTemplate *PodTemplateSpec `json:"template,omitempty"`
 	// Deprecated:
 	// Use camel trait (camel.properties) to manage properties
 	// Use mount trait (mount.configs) to manage configs
@@ -293,6 +294,9 @@ type IntegrationCondition struct {
 
 // PodSpecTemplate represent a template used to deploy an Integration `Pod`.
 type PodSpecTemplate struct {
+	// labels to be added to the pods
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// the specification
 	Spec PodSpec `json:"spec,omitempty"`
 }

--- a/pkg/apis/camel/v1/integration_types_support.go
+++ b/pkg/apis/camel/v1/integration_types_support.go
@@ -525,3 +525,13 @@ func ToYamlDSL(flows []Flow) ([]byte, error) {
 
 	return yamldata, nil
 }
+
+func (integration *Integration) GetPodSpecLabels() map[string]string {
+	if integration.Spec.PodTemplate == nil {
+		return map[string]string{}
+	}
+	if integration.Spec.PodTemplate.Labels == nil {
+		return map[string]string{}
+	}
+	return integration.Spec.PodTemplate.Labels
+}

--- a/pkg/trait/cron.go
+++ b/pkg/trait/cron.go
@@ -19,6 +19,7 @@ package trait
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -246,6 +247,10 @@ func (t *cronTrait) getCronJobFor(e *Environment) *batchv1.CronJob {
 	if t.BackoffLimit != nil {
 		backoffLimit = *t.BackoffLimit
 	}
+	podSpecLabels := map[string]string{
+		v1.IntegrationLabel: e.Integration.Name,
+	}
+	maps.Copy(podSpecLabels, e.Integration.GetPodSpecLabels())
 	cronjob := batchv1.CronJob{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "CronJob",
@@ -270,9 +275,7 @@ func (t *cronTrait) getCronJobFor(e *Environment) *batchv1.CronJob {
 					BackoffLimit:          &backoffLimit,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								v1.IntegrationLabel: e.Integration.Name,
-							},
+							Labels:      podSpecLabels,
 							Annotations: annotations,
 						},
 						Spec: corev1.PodSpec{

--- a/pkg/trait/deployment.go
+++ b/pkg/trait/deployment.go
@@ -19,6 +19,7 @@ package trait
 
 import (
 	"fmt"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -123,6 +124,11 @@ func (t *deploymentTrait) getDeploymentFor(e *Environment) *appsv1.Deployment {
 		deadline = *t.ProgressDeadlineSeconds
 	}
 
+	podSpecLabels := map[string]string{
+		v1.IntegrationLabel: e.Integration.Name,
+	}
+	maps.Copy(podSpecLabels, e.Integration.GetPodSpecLabels())
+
 	deployment := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -146,9 +152,7 @@ func (t *deploymentTrait) getDeploymentFor(e *Environment) *appsv1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1.IntegrationLabel: e.Integration.Name,
-					},
+					Labels:      podSpecLabels,
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/trait/deployment_test.go
+++ b/pkg/trait/deployment_test.go
@@ -103,6 +103,11 @@ func TestApplyDeploymentTraitWhileDeployingIntegrationDoesSucceed(t *testing.T) 
 	assert.Len(t, conditions, 1)
 	assert.Equal(t, v1.IntegrationConditionDeploymentAvailable, conditions[0].Type)
 	assert.Equal(t, "deployment name is integration-name", conditions[0].Message)
+
+	assert.NotNil(t, deployment.Spec.Template.Labels)
+	assert.Equal(t, 2, len(deployment.Spec.Template.Labels))
+	assert.Equal(t, "production", deployment.Spec.Template.Labels["environment"])
+	assert.Equal(t, "integration-name", deployment.Spec.Template.Labels["camel.apache.org/integration"])
 }
 
 func TestApplyDeploymentTraitWhileRunningIntegrationDoesSucceed(t *testing.T) {
@@ -297,6 +302,13 @@ func createNominalDeploymentTest() (*deploymentTrait, *Environment) {
 			Spec: v1.IntegrationSpec{
 				Replicas: &replicas,
 				Traits:   v1.Traits{},
+				PodTemplate: &v1.PodSpecTemplate{
+					Labels: map[string]string{
+						"environment": "production",
+					},
+					Spec: v1.PodSpec{
+						Containers: make([]corev1.Container, 0),
+					}},
 			},
 			Status: v1.IntegrationStatus{
 				Phase: v1.IntegrationPhaseDeploying,

--- a/pkg/trait/knative_service.go
+++ b/pkg/trait/knative_service.go
@@ -19,6 +19,7 @@ package trait
 
 import (
 	"fmt"
+	"maps"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -224,6 +225,10 @@ func (t *knativeServiceTrait) getServiceFor(e *Environment) (*serving.Service, e
 		serviceLabels[knativeServingVisibilityLabel] = t.Visibility
 	}
 
+	podSpecLabels := map[string]string{
+		v1.IntegrationLabel: e.Integration.Name,
+	}
+	maps.Copy(podSpecLabels, e.Integration.GetPodSpecLabels())
 	svc := serving.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -239,9 +244,7 @@ func (t *knativeServiceTrait) getServiceFor(e *Environment) (*serving.Service, e
 			ConfigurationSpec: serving.ConfigurationSpec{
 				Template: serving.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							v1.IntegrationLabel: e.Integration.Name,
-						},
+						Labels:      podSpecLabels,
 						Annotations: revisionAnnotations,
 					},
 					Spec: serving.RevisionSpec{

--- a/pkg/trait/knative_service_test.go
+++ b/pkg/trait/knative_service_test.go
@@ -71,6 +71,13 @@ func TestKnativeService(t *testing.T) {
 			},
 			Spec: v1.IntegrationSpec{
 				Profile: v1.TraitProfileKnative,
+				PodTemplate: &v1.PodSpecTemplate{
+					Labels: map[string]string{
+						"environment": "production",
+					},
+					Spec: v1.PodSpec{
+						Containers: make([]corev1.Container, 0),
+					}},
 				Sources: []v1.SourceSpec{
 					{
 						DataSpec: v1.DataSpec{
@@ -188,6 +195,11 @@ func TestKnativeService(t *testing.T) {
 	assert.Equal(t, boolean.TrueString, environment.ApplicationProperties["camel.k.sources[0].compressed"])
 	envVarHasValue(t, spec.Containers[0].Env, "CAMEL_K_CONF", filepath.FromSlash("/etc/camel/application.properties"))
 	envVarHasValue(t, spec.Containers[0].Env, "CAMEL_K_CONF_D", filepath.FromSlash("/etc/camel/conf.d"))
+
+	assert.NotNil(t, s.Spec.Template.Labels)
+	assert.Equal(t, 2, len(s.Spec.Template.Labels))
+	assert.Equal(t, "production", s.Spec.Template.Labels["environment"])
+	assert.Equal(t, KnativeServiceTestName, s.Spec.Template.Labels["camel.apache.org/integration"])
 }
 
 // envVarHasValue --.


### PR DESCRIPTION
closes #6276 

<!-- Description -->

Support for specifying pod template labels on the integration spec


<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
Added support for specifiying pod template labels on the Integration spec
```
