### PR TITLE
cli(reset): add force flag, namespace confirmation prompt, update e2e test

### DIFF
--- a/e2e/advanced/reset_test.go
+++ b/e2e/advanced/reset_test.go
@@ -46,7 +46,7 @@ func TestKamelReset(t *testing.T) {
 			g.Eventually(Kit(t, ctx, ns, IntegrationKit(t, ctx, ns, name)())).Should(Not(BeNil()))
 			g.Eventually(Integration(t, ctx, ns, name)).Should(Not(BeNil()))
 
-			g.Expect(Kamel(t, ctx, "reset", "-n", ns, "-f").Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "reset", "-n", ns, "--force").Execute()).To(Succeed())
 			g.Expect(Integration(t, ctx, ns, name)()).To(BeNil())
 			g.Expect(Kits(t, ctx, ns)()).To(HaveLen(0))
 		})
@@ -59,7 +59,7 @@ func TestKamelReset(t *testing.T) {
 			g.Eventually(Kit(t, ctx, ns, IntegrationKit(t, ctx, ns, name)())).Should(Not(BeNil()))
 			g.Eventually(Integration(t, ctx, ns, name)).Should(Not(BeNil()))
 
-			g.Expect(Kamel(t, ctx, "reset", "-n", ns, "--skip-integrations", "-f").Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "reset", "-n", ns, "--skip-integrations", "--force").Execute()).To(Succeed())
 			g.Expect(Integration(t, ctx, ns, name)()).To(Not(BeNil()))
 			g.Expect(Kits(t, ctx, ns)()).To(HaveLen(0))
 		})
@@ -73,7 +73,7 @@ func TestKamelReset(t *testing.T) {
 			g.Eventually(Kit(t, ctx, ns, kitName)).Should(Not(BeNil()))
 			g.Eventually(Integration(t, ctx, ns, name)).Should(Not(BeNil()))
 
-			g.Expect(Kamel(t, ctx, "reset", "-n", ns, "--skip-kits", "-f").Execute()).To(Succeed())
+			g.Expect(Kamel(t, ctx, "reset", "-n", ns, "--skip-kits", "--force").Execute()).To(Succeed())
 			g.Expect(Integration(t, ctx, ns, name)()).To(BeNil())
 			g.Expect(Kit(t, ctx, ns, kitName)()).To(Not(BeNil()))
 		})

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/client"
@@ -64,7 +63,7 @@ func (o *resetCmdOptions) reset(cmd *cobra.Command, _ []string) {
 		fmt.Fprint(cmd.OutOrStdout(), "Type the namespace to confirm: ")
 
 		var input string
-		if _, err := fmt.Fscan(os.Stdin, &input); err != nil {
+		if _, err := fmt.Fscan(cmd.InOrStdin(), &input); err != nil {
 			fmt.Fprint(cmd.ErrOrStderr(), err)
 			return
 		}


### PR DESCRIPTION
### Updates
Based on @squakez feedback on implementation of a confirmation step in `reset` command -

– Added `Force` (`--force`) option
– Added namespace confirmation when not forced
– Updated e2e tests to use `-f`
– Supersedes previous PR #6356 because that branch used an invalid Unicode character in its name, breaking GitHub branch tracking

Thank you for the opportunity 😄
<!-- Description -->




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

