### PR TITLE
feat: Add ownership claiming on CK helm charts in artifacthub

### DIFF
--- a/docs/charts/artifacthub-repo.yml
+++ b/docs/charts/artifacthub-repo.yml
@@ -1,0 +1,7 @@
+owners: # (optional, used to claim repository ownership)
+  - name: acosentino
+    email: acosentino@apache.org
+  - name: gansheer
+    email: gaelle.fournier.work@gmail.com
+  - name: pcongiusti
+    email: pcongiusti@apache.org

--- a/helm/camel-k/Chart.yaml
+++ b/helm/camel-k/Chart.yaml
@@ -56,3 +56,5 @@ maintainers:
     email: pcongiusti@apache.org
   - name: acosentino
     email: acosentino@apache.org
+  - name: gansheer
+    email: gaelle.fournier.work@gmail.com


### PR DESCRIPTION
Ref #6434

@squakez The artifacthub-repo.yml requires an account matching email address on your artifacthub repo for the ownership claiming




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

