### PR TITLE
chore(operator): add runtime provider to operator startup log

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -74,6 +74,7 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Camel K Operator Version: %v", defaults.Version))
 	log.Info(fmt.Sprintf("Camel K Default Runtime Version: %v", defaults.DefaultRuntimeVersion))
+	log.Info(fmt.Sprintf("Camel K Default Runtime Provider: %v", defaults.DefaultRuntimeProvider))
 	log.Info(fmt.Sprintf("Camel K Git Commit: %v", defaults.GitCommit))
 	log.Info(fmt.Sprintf("Camel K Operator ID: %v", defaults.OperatorID()))
 


### PR DESCRIPTION
<!-- Description -->
Fixes #6656

Logs the default runtime provider in the operator startup banner, alongside the existing default runtime version line.





<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

