### PR TITLE
fix(event): handle typed nil in NotifyError to prevent build controller panic

### DIFF
--- a/pkg/event/manager.go
+++ b/pkg/event/manager.go
@@ -20,6 +20,7 @@ package event
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -203,7 +204,7 @@ func NotifyError(recorder events.EventRecorder, old, newResource runtime.Object,
 	reason := kind + "Error"
 	action := kind + "Reconciliation"
 	res := old
-	if newResource != nil {
+	if newResource != nil && !reflect.ValueOf(newResource).IsNil() {
 		res = newResource
 	}
 	if res == nil {


### PR DESCRIPTION
Fixes #6587

## Problem

When an action's `Handle()` returns `(nil, err)`, `newTarget` is a typed nil `*v1.Build`. When passed as a `runtime.Object` interface parameter to `NotifyError`, the check `newResource != nil` evaluates to `true` because the interface has type information even though the underlying pointer is nil.

This causes `recorder.Eventf` → `reference.GetReference` → `obj.GetObjectKind()` to panic on the nil pointer, crashing the build controller on every reconcile. The build pod never spawns.

This was introduced in #6492 when migrating from `record.EventRecorder` to `events.EventRecorder` — the new recorder goes through `GetReference` whereas the old one did not.

## Fix

Use `reflect.ValueOf(newResource).IsNil()` to properly detect typed nils before using the value.

## Testing

Reproduced the panic consistently on 2.10.0 (Helm install, EKS). Built a custom operator image from this branch and deployed it to a live EKS cluster. Build controller completed a full build lifecycle without panicking — kit reached `Ready` state with a valid image reference.

Note: the e2e test suite won't cover this path as it only exercises the happy path where `Handle()` doesn't return `(nil, err)`.