### PR TITLE
feat: Set helm repo id from artifacthub

### DIFF
--- a/docs/charts/artifacthub-repo.yml
+++ b/docs/charts/artifacthub-repo.yml
@@ -1,3 +1,4 @@
+repositoryID: d95c9d48-a584-4362-a92d-c8bec24d87a7
 owners: # (optional, used to claim repository ownership)
   - name: acosentino
     email: acosentino@apache.org


### PR DESCRIPTION
Ref #6477 

Sets the repository id for the claimed chart repo on artifacthub.


<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

