### PR TITLE
[release-2.8.x] feat(api): deprecate builder pod namespace

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -602,6 +602,8 @@ string
 
 The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
 
+Deprecated: no longer in use.
+
 |`strategy` +
 *xref:#_camel_apache_org_v1_BuildStrategy[BuildStrategy]*
 |

--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -110,8 +110,10 @@ spec:
                       for `pod` strategy
                     type: object
                   operatorNamespace:
-                    description: The namespace where to run the builder Pod (must
-                      be the same of the operator in charge of this Build reconciliation).
+                    description: |-
+                      The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                      Deprecated: no longer in use.
                     type: string
                   orderStrategy:
                     description: the build order strategy to adopt
@@ -194,9 +196,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -304,9 +307,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -926,9 +930,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1007,9 +1012,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1117,9 +1123,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1226,9 +1233,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1842,9 +1850,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1945,9 +1954,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -3382,8 +3392,10 @@ spec:
                           for `pod` strategy
                         type: object
                       operatorNamespace:
-                        description: The namespace where to run the builder Pod (must
-                          be the same of the operator in charge of this Build reconciliation).
+                        description: |-
+                          The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                          Deprecated: no longer in use.
                         type: string
                       orderStrategy:
                         description: the build order strategy to adopt
@@ -5589,8 +5601,10 @@ spec:
                           for `pod` strategy
                         type: object
                       operatorNamespace:
-                        description: The namespace where to run the builder Pod (must
-                          be the same of the operator in charge of this Build reconciliation).
+                        description: |-
+                          The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                          Deprecated: no longer in use.
                         type: string
                       orderStrategy:
                         description: the build order strategy to adopt

--- a/pkg/apis/camel/v1/build_types_support.go
+++ b/pkg/apis/camel/v1/build_types_support.go
@@ -38,16 +38,6 @@ func NewBuild(namespace string, name string) *Build {
 	}
 }
 
-// BuilderPodNamespace returns the namespace of the operator in charge to reconcile this Build.
-func (build *Build) BuilderPodNamespace() string {
-	for _, t := range build.Spec.Tasks {
-		if t.Builder != nil {
-			return t.Builder.Configuration.BuilderPodNamespace
-		}
-	}
-	return ""
-}
-
 // BuilderConfiguration returns the builder configuration for this Build.
 func (build *Build) BuilderConfiguration() *BuildConfiguration {
 	return build.TaskConfiguration("builder")

--- a/pkg/apis/camel/v1/common_types.go
+++ b/pkg/apis/camel/v1/common_types.go
@@ -41,7 +41,9 @@ type BuildConfiguration struct {
 	// The container image to be used to run the build.
 	ToolImage string `json:"toolImage,omitempty"`
 	// The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
-	BuilderPodNamespace string `json:"operatorNamespace,omitempty"`
+	//
+	// Deprecated: no longer in use.
+	DeprecatedBuilderPodNamespace string `json:"operatorNamespace,omitempty"`
 	// the strategy to adopt
 	Strategy BuildStrategy `property:"strategy" json:"strategy,omitempty"`
 	// the build order strategy to adopt

--- a/pkg/client/camel/applyconfiguration/camel/v1/buildconfiguration.go
+++ b/pkg/client/camel/applyconfiguration/camel/v1/buildconfiguration.go
@@ -26,17 +26,17 @@ import (
 // BuildConfigurationApplyConfiguration represents a declarative configuration of the BuildConfiguration type for use
 // with apply.
 type BuildConfigurationApplyConfiguration struct {
-	ToolImage           *string                     `json:"toolImage,omitempty"`
-	BuilderPodNamespace *string                     `json:"operatorNamespace,omitempty"`
-	Strategy            *camelv1.BuildStrategy      `json:"strategy,omitempty"`
-	OrderStrategy       *camelv1.BuildOrderStrategy `json:"orderStrategy,omitempty"`
-	RequestCPU          *string                     `json:"requestCPU,omitempty"`
-	RequestMemory       *string                     `json:"requestMemory,omitempty"`
-	LimitCPU            *string                     `json:"limitCPU,omitempty"`
-	LimitMemory         *string                     `json:"limitMemory,omitempty"`
-	NodeSelector        map[string]string           `json:"nodeSelector,omitempty"`
-	Annotations         map[string]string           `json:"annotations,omitempty"`
-	ImagePlatforms      []string                    `json:"platforms,omitempty"`
+	ToolImage                     *string                     `json:"toolImage,omitempty"`
+	DeprecatedBuilderPodNamespace *string                     `json:"operatorNamespace,omitempty"`
+	Strategy                      *camelv1.BuildStrategy      `json:"strategy,omitempty"`
+	OrderStrategy                 *camelv1.BuildOrderStrategy `json:"orderStrategy,omitempty"`
+	RequestCPU                    *string                     `json:"requestCPU,omitempty"`
+	RequestMemory                 *string                     `json:"requestMemory,omitempty"`
+	LimitCPU                      *string                     `json:"limitCPU,omitempty"`
+	LimitMemory                   *string                     `json:"limitMemory,omitempty"`
+	NodeSelector                  map[string]string           `json:"nodeSelector,omitempty"`
+	Annotations                   map[string]string           `json:"annotations,omitempty"`
+	ImagePlatforms                []string                    `json:"platforms,omitempty"`
 }
 
 // BuildConfigurationApplyConfiguration constructs a declarative configuration of the BuildConfiguration type for use with
@@ -53,11 +53,11 @@ func (b *BuildConfigurationApplyConfiguration) WithToolImage(value string) *Buil
 	return b
 }
 
-// WithBuilderPodNamespace sets the BuilderPodNamespace field in the declarative configuration to the given value
+// WithDeprecatedBuilderPodNamespace sets the DeprecatedBuilderPodNamespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the BuilderPodNamespace field is set to the value of the last call.
-func (b *BuildConfigurationApplyConfiguration) WithBuilderPodNamespace(value string) *BuildConfigurationApplyConfiguration {
-	b.BuilderPodNamespace = &value
+// If called multiple times, the DeprecatedBuilderPodNamespace field is set to the value of the last call.
+func (b *BuildConfigurationApplyConfiguration) WithDeprecatedBuilderPodNamespace(value string) *BuildConfigurationApplyConfiguration {
+	b.DeprecatedBuilderPodNamespace = &value
 	return b
 }
 

--- a/pkg/controller/build/build_monitor_test.go
+++ b/pkg/controller/build/build_monitor_test.go
@@ -685,10 +685,9 @@ func newBuildWithLayoutInPhase(namespace string, name string, layout string, pha
 					Builder: &v1.BuilderTask{
 						BaseTask: v1.BaseTask{
 							Configuration: v1.BuildConfiguration{
-								Strategy:            v1.BuildStrategyRoutine,
-								OrderStrategy:       v1.BuildOrderStrategySequential,
-								ToolImage:           "camel:latest",
-								BuilderPodNamespace: "ns",
+								Strategy:      v1.BuildStrategyRoutine,
+								OrderStrategy: v1.BuildOrderStrategySequential,
+								ToolImage:     "camel:latest",
 							},
 						},
 						Dependencies: dependencies,

--- a/pkg/controller/build/build_pod.go
+++ b/pkg/controller/build/build_pod.go
@@ -49,7 +49,7 @@ func newBuildPod(ctx context.Context, client client.Client, build *v1.Build) *co
 	for _, task := range build.Spec.Tasks {
 		// get pod security context from security context constraint configuration in namespace
 		if task.S2i != nil {
-			podSecurityContextConstrained, _ := openshift.GetOpenshiftPodSecurityContextRestricted(ctx, client, build.BuilderPodNamespace())
+			podSecurityContextConstrained, _ := openshift.GetOpenshiftPodSecurityContextRestricted(ctx, client, build.Namespace)
 			if podSecurityContextConstrained != nil {
 				podSecurityContext = podSecurityContextConstrained
 			}
@@ -61,7 +61,7 @@ func newBuildPod(ctx context.Context, client client.Client, build *v1.Build) *co
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: build.BuilderPodNamespace(),
+			Namespace: build.Namespace,
 			Name:      buildPodName(build),
 			Labels: map[string]string{
 				"camel.apache.org/build":     build.Name,
@@ -149,7 +149,7 @@ func deleteBuilderPod(ctx context.Context, c ctrl.Writer, build *v1.Build) error
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: build.BuilderPodNamespace(),
+			Namespace: build.Namespace,
 			Name:      buildPodName(build),
 		},
 	}
@@ -164,7 +164,7 @@ func deleteBuilderPod(ctx context.Context, c ctrl.Writer, build *v1.Build) error
 
 func getBuilderPod(ctx context.Context, c ctrl.Reader, build *v1.Build) (*corev1.Pod, error) {
 	pod := corev1.Pod{}
-	err := c.Get(ctx, ctrl.ObjectKey{Namespace: build.BuilderPodNamespace(), Name: buildPodName(build)}, &pod)
+	err := c.Get(ctx, ctrl.ObjectKey{Namespace: build.Namespace, Name: buildPodName(build)}, &pod)
 	if err != nil && k8serrors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -220,7 +220,7 @@ func addBuildTaskToPod(ctx context.Context, client client.Client, build *v1.Buil
 
 	// get security context from security context constraint configuration in namespace
 	if taskName == "s2i" {
-		securityContextConstrained, _ := openshift.GetOpenshiftSecurityContextRestricted(ctx, client, build.BuilderPodNamespace())
+		securityContextConstrained, _ := openshift.GetOpenshiftSecurityContextRestricted(ctx, client, build.Namespace)
 		if securityContextConstrained != nil {
 			container.SecurityContext = securityContextConstrained
 		}

--- a/pkg/controller/build/build_pod_test.go
+++ b/pkg/controller/build/build_pod_test.go
@@ -36,7 +36,8 @@ func TestNewBuildPodConfiguration(t *testing.T) {
 
 	build := v1.Build{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "theBuildName",
+			Name:      "theBuildName",
+			Namespace: "theNamespace",
 		},
 		Spec: v1.BuildSpec{
 			Tasks: []v1.Task{
@@ -45,9 +46,8 @@ func TestNewBuildPodConfiguration(t *testing.T) {
 						BaseTask: v1.BaseTask{
 							Name: "builder",
 							Configuration: v1.BuildConfiguration{
-								BuilderPodNamespace: "theNamespace",
-								NodeSelector:        map[string]string{"node": "selector"},
-								Annotations:         map[string]string{"annotation": "value"},
+								NodeSelector: map[string]string{"node": "selector"},
+								Annotations:  map[string]string{"annotation": "value"},
 							},
 						},
 					},

--- a/pkg/controller/build/monitor_pod.go
+++ b/pkg/controller/build/monitor_pod.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/v2/pkg/platform"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes"
 	"github.com/apache/camel-k/v2/pkg/util/kubernetes/log"
 )
@@ -68,26 +67,14 @@ func (action *monitorPodAction) Handle(ctx context.Context, build *v1.Build) (*v
 		return nil, err
 	}
 
-	//nolint:nestif
 	if pod == nil {
 		switch build.Status.Phase {
 
 		case v1.BuildPhasePending:
 			pod = newBuildPod(ctx, action.client, build)
-			// If the Builder Pod is in the Build namespace, we can set the ownership to it. If not (global operator mode)
-			// we set the ownership to the Operator Pod instead
-			var owner metav1.Object
-			owner = build
-			if build.Namespace != pod.Namespace {
-				operatorPod := platform.GetOperatorPod(ctx, action.client, pod.Namespace)
-				if operatorPod != nil {
-					owner = operatorPod
-				}
-			}
-			if err = controllerutil.SetControllerReference(owner, pod, action.client.GetScheme()); err != nil {
+			if err = controllerutil.SetControllerReference(build, pod, action.client.GetScheme()); err != nil {
 				return nil, err
 			}
-
 			if err = action.client.Create(ctx, pod); err != nil {
 				return nil, fmt.Errorf("cannot create build pod: %w", err)
 			}

--- a/pkg/controller/integration/build.go
+++ b/pkg/controller/integration/build.go
@@ -122,7 +122,6 @@ func (action *buildAction) createBuild(ctx context.Context, it *v1.Integration) 
 	// The build operation, when executed as a Pod, should be executed by a container image containing the
 	// `kamel builder` command. Likely the same image running the operator should be fine.
 	buildConfig.ToolImage = platform.OperatorImage
-	buildConfig.BuilderPodNamespace = it.Namespace
 	v1.SetBuilderConfigurationTasks(env.Pipeline, buildConfig)
 
 	// We need to ensure the presence of the camel-k-builder service account

--- a/pkg/controller/integrationkit/build.go
+++ b/pkg/controller/integrationkit/build.go
@@ -130,8 +130,6 @@ func (action *buildAction) createBuild(ctx context.Context, kit *v1.IntegrationK
 		annotations[v1.OperatorIDAnnotation] = operatorID
 	}
 
-	// We may need to change certain builder configuration values
-	operatorNamespace := platform.GetOperatorNamespace()
 	buildConfig := v1.ConfigurationTasksByName(env.Pipeline, "builder")
 	if buildConfig.IsEmpty() {
 		// default to IntegrationPlatform configuration
@@ -151,7 +149,6 @@ func (action *buildAction) createBuild(ctx context.Context, kit *v1.IntegrationK
 	// The build operation, when executed as a Pod, should be executed by a container image containing the
 	// `kamel builder` command. Likely the same image running the operator should be fine.
 	buildConfig.ToolImage = platform.OperatorImage
-	buildConfig.BuilderPodNamespace = operatorNamespace
 	v1.SetBuilderConfigurationTasks(env.Pipeline, buildConfig)
 
 	build := &v1.Build{

--- a/pkg/platform/operator.go
+++ b/pkg/platform/operator.go
@@ -26,9 +26,7 @@ import (
 	camelv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
 	coordination "k8s.io/api/coordination/v1"
-	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -55,27 +53,6 @@ func IsCurrentOperatorGlobal() bool {
 
 	log.Debug("Operator is local to namespace")
 	return false
-}
-
-// GetOperatorPod returns the Pod which is running the operator in a given namespace.
-func GetOperatorPod(ctx context.Context, c ctrl.Reader, ns string) *corev1.Pod {
-	lst := corev1.PodList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-	}
-	if err := c.List(ctx, &lst,
-		ctrl.InNamespace(ns),
-		ctrl.MatchingLabels{
-			"camel.apache.org/component": "operator",
-		}); err != nil {
-		return nil
-	}
-	if len(lst.Items) == 0 {
-		return nil
-	}
-	return &lst.Items[0]
 }
 
 // GetOperatorWatchNamespace returns the namespace the operator watches.

--- a/pkg/resources/config/crd/bases/camel.apache.org_builds.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_builds.yaml
@@ -110,8 +110,10 @@ spec:
                       for `pod` strategy
                     type: object
                   operatorNamespace:
-                    description: The namespace where to run the builder Pod (must
-                      be the same of the operator in charge of this Build reconciliation).
+                    description: |-
+                      The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                      Deprecated: no longer in use.
                     type: string
                   orderStrategy:
                     description: the build order strategy to adopt
@@ -194,9 +196,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -304,9 +307,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -926,9 +930,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1007,9 +1012,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1117,9 +1123,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1226,9 +1233,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1842,9 +1850,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt
@@ -1945,9 +1954,10 @@ spec:
                                 Only used for `pod` strategy
                               type: object
                             operatorNamespace:
-                              description: The namespace where to run the builder
-                                Pod (must be the same of the operator in charge of
-                                this Build reconciliation).
+                              description: |-
+                                The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                                Deprecated: no longer in use.
                               type: string
                             orderStrategy:
                               description: the build order strategy to adopt

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -133,8 +133,10 @@ spec:
                           for `pod` strategy
                         type: object
                       operatorNamespace:
-                        description: The namespace where to run the builder Pod (must
-                          be the same of the operator in charge of this Build reconciliation).
+                        description: |-
+                          The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                          Deprecated: no longer in use.
                         type: string
                       orderStrategy:
                         description: the build order strategy to adopt
@@ -2340,8 +2342,10 @@ spec:
                           for `pod` strategy
                         type: object
                       operatorNamespace:
-                        description: The namespace where to run the builder Pod (must
-                          be the same of the operator in charge of this Build reconciliation).
+                        description: |-
+                          The namespace where to run the builder Pod (must be the same of the operator in charge of this Build reconciliation).
+
+                          Deprecated: no longer in use.
                         type: string
                       orderStrategy:
                         description: the build order strategy to adopt


### PR DESCRIPTION
It is no longer needed as we can infer it from the Build custom resource

<!-- Description -->




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

