### PR TITLE
Update Camel-K operator names to include operatorId

### DIFF
--- a/helm/camel-k/templates/rbacs-descoped.yaml
+++ b/helm/camel-k/templates/rbacs-descoped.yaml
@@ -20,7 +20,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator
+  name: camel-k-operator-{{ .Values.operator.operatorId }}
 rules:
 - apiGroups:
   - camel.apache.org
@@ -210,7 +210,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-events
+  name: camel-k-operator-events-{{ .Values.operator.operatorId }}
 rules:
 - apiGroups:
   - ""
@@ -229,7 +229,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-keda
+  name: camel-k-operator-keda-{{ .Values.operator.operatorId }}
 rules:
 - apiGroups:
   - keda.sh
@@ -248,7 +248,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-knative
+  name: camel-k-operator-knative-{{ .Values.operator.operatorId }}
 rules:
 - apiGroups:
   - serving.knative.dev
@@ -307,7 +307,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-leases
+  name: camel-k-operator-leases-{{ .Values.operator.operatorId }}
 rules:
 - apiGroups:
   - coordination.k8s.io
@@ -327,7 +327,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-openshift
+  name: camel-k-operator-openshift-{{ .Values.operator.operatorId }}
 rules:
 - apiGroups:
   - camel.apache.org
@@ -416,7 +416,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-podmonitors
+  name: camel-k-operator-podmonitors-{{ .Values.operator.operatorId }}
 rules:
 - apiGroups:
   - monitoring.coreos.com
@@ -434,7 +434,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-strimzi
+  name: camel-k-operator-strimzi-{{ .Values.operator.operatorId }}
 rules:
 - apiGroups:
   - kafka.strimzi.io
@@ -451,11 +451,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator
+  name: camel-k-operator-{{ .Values.operator.operatorId }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator
+  name: camel-k-operator-{{ .Values.operator.operatorId }}
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
@@ -466,11 +466,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-events
+  name: camel-k-operator-events-{{ .Values.operator.operatorId }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-events
+  name: camel-k-operator-events-{{ .Values.operator.operatorId }}
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
@@ -481,11 +481,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-keda
+  name: camel-k-operator-keda-{{ .Values.operator.operatorId }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-keda
+  name: camel-k-operator-keda-{{ .Values.operator.operatorId }}
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
@@ -496,11 +496,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-knative
+  name: camel-k-operator-knative-{{ .Values.operator.operatorId }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-knative
+  name: camel-k-operator-knative-{{ .Values.operator.operatorId }}
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
@@ -511,11 +511,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-leases
+  name: camel-k-operator-leases-{{ .Values.operator.operatorId }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-leases
+  name: camel-k-operator-leases-{{ .Values.operator.operatorId }}
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
@@ -526,11 +526,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-openshift
+  name: camel-k-operator-openshift-{{ .Values.operator.operatorId }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-openshift
+  name: camel-k-operator-openshift-{{ .Values.operator.operatorId }}
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
@@ -541,11 +541,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-podmonitors
+  name: camel-k-operator-podmonitors-{{ .Values.operator.operatorId }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-podmonitors
+  name: camel-k-operator-podmonitors-{{ .Values.operator.operatorId }}
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator
@@ -556,11 +556,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-strimzi
+  name: camel-k-operator-strimzi-{{ .Values.operator.operatorId }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-strimzi
+  name: camel-k-operator-strimzi-{{ .Values.operator.operatorId }}
 subjects:
 - kind: ServiceAccount
   name: camel-k-operator


### PR DESCRIPTION
<!-- Description -->




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->
This pull request updates the `helm/camel-k/templates/rbacs-descoped.yaml` file to add support for multiple operator instances by parameterizing the names of `ClusterRole` and `ClusterRoleBinding` resources with the operator ID. This change enables each operator instance to have its own distinct RBAC resources, improving isolation and flexibility in multi-operator deployments.

RBAC resource naming updates for operator instance isolation:

* Parameterized the `ClusterRole` names with `{{ .Values.operator.operatorId }}` for all operator-related roles, including `camel-k-operator`, `camel-k-operator-events`, `camel-k-operator-keda`, `camel-k-operator-knative`, `camel-k-operator-leases`, `camel-k-operator-openshift`, `camel-k-operator-podmonitors`, and `camel-k-operator-strimzi`. [[1]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L23-R23) [[2]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L213-R213) [[3]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L232-R232) [[4]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L251-R251) [[5]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L310-R310) [[6]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L330-R330) [[7]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L419-R419) [[8]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L437-R437)

* Parameterized the `ClusterRoleBinding` names and their referenced `ClusterRole` names with `{{ .Values.operator.operatorId }}` for all operator-related bindings, ensuring role bindings are unique per operator instance. [[1]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L454-R458) [[2]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L469-R473) [[3]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L484-R488) [[4]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L499-R503) [[5]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L514-R518) [[6]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L529-R533) [[7]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L544-R548) [[8]](diffhunk://#diff-602cfdd6f174b3f6a50b2d167f6eded57e9c171305ea738811070cf7cd714293L559-R563)

