### PR TITLE
[release-2.10.x] feat(api): deprecate builder pod namespace

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -602,6 +602,8 @@ string
 
 The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
 
+Deprecated: no longer in use.
+
 |`strategy` +
 *xref:#_camel_apache_org_v1_BuildStrategy[BuildStrategy]*
 |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/camel-k/v2
 
-go 1.25.9
+go 1.25.10
 
 require (
 	dario.cat/mergo v1.0.2

--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -111,8 +111,10 @@ spec:
                       for `pod` strategy
                     type: object
                   operatorNamespace:
-                    description: The namespace where to run the builder Pod (must
-                      be the same of the operator in charge of this Build reconciliation).
+                    description: |-
+                      The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                      Deprecated: no longer in use.
                     type: string
                   orderStrategy:
                     description: the build order strategy to adopt
@@ -198,9 +200,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -308,9 +311,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -937,9 +941,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1018,9 +1023,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1129,9 +1135,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1238,9 +1245,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1861,9 +1869,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1965,9 +1974,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -3418,8 +3428,10 @@ spec:
                           for `pod` strategy
                         type: object
                       operatorNamespace:
-                        description: The namespace where to run the builder Pod (must
-                          be the same of the operator in charge of this Build reconciliation).
+                        description: |-
+                          The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                          Deprecated: no longer in use.
                         type: string
                       orderStrategy:
                         description: the build order strategy to adopt
@@ -5895,8 +5907,10 @@ spec:
                           for `pod` strategy
                         type: object
                       operatorNamespace:
-                        description: The namespace where to run the builder Pod (must
-                          be the same of the operator in charge of this Build reconciliation).
+                        description: |-
+                          The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                          Deprecated: no longer in use.
                         type: string
                       orderStrategy:
                         description: the build order strategy to adopt

--- a/pkg/apis/camel/v1/build_types_support.go
+++ b/pkg/apis/camel/v1/build_types_support.go
@@ -38,17 +38,6 @@ func NewBuild(namespace string, name string) *Build {
 	}
 }
 
-// BuilderPodNamespace returns the namespace of the operator in charge to reconcile this Build.
-func (build *Build) BuilderPodNamespace() string {
-	for _, t := range build.Spec.Tasks {
-		if t.Builder != nil {
-			return t.Builder.Configuration.BuilderPodNamespace
-		}
-	}
-
-	return ""
-}
-
 // BuilderConfiguration returns the builder configuration for this Build.
 func (build *Build) BuilderConfiguration() *BuildConfiguration {
 	return build.TaskConfiguration("builder")

--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -49,7 +49,9 @@ type BuildConfiguration struct {
 	// The container image to be used to run the build.
 	ToolImage string `json:"toolImage,omitempty"`
 	// The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
-	BuilderPodNamespace string `json:"operatorNamespace,omitempty"`
+	//
+	// Deprecated: no longer in use.
+	DeprecatedBuilderPodNamespace string `json:"operatorNamespace,omitempty"`
 	// the strategy to adopt
 	Strategy BuildStrategy `json:"strategy,omitempty" property:"strategy"`
 	// the build order strategy to adopt

--- a/pkg/client/camel/applyconfiguration/camel/v1/buildconfiguration.go
+++ b/pkg/client/camel/applyconfiguration/camel/v1/buildconfiguration.go
@@ -31,7 +31,9 @@ type BuildConfigurationApplyConfiguration struct {
 	// The container image to be used to run the build.
 	ToolImage *string `json:"toolImage,omitempty"`
 	// The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
-	BuilderPodNamespace *string `json:"operatorNamespace,omitempty"`
+	//
+	// Deprecated: no longer in use.
+	DeprecatedBuilderPodNamespace *string `json:"operatorNamespace,omitempty"`
 	// the strategy to adopt
 	Strategy *camelv1.BuildStrategy `json:"strategy,omitempty"`
 	// the build order strategy to adopt
@@ -66,11 +68,11 @@ func (b *BuildConfigurationApplyConfiguration) WithToolImage(value string) *Buil
 	return b
 }
 
-// WithBuilderPodNamespace sets the BuilderPodNamespace field in the declarative configuration to the given value
+// WithDeprecatedBuilderPodNamespace sets the DeprecatedBuilderPodNamespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the BuilderPodNamespace field is set to the value of the last call.
-func (b *BuildConfigurationApplyConfiguration) WithBuilderPodNamespace(value string) *BuildConfigurationApplyConfiguration {
-	b.BuilderPodNamespace = &value
+// If called multiple times, the DeprecatedBuilderPodNamespace field is set to the value of the last call.
+func (b *BuildConfigurationApplyConfiguration) WithDeprecatedBuilderPodNamespace(value string) *BuildConfigurationApplyConfiguration {
+	b.DeprecatedBuilderPodNamespace = &value
 	return b
 }
 

--- a/pkg/controller/build/build_monitor_test.go
+++ b/pkg/controller/build/build_monitor_test.go
@@ -685,10 +685,9 @@ func newBuildWithLayoutInPhase(namespace string, name string, layout string, pha
 					Builder: &v1.BuilderTask{
 						BaseTask: v1.BaseTask{
 							Configuration: v1.BuildConfiguration{
-								Strategy:            v1.BuildStrategyRoutine,
-								OrderStrategy:       v1.BuildOrderStrategySequential,
-								ToolImage:           "camel:latest",
-								BuilderPodNamespace: "ns",
+								Strategy:      v1.BuildStrategyRoutine,
+								OrderStrategy: v1.BuildOrderStrategySequential,
+								ToolImage:     "camel:latest",
 							},
 						},
 						Dependencies: dependencies,

--- a/pkg/controller/build/build_pod.go
+++ b/pkg/controller/build/build_pod.go
@@ -50,7 +50,7 @@ func newBuildPod(ctx context.Context, client client.Client, build *v1.Build) *co
 		// get pod security context from security context constraint configuration in namespace
 		//nolint:staticcheck
 		if task.S2i != nil {
-			podSecurityContextConstrained, _ := openshift.GetOpenshiftPodSecurityContextRestricted(ctx, client, build.BuilderPodNamespace())
+			podSecurityContextConstrained, _ := openshift.GetOpenshiftPodSecurityContextRestricted(ctx, client, build.Namespace)
 			if podSecurityContextConstrained != nil {
 				podSecurityContext = podSecurityContextConstrained
 			}
@@ -62,7 +62,7 @@ func newBuildPod(ctx context.Context, client client.Client, build *v1.Build) *co
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: build.BuilderPodNamespace(),
+			Namespace: build.Namespace,
 			Name:      buildPodName(build),
 			Labels: map[string]string{
 				"camel.apache.org/build":     build.Name,
@@ -151,7 +151,7 @@ func deleteBuilderPod(ctx context.Context, c ctrl.Writer, build *v1.Build) error
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: build.BuilderPodNamespace(),
+			Namespace: build.Namespace,
 			Name:      buildPodName(build),
 		},
 	}
@@ -166,7 +166,7 @@ func deleteBuilderPod(ctx context.Context, c ctrl.Writer, build *v1.Build) error
 
 func getBuilderPod(ctx context.Context, c ctrl.Reader, build *v1.Build) (*corev1.Pod, error) {
 	pod := corev1.Pod{}
-	err := c.Get(ctx, ctrl.ObjectKey{Namespace: build.BuilderPodNamespace(), Name: buildPodName(build)}, &pod)
+	err := c.Get(ctx, ctrl.ObjectKey{Namespace: build.Namespace, Name: buildPodName(build)}, &pod)
 	if err != nil && k8serrors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -222,7 +222,7 @@ func addBuildTaskToPod(ctx context.Context, client client.Client, build *v1.Buil
 
 	// get security context from security context constraint configuration in namespace
 	if taskName == "s2i" {
-		securityContextConstrained, _ := openshift.GetOpenshiftSecurityContextRestricted(ctx, client, build.BuilderPodNamespace())
+		securityContextConstrained, _ := openshift.GetOpenshiftSecurityContextRestricted(ctx, client, build.Namespace)
 		if securityContextConstrained != nil {
 			container.SecurityContext = securityContextConstrained
 		}

--- a/pkg/controller/build/build_pod_test.go
+++ b/pkg/controller/build/build_pod_test.go
@@ -35,7 +35,8 @@ func TestNewBuildPodConfiguration(t *testing.T) {
 
 	build := v1.Build{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "theBuildName",
+			Name:      "theBuildName",
+			Namespace: "theNamespace",
 		},
 		Spec: v1.BuildSpec{
 			Tasks: []v1.Task{
@@ -44,9 +45,8 @@ func TestNewBuildPodConfiguration(t *testing.T) {
 						BaseTask: v1.BaseTask{
 							Name: "builder",
 							Configuration: v1.BuildConfiguration{
-								BuilderPodNamespace: "theNamespace",
-								NodeSelector:        map[string]string{"node": "selector"},
-								Annotations:         map[string]string{"annotation": "value"},
+								NodeSelector: map[string]string{"node": "selector"},
+								Annotations:  map[string]string{"annotation": "value"},
 							},
 						},
 					},

--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/v2/pkg/platform"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes/log"
 )
@@ -69,25 +68,13 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 		return nil, err
 	}
 
-	//nolint:nestif
 	if pod == nil {
 		switch build.Status.Phase {
 		case v1.BuildPhasePending:
 			pod = newBuildPod(ctx, action.client, build)
-			// If the Builder Pod is in the Build namespace, we can set the ownership to it. If not (global operator mode)
-			// we set the ownership to the Operator Pod instead
-			var owner metav1.Object
-			owner = build
-			if build.Namespace != pod.Namespace {
-				operatorPod := platform.GetOperatorPod(ctx, action.client, pod.Namespace)
-				if operatorPod != nil {
-					owner = operatorPod
-				}
-			}
-			if err = controllerutil.SetControllerReference(owner, pod, action.client.GetScheme()); err != nil {
+			if err = controllerutil.SetControllerReference(build, pod, action.client.GetScheme()); err != nil {
 				return nil, err
 			}
-
 			if err = action.client.Create(ctx, pod); err != nil {
 				return nil, fmt.Errorf("cannot create build pod: %w", err)
 			}

--- a/pkg/controller/build/monitor_pod_test.go
+++ b/pkg/controller/build/monitor_pod_test.go
@@ -47,11 +47,6 @@ func TestHandle_PodSucceeded(t *testing.T) {
 			Tasks: []v1.Task{
 				{
 					Custom: &v1.UserTask{
-						BaseTask: v1.BaseTask{
-							Configuration: v1.BuildConfiguration{
-								BuilderPodNamespace: "default",
-							},
-						},
 						PublishingImage: "my-camel-k-container-image",
 					},
 				},
@@ -66,7 +61,7 @@ func TestHandle_PodSucceeded(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        buildPodName(build),
-			Namespace:   build.BuilderPodNamespace(),
+			Namespace:   build.Namespace,
 			Annotations: map[string]string{},
 		},
 		Status: corev1.PodStatus{
@@ -118,11 +113,6 @@ func TestHandle_PodFailed(t *testing.T) {
 			Tasks: []v1.Task{
 				{
 					Custom: &v1.UserTask{
-						BaseTask: v1.BaseTask{
-							Configuration: v1.BuildConfiguration{
-								BuilderPodNamespace: "default",
-							},
-						},
 						PublishingImage: "my-camel-k-container-image",
 					},
 				},
@@ -137,7 +127,7 @@ func TestHandle_PodFailed(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        buildPodName(build),
-			Namespace:   build.BuilderPodNamespace(),
+			Namespace:   build.Namespace,
 			Annotations: map[string]string{},
 		},
 		Status: corev1.PodStatus{

--- a/pkg/controller/integration/build.go
+++ b/pkg/controller/integration/build.go
@@ -125,7 +125,6 @@ func (action *buildAction) createBuild(ctx context.Context, it *v1.Integration) 
 	// The build operation, when executed as a Pod, should be executed by a container image containing the
 	// `kamel builder` command. Likely the same image running the operator should be fine.
 	buildConfig.ToolImage = platform.OperatorImage
-	buildConfig.BuilderPodNamespace = it.Namespace
 	v1.SetBuilderConfigurationTasks(env.Pipeline, buildConfig)
 
 	// We need to ensure the presence of the camel-k-builder service account

--- a/pkg/controller/integrationkit/build.go
+++ b/pkg/controller/integrationkit/build.go
@@ -131,8 +131,6 @@ func (action *buildAction) createBuild(ctx context.Context, kit *v1.IntegrationK
 		annotations[v1.OperatorIDAnnotation] = operatorID
 	}
 
-	// We may need to change certain builder configuration values
-	operatorNamespace := platform.GetOperatorNamespace()
 	buildConfig := v1.ConfigurationTasksByName(env.Pipeline, "builder")
 	if buildConfig.IsEmpty() {
 		// default to IntegrationPlatform configuration
@@ -152,7 +150,6 @@ func (action *buildAction) createBuild(ctx context.Context, kit *v1.IntegrationK
 	// The build operation, when executed as a Pod, should be executed by a container image containing the
 	// `kamel builder` command. Likely the same image running the operator should be fine.
 	buildConfig.ToolImage = platform.OperatorImage
-	buildConfig.BuilderPodNamespace = operatorNamespace
 	v1.SetBuilderConfigurationTasks(env.Pipeline, buildConfig)
 
 	build := &v1.Build{

--- a/pkg/platform/operator.go
+++ b/pkg/platform/operator.go
@@ -25,9 +25,7 @@ import (
 	camelv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	coordination "k8s.io/api/coordination/v1"
-	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -56,28 +54,6 @@ func IsCurrentOperatorGlobal() bool {
 	log.Debug("Operator is local to namespace")
 
 	return false
-}
-
-// GetOperatorPod returns the Pod which is running the operator in a given namespace.
-func GetOperatorPod(ctx context.Context, c ctrl.Reader, ns string) *corev1.Pod {
-	lst := corev1.PodList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-	}
-	if err := c.List(ctx, &lst,
-		ctrl.InNamespace(ns),
-		ctrl.MatchingLabels{
-			"camel.apache.org/component": "operator",
-		}); err != nil {
-		return nil
-	}
-	if len(lst.Items) == 0 {
-		return nil
-	}
-
-	return &lst.Items[0]
 }
 
 // GetOperatorWatchNamespace returns the namespace the operator watches.

--- a/pkg/resources/config/crd/bases/camel.apache.org_builds.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_builds.yaml
@@ -111,8 +111,10 @@ spec:
                       for `pod` strategy
                     type: object
                   operatorNamespace:
-                    description: The namespace where to run the builder Pod (must
-                      be the same of the operator in charge of this Build reconciliation).
+                    description: |-
+                      The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                      Deprecated: no longer in use.
                     type: string
                   orderStrategy:
                     description: the build order strategy to adopt
@@ -198,9 +200,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -308,9 +311,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -937,9 +941,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1018,9 +1023,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1129,9 +1135,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1238,9 +1245,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1861,9 +1869,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1965,9 +1974,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -134,8 +134,10 @@ spec:
                           for `pod` strategy
                         type: object
                       operatorNamespace:
-                        description: The namespace where to run the builder Pod (must
-                          be the same of the operator in charge of this Build reconciliation).
+                        description: |-
+                          The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                          Deprecated: no longer in use.
                         type: string
                       orderStrategy:
                         description: the build order strategy to adopt
@@ -2611,8 +2613,10 @@ spec:
                           for `pod` strategy
                         type: object
                       operatorNamespace:
-                        description: The namespace where to run the builder Pod (must
-                          be the same of the operator in charge of this Build reconciliation).
+                        description: |-
+                          The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                          Deprecated: no longer in use.
                         type: string
                       orderStrategy:
                         description: the build order strategy to adopt


### PR DESCRIPTION
It is no longer needed as we can infer it from the Build custom resource

<!-- Description -->




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

