### PR TITLE
build: repopulate TypeMeta after client.Get to avoid event recorder nil deref

### DIFF
--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/log"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -137,6 +138,15 @@ func (r *reconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 		}
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
+	}
+
+	// controller-runtime strips TypeMeta from objects returned by client.Get
+	// (kubernetes-sigs/controller-runtime#1735). The new events.EventRecorder
+	// goes through reference.GetReference, which calls GetObjectKind() and
+	// nil-derefs without TypeMeta. Repopulate it so the event recorder works.
+	instance.TypeMeta = metav1.TypeMeta{
+		Kind:       v1.BuildKind,
+		APIVersion: v1.SchemeGroupVersion.String(),
 	}
 
 	// Only process resources assigned to the operator


### PR DESCRIPTION
Fixes #6587.

After PR #6492 migrated the build controller from `record.EventRecorder` to `events.EventRecorder`, every event publish went through `reference.GetReference(scheme, obj)` which calls `obj.GetObjectKind()`. controller-runtime strips `TypeMeta` from objects returned by `client.Get` (kubernetes-sigs/controller-runtime#1735), so `GetObjectKind()` nil-derefs and the build controller panics on every reconcile.

Repopulate `TypeMeta` immediately after `client.Get` returns. The same pattern likely affects the pipe, integration, integrationkit, integrationplatform, and catalog controllers (all migrated to `events.EventRecorder`); happy to send a sibling PR if you'd like the sweep, but filing Build alone first per the issue scope.