### PR TITLE
fix(trait): health ports configuration

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -7273,6 +7273,13 @@ string
 
 The liveness probe path to use (default provided by the Catalog runtime used).
 
+|`livenessPort` +
+int32
+|
+
+
+The liveness port to use (default 8080).
+
 |`readinessProbeEnabled` +
 bool
 |
@@ -7329,6 +7336,13 @@ string
 
 The readiness probe path to use (default provided by the Catalog runtime used).
 
+|`readinessPort` +
+int32
+|
+
+
+The readiness port to use (default 8080).
+
 |`startupProbeEnabled` +
 bool
 |
@@ -7384,6 +7398,13 @@ string
 
 
 The startup probe path to use (default provided by the Catalog runtime used).
+
+|`startupPort` +
+int32
+|
+
+
+The startup port to use (default 8080).
 
 
 |===

--- a/docs/modules/traits/pages/health.adoc
+++ b/docs/modules/traits/pages/health.adoc
@@ -61,6 +61,10 @@ The following configuration options are available:
 | string
 | The liveness probe path to use (default provided by the Catalog runtime used).
 
+| health.liveness-port
+| int32
+| The liveness port to use (default 8080).
+
 | health.readiness-probe-enabled
 | bool
 | Configures the readiness probe for the integration container (default `true`).
@@ -93,6 +97,10 @@ The following configuration options are available:
 | string
 | The readiness probe path to use (default provided by the Catalog runtime used).
 
+| health.readiness-port
+| int32
+| The readiness port to use (default 8080).
+
 | health.startup-probe-enabled
 | bool
 | Configures the startup probe for the integration container (default `false`).
@@ -124,6 +132,10 @@ The following configuration options are available:
 | health.startup-probe
 | string
 | The startup probe path to use (default provided by the Catalog runtime used).
+
+| health.startup-port
+| int32
+| The startup port to use (default 8080).
 
 |===
 

--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -4360,6 +4360,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -4396,6 +4400,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -4430,6 +4438,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -6615,6 +6627,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -6651,6 +6667,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -6685,6 +6705,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -8772,6 +8796,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -8808,6 +8836,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -8842,6 +8874,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -10906,6 +10942,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -10942,6 +10982,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -10976,6 +11020,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -19873,6 +19921,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -19909,6 +19961,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -19943,6 +19999,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -21956,6 +22016,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -21992,6 +22056,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -22026,6 +22094,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -32284,6 +32356,10 @@ spec:
                             description: How often to perform the liveness probe.
                             format: int32
                             type: integer
+                          livenessPort:
+                            description: The liveness port to use (default 8080).
+                            format: int32
+                            type: integer
                           livenessProbe:
                             description: The liveness probe path to use (default provided
                               by the Catalog runtime used).
@@ -32320,6 +32396,10 @@ spec:
                             description: How often to perform the readiness probe.
                             format: int32
                             type: integer
+                          readinessPort:
+                            description: The readiness port to use (default 8080).
+                            format: int32
+                            type: integer
                           readinessProbe:
                             description: The readiness probe path to use (default
                               provided by the Catalog runtime used).
@@ -32354,6 +32434,10 @@ spec:
                             type: integer
                           startupPeriod:
                             description: How often to perform the startup probe.
+                            format: int32
+                            type: integer
+                          startupPort:
+                            description: The startup port to use (default 8080).
                             format: int32
                             type: integer
                           startupProbe:

--- a/pkg/apis/camel/v1/trait/health.go
+++ b/pkg/apis/camel/v1/trait/health.go
@@ -41,6 +41,8 @@ type HealthTrait struct {
 	LivenessFailureThreshold int32 `property:"liveness-failure-threshold" json:"livenessFailureThreshold,omitempty"`
 	// The liveness probe path to use (default provided by the Catalog runtime used).
 	LivenessProbe string `property:"liveness-probe" json:"livenessProbe,omitempty"`
+	// The liveness port to use (default 8080).
+	LivenessPort int32 `property:"liveness-port" json:"livenessPort,omitempty"`
 
 	// Configures the readiness probe for the integration container (default `true`).
 	ReadinessProbeEnabled *bool `property:"readiness-probe-enabled" json:"readinessProbeEnabled,omitempty"`
@@ -58,6 +60,8 @@ type HealthTrait struct {
 	ReadinessFailureThreshold int32 `property:"readiness-failure-threshold" json:"readinessFailureThreshold,omitempty"`
 	// The readiness probe path to use (default provided by the Catalog runtime used).
 	ReadinessProbe string `property:"readiness-probe" json:"readinessProbe,omitempty"`
+	// The readiness port to use (default 8080).
+	ReadinessPort int32 `property:"readiness-port" json:"readinessPort,omitempty"`
 
 	// Configures the startup probe for the integration container (default `false`).
 	StartupProbeEnabled *bool `property:"startup-probe-enabled" json:"startupProbeEnabled,omitempty"`
@@ -75,4 +79,6 @@ type HealthTrait struct {
 	StartupFailureThreshold int32 `property:"startup-failure-threshold" json:"startupFailureThreshold,omitempty"`
 	// The startup probe path to use (default provided by the Catalog runtime used).
 	StartupProbe string `property:"startup-probe" json:"startupProbe,omitempty"`
+	// The startup port to use (default 8080).
+	StartupPort int32 `property:"startup-port" json:"startupPort,omitempty"`
 }

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -1111,6 +1111,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -1147,6 +1151,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -1181,6 +1189,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -3366,6 +3378,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -3402,6 +3418,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -3436,6 +3456,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -979,6 +979,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -1015,6 +1019,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -1049,6 +1057,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -3113,6 +3125,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -3149,6 +3165,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -3183,6 +3203,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -7792,6 +7792,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -7828,6 +7832,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -7862,6 +7870,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:
@@ -9875,6 +9887,10 @@ spec:
                         description: How often to perform the liveness probe.
                         format: int32
                         type: integer
+                      livenessPort:
+                        description: The liveness port to use (default 8080).
+                        format: int32
+                        type: integer
                       livenessProbe:
                         description: The liveness probe path to use (default provided
                           by the Catalog runtime used).
@@ -9911,6 +9927,10 @@ spec:
                         description: How often to perform the readiness probe.
                         format: int32
                         type: integer
+                      readinessPort:
+                        description: The readiness port to use (default 8080).
+                        format: int32
+                        type: integer
                       readinessProbe:
                         description: The readiness probe path to use (default provided
                           by the Catalog runtime used).
@@ -9945,6 +9965,10 @@ spec:
                         type: integer
                       startupPeriod:
                         description: How often to perform the startup probe.
+                        format: int32
+                        type: integer
+                      startupPort:
+                        description: The startup port to use (default 8080).
                         format: int32
                         type: integer
                       startupProbe:

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -7847,6 +7847,10 @@ spec:
                             description: How often to perform the liveness probe.
                             format: int32
                             type: integer
+                          livenessPort:
+                            description: The liveness port to use (default 8080).
+                            format: int32
+                            type: integer
                           livenessProbe:
                             description: The liveness probe path to use (default provided
                               by the Catalog runtime used).
@@ -7883,6 +7887,10 @@ spec:
                             description: How often to perform the readiness probe.
                             format: int32
                             type: integer
+                          readinessPort:
+                            description: The readiness port to use (default 8080).
+                            format: int32
+                            type: integer
                           readinessProbe:
                             description: The readiness probe path to use (default
                               provided by the Catalog runtime used).
@@ -7917,6 +7925,10 @@ spec:
                             type: integer
                           startupPeriod:
                             description: How often to perform the startup probe.
+                            format: int32
+                            type: integer
+                          startupPort:
+                            description: The startup port to use (default 8080).
                             format: int32
                             type: integer
                           startupProbe:

--- a/pkg/trait/health.go
+++ b/pkg/trait/health.go
@@ -181,6 +181,7 @@ func (t *healthTrait) newLivenessProbe(port *intstr.IntOrString, path string) *c
 			HTTPGet: &corev1.HTTPGetAction{
 				Path:   path,
 				Scheme: t.getLivenessScheme(),
+				Port:   *t.getLivenessPort(port),
 			},
 		},
 		InitialDelaySeconds: t.LivenessInitialDelay,
@@ -188,10 +189,6 @@ func (t *healthTrait) newLivenessProbe(port *intstr.IntOrString, path string) *c
 		PeriodSeconds:       t.LivenessPeriod,
 		SuccessThreshold:    t.LivenessSuccessThreshold,
 		FailureThreshold:    t.LivenessFailureThreshold,
-	}
-
-	if port != nil {
-		p.HTTPGet.Port = *port
 	}
 
 	return &p
@@ -203,6 +200,7 @@ func (t *healthTrait) newReadinessProbe(port *intstr.IntOrString, path string) *
 			HTTPGet: &corev1.HTTPGetAction{
 				Path:   path,
 				Scheme: t.getReadinessScheme(),
+				Port:   *t.getReadinessPort(port),
 			},
 		},
 		InitialDelaySeconds: t.ReadinessInitialDelay,
@@ -210,10 +208,6 @@ func (t *healthTrait) newReadinessProbe(port *intstr.IntOrString, path string) *
 		PeriodSeconds:       t.ReadinessPeriod,
 		SuccessThreshold:    t.ReadinessSuccessThreshold,
 		FailureThreshold:    t.ReadinessFailureThreshold,
-	}
-
-	if port != nil {
-		p.HTTPGet.Port = *port
 	}
 
 	return &p
@@ -225,6 +219,7 @@ func (t *healthTrait) newStartupProbe(port *intstr.IntOrString, path string) *co
 			HTTPGet: &corev1.HTTPGetAction{
 				Path:   path,
 				Scheme: t.getStartupScheme(),
+				Port:   *t.getStartupPort(port),
 			},
 		},
 		InitialDelaySeconds: t.StartupInitialDelay,
@@ -234,9 +229,32 @@ func (t *healthTrait) newStartupProbe(port *intstr.IntOrString, path string) *co
 		FailureThreshold:    t.StartupFailureThreshold,
 	}
 
-	if port != nil {
-		p.HTTPGet.Port = *port
+	return &p
+}
+
+func (t *healthTrait) getLivenessPort(port *intstr.IntOrString) *intstr.IntOrString {
+	if t.LivenessPort != 0 {
+		livenessPort := intstr.FromInt32(t.LivenessPort)
+		return &livenessPort
 	}
 
-	return &p
+	return port
+}
+
+func (t *healthTrait) getReadinessPort(port *intstr.IntOrString) *intstr.IntOrString {
+	if t.ReadinessPort != 0 {
+		readinessPort := intstr.FromInt32(t.ReadinessPort)
+		return &readinessPort
+	}
+
+	return port
+}
+
+func (t *healthTrait) getStartupPort(port *intstr.IntOrString) *intstr.IntOrString {
+	if t.StartupPort != 0 {
+		startupPort := intstr.FromInt32(t.StartupPort)
+		return &startupPort
+	}
+
+	return port
 }


### PR DESCRIPTION
Closes #3877

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
