### PR TITLE
fix: upgrade go to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/camel-k/v2
 
-go 1.25.5
+go 1.25.6
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Fix security issue:

```
GOBIN=/home/runner/work/camel-k/camel-k/bin go install golang.org/x/vuln/cmd/govulncheck@latest
go: downloading golang.org/x/vuln v1.1.4
go: downloading golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7
go: downloading golang.org/x/mod v0.22.0
go: downloading golang.org/x/tools v0.29.0
go: downloading golang.org/x/sync v0.10.0
=== Symbol Results ===

Vulnerability #1: GO-2026-4341
    Memory exhaustion in query parameter parsing in net/url
  More info: https://pkg.go.dev/vuln/GO-2026-4341
  Standard library
    Found in: net/url@go1.25.5
    Fixed in: net/url@go1.25.6
    Example traces found:
Error:       #1: pkg/trait/keda/uri_parser.go:43:37: keda.ParseComponentURI calls url.ParseQuery
Error:       #2: pkg/util/source/kamelet.go:55:32: source.getKameletParam calls url.URL.Query

Vulnerability #2: GO-2026-4340
    Handshake messages may be processed at the incorrect encryption level in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4340
  Standard library
    Found in: crypto/tls@go1.25.5
    Fixed in: crypto/tls@go1.25.6
    Example traces found:
Error:       #1: pkg/util/kubernetes/log/util.go:53:28: log.DumpLog calls rest.Request.Stream, which eventually calls tls.Conn.HandshakeContext
Error:       #2: pkg/util/util.go:214:24: util.CopyFile calls io.Copy, which eventually calls tls.Conn.Read
Error:       #3: pkg/cmd/root.go:266:14: cmd.RootCmdOptions.PrintfVerboseErrf calls fmt.Fprintf, which calls tls.Conn.Write
Error:       #4: pkg/util/kubernetes/log/util.go:53:28: log.DumpLog calls rest.Request.Stream, which eventually calls tls.Dialer.DialContext

Your code is affected by 2 vulnerabilities from the Go standard library.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
make: *** [Makefile:413: vuln] Error 3
Error: Process completed with exit code 2.
```