### PR TITLE
feat(tests): add error log checking for operator pod in user tests

### DIFF
--- a/e2e/support/test_support.go
+++ b/e2e/support/test_support.go
@@ -2861,6 +2861,10 @@ func deleteTestNamespace(t *testing.T, ctx context.Context, ns ctrl.Object) {
 		return
 	}
 
+	// Check for error logs before deleting the test namespace
+	g := gomega.NewWithT(t)
+	g.Expect(OperatorLogs(t, ctx, ns.GetName())()).ShouldNot(gomega.ContainSubstring(`"level":"error"`))
+
 	var oc bool
 	var err error
 	if oc, err = openshift.IsOpenShift(TestClient(t)); err != nil {


### PR DESCRIPTION
Closes: #6517 

adds automatic error log checking  the operator pod before deleting namespace, this helps detect potencial issues that might not be caught  otherwise during  test executtion
