### PR TITLE
[Backport 2.9.x] fix(operator): restore missing PVC RBAC permissions

### DIFF
--- a/helm/camel-k/templates/rbacs-descoped.yaml
+++ b/helm/camel-k/templates/rbacs-descoped.yaml
@@ -152,6 +152,9 @@ rules:
   - persistentvolumeclaims
   verbs:
   - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - policy
   resources:

--- a/helm/camel-k/templates/rbacs-namespaced.yaml
+++ b/helm/camel-k/templates/rbacs-namespaced.yaml
@@ -165,6 +165,9 @@ rules:
   - persistentvolumeclaims
   verbs:
   - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/pkg/resources/config/rbac/descoped/operator-cluster-role.yaml
+++ b/pkg/resources/config/rbac/descoped/operator-cluster-role.yaml
@@ -156,6 +156,9 @@ rules:
   - persistentvolumeclaims
   verbs:
   - create
+  - get
+  - list
+  - watch
 # Required by PDB trait
 - apiGroups:
   - policy

--- a/pkg/resources/config/rbac/namespaced/operator-role.yaml
+++ b/pkg/resources/config/rbac/namespaced/operator-role.yaml
@@ -169,6 +169,9 @@ rules:
   - persistentvolumeclaims
   verbs:
   - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - storage.k8s.io
   resources:


### PR DESCRIPTION
Fixes #6433

The `mount` trait in Camel K 2.9.0 requires `get`, `list`, and `watch` permissions for `PersistentVolumeClaims` to verify their existence. These permissions were missing in the operator roles.

