### PR TITLE
[Backport 2.9.x] fix: upgrade go to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/camel-k/v2
 
-go 1.25.5
+go 1.25.6
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
See #6475 




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

