### PR TITLE
feat(ctrl): dry build

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -26,6 +26,7 @@
 ** xref:running/self-managed.adoc[Self managed Integrations]
 ** xref:running/synthetic.adoc[Synthetic Integrations]
 ** xref:running/promoting.adoc[Promote an Integration]
+** xref:running/dry-build.adoc[Dry build]
 * xref:pipes/pipes.adoc[Run an Pipe]
 ** xref:pipes/bind-cli.adoc[kamel bind CLI]
 ** xref:pipes/error-handler.adoc[Error Handler]

--- a/docs/modules/ROOT/pages/running/dry-build.adoc
+++ b/docs/modules/ROOT/pages/running/dry-build.adoc
@@ -1,0 +1,40 @@
+= Dry Build
+
+Camel K have been originally designed to immediately execute an Integration. However, since version 2.9 you can split the **build** phase and the **deployment** phase performing a **dry build**.
+
+When you build an Integration, you can add a new annotation, `camel.apache.org/dont-run-after-build: "true"`. This is telling the operator to perform a regular build but not to deploy the application (neither to create any resource associated to it). It basically just compile the application and push the container image to be eventually run later.
+
+This feature enables you the possibility to separate the build from the execution phase giving you a powerful flexibility to accommodate your development process (which may require also testing, performance, security audits, ...). You may have a cluster dedicated for building images, and another cluster (maybe private with no access to the internet) for running the applications.
+
+As the `kamel run` command can be helpful for this operation, we've added a flag which will take care to add that annotation for you: `kamel run my-app.yaml --dont-run-after-build`.
+
+[[deploy]]
+== Deploy an application
+
+The presence of this feature will let you build the application without the need to run it. At any point you can decide to **deploy** the application by turning its phase to `Deploying`. The operator will be in charge to do the deployment as it used to do before.
+
+It would be something like:
+
+```bash
+kubectl patch it my-app --type=merge --subresource=status   -p '{"status":{"phase":"Deploying"}}'
+```
+
+As the patching on an Integration custom resource can be boring, we've introduced a new CLI `kamel deploy` command. You can provide to it the name(s) of the Integration(s) you want to deploy and it will take care to patch their status for you. The `kamel deploy` and the patch to "Deploying" are equivalent.
+
+[[undeploy]]
+== Undeploy an application
+
+Specular to that, we have the **undeploy** operation. If at any point in time you want to bring the Integration back to its original status, then just patch its phase to an empty string (which represent the `Initialization` phase). The operator will take care to revert it and to clean all the resources associated.
+
+It would be something like:
+
+```bash
+kubectl patch it my-app --type=merge --subresource=status   -p '{"status":{"phase":""}}'
+```
+
+Also here, you will find handy the `kamel undeploy` CLI command. It also expects one ore more Integration names you want to undeploy. The `kamel undeploy` and the patch to "" are equivalent.
+
+[[references]]
+== Complement to other features
+
+This feature will fit into the rest of build features such as xref:running/build-from-git.adoc[Git hosted Integrations], xref:running/self-managed.adoc[self managed Integrations] and xref:running/promoting.adoc[environment promotions].

--- a/e2e/common/cli/deploy_test.go
+++ b/e2e/common/cli/deploy_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+// +build integration
+
+// To enable compilation of this file in Goland, go to "Settings -> Go -> Vendoring & Build Tags -> Custom Tags" and add "integration"
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/apache/camel-k/v2/e2e/support"
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+)
+
+func TestBuildDontRun(t *testing.T) {
+	t.Parallel()
+	WithNewTestNamespace(t, func(ctx context.Context, g *WithT, ns string) {
+		name := RandomizedSuffixName("deploy")
+		t.Run("build and dont run integration", func(t *testing.T) {
+			g.Expect(KamelRun(t, ctx, ns, "files/yaml.yaml",
+				"--name", name,
+				"--dont-run-after-build",
+			).Execute()).To(Succeed())
+			// The integration should not change phase until the user request it
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutMedium).Should(Equal(v1.IntegrationPhaseBuildComplete))
+			g.Consistently(IntegrationPhase(t, ctx, ns, name), 10*time.Second).Should(Equal(v1.IntegrationPhaseBuildComplete))
+			g.Eventually(Deployment(t, ctx, ns, name)).Should(BeNil())
+		})
+		t.Run("deploy the integration", func(t *testing.T) {
+			g.Expect(Kamel(t, ctx, "deploy", name, "-n", ns).Execute()).To(Succeed())
+			// The integration should run immediately
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseRunning))
+			g.Eventually(Deployment(t, ctx, ns, name)).ShouldNot(BeNil())
+			g.Eventually(IntegrationPodPhase(t, ctx, ns, name)).Should(Equal(corev1.PodRunning))
+			g.Eventually(IntegrationConditionStatus(t, ctx, ns, name, v1.IntegrationConditionReady)).
+				Should(Equal(corev1.ConditionTrue))
+			g.Eventually(IntegrationLogs(t, ctx, ns, name)).Should(ContainSubstring("Magicstring!"))
+		})
+		t.Run("undeploy the integration", func(t *testing.T) {
+			g.Expect(Kamel(t, ctx, "undeploy", name, "-n", ns).Execute()).To(Succeed())
+			// The integration should change phase suddenly and the resources associated cleared
+			g.Eventually(IntegrationPhase(t, ctx, ns, name), TestTimeoutShort).Should(Equal(v1.IntegrationPhaseBuildComplete))
+			g.Eventually(IntegrationPodsNumbers(t, ctx, ns, name)).Should(Equal(ptr.To(int32(0))))
+			g.Eventually(Deployment(t, ctx, ns, name)).Should(BeNil())
+		})
+	})
+}

--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -34,6 +34,10 @@ const (
 	IntegrationProfileAnnotation = "camel.apache.org/integration-profile.id"
 	// IntegrationProfileNamespaceAnnotation integration profile id annotation label.
 	IntegrationProfileNamespaceAnnotation = "camel.apache.org/integration-profile.namespace"
+	// IntegrationDontRunAfterBuildAnnotation -- .
+	IntegrationDontRunAfterBuildAnnotation = "camel.apache.org/dont-run-after-build"
+	// IntegrationDontRunAfterBuildAnnotationTrueValue -- .
+	IntegrationDontRunAfterBuildAnnotationTrueValue = "true"
 )
 
 // BuildConfiguration represent the configuration required to build the runtime.

--- a/pkg/apis/camel/v1/integration_types.go
+++ b/pkg/apis/camel/v1/integration_types.go
@@ -164,9 +164,11 @@ const (
 	// IntegrationPhaseBuildingKit if building from a Camel route.
 	IntegrationPhaseBuildingKit IntegrationPhase = "Building Kit"
 	// IntegrationPhaseBuildSubmitted if building from a Git repository.
-	IntegrationPhaseBuildSubmitted IntegrationPhase = "BuildSubmitted"
+	IntegrationPhaseBuildSubmitted IntegrationPhase = "Build Submitted"
 	// IntegrationPhaseBuildRunning if building from a Git repository.
-	IntegrationPhaseBuildRunning IntegrationPhase = "BuildRunning"
+	IntegrationPhaseBuildRunning IntegrationPhase = "Build Running"
+	// IntegrationPhaseBuildComplete --.
+	IntegrationPhaseBuildComplete IntegrationPhase = "Build Complete"
 	// IntegrationPhaseDeploying --.
 	IntegrationPhaseDeploying IntegrationPhase = "Deploying"
 	// IntegrationPhaseRunning --.

--- a/pkg/cmd/bind_test.go
+++ b/pkg/cmd/bind_test.go
@@ -31,7 +31,6 @@ import (
 
 const cmdBind = "bind"
 
-// nolint: unparam
 func initializeBindCmdOptions(t *testing.T) (*bindCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 

--- a/pkg/cmd/builder_test.go
+++ b/pkg/cmd/builder_test.go
@@ -27,7 +27,6 @@ import (
 
 const cmdBuilder = "builder"
 
-// nolint: unparam
 func initializeBuilderCmdOptions(t *testing.T) (*builderCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 

--- a/pkg/cmd/debug_test.go
+++ b/pkg/cmd/debug_test.go
@@ -32,7 +32,6 @@ import (
 
 const cmdDebug = "debug"
 
-// nolint: unparam
 func initializeDebugCmdOptions(t *testing.T, initObjs ...runtime.Object) (*cobra.Command, *debugCmdOptions) {
 	t.Helper()
 	fakeClient, err := internal.NewFakeClient(initObjs...)

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -88,7 +88,7 @@ func (command *deleteCmdOptions) run(cmd *cobra.Command, args []string) error {
 					return err
 				}
 			} else {
-				err := deleteIntegration(command.Context, cmd, c, integration)
+				err := deletePipeOrIntegration(command.Context, cmd, c, integration)
 				if err != nil {
 					return err
 				}
@@ -109,7 +109,7 @@ func (command *deleteCmdOptions) run(cmd *cobra.Command, args []string) error {
 		}
 		for i := range integrationList.Items {
 			integration := integrationList.Items[i]
-			err := deleteIntegration(command.Context, cmd, c, &integration)
+			err := deletePipeOrIntegration(command.Context, cmd, c, &integration)
 			if err != nil {
 				return err
 			}
@@ -124,19 +124,7 @@ func (command *deleteCmdOptions) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getIntegration(ctx context.Context, c client.Client, name string, namespace string) (*v1.Integration, error) {
-	key := k8sclient.ObjectKey{
-		Name:      name,
-		Namespace: namespace,
-	}
-	answer := v1.NewIntegration(namespace, name)
-	if err := c.Get(ctx, key, &answer); err != nil {
-		return nil, err
-	}
-	return &answer, nil
-}
-
-func deleteIntegration(ctx context.Context, cmd *cobra.Command, c client.Client, integration *v1.Integration) error {
+func deletePipeOrIntegration(ctx context.Context, cmd *cobra.Command, c client.Client, integration *v1.Integration) error {
 	deletedPipes, pipe, err := deletePipeIfExists(ctx, c, integration)
 	if err != nil {
 		return err

--- a/pkg/cmd/delete_test.go
+++ b/pkg/cmd/delete_test.go
@@ -27,7 +27,6 @@ import (
 
 const cmdDelete = "delete"
 
-// nolint: unparam
 func initializeDeleteCmdOptions(t *testing.T) (*deleteCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -1,0 +1,95 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// newCmdDeploy --.
+func newCmdDeploy(rootCmdOptions *RootCmdOptions) (*cobra.Command, *deployCmdOptions) {
+	options := deployCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+	cmd := cobra.Command{
+		Use:     "deploy my-it",
+		Short:   "Deploy an Integration",
+		Long:    "Deploy an Integration that was previously built",
+		PreRunE: decode(&options, options.Flags),
+		RunE:    options.run,
+	}
+
+	return &cmd, &options
+}
+
+type deployCmdOptions struct {
+	*RootCmdOptions
+}
+
+func (o *deployCmdOptions) validate(_ *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("deploy requires an Integration name argument")
+	}
+	return nil
+}
+
+func (o *deployCmdOptions) run(cmd *cobra.Command, args []string) error {
+	if err := o.validate(cmd, args); err != nil {
+		return err
+	}
+
+	name := args[0]
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return fmt.Errorf("could not retrieve cluster client: %w", err)
+	}
+
+	existing, err := getIntegration(o.Context, c, name, o.Namespace)
+	if err != nil {
+		return fmt.Errorf("could not get Integration "+name+": %w", err)
+	}
+	if existing.Status.Phase != v1.IntegrationPhaseBuildComplete {
+		return fmt.Errorf("could not run an Integration in %s status", existing.Status.Phase)
+	}
+
+	integration := existing.DeepCopy()
+	integration.Status.Phase = v1.IntegrationPhaseDeploying
+
+	patch := ctrl.MergeFrom(existing)
+	d, err := patch.Data(integration)
+	if err != nil {
+		return err
+	}
+
+	if string(d) == "{}" {
+		fmt.Fprintln(cmd.OutOrStdout(), `Integration "`+name+`" unchanged`)
+		return nil
+	}
+	err = c.Status().Patch(o.Context, integration, patch)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), `Integration "`+name+`" deployed`)
+	return nil
+}

--- a/pkg/cmd/deploy_test.go
+++ b/pkg/cmd/deploy_test.go
@@ -1,0 +1,89 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/v2/pkg/internal"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const cmdDeploy = "deploy"
+
+func initializeDeployCmdOptions(t *testing.T, initObjs ...runtime.Object) (*cobra.Command, *deployCmdOptions) {
+	t.Helper()
+	fakeClient, err := internal.NewFakeClient(initObjs...)
+	require.NoError(t, err)
+	options, rootCmd := kamelTestPreAddCommandInitWithClient(fakeClient)
+	options.Namespace = "default"
+	deployCmdOptions := addTestDeployCmd(*options, rootCmd)
+	kamelTestPostAddCommandInit(t, rootCmd, options)
+
+	return rootCmd, deployCmdOptions
+}
+
+func addTestDeployCmd(options RootCmdOptions, rootCmd *cobra.Command) *deployCmdOptions {
+	deployCmd, deployOptions := newCmdDeploy(&options)
+	deployCmd.Args = ArbitraryArgs
+	rootCmd.AddCommand(deployCmd)
+	return deployOptions
+}
+
+func TestDeployNonExistingFlag(t *testing.T) {
+	cmd, _ := initializeDeployCmdOptions(t)
+	_, err := ExecuteCommand(cmd, cmdDeploy, "--nonExistingFlag")
+	require.Error(t, err)
+	assert.Equal(t, "unknown flag: --nonExistingFlag", err.Error())
+}
+
+func TestDeployMissingInput(t *testing.T) {
+	cmd, _ := initializeDeployCmdOptions(t)
+	_, err := ExecuteCommand(cmd, cmdDeploy)
+	require.Error(t, err)
+	assert.Equal(t, "deploy requires an Integration name argument", err.Error())
+}
+
+func TestDeployMissingIntegration(t *testing.T) {
+	cmd, _ := initializeDeployCmdOptions(t)
+	_, err := ExecuteCommand(cmd, cmdDeploy, "missing-it")
+	require.Error(t, err)
+	assert.Equal(t, "could not get Integration missing-it: integrations.camel.apache.org \"missing-it\" not found", err.Error())
+}
+
+func TestDeployCantDeployRunningIntegration(t *testing.T) {
+	it := v1.NewIntegration("default", "my-it")
+	it.Status.Phase = v1.IntegrationPhaseRunning
+	cmd, _ := initializeDeployCmdOptions(t, &it)
+	_, err := ExecuteCommand(cmd, cmdDeploy, "my-it")
+	require.Error(t, err)
+	assert.Equal(t, "could not run an Integration in Running status", err.Error())
+}
+
+func TestDeployIntegration(t *testing.T) {
+	it := v1.NewIntegration("default", "my-it")
+	it.Status.Phase = v1.IntegrationPhaseBuildComplete
+	cmd, _ := initializeDeployCmdOptions(t, &it)
+	output, err := ExecuteCommand(cmd, cmdDeploy, "my-it")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Integration \"my-it\" deployed")
+}

--- a/pkg/cmd/kit_create_test.go
+++ b/pkg/cmd/kit_create_test.go
@@ -27,7 +27,6 @@ import (
 
 const subCmdKit = "create"
 
-// nolint: unparam
 func initializeKitCreateCmdOptions(t *testing.T) (*kitCreateCommandOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 

--- a/pkg/cmd/operator_test.go
+++ b/pkg/cmd/operator_test.go
@@ -28,7 +28,6 @@ import (
 
 const cmdOperator = "operator"
 
-// nolint: unparam
 func initializeOperatorCmdOptions(t *testing.T) (*operatorCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 
@@ -39,7 +38,6 @@ func initializeOperatorCmdOptions(t *testing.T) (*operatorCmdOptions, *cobra.Com
 	return operatorCmdOptions, rootCmd, *options
 }
 
-// nolint: unparam
 func addTestOperatorCmd(options RootCmdOptions, rootCmd *cobra.Command) *operatorCmdOptions {
 	// add a testing version of operator Command
 	operatorCmd, operatorOptions := newCmdOperator(&options)

--- a/pkg/cmd/promote_test.go
+++ b/pkg/cmd/promote_test.go
@@ -38,7 +38,6 @@ import (
 
 const cmdPromote = "promote"
 
-// nolint: unparam
 func initializePromoteCmdOptions(t *testing.T, initObjs ...runtime.Object) (*promoteCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 	fakeClient, err := internal.NewFakeClient(initObjs...)

--- a/pkg/cmd/rebuild.go
+++ b/pkg/cmd/rebuild.go
@@ -79,7 +79,7 @@ func (o *rebuildCmdOptions) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else if len(args) > 0 {
-		if integrations, err = o.getIntegrations(c, args); err != nil {
+		if integrations, err = getIntegrations(o.Context, c, args, o.Namespace); err != nil {
 			return err
 		}
 	}
@@ -98,22 +98,6 @@ func (o *rebuildCmdOptions) listAllIntegrations(c client.Client) ([]v1.Integrati
 		return nil, fmt.Errorf("could not retrieve integrations from namespace %s: %w", o.Namespace, err)
 	}
 	return list.Items, nil
-}
-
-func (o *rebuildCmdOptions) getIntegrations(c client.Client, names []string) ([]v1.Integration, error) {
-	ints := make([]v1.Integration, 0, len(names))
-	for _, n := range names {
-		it := v1.NewIntegration(o.Namespace, n)
-		key := k8sclient.ObjectKey{
-			Name:      n,
-			Namespace: o.Namespace,
-		}
-		if err := c.Get(o.Context, key, &it); err != nil {
-			return nil, fmt.Errorf("could not find integration %s in namespace %s: %w", it.Name, o.Namespace, err)
-		}
-		ints = append(ints, it)
-	}
-	return ints, nil
 }
 
 func (o *rebuildCmdOptions) rebuildIntegrations(c k8sclient.StatusClient, integrations []v1.Integration) error {

--- a/pkg/cmd/rebuild_test.go
+++ b/pkg/cmd/rebuild_test.go
@@ -27,7 +27,6 @@ import (
 
 const cmdRebuild = "rebuild"
 
-// nolint: unparam
 func initializeRebuildCmdOptions(t *testing.T) (*rebuildCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 
@@ -56,6 +55,7 @@ func TestRebuildNonExistingFlag(t *testing.T) {
 	_, rootCmd, _ := initializeRebuildCmdOptions(t)
 	_, err := ExecuteCommand(rootCmd, cmdRebuild, "--nonExistingFlag")
 	require.Error(t, err)
+	assert.Equal(t, "unknown flag: --nonExistingFlag", err.Error())
 }
 
 func TestRebuildAllFlag(t *testing.T) {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -137,6 +137,7 @@ func addKamelSubcommands(cmd *cobra.Command, options *RootCmdOptions) {
 	cmd.AddCommand(newCmdCompletion(cmd))
 	cmd.AddCommand(cmdOnly(newCmdVersion(options)))
 	cmd.AddCommand(cmdOnly(newCmdRun(options)))
+	cmd.AddCommand(cmdOnly(newCmdDeploy(options)))
 	cmd.AddCommand(cmdOnly(newCmdGet(options)))
 	cmd.AddCommand(cmdOnly(newCmdDelete(options)))
 	cmd.AddCommand(cmdOnly(newCmdLog(options)))
@@ -149,6 +150,7 @@ func addKamelSubcommands(cmd *cobra.Command, options *RootCmdOptions) {
 	cmd.AddCommand(cmdOnly(newCmdDump(options)))
 	cmd.AddCommand(cmdOnly(newCmdBind(options)))
 	cmd.AddCommand(cmdOnly(newCmdPromote(options)))
+	cmd.AddCommand(cmdOnly(newCmdUndeploy(options)))
 }
 
 func addHelpSubCommands(cmd *cobra.Command) error {

--- a/pkg/cmd/run_test.go
+++ b/pkg/cmd/run_test.go
@@ -54,7 +54,6 @@ const (
 `
 )
 
-// nolint: unparam
 func initializeRunCmdOptions(t *testing.T) (*runCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 
@@ -65,7 +64,6 @@ func initializeRunCmdOptions(t *testing.T) (*runCmdOptions, *cobra.Command, Root
 	return runCmdOptions, rootCmd, *options
 }
 
-// nolint: unparam
 func initializeRunCmdOptionsWithOutput(t *testing.T) (*runCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 	defaultIntegrationPlatform := v1.NewIntegrationPlatform("default", platform.DefaultPlatformName)

--- a/pkg/cmd/undeploy.go
+++ b/pkg/cmd/undeploy.go
@@ -1,0 +1,105 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+)
+
+func newCmdUndeploy(rootCmdOptions *RootCmdOptions) (*cobra.Command, *undeployCmdOptions) {
+	options := undeployCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+	cmd := cobra.Command{
+		Use:     "undeploy [integration1] [integration2] ...",
+		Short:   "Undeploy one or more integrations previously deployed.",
+		Long:    `Clear the state of one or more integrations causing them to move back to a Build Complete status.`,
+		PreRunE: decode(&options, options.Flags),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.validate(args); err != nil {
+				return err
+			}
+			return options.run(cmd, args)
+		},
+	}
+
+	return &cmd, &options
+}
+
+type undeployCmdOptions struct {
+	*RootCmdOptions
+}
+
+func (o *undeployCmdOptions) validate(args []string) error {
+	if len(args) == 0 {
+		return errors.New("undeploy requires an Integration name argument")
+	}
+
+	return nil
+}
+
+func (o *undeployCmdOptions) run(cmd *cobra.Command, args []string) error {
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return err
+	}
+	var integrations []v1.Integration
+	if len(args) > 0 {
+		if integrations, err = getIntegrations(o.Context, c, args, o.Namespace); err != nil {
+			return err
+		}
+	}
+
+	undeployed, err := o.undeployIntegrations(cmd, c, integrations)
+	// We print the number of undeployed integrations anyway (they could have been correctly processed)
+	fmt.Fprintln(cmd.OutOrStdout(), undeployed, "integrations have been undeployed")
+
+	return err
+}
+
+func (o *undeployCmdOptions) undeployIntegrations(cmd *cobra.Command, c k8sclient.StatusClient, integrations []v1.Integration) (int, error) {
+	undeployed := 0
+	for _, i := range integrations {
+		if i.Status.Phase != v1.IntegrationPhaseRunning {
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"warning: could not undeploy integration %s, it is not in status %s\n",
+				i.Name, v1.IntegrationPhaseRunning)
+			continue
+		}
+		if i.Annotations[v1.IntegrationDontRunAfterBuildAnnotation] != "true" {
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"warning: could not undeploy integration %s, it is not annotated with %s=true\n",
+				i.Name, v1.IntegrationDontRunAfterBuildAnnotation)
+			continue
+		}
+		it := i
+		it.Status.Phase = v1.IntegrationPhaseInitialization
+		if err := c.Status().Update(o.Context, &it); err != nil {
+			return undeployed, fmt.Errorf("could not undeploy %s in namespace %s: %w", it.Name, o.Namespace, err)
+		}
+		undeployed++
+	}
+	return undeployed, nil
+}

--- a/pkg/cmd/undeploy_test.go
+++ b/pkg/cmd/undeploy_test.go
@@ -1,0 +1,103 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/v2/pkg/internal"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const cmdUndeploy = "undeploy"
+
+func initializeUndeployCmdOptions(t *testing.T, initObjs ...runtime.Object) (*cobra.Command, *undeployCmdOptions) {
+	t.Helper()
+	fakeClient, err := internal.NewFakeClient(initObjs...)
+	require.NoError(t, err)
+	options, rootCmd := kamelTestPreAddCommandInitWithClient(fakeClient)
+	options.Namespace = "default"
+	undeployCmdOptions := addTestUndeployCmd(*options, rootCmd)
+	kamelTestPostAddCommandInit(t, rootCmd, options)
+
+	return rootCmd, undeployCmdOptions
+}
+
+func addTestUndeployCmd(options RootCmdOptions, rootCmd *cobra.Command) *undeployCmdOptions {
+	undeployCmd, undeployOptions := newCmdUndeploy(&options)
+	undeployCmd.Args = ArbitraryArgs
+	rootCmd.AddCommand(undeployCmd)
+	return undeployOptions
+}
+
+func TestUndeployNonExistingFlag(t *testing.T) {
+	cmd, _ := initializeUndeployCmdOptions(t)
+	_, err := ExecuteCommand(cmd, cmdUndeploy, "--nonExistingFlag")
+	require.Error(t, err)
+	assert.Equal(t, "unknown flag: --nonExistingFlag", err.Error())
+}
+
+func TestUndeployNoArgs(t *testing.T) {
+	cmd, _ := initializeUndeployCmdOptions(t)
+	_, err := ExecuteCommand(cmd, cmdUndeploy)
+	require.Error(t, err)
+	assert.Equal(t, "undeploy requires an Integration name argument", err.Error())
+}
+
+func TestUndeployMissingIntegrations(t *testing.T) {
+	cmd, _ := initializeUndeployCmdOptions(t)
+	_, err := ExecuteCommand(cmd, cmdUndeploy, "missing")
+	require.Error(t, err)
+	assert.Equal(t,
+		"could not find integration missing in namespace default: integrations.camel.apache.org \"missing\" not found",
+		err.Error())
+}
+
+func TestUndeployNotRunningIntegrations(t *testing.T) {
+	it := v1.NewIntegration("default", "my-it")
+	it.Status.Phase = v1.IntegrationPhaseBuildRunning
+	cmd, _ := initializeUndeployCmdOptions(t, &it)
+	output, err := ExecuteCommand(cmd, cmdUndeploy, "my-it")
+	require.NoError(t, err)
+	assert.Contains(t, output, "could not undeploy integration my-it, it is not in status Running")
+}
+
+func TestUndeployMissingDontRunAnnotationIntegrations(t *testing.T) {
+	it := v1.NewIntegration("default", "my-it")
+	it.Status.Phase = v1.IntegrationPhaseRunning
+	cmd, _ := initializeUndeployCmdOptions(t, &it)
+	output, err := ExecuteCommand(cmd, cmdUndeploy, "my-it")
+	require.NoError(t, err)
+	assert.Contains(t, output, "could not undeploy integration my-it, it is not annotated with camel.apache.org/dont-run-after-build=true")
+}
+
+func TestUndeployIntegrations(t *testing.T) {
+	it := v1.NewIntegration("default", "my-it")
+	it.Status.Phase = v1.IntegrationPhaseRunning
+	it.Annotations = map[string]string{
+		v1.IntegrationDontRunAfterBuildAnnotation: "true",
+	}
+	cmd, _ := initializeUndeployCmdOptions(t, &it)
+	output, err := ExecuteCommand(cmd, cmdUndeploy, "my-it")
+	require.NoError(t, err)
+	assert.Contains(t, output, "1 integrations have been undeployed")
+}

--- a/pkg/cmd/version_test.go
+++ b/pkg/cmd/version_test.go
@@ -34,7 +34,6 @@ import (
 
 const cmdVersion = "version"
 
-// nolint: unparam
 func initializeVersionCmdOptions(t *testing.T, initObjs ...runtime.Object) (*versionCmdOptions, *cobra.Command, RootCmdOptions) {
 	t.Helper()
 

--- a/pkg/controller/integration/build.go
+++ b/pkg/controller/integration/build.go
@@ -226,7 +226,11 @@ func (action *buildAction) handleBuildRunning(ctx context.Context, it *v1.Integr
 			}
 			it.Status.Image = fmt.Sprintf("%s@%s", image, build.Status.Digest)
 		}
-		it.Status.Phase = v1.IntegrationPhaseDeploying
+		if it.Annotations[v1.IntegrationDontRunAfterBuildAnnotation] == v1.IntegrationDontRunAfterBuildAnnotationTrueValue {
+			it.Status.Phase = v1.IntegrationPhaseBuildComplete
+		} else {
+			it.Status.Phase = v1.IntegrationPhaseDeploying
+		}
 	case v1.BuildPhaseError, v1.BuildPhaseInterrupted, v1.BuildPhaseFailed:
 		it.Status.Phase = v1.IntegrationPhaseError
 		reason := fmt.Sprintf("Build%s", build.Status.Phase)

--- a/pkg/controller/integration/initialize.go
+++ b/pkg/controller/integration/initialize.go
@@ -71,7 +71,11 @@ func (action *initializeAction) Handle(ctx context.Context, integration *v1.Inte
 	}
 
 	if integration.Status.Image != "" {
-		integration.Status.Phase = v1.IntegrationPhaseDeploying
+		if integration.Annotations[v1.IntegrationDontRunAfterBuildAnnotation] == v1.IntegrationDontRunAfterBuildAnnotationTrueValue {
+			integration.Status.Phase = v1.IntegrationPhaseBuildComplete
+		} else {
+			integration.Status.Phase = v1.IntegrationPhaseDeploying
+		}
 		return integration, nil
 	}
 

--- a/pkg/controller/integration/monitor_unknown.go
+++ b/pkg/controller/integration/monitor_unknown.go
@@ -53,7 +53,11 @@ func (action *monitorUnknownAction) Handle(ctx context.Context, integration *v1.
 	}
 	// We're good to monitor this again
 	if environment.Platform != nil && environment.Platform.Status.Phase == v1.IntegrationPlatformPhaseReady {
-		integration.Status.Phase = v1.IntegrationPhaseRunning
+		if integration.Annotations[v1.IntegrationDontRunAfterBuildAnnotation] == v1.IntegrationDontRunAfterBuildAnnotationTrueValue {
+			integration.Status.Phase = v1.IntegrationPhaseBuildComplete
+		} else {
+			integration.Status.Phase = v1.IntegrationPhaseRunning
+		}
 		integration.Status.SetCondition(
 			v1.IntegrationConditionPlatformAvailable,
 			corev1.ConditionTrue,

--- a/pkg/internal/client.go
+++ b/pkg/internal/client.go
@@ -190,6 +190,10 @@ func (c *FakeClient) Patch(ctx context.Context, obj controller.Object, patch con
 	return nil
 }
 
+func (c *FakeClient) Status() controller.SubResourceWriter {
+	return &FakeStatusWriter{client: c}
+}
+
 func (c *FakeClient) DisableAPIGroupDiscovery(group string) {
 	c.disabledGroups = append(c.disabledGroups, group)
 }

--- a/pkg/internal/fakeStatusWriter.go
+++ b/pkg/internal/fakeStatusWriter.go
@@ -1,0 +1,39 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+
+	controller "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type FakeStatusWriter struct {
+	client *FakeClient
+}
+
+func (s *FakeStatusWriter) Patch(ctx context.Context, obj controller.Object, patch controller.Patch, opts ...controller.SubResourcePatchOption) error {
+	return s.client.Patch(ctx, obj, patch)
+}
+func (c *FakeStatusWriter) Create(ctx context.Context, obj controller.Object, subResource controller.Object, opts ...controller.SubResourceCreateOption) error {
+	return nil
+}
+
+func (c *FakeStatusWriter) Update(ctx context.Context, obj controller.Object, opts ...controller.SubResourceUpdateOption) error {
+	return nil
+}


### PR DESCRIPTION
* Add an annotation `dont-run-after-build` which tell the operator not to run the application right after the build
* Add the deploy/undeploy CLI command to simplify the usage of the new feature

Closes #5588

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
