### PR TITLE
Fix Kafka setup by ensuring Strimzi CRDs are established before applying resources

### DIFF
--- a/e2e/kafka/setup/kafka-ephemeral.yaml
+++ b/e2e/kafka/setup/kafka-ephemeral.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ---------------------------------------------------------------------------
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: controller
@@ -32,8 +32,7 @@ spec:
         type: ephemeral
         kraftMetadata: shared
 ---
-
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker
@@ -51,8 +50,7 @@ spec:
         type: ephemeral
         kraftMetadata: shared
 ---
-
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/e2e/kafka/setup/kafka-topic.yaml
+++ b/e2e/kafka/setup/kafka-topic.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ---------------------------------------------------------------------------
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: my-topic

--- a/e2e/kafka/setup/setup.sh
+++ b/e2e/kafka/setup/setup.sh
@@ -23,13 +23,18 @@
 #
 ####
 
-kubectl create namespace kafka
-kubectl create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
+kubectl create namespace kafka --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply --server-side -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
 kubectl rollout status deployment strimzi-cluster-operator -n kafka --timeout=180s
+
+# Wait for CRDs to be established
+kubectl wait --for=condition=established crd/kafkas.kafka.strimzi.io --timeout=60s
+kubectl wait --for=condition=established crd/kafkanodepools.kafka.strimzi.io --timeout=60s
+kubectl wait --for=condition=established crd/kafkatopics.kafka.strimzi.io --timeout=60s
 
 #### Setup Keda operator
 # it creates by default a keda namespace
-kubectl apply -f https://github.com/kedacore/keda/releases/download/v2.17.2/keda-2.17.2.yaml
+kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/v2.17.2/keda-2.17.2.yaml
 kubectl rollout status deployment keda-operator -n keda --timeout=180s
 
 #### Setup a Kafka cluster which we'll use for testing


### PR DESCRIPTION
fixes: #6596

The Kafka setup fails with errors like:

"no matches for kind KafkaNodePool in version kafka.strimzi.io/v1beta2"

Although Strimzi CRDs are installed, they are not fully established when Kafka resources are applied. This creates a race condition where Kubernetes does not yet recognize the resource types.

This PR adds explicit waits to ensure CRDs are established before applying Kafka resources.

Additionally, KEDA installation is updated to use server-side apply to avoid annotation size issues.