### PR TITLE
fix(helm): parameterize resource names to enable multi-operator sharding via Helm

### DIFF
--- a/helm/camel-k/templates/operator-deployment.yaml
+++ b/helm/camel-k/templates/operator-deployment.yaml
@@ -26,12 +26,12 @@ metadata:
   annotations:
     {{ toYaml . | nindent 4 }}
   {{- end }}
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: camel-k-operator
+      name: {{ include "camel-k.fullname" . }}-operator
   strategy:
     type: Recreate
   template:
@@ -39,7 +39,7 @@ spec:
       labels:
         app: camel-k
         camel.apache.org/component: operator
-        name: camel-k-operator
+        name: {{ include "camel-k.fullname" . }}-operator
     spec:
     {{- if .Values.operator.imagePullSecrets }}
       imagePullSecrets:
@@ -111,7 +111,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: camel-k-operator
+      serviceAccountName: {{ include "camel-k.fullname" . }}-operator
       {{- with .Values.operator.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/camel-k/templates/operator-svcs.yaml
+++ b/helm/camel-k/templates/operator-svcs.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   labels:
     app: "camel-k"
     {{- include "camel-k.labels" . | nindent 4 }}
@@ -32,6 +32,6 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: camel-k-builder
+  name: {{ include "camel-k.fullname" . }}-builder
   labels:
     app: "camel-k"

--- a/helm/camel-k/templates/rbacs-common.yaml
+++ b/helm/camel-k/templates/rbacs-common.yaml
@@ -19,7 +19,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-builder
+  name: {{ include "camel-k.fullname" . }}-builder
 rules:
 - apiGroups:
   - camel.apache.org
@@ -61,7 +61,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-builder-openshift
+  name: {{ include "camel-k.fullname" . }}-builder-openshift
 rules:
 - apiGroups:
   - ""
@@ -112,7 +112,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-kamelet-viewer
+  name: {{ include "camel-k.fullname" . }}-kamelet-viewer
 rules:
 - apiGroups:
   - camel.apache.org
@@ -128,39 +128,39 @@ kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-builder
+  name: {{ include "camel-k.fullname" . }}-builder
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-builder
+  name: {{ include "camel-k.fullname" . }}-builder
 subjects:
 - kind: ServiceAccount
-  name: camel-k-builder
+  name: {{ include "camel-k.fullname" . }}-builder
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-builder-openshift
+  name: {{ include "camel-k.fullname" . }}-builder-openshift
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-builder-openshift
+  name: {{ include "camel-k.fullname" . }}-builder-openshift
 subjects:
 - kind: ServiceAccount
-  name: camel-k-builder
+  name: {{ include "camel-k.fullname" . }}-builder
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-kamelet-viewer
+  name: {{ include "camel-k.fullname" . }}-kamelet-viewer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-kamelet-viewer
+  name: {{ include "camel-k.fullname" . }}-kamelet-viewer
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/helm/camel-k/templates/rbacs-descoped.yaml
+++ b/helm/camel-k/templates/rbacs-descoped.yaml
@@ -20,7 +20,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 rules:
 - apiGroups:
   - camel.apache.org
@@ -210,7 +210,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-events
+  name: {{ include "camel-k.fullname" . }}-operator-events
 rules:
 - apiGroups:
   - ""
@@ -229,7 +229,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-keda
+  name: {{ include "camel-k.fullname" . }}-operator-keda
 rules:
 - apiGroups:
   - keda.sh
@@ -248,7 +248,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-knative
+  name: {{ include "camel-k.fullname" . }}-operator-knative
 rules:
 - apiGroups:
   - serving.knative.dev
@@ -307,7 +307,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-leases
+  name: {{ include "camel-k.fullname" . }}-operator-leases
 rules:
 - apiGroups:
   - coordination.k8s.io
@@ -327,7 +327,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-openshift
+  name: {{ include "camel-k.fullname" . }}-operator-openshift
 rules:
 - apiGroups:
   - camel.apache.org
@@ -416,7 +416,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-podmonitors
+  name: {{ include "camel-k.fullname" . }}-operator-podmonitors
 rules:
 - apiGroups:
   - monitoring.coreos.com
@@ -434,7 +434,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-strimzi
+  name: {{ include "camel-k.fullname" . }}-operator-strimzi
 rules:
 - apiGroups:
   - kafka.strimzi.io
@@ -451,14 +451,14 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -466,14 +466,14 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-events
+  name: {{ include "camel-k.fullname" . }}-operator-events
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-events
+  name: {{ include "camel-k.fullname" . }}-operator-events
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -481,14 +481,14 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-keda
+  name: {{ include "camel-k.fullname" . }}-operator-keda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-keda
+  name: {{ include "camel-k.fullname" . }}-operator-keda
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -496,14 +496,14 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-knative
+  name: {{ include "camel-k.fullname" . }}-operator-knative
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-knative
+  name: {{ include "camel-k.fullname" . }}-operator-knative
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -511,14 +511,14 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-leases
+  name: {{ include "camel-k.fullname" . }}-operator-leases
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-leases
+  name: {{ include "camel-k.fullname" . }}-operator-leases
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -526,14 +526,14 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-openshift
+  name: {{ include "camel-k.fullname" . }}-operator-openshift
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-openshift
+  name: {{ include "camel-k.fullname" . }}-operator-openshift
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -541,14 +541,14 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-podmonitors
+  name: {{ include "camel-k.fullname" . }}-operator-podmonitors
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-podmonitors
+  name: {{ include "camel-k.fullname" . }}-operator-podmonitors
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -556,13 +556,13 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-strimzi
+  name: {{ include "camel-k.fullname" . }}-operator-strimzi
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: camel-k-operator-strimzi
+  name: {{ include "camel-k.fullname" . }}-operator-strimzi
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
   namespace: '{{ .Release.Namespace }}'
 {{- end }}

--- a/helm/camel-k/templates/rbacs-namespaced.yaml
+++ b/helm/camel-k/templates/rbacs-namespaced.yaml
@@ -20,7 +20,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 rules:
 - apiGroups:
   - camel.apache.org
@@ -204,7 +204,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-events
+  name: {{ include "camel-k.fullname" . }}-operator-events
 rules:
 - apiGroups:
   - ""
@@ -223,7 +223,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-keda
+  name: {{ include "camel-k.fullname" . }}-operator-keda
 rules:
 - apiGroups:
   - keda.sh
@@ -242,7 +242,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-knative
+  name: {{ include "camel-k.fullname" . }}-operator-knative
 rules:
 - apiGroups:
   - serving.knative.dev
@@ -301,7 +301,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-leases
+  name: {{ include "camel-k.fullname" . }}-operator-leases
 rules:
 - apiGroups:
   - coordination.k8s.io
@@ -321,7 +321,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-openshift
+  name: {{ include "camel-k.fullname" . }}-operator-openshift
 rules:
 - apiGroups:
   - camel.apache.org
@@ -410,7 +410,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-podmonitors
+  name: {{ include "camel-k.fullname" . }}-operator-podmonitors
 rules:
 - apiGroups:
   - monitoring.coreos.com
@@ -428,7 +428,7 @@ kind: Role
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-strimzi
+  name: {{ include "camel-k.fullname" . }}-operator-strimzi
 rules:
 - apiGroups:
   - kafka.strimzi.io
@@ -445,110 +445,110 @@ kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-events
+  name: {{ include "camel-k.fullname" . }}-operator-events
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-operator-events
+  name: {{ include "camel-k.fullname" . }}-operator-events
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-keda
+  name: {{ include "camel-k.fullname" . }}-operator-keda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-operator-keda
+  name: {{ include "camel-k.fullname" . }}-operator-keda
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-knative
+  name: {{ include "camel-k.fullname" . }}-operator-knative
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-operator-knative
+  name: {{ include "camel-k.fullname" . }}-operator-knative
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-leases
+  name: {{ include "camel-k.fullname" . }}-operator-leases
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-operator-leases
+  name: {{ include "camel-k.fullname" . }}-operator-leases
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-openshift
+  name: {{ include "camel-k.fullname" . }}-operator-openshift
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-operator-openshift
+  name: {{ include "camel-k.fullname" . }}-operator-openshift
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-podmonitors
+  name: {{ include "camel-k.fullname" . }}-operator-podmonitors
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-operator-podmonitors
+  name: {{ include "camel-k.fullname" . }}-operator-podmonitors
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     app: camel-k
-  name: camel-k-operator-strimzi
+  name: {{ include "camel-k.fullname" . }}-operator-strimzi
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: camel-k-operator-strimzi
+  name: {{ include "camel-k.fullname" . }}-operator-strimzi
 subjects:
 - kind: ServiceAccount
-  name: camel-k-operator
+  name: {{ include "camel-k.fullname" . }}-operator
 {{- end }}


### PR DESCRIPTION
## Summary

Parameterize all hardcoded Kubernetes resource names in Helm chart templates using the existing `{{ include "camel-k.fullname" . }}` helper, enabling installation of multiple Camel-K operators on the same cluster via Helm without resource name collisions in same or different namespaces.

Fixes #6145, #6533

## Problem

The official Camel-K documentation describes an operator sharding pattern when you set `global:true` during helm install where each operator has a unique `OPERATOR_ID` and only reconciles resources annotated with the matching `camel.apache.org/operator.id`. However, installing multiple operators via Helm fails because **all resource names are hardcoded** to `camel-k-*` regardless of the Helm release name or custom value.

Since `ClusterRoles` and `ClusterRoleBindings` are cluster-scoped (shared across all namespaces), the second `helm install` immediately collides with the first:

```bash
helm install camel-k-shard-1 camel-k/camel-k \
  --namespace camel-k-shard-1 \
  --create-namespace \
  --set-string operator.global=true \
  --set operator.operatorId=camel-k-shard-1

helm install camel-k-shard-2 camel-k/camel-k \
  --namespace camel-k-shard-2 \
  --create-namespace \
  --set-string operator.global=true \
  --set operator.operatorId=camel-k-shard-2

# Error: INSTALLATION FAILED: unable to continue with install:
# ClusterRole "camel-k-operator" in namespace "" exists and cannot be
# imported into the current release: invalid ownership metadata;
# annotation validation error: key "meta.helm.sh/release-name" must equal
# "camel-k-shard-2": current value is "camel-k-shard-1"
```

PR #6191 previously removed several unnecessary cluster-scoped resources but the core problem remained, resource names were still hardcoded and not parameterized by release name.


## Backward Compatibility

**Fully backward compatible**

The `camel-k.fullname` helper returns `camel-k` when the release name is `camel-k` (the standard install). All resource names resolve to their original hardcoded values and the rendered output is identical to the original chart for both `global: true` and `global: false` modes.

```bash
# Standard install — output identical to before this fix
helm install camel-k camel-k/camel-k --namespace camel-k --create-namespace
```


## Supported Deployment Patterns

| Pattern | Before | After |
|---------|--------|-------|
| Single operator, `global: false` | ✅ | ✅ |
| Single operator, `global: true` | ✅ | ✅ |
| Multiple global operators, separate namespaces | ❌ ClusterRole collision | ✅ |
| Multiple global operators, same namespace | ❌ All resource collisions | ✅ |
| Multiple namespaced operators, same namespace | ❌ All resource collisions | ✅ |
| Mixed global + namespaced operators | ❌ ClusterRole collision | ✅ |

---

## Usage Examples

### Single operator (unchanged behaviour)

```bash
helm install camel-k camel-k/camel-k \
  --namespace camel-k \
  --create-namespace
```

### Multiple global operators - separate namespaces

Each operator in its own namespace, watching the entire cluster, only reconciling integrations annotated with its `operator.id`:

```bash
helm install camel-k-shard-1 camel-k/camel-k \
  --namespace camel-k-shard-1 \
  --create-namespace \
  --set-string operator.global=true \
  --set operator.operatorId=camel-k-shard-1

helm install camel-k-shard-2 camel-k/camel-k \
  --namespace camel-k-shard-2 \
  --create-namespace \
  --set-string operator.global=true \
  --set operator.operatorId=camel-k-shard-2
```

### Multiple global operators - same namespace

All operators managed in a single namespace. Enables IntegrationKit sharing across shards (same runtime = reuse of already built kits):

```bash
helm install camel-k-shard-1 camel-k/camel-k \
  --namespace camel-k-operators \
  --create-namespace \
  --set-string operator.global=true \
  --set operator.operatorId=camel-k-shard-1

helm install camel-k-shard-2 camel-k/camel-k \
  --namespace camel-k-operators \
  --set-string operator.global=true \
  --set operator.operatorId=camel-k-shard-2
```

## Known Limitation

The **builder ServiceAccount name** (`camel-k-builder`) is hardcoded in Go code at `pkg/platform/defaults.go`:

```go
BuilderServiceAccount = "camel-k-builder"
```

Builder pods always use this SA name regardless of the Helm release name. This means:

- Helm creates per-release builder SAs (e.g., `camel-k-shard-1-builder`) for RBAC consistency
- The operator Go code creates and uses `camel-k-builder` at runtime for actual builder pods

This is pre-existing behaviour, unchanged by this PR.

---