### PR TITLE
fix(trait): report builder task strategy errors

### DIFF
--- a/pkg/controller/integration/build_kit_test.go
+++ b/pkg/controller/integration/build_kit_test.go
@@ -130,12 +130,19 @@ func TestCamelBuildKitKitSetOnIntegration(t *testing.T) {
 	// Move IntegrationKit phase to ready status
 	it.Status.Phase = v1.IntegrationPhaseBuildingKit
 	ik.Status.Phase = v1.IntegrationKitPhaseError
+	ik.Status.Failure = &v1.Failure{
+		Reason: "Pipeline tasks unavailable when using `routine` platform build strategy: use `pod` instead.",
+		Time:   metav1.Now(),
+	}
 	c, err = internal.NewFakeClient(it, ik)
 	require.NoError(t, err)
 	a.InjectClient(c)
 	handledIt, err = a.Handle(context.TODO(), it)
 	require.NoError(t, err)
 	assert.Equal(t, v1.IntegrationPhaseError, handledIt.Status.Phase)
+	kitAvailable := handledIt.Status.GetCondition(v1.IntegrationConditionKitAvailable)
+	require.NotNil(t, kitAvailable)
+	assert.Contains(t, kitAvailable.Message, "Pipeline tasks unavailable when using `routine` platform build strategy: use `pod` instead.")
 
 	// Remove IntegrationKit
 	it.Status.Phase = v1.IntegrationPhaseBuildingKit

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/camel-k/v2/pkg/util/boolean"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
@@ -336,6 +337,10 @@ func failIntegrationKit(e *Environment, conditionType v1.IntegrationKitCondition
 	if e.IntegrationKit != nil {
 		e.IntegrationKit.Status.Phase = v1.IntegrationKitPhaseError
 		e.IntegrationKit.Status.SetCondition(conditionType, status, reason, message)
+		e.IntegrationKit.Status.Failure = &v1.Failure{
+			Reason: message,
+			Time:   metav1.Now(),
+		}
 		if err := e.Client.Status().Update(e.Ctx, e.IntegrationKit); err != nil {
 			return err
 		}

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -198,6 +198,8 @@ func TestCustomTaskBuilderTraitInvalidStrategy(t *testing.T) {
 	assert.Equal(t, v1.IntegrationKitPhaseError, env.IntegrationKit.Status.Phase)
 	assert.Equal(t, corev1.ConditionFalse, env.IntegrationKit.Status.Conditions[0].Status)
 	assert.Equal(t, env.IntegrationKit.Status.Conditions[0].Type, v1.IntegrationKitConditionType("IntegrationKitTasksValid"))
+	require.NotNil(t, env.IntegrationKit.Status.Failure)
+	assert.Equal(t, "Pipeline tasks unavailable when using `routine` platform build strategy: use `pod` instead.", env.IntegrationKit.Status.Failure.Reason)
 }
 
 func TestCustomTaskBuilderTraitInvalidStrategyOverride(t *testing.T) {
@@ -213,6 +215,8 @@ func TestCustomTaskBuilderTraitInvalidStrategyOverride(t *testing.T) {
 	assert.Equal(t, v1.IntegrationKitPhaseError, env.IntegrationKit.Status.Phase)
 	assert.Equal(t, corev1.ConditionFalse, env.IntegrationKit.Status.Conditions[0].Status)
 	assert.Equal(t, env.IntegrationKit.Status.Conditions[0].Type, v1.IntegrationKitConditionType("IntegrationKitTasksValid"))
+	require.NotNil(t, env.IntegrationKit.Status.Failure)
+	assert.Equal(t, "Pipeline tasks unavailable when using `routine` platform build strategy: use `pod` instead.", env.IntegrationKit.Status.Failure.Reason)
 }
 
 func TestMavenProfilesBuilderTrait(t *testing.T) {


### PR DESCRIPTION
Fixes #6637

Running an Integration with `builder.tasks` and a non-`pod` build strategy moves the related IntegrationKit to `Error`, but the Integration only reports the generic kit error state.

The builder trait already sets a specific `IntegrationKitTasksValid` condition. However, the Integration status uses `IntegrationKit.Status.Failure` when appending the detailed failure reason, and this path was not populated for this builder trait failure.

## Description

* Set `IntegrationKit.Status.Failure` when the builder trait reports a fatal IntegrationKit configuration error.
* Cover the `builder.tasks` plus `routine` build strategy path with unit assertions.
* Verify the Integration build-kit action includes the propagated failure reason in the Integration condition.

**Release Note**
```release-note
fix(trait): Report builder task strategy errors on Integration status
```