### PR TITLE
chore: camel monitor renaming

### DIFF
--- a/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
@@ -67,9 +67,9 @@ The following environment variables can be configured on the operator Deployment
 |`false`
 |When set to `true`, enables synthetic Integration support for managing external workloads.
 
-|`CAMEL_DASHBOARD_APP_LABEL`
-|`camel.apache.org/app`
-|If it exists, the operator add this label beside regular Camel K labels in order to let the Camel Dashboard discover and monitor the application.
+|`CAMEL_MONITOR_OPERATOR_LABEL`
+|`camel.apache.org/monitor`
+|If it exists, the operator add this label beside regular Camel K labels in order to let the Camel Monitor operator discover and monitor the application.
 
 |`LOG_LEVEL`
 |`info`

--- a/docs/modules/ROOT/pages/observability/dashboard.adoc
+++ b/docs/modules/ROOT/pages/observability/dashboard.adoc
@@ -1,14 +1,14 @@
-= Camel Dashboard
+= Camel Monitor Operator
 
-https://camel-tooling.github.io/camel-dashboard/[Camel Dashboard] is a Kubernetes operator that you can use to monitor your fleet of Camel applications deployed in the cloud. Whether you use Camel K to deploy or not, the Dashboard is a great tool that you can use to monitor your Camel fleet.
+https://camel-tooling.github.io/camel-dashboard/docs/installation-guide/advanced/operator/[Camel Monitor operator] is a Kubernetes operator that you can use to **monitor your fleet of Camel applications** deployed in the cloud. Whether you use Camel K to deploy or not, the Camel Monitor operator is a great tool that you can use to monitor your Camel fleet.
 
 NOTE: the project is in developer preview mode.
 
-The Camel Dashboard was originally born as a spin off from Camel K Synthetic Integrations features and matured into a brand new operator whose goal is to provide a meaningful set of information about typical KPIs of your fleet of Camel workloads running on the cloud.
+The Camel Monitor operator (and the GUI exposed via https://camel-tooling.github.io/camel-dashboard/[Camel Dashboard]) was originally born as a spin off from Camel K Synthetic Integrations feature and matured into a brand new operator whose goal is to provide a meaningful set of information about typical KPIs of your fleet of Camel workloads running on the cloud.
 
-From Camel K version 2.10.0 onward, the applications deployed by the operator will be automatically instructed with the labels required by the Dashboard to discover and monitor. This is controlled via a Kubernetes label injected to the Deployments (or CronJob or KnativeService) configured on the operator side with the environment variable `CAMEL_DASHBOARD_APP_LABEL` (set by default to `camel.apache.org/app`).
+From Camel K version 2.10.0 onward, the applications deployed by the operator will be automatically instructed with the labels required by the Camel Monitor operator to discover and monitor. This is controlled via a Kubernetes label injected to the Deployments (or CronJob or KnativeService) configured on the Camel K operator side with the environment variable `CAMEL_MONITOR_OPERATOR_LABEL` (set by default to `camel.apache.org/monitor`).
 
-On the Camel Dashboard side, any application containing the label will be watched and monitored providing a set of useful Camel metrics (for example, health, number of exchanges succeeded, failed, ...).
+On the Camel Monitor side, any application containing the label will be watched and monitored providing a set of useful Camel metrics (for example, health, number of exchanges succeeded, failed, ...).
 
 You will need to include the `camel-observability-services` component into your application in order to get the full power of this monitoring tool. As an example:
 
@@ -30,16 +30,16 @@ spec:
                 simple: "Hello!"
             - to: "log:myLogger"
   traits:
-    # We need a provide any version supporting camel-observability-services
+    # We need a provide any version supporting camel-observability-services (introduced in Camel 4.9.0)
     camel:
       runtimeProvider: plain-quarkus
       runtimeVersion: 3.30.8
 ```
 
-The information will be stored in a Custom Resource provided by the Camel Dashboard installation procedure: `CamelApp`. Here a basic example:
+The information will be stored in a Custom Resource provided by the Camel Monitor installation procedure: `CamelMonitor` (or abbreviated to `cmon`). Here a basic example:
 
 ```bash
-$ kubectl get camelapp -w
+$ kubectl get cmon -w
 
 NAME           IMAGE                                              PHASE     REPLICAS   HEALTHY   MONITORED   INFO                        EXCHANGE SLI   LAST EXCHANGE
 camel-sample   10.104.35.69/camel-k/camel-k-kit-d67egl6snmec...   Running   1          True      True        Quarkus - 3.30.8 (4.16.0)                  4m3s
@@ -48,11 +48,11 @@ camel-sample   10.104.35.69/camel-k/camel-k-kit-d67egl6snmec...   Running   1   
 More in detail, the specific info are stored in the custom resource status:
 
 ```bash
-$ kubectl get camelapp -o yaml
+$ kubectl get cmon -o yaml
 apiVersion: v1
 items:
 - apiVersion: camel.apache.org/v1alpha1
-  kind: CamelApp
+  kind: CamelMonitor
   metadata:
     annotations:
       camel.apache.org/imported-from-kind: Deployment
@@ -99,6 +99,6 @@ items:
       samplingInterval: 60000000000
 ```
 
-NOTE: Camel K won't require the availability of Camel Dashboard to work, neither Camel Dashboard would require Camel K, they are independent projects which can cooperate to provide a Build and Monitoring tool.
+NOTE: Camel K won't require the availability of Camel Monitor operator to work, neither Camel Monitor operator would require Camel K. They are independent projects which can cooperate to provide a Build and Monitoring tool respectively.
 
 Learn more by reading the official https://camel-tooling.github.io/camel-dashboard/[Camel Dashboard documentation].

--- a/pkg/resources/config/manager/operator-deployment.yaml
+++ b/pkg/resources/config/manager/operator-deployment.yaml
@@ -72,11 +72,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            # Used to automatically enable Camel Dashboard project monitoring
-            # Keep the default value or change it to the same label used by the dashboard
+            # Used to automatically enable Camel Monitor operator project monitoring
+            # Keep the default value or change it to the same label used by the project
             # Note: remove the variable to disable the feature.
-            - name: CAMEL_DASHBOARD_APP_LABEL
-              value: "camel.apache.org/app"
+            - name: CAMEL_MONITOR_OPERATOR_LABEL
+              value: "camel.apache.org/monitor"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/pkg/trait/deployment_test.go
+++ b/pkg/trait/deployment_test.go
@@ -325,7 +325,7 @@ func createNominalDeploymentTest() (*deploymentTrait, *Environment) {
 }
 
 func TestApplyDeploymentWithCamelDashboardLabel(t *testing.T) {
-	t.Setenv(kubernetes.CamelDashboardAppLabelEnvVar, "my-dashboard-label")
+	t.Setenv(kubernetes.CamelMonitorOperatorLabelEnvVar, "my-dashboard-label")
 
 	deploymentTrait, environment := createNominalDeploymentTest()
 	err := deploymentTrait.Apply(environment)

--- a/pkg/util/kubernetes/labels.go
+++ b/pkg/util/kubernetes/labels.go
@@ -23,7 +23,7 @@ import (
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 )
 
-const CamelDashboardAppLabelEnvVar = "CAMEL_DASHBOARD_APP_LABEL"
+const CamelMonitorOperatorLabelEnvVar = "CAMEL_MONITOR_OPERATOR_LABEL"
 
 // DeploymentLabels returns the fixed labels assigned to each Camel workload.
 func DeploymentLabels(integrationName string) map[string]string {
@@ -31,7 +31,7 @@ func DeploymentLabels(integrationName string) map[string]string {
 		// Required by Camel K
 		v1.IntegrationLabel: integrationName,
 	}
-	camelDashboardLabel, ok := os.LookupEnv(CamelDashboardAppLabelEnvVar)
+	camelDashboardLabel, ok := os.LookupEnv(CamelMonitorOperatorLabelEnvVar)
 	if ok && camelDashboardLabel != "" {
 		// Will automatically enable App discovery by Camel Dashboard
 		labels[camelDashboardLabel] = integrationName


### PR DESCRIPTION
<!-- Description -->

Camel Dashboard project renamed the monitoring operator.


<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

