### PR TITLE
fix(ci): enable whitespace linter and fix violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,6 @@ linters:
     - tagliatelle
     - testpackage
     - varnamelen
-    - whitespace
     - wrapcheck
     - wsl
     - wsl_v5

--- a/pkg/apis/camel/v1/maven_types_support.go
+++ b/pkg/apis/camel/v1/maven_types_support.go
@@ -124,9 +124,7 @@ func (m PluginProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 			if err := e.EncodeToken(nestedPropertyStart.End()); err != nil {
 				return err
 			}
-
 		}
 	}
-
 	return e.EncodeToken(start.End())
 }

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -81,7 +81,6 @@ func (t *builderTask) Do(ctx context.Context) v1.BuildStatus {
 steps:
 	for _, step := range steps {
 		select {
-
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.Canceled) {
 				// Context canceled

--- a/pkg/builder/image.go
+++ b/pkg/builder/image.go
@@ -136,7 +136,6 @@ func incrementalImageContext(ctx *builderContext) error {
 
 		bestImage, commonLibs := findBestImage(images, ctx.Artifacts)
 		if bestImage.Image != "" {
-
 			log.Infof("Selected %s as base image for %s", bestImage.Image, ctx.Build.Name)
 			ctx.BaseImage = bestImage.Image
 			ctx.SelectedArtifacts = make([]v1.Artifact, 0)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -124,7 +124,6 @@ func NewClient(fastDiscovery bool) (Client, error) {
 
 // NewClientWithConfig creates a new k8s client that can be used from outside or in the cluster.
 func NewClientWithConfig(fastDiscovery bool, cfg *rest.Config) (Client, error) {
-
 	// The below call to apis.AddToScheme is not thread safe in the k8s API
 	// We try to synchronize here across all k8s clients
 	// https://github.com/apache/camel-k/issues/5315

--- a/pkg/cmd/operator.go
+++ b/pkg/cmd/operator.go
@@ -58,7 +58,6 @@ type operatorCmdOptions struct {
 }
 
 func (o *operatorCmdOptions) run(_ *cobra.Command, _ []string) {
-
 	leaderElectionID := o.LeaderElectionID
 	if leaderElectionID == "" {
 		if defaults.OperatorID() != "" {

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -82,7 +82,6 @@ func printVersion() {
 
 // Run starts the Camel K operator.
 func Run(healthPort, monitoringPort int32, leaderElection bool, leaderElectionID string) {
-
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -868,9 +868,7 @@ func (o *runCmdOptions) applyDependencies(cmd *cobra.Command, it *v1.Integration
 			}
 		}
 		addDependency(cmd, it, item, catalog)
-
 	}
-
 	return nil
 }
 

--- a/pkg/controller/build/build_monitor.go
+++ b/pkg/controller/build/build_monitor.go
@@ -42,7 +42,6 @@ type Monitor struct {
 }
 
 func (bm *Monitor) canSchedule(ctx context.Context, c ctrl.Reader, build *v1.Build) (bool, *v1.BuildCondition, error) {
-
 	var runningBuildsTotal int32
 	runningBuilds.Range(func(_, v interface{}) bool {
 		runningBuildsTotal++

--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -72,7 +72,6 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 	//nolint:nestif
 	if pod == nil {
 		switch build.Status.Phase {
-
 		case v1.BuildPhasePending:
 			pod = newBuildPod(ctx, action.client, build)
 			// If the Builder Pod is in the Build namespace, we can set the ownership to it. If not (global operator mode)
@@ -103,7 +102,6 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 	}
 
 	switch pod.Status.Phase {
-
 	case corev1.PodPending, corev1.PodRunning:
 		// Pod remains in pending phase when init containers execute
 		if action.isPodScheduled(pod) {
@@ -337,7 +335,6 @@ func (action *monitorPodAction) setConditionsFromTerminationMessages(ctx context
 			buildStatus.SetCondition(containerConditionType, containerSucceeded, terminationReason, terminationMessage)
 		}
 	}
-
 }
 
 // we expect that the last task is any of the supported publishing task
@@ -345,9 +342,7 @@ func (action *monitorPodAction) setConditionsFromTerminationMessages(ctx context
 func publishTask(tasks []v1.Task) *v1.Task {
 	if len(tasks) > 0 {
 		return &tasks[len(tasks)-1]
-
 	}
-
 	return nil
 }
 

--- a/pkg/controller/build/monitor_routine.go
+++ b/pkg/controller/build/monitor_routine.go
@@ -60,7 +60,6 @@ func (action *monitorRoutineAction) CanHandle(build *v1.Build) bool {
 // Handle handles the builds.
 func (action *monitorRoutineAction) Handle(ctx context.Context, build *v1.Build) (*v1.Build, error) {
 	switch build.Status.Phase {
-
 	case v1.BuildPhasePending:
 		if _, ok := routines.Load(build.Name); ok {
 			// Something went wrong. Let's fail the Build to start over a clean state.

--- a/pkg/controller/build/schedule.go
+++ b/pkg/controller/build/schedule.go
@@ -86,7 +86,6 @@ func (action *scheduleAction) toUpdatedCondition(ctx context.Context, build *v1.
 		}
 		b.Status.SetConditions(*condition)
 	})
-
 }
 
 func (action *scheduleAction) toUpdatedStatus(ctx context.Context, build *v1.Build, condition *v1.BuildCondition, phase v1.BuildPhase) error {

--- a/pkg/controller/catalog/initialize.go
+++ b/pkg/controller/catalog/initialize.go
@@ -57,7 +57,6 @@ func (action *initializeAction) Handle(ctx context.Context, catalog *v1.CamelCat
 	}
 
 	return initialize(catalog)
-
 }
 
 func initialize(catalog *v1.CamelCatalog) (*v1.CamelCatalog, error) {

--- a/pkg/controller/integration/build_kit.go
+++ b/pkg/controller/integration/build_kit.go
@@ -158,7 +158,6 @@ kits:
 }
 
 func (action *buildKitAction) checkIntegrationKit(ctx context.Context, integration *v1.Integration) (*v1.Integration, error) {
-
 	// IntegrationKit fully defined so find it
 	action.L.Debugf("Finding integration kit %s for integration %s\n",
 		integration.Status.IntegrationKit.Name, integration.Name)
@@ -175,7 +174,6 @@ func (action *buildKitAction) checkIntegrationKit(ctx context.Context, integrati
 		if err != nil {
 			return nil, fmt.Errorf("unable to match any integration kit with integration %s/%s: %w",
 				integration.Namespace, integration.Name, err)
-
 		}
 
 		if !match {

--- a/pkg/controller/integrationkit/build.go
+++ b/pkg/controller/integrationkit/build.go
@@ -82,7 +82,6 @@ func (action *buildAction) handleBuildSubmitted(ctx context.Context, kit *v1.Int
 		build.Status.Phase == v1.BuildPhaseError ||
 		build.Status.Phase == v1.BuildPhaseInterrupted ||
 		build.Status.Phase == v1.BuildPhaseSucceeded {
-
 		b, err := action.createBuild(ctx, kit)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/pipe/integration.go
+++ b/pkg/controller/pipe/integration.go
@@ -253,9 +253,7 @@ func configureBinding(integration *v1.Integration, bindings ...*bindings.Binding
 
 			integration.Spec.AddConfigurationProperty(entry)
 		}
-
 	}
-
 	return nil
 }
 

--- a/pkg/controller/pipe/monitor.go
+++ b/pkg/controller/pipe/monitor.go
@@ -117,7 +117,6 @@ func (action *monitorAction) Handle(ctx context.Context, pipe *v1.Pipe) (*v1.Pip
 	target := pipe.DeepCopy()
 
 	switch it.Status.Phase {
-
 	case v1.IntegrationPhaseRunning:
 		target.Status.Phase = v1.PipePhaseReady
 		setPipeReadyCondition(target, &it)
@@ -175,7 +174,6 @@ func setPipeReadyCondition(kb *v1.Pipe, it *v1.Integration) {
 		}
 
 		kb.Status.SetConditions(c)
-
 	} else {
 		kb.Status.SetCondition(
 			v1.PipeConditionReady,

--- a/pkg/install/common.go
+++ b/pkg/install/common.go
@@ -62,7 +62,6 @@ func Resource(ctx context.Context, c client.Client, namespace string, force bool
 
 func ResourceOrCollect(ctx context.Context, c client.Client, namespace string, collection *kubernetes.Collection,
 	force bool, customizer ResourceCustomizer, name string) error {
-
 	content, err := resources.ResourceAsString(name)
 	if err != nil {
 		return err

--- a/pkg/internal/knative/types_support.go
+++ b/pkg/internal/knative/types_support.go
@@ -26,7 +26,6 @@ import (
 // BuildCamelServiceDefinition creates a CamelServiceDefinition from a given URL.
 func BuildCamelServiceDefinition(name string, endpointKind CamelEndpointKind, serviceType CamelServiceType,
 	serviceURL url.URL, apiVersion, kind string) (CamelServiceDefinition, error) {
-
 	definition := CamelServiceDefinition{
 		Name:        name,
 		URL:         serviceURL.String(),

--- a/pkg/platform/defaults.go
+++ b/pkg/platform/defaults.go
@@ -120,7 +120,6 @@ func configureRegistry(ctx context.Context, c client.Client, p *v1.IntegrationPl
 	if p.Status.Cluster == v1.IntegrationPlatformClusterOpenShift &&
 		p.Status.Build.PublishStrategy == v1.IntegrationPlatformBuildPublishStrategyS2I &&
 		p.Status.Build.Registry.Address == "" {
-
 		err := configureForOpenShiftS2i(ctx, c, p)
 		if err != nil {
 			return err

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -259,7 +259,6 @@ func (t *builderTrait) Apply(e *Environment) error {
 	// Publishing task
 	tag := getTag(e)
 	switch e.Platform.Status.Build.PublishStrategy {
-
 	case v1.IntegrationPlatformBuildPublishStrategyJib:
 		jibTask := v1.Task{Jib: &v1.JibTask{
 			BaseTask: v1.BaseTask{

--- a/pkg/trait/knative.go
+++ b/pkg/trait/knative.go
@@ -543,7 +543,6 @@ func (t *knativeTrait) withServiceDo(
 	serviceType knativeapi.CamelServiceType,
 	endpointKind knativeapi.CamelEndpointKind,
 	gen func(ref *corev1.ObjectReference, serviceURI string, urlProvider func() (*url.URL, error)) error) error {
-
 	for _, serviceURI := range t.extractServices(serviceURIs, serviceType) {
 		ref, err := knativeutil.ExtractObjectReference(serviceURI)
 		if err != nil {

--- a/pkg/trait/mount.go
+++ b/pkg/trait/mount.go
@@ -509,6 +509,5 @@ func (t *mountTrait) addSourcesProperties(e *Environment) {
 
 			idx++
 		}
-
 	}
 }

--- a/pkg/trait/pod.go
+++ b/pkg/trait/pod.go
@@ -102,7 +102,6 @@ func (t *podTrait) Apply(e *Environment) error {
 				}
 			}
 		})
-
 	}
 	if err != nil {
 		return err

--- a/pkg/trait/resolver.go
+++ b/pkg/trait/resolver.go
@@ -89,7 +89,6 @@ func resolveIntegrationSources(
 	integration *v1.Integration,
 	originalSourcesOnly bool,
 	resources *kubernetes.Collection) ([]v1.SourceSpec, error) {
-
 	if integration == nil {
 		return nil, nil
 	}

--- a/pkg/util/bindings/catalog.go
+++ b/pkg/util/bindings/catalog.go
@@ -78,7 +78,6 @@ func validateEndpoint(ctx BindingContext, e v1.Endpoint) error {
 			}
 			return errors.New("cross-namespace Pipe references are not allowed for Knative")
 		}
-
 	}
 	return nil
 }

--- a/pkg/util/camel/camel_runtime.go
+++ b/pkg/util/camel/camel_runtime.go
@@ -68,7 +68,6 @@ func CreateCatalog(
 				runtime.Version,
 				runtime.Provider,
 				catalogName, err)
-
 		}
 	}
 

--- a/pkg/util/camel/camel_runtime_catalog.go
+++ b/pkg/util/camel/camel_runtime_catalog.go
@@ -180,7 +180,6 @@ func (c *RuntimeCatalog) VisitSchemes(visitor func(string, v1.CamelScheme) bool)
 
 // DecodeComponent parses the given URI and return a camel artifact and a scheme.
 func (c *RuntimeCatalog) DecodeComponent(uri string) (*v1.CamelArtifact, *v1.CamelScheme) {
-
 	var uriSplit []string
 
 	// Decode URI using formats http://my-site/test?param=value or log:info

--- a/pkg/util/camel/catalog.go
+++ b/pkg/util/camel/catalog.go
@@ -51,7 +51,6 @@ func catalogForRuntimeProvider(provider v1.RuntimeProvider) (*RuntimeCatalog, er
 	}
 
 	for _, name := range names {
-
 		content, err := resources.Resource(name)
 		if err != nil {
 			return nil, err
@@ -79,7 +78,6 @@ func GenerateCatalog(
 	mvn v1.MavenSpec,
 	runtime v1.RuntimeSpec,
 	extraRepositories []string) (*RuntimeCatalog, error) {
-
 	userSettings, err := kubernetes.ResolveValueSource(ctx, client, namespace, &mvn.Settings)
 	if err != nil {
 		return nil, err
@@ -112,7 +110,6 @@ func GenerateCatalogCommon(
 	caCert [][]byte,
 	mvn v1.MavenSpec,
 	runtime v1.RuntimeSpec) (*RuntimeCatalog, error) {
-
 	catalog := v1.CamelCatalog{}
 
 	err := util.WithTempDir("camel-catalog", func(tmpDir string) error {
@@ -167,7 +164,6 @@ func GenerateCatalogCommon(
 
 func generateMavenProject(runtimeVersion string) maven.Project {
 	p := maven.NewProjectWithGAV("org.apache.camel.k.integration", "camel-k-catalog-generator", defaults.Version)
-
 	plugin := maven.Plugin{
 		GroupID:    "org.apache.camel.k",
 		ArtifactID: "camel-k-maven-plugin",

--- a/pkg/util/knative/knative.go
+++ b/pkg/util/knative/knative.go
@@ -168,7 +168,6 @@ func CreateSinkBinding(source corev1.ObjectReference, target corev1.ObjectRefere
 // GetAddressableReference looks up the resource among all given types and returns an object reference to it.
 func GetAddressableReference(ctx context.Context, c client.Client,
 	possibleReferences []corev1.ObjectReference, namespace string, name string) (*corev1.ObjectReference, error) {
-
 	for _, ref := range possibleReferences {
 		sink := ref.DeepCopy()
 		sink.Namespace = namespace

--- a/pkg/util/s2i/build.go
+++ b/pkg/util/s2i/build.go
@@ -51,7 +51,6 @@ func WaitForS2iBuildCompletion(ctx context.Context, c client.Client, build *buil
 	key := ctrl.ObjectKeyFromObject(build)
 	for {
 		select {
-
 		case <-ctx.Done():
 			return ctx.Err()
 

--- a/pkg/util/source/inspector_yaml.go
+++ b/pkg/util/source/inspector_yaml.go
@@ -129,7 +129,6 @@ func (i YAMLInspector) parseStep(key string, content interface{}, meta *Metadata
 		maybeURI = t
 	case map[interface{}]interface{}:
 		for k, v := range t {
-
 			if s, ok := k.(string); ok {
 				if dependency, ok := i.catalog.GetLanguageDependency(s); ok {
 					meta.AddDependency(dependency)
@@ -214,7 +213,6 @@ func (i YAMLInspector) parseStep(key string, content interface{}, meta *Metadata
 func (i YAMLInspector) parseStepsParam(steps []interface{}, meta *Metadata) error {
 	for _, raw := range steps {
 		if step, stepFormatOk := raw.(map[interface{}]interface{}); stepFormatOk {
-
 			if len(step) != 1 {
 				return fmt.Errorf("unable to parse step: %v", step)
 			}


### PR DESCRIPTION
<!-- Description -->

Enables the `whitespace` linter in `.golangci.yml` and removes all reported leading/trailing blank-line violations across the codebase.

Issue: #5486 
<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

