### PR TITLE
fix(cli): Remove completion option on help

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -88,6 +88,9 @@ func kamelPreAddCommandInit(options *RootCmdOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.Namespace, "namespace", "n", "", "Namespace to use for all operations")
 	cmd.PersistentFlags().BoolVarP(&options.Verbose, "verbose", "V", false, "Verbose logging")
 
+	// Disable the default completion command
+	cmd.CompletionOptions.DisableDefaultCmd = true
+
 	cobra.AddTemplateFunc("wrappedFlagUsages", wrappedFlagUsages)
 	cmd.SetUsageTemplate(usageTemplate)
 


### PR DESCRIPTION
Closes #6429 

Remove default `completion` option in help.

```
./kamel --help
Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless
superpowers.

Usage:
  kamel [command]

Available Commands:
  bind        Bind Kubernetes resources, such as Kamelets, in an integration flow.
  debug       Debug an integration running on Kubernetes
  deploy      Deploy an Integration or Pipe that was previously built
  help        Help about any command
  log         Print the logs of an integration
  promote     Promote an Integration/Pipe from an environment to another
  rebuild     Clear the state of integrations to rebuild them.
  reset       Reset the Camel K installation
  run         Build and run the Integration on Kubernetes.
  undeploy    Undeploy one or more Integrations or Pipes previously deployed.
  version     Display client version

Flags:
  -h, --help                 help for kamel
      --kube-config string   Path to the kube config file to use for CLI requests
  -n, --namespace string     Namespace to use for all operations
  -V, --verbose              Verbose logging

Use "kamel [command] --help" for more information about a command.

```

<!-- Description -->




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

