### PR TITLE
Fix #6663: skip auto-inferred trait defaults in .status.traits

### DIFF
--- a/pkg/trait/container.go
+++ b/pkg/trait/container.go
@@ -66,6 +66,7 @@ type containerTrait struct {
 	traitv1.ContainerTrait `property:",squash"`
 
 	containerPorts []containerPort
+	expose         *bool
 }
 
 // containerPort is supporting port parsing.
@@ -93,7 +94,7 @@ func (t *containerTrait) Configure(e *Environment) (bool, *TraitCondition, error
 	if ptr.Deref(t.Auto, true) {
 		if t.Expose == nil {
 			if e.Resources.GetServiceForIntegration(e.Integration) != nil {
-				t.Expose = new(true)
+				t.expose = new(true)
 			}
 		}
 	}
@@ -214,7 +215,7 @@ func (t *containerTrait) configureContainer(e *Environment) error {
 		// Knative does not like anybody touching the container ports
 		t.configurePorts(&container)
 	}
-	if knative || ptr.Deref(t.Expose, false) {
+	if knative || t.isExpose() {
 		t.configureService(e, &container, knative)
 	}
 	t.configureCapabilities(e)
@@ -356,9 +357,7 @@ func (t *containerTrait) setSecurityContext(e *Environment, container *corev1.Co
 		return err
 	}
 
-	t.RunAsUser = runAsUser
-
-	sc.RunAsUser = t.RunAsUser
+	sc.RunAsUser = runAsUser
 	container.SecurityContext = &sc
 
 	return nil
@@ -384,6 +383,14 @@ func (t *containerTrait) getUser(e *Environment) (*int64, error) {
 	}
 
 	return runAsUser, nil
+}
+
+func (t *containerTrait) isExpose() bool {
+	if t.Expose != nil {
+		return *t.Expose
+	}
+
+	return ptr.Deref(t.expose, false)
 }
 
 func (t *containerTrait) getPort() int32 {

--- a/pkg/trait/container_test.go
+++ b/pkg/trait/container_test.go
@@ -144,7 +144,7 @@ func TestContainerWithOpenshift(t *testing.T) {
 	conditions, traits, err := traitCatalog.apply(&environment)
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, traits)
+	assert.Empty(t, traits)
 	assert.NotEmpty(t, conditions)
 	assert.NotEmpty(t, environment.ExecutedTraits)
 	assert.NotNil(t, environment.GetTrait("deployment"))

--- a/pkg/trait/mount_test.go
+++ b/pkg/trait/mount_test.go
@@ -47,7 +47,7 @@ func TestMountVolumesEmpty(t *testing.T) {
 	conditions, traits, err := traitCatalog.apply(environment)
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, traits)
+	assert.Empty(t, traits)
 	assert.NotEmpty(t, conditions)
 	assert.NotEmpty(t, environment.ExecutedTraits)
 	assert.NotNil(t, environment.GetTrait("mount"))

--- a/pkg/trait/route_test.go
+++ b/pkg/trait/route_test.go
@@ -198,7 +198,7 @@ func TestRoute_Default(t *testing.T) {
 
 	conditions, traits, err := traitsCatalog.apply(environment)
 	require.NoError(t, err)
-	assert.NotEmpty(t, traits)
+	assert.Empty(t, traits)
 	assert.NotEmpty(t, conditions)
 	assert.NotEmpty(t, environment.ExecutedTraits)
 	assert.NotNil(t, environment.GetTrait("container"))
@@ -235,7 +235,7 @@ func TestRoute_Disabled(t *testing.T) {
 	traitsCatalog := environment.Catalog
 	conditions, traits, err := traitsCatalog.apply(environment)
 	require.NoError(t, err)
-	assert.NotEmpty(t, traits)
+	assert.Empty(t, traits)
 	assert.Contains(t, conditions, expectedCondition)
 	assert.NotEmpty(t, environment.ExecutedTraits)
 	assert.Nil(t, environment.GetTrait("route"))

--- a/pkg/trait/security_context_test.go
+++ b/pkg/trait/security_context_test.go
@@ -78,7 +78,7 @@ func TestDefaultPodOpenshiftSecurityContext(t *testing.T) {
 	conditions, traits, err := traitCatalog.apply(environment)
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, traits)
+	assert.Empty(t, traits)
 	assert.NotEmpty(t, conditions)
 	assert.NotEmpty(t, environment.ExecutedTraits)
 	assert.NotNil(t, environment.GetTrait("deployment"))

--- a/pkg/trait/service.go
+++ b/pkg/trait/service.go
@@ -86,6 +86,7 @@ func (t *serviceTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 		return false, nil, nil
 	}
 
+	enabled := ptr.Deref(t.Enabled, false)
 	if ptr.Deref(t.Auto, true) {
 		exposeHTTPServices, err := e.ConsumeMeta(false, func(meta metadata.IntegrationMetadata) bool {
 			return meta.ExposesHTTPServices
@@ -103,7 +104,7 @@ func (t *serviceTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 			return false, condition, err
 		}
 
-		t.Enabled = new(exposeHTTPServices)
+		enabled = exposeHTTPServices
 	}
 
 	servicePorts, err := t.parseServicePorts()
@@ -112,7 +113,7 @@ func (t *serviceTrait) Configure(e *Environment) (bool, *TraitCondition, error) 
 	}
 	t.servicePorts = servicePorts
 
-	return ptr.Deref(t.Enabled, false) || len(t.servicePorts) > 0, nil, nil
+	return enabled || len(t.servicePorts) > 0, nil, nil
 }
 
 func (t *serviceTrait) Apply(e *Environment) error {

--- a/pkg/trait/service_test.go
+++ b/pkg/trait/service_test.go
@@ -575,10 +575,9 @@ func TestServiceWithKnativeServiceDisabledInIntegrationPlatform(t *testing.T) {
 		"KnativeServiceNotAvailable",
 		"explicitly disabled",
 	)
-	conditions, traits, err := traitCatalog.apply(&environment)
+	conditions, _, err := traitCatalog.apply(&environment)
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, traits)
 	assert.Contains(t, conditions, expectedCondition)
 	assert.NotEmpty(t, environment.ExecutedTraits)
 	assert.NotNil(t, environment.GetTrait(serviceTraitID))
@@ -633,7 +632,10 @@ func TestServiceAutoConfiguration(t *testing.T) {
 	}
 	_, traits, err := traitCatalog.apply(&environment)
 	require.NoError(t, err)
-	assert.Equal(t, ptr.To(true), traits.Service.Enabled)
+	assert.NotNil(t, environment.GetTrait(serviceTraitID))
+	if traits.Service != nil {
+		assert.Nil(t, traits.Service.Enabled)
+	}
 }
 
 func TestServiceAnnotationsAndLables(t *testing.T) {

--- a/pkg/trait/service_test.go
+++ b/pkg/trait/service_test.go
@@ -575,13 +575,14 @@ func TestServiceWithKnativeServiceDisabledInIntegrationPlatform(t *testing.T) {
 		"KnativeServiceNotAvailable",
 		"explicitly disabled",
 	)
-	conditions, _, err := traitCatalog.apply(&environment)
+	conditions, traits, err := traitCatalog.apply(&environment)
 
 	require.NoError(t, err)
 	assert.Contains(t, conditions, expectedCondition)
 	assert.NotEmpty(t, environment.ExecutedTraits)
 	assert.NotNil(t, environment.GetTrait(serviceTraitID))
 	assert.Nil(t, environment.GetTrait(knativeServiceTraitID))
+	assert.Nil(t, traits.Service)
 }
 
 func TestServiceAutoConfiguration(t *testing.T) {
@@ -633,9 +634,7 @@ func TestServiceAutoConfiguration(t *testing.T) {
 	_, traits, err := traitCatalog.apply(&environment)
 	require.NoError(t, err)
 	assert.NotNil(t, environment.GetTrait(serviceTraitID))
-	if traits.Service != nil {
-		assert.Nil(t, traits.Service.Enabled)
-	}
+	assert.Nil(t, traits.Service)
 }
 
 func TestServiceAnnotationsAndLables(t *testing.T) {

--- a/pkg/trait/trait.go
+++ b/pkg/trait/trait.go
@@ -60,7 +60,7 @@ func Apply(ctx context.Context, c client.Client, integration *v1.Integration, ki
 	environment.Catalog = catalog
 
 	// invoke the trait framework to determine the needed resources
-	conditions, _, err := catalog.apply(environment)
+	conditions, traits, err := catalog.apply(environment)
 	// WARNING: Conditions contains informative message coming from the trait execution and useful to be reported into it or ik CR
 	// they must be applied before returning after an error
 	for _, tc := range conditions {
@@ -74,12 +74,13 @@ func Apply(ctx context.Context, c client.Client, integration *v1.Integration, ki
 	if err != nil {
 		return nil, fmt.Errorf("error during trait customization: %w", err)
 	}
-	// Only reflect user-specified trait values in the status.
-	// Auto-inferred defaults (e.g. container.expose, service.enabled) must not
-	// leak into .status.traits because they cause unnecessary pod restarts and
-	// clutter the status with values the user never configured.
+	// Set the executed traits taking care to merge in order to avoid the distinct execution
+	// phase to clean up any previous executed trait
 	if integration != nil {
 		integration.Status.Traits = integration.Spec.Traits.DeepCopy()
+		if err := integration.Status.Traits.Merge(*traits); err != nil {
+			return nil, fmt.Errorf("error setting status traits: %w", err)
+		}
 	}
 
 	postActionErrors := make([]error, 0)

--- a/pkg/trait/trait.go
+++ b/pkg/trait/trait.go
@@ -60,7 +60,7 @@ func Apply(ctx context.Context, c client.Client, integration *v1.Integration, ki
 	environment.Catalog = catalog
 
 	// invoke the trait framework to determine the needed resources
-	conditions, traits, err := catalog.apply(environment)
+	conditions, _, err := catalog.apply(environment)
 	// WARNING: Conditions contains informative message coming from the trait execution and useful to be reported into it or ik CR
 	// they must be applied before returning after an error
 	for _, tc := range conditions {
@@ -74,13 +74,12 @@ func Apply(ctx context.Context, c client.Client, integration *v1.Integration, ki
 	if err != nil {
 		return nil, fmt.Errorf("error during trait customization: %w", err)
 	}
-	// Set the executed traits taking care to merge in order to avoid the distinct execution
-	// phase to clean up any previous executed trait
+	// Only reflect user-specified trait values in the status.
+	// Auto-inferred defaults (e.g. container.expose, service.enabled) must not
+	// leak into .status.traits because they cause unnecessary pod restarts and
+	// clutter the status with values the user never configured.
 	if integration != nil {
 		integration.Status.Traits = integration.Spec.Traits.DeepCopy()
-		if err := integration.Status.Traits.Merge(*traits); err != nil {
-			return nil, fmt.Errorf("error setting status traits: %w", err)
-		}
 	}
 
 	postActionErrors := make([]error, 0)

--- a/pkg/trait/trait_test.go
+++ b/pkg/trait/trait_test.go
@@ -345,6 +345,50 @@ func TestDefaultIntegrationErrorTraitsSetting(t *testing.T) {
 	testDefaultIntegrationPhaseTraitsSetting(t, v1.IntegrationPhaseError)
 }
 
+func TestAutoInferredServiceTraitsDoNotLeakIntoStatus(t *testing.T) {
+	it := &v1.Integration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-it",
+			Namespace: "ns",
+		},
+		Spec: v1.IntegrationSpec{
+			Sources: []v1.SourceSpec{
+				{
+					DataSpec: v1.DataSpec{
+						Name:    "file.java",
+						Content: `from("servlet:http").to("log:info")`,
+					},
+					Language: v1.LanguageJavaSource,
+				},
+			},
+		},
+		Status: v1.IntegrationStatus{
+			Phase: v1.IntegrationPhaseRunning,
+			Conditions: []v1.IntegrationCondition{
+				{
+					Type:   v1.IntegrationConditionDeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	// Load the default catalog
+	camelCatalogData, err := resources.Resource(fmt.Sprintf("/resources/camel-catalog-%s.yaml", defaults.CamelKRuntimeCatalogVersion))
+	require.NoError(t, err)
+	var cat v1.CamelCatalog
+	err = yaml.Unmarshal(camelCatalogData, &cat)
+	require.NoError(t, err)
+	cat.Namespace = "default"
+	platform.SingletonPlatform.CatalogNamespace = cat.Namespace
+
+	client, err := internal.NewFakeClient(&cat)
+	require.NoError(t, err)
+	env, err := Apply(context.Background(), client, it, nil)
+	require.NoError(t, err)
+	require.NotNil(t, env.Resources.GetServiceForIntegration(it))
+	assert.Equal(t, &v1.Traits{}, env.Integration.Status.Traits)
+}
+
 func TestIntegrationTraitsSetting(t *testing.T) {
 	it := &v1.Integration{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/trait/trait_test.go
+++ b/pkg/trait/trait_test.go
@@ -389,6 +389,58 @@ func TestAutoInferredServiceTraitsDoNotLeakIntoStatus(t *testing.T) {
 	assert.Equal(t, &v1.Traits{}, env.Integration.Status.Traits)
 }
 
+func TestUserSpecifiedTraitValuesStillAppearInStatus(t *testing.T) {
+	it := &v1.Integration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-it",
+			Namespace: "ns",
+		},
+		Spec: v1.IntegrationSpec{
+			Sources: []v1.SourceSpec{
+				{
+					DataSpec: v1.DataSpec{
+						Name:    "file.java",
+						Content: `from("servlet:http").to("log:info")`,
+					},
+					Language: v1.LanguageJavaSource,
+				},
+			},
+			Traits: v1.Traits{
+				Container: &traitv1.ContainerTrait{
+					Port: 9090,
+				},
+			},
+		},
+		Status: v1.IntegrationStatus{
+			Phase: v1.IntegrationPhaseRunning,
+			Conditions: []v1.IntegrationCondition{
+				{
+					Type:   v1.IntegrationConditionDeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	camelCatalogData, err := resources.Resource(fmt.Sprintf("/resources/camel-catalog-%s.yaml", defaults.CamelKRuntimeCatalogVersion))
+	require.NoError(t, err)
+	var cat v1.CamelCatalog
+	err = yaml.Unmarshal(camelCatalogData, &cat)
+	require.NoError(t, err)
+	cat.Namespace = "default"
+	platform.SingletonPlatform.CatalogNamespace = cat.Namespace
+
+	client, err := internal.NewFakeClient(&cat)
+	require.NoError(t, err)
+	env, err := Apply(context.Background(), client, it, nil)
+	require.NoError(t, err)
+	require.NotNil(t, env.Resources.GetServiceForIntegration(it))
+	assert.Equal(t, &v1.Traits{
+		Container: &traitv1.ContainerTrait{
+			Port: 9090,
+		},
+	}, env.Integration.Status.Traits)
+}
+
 func TestIntegrationTraitsSetting(t *testing.T) {
 	it := &v1.Integration{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #6663

## Summary

Previous approach (stopping executed traits from being written to `Status.Traits`) was incorrect — it broke the `feat(api): store executed traits in status` contract used by GitOps export and platform/profile propagation.

This revision keeps executed traits in status but stops auto-inferred defaults from leaking into serialized API trait fields (Option B):

- **service trait**: auto-detected `enabled` is carried in a local variable instead of mutating `t.Enabled`
- **container trait**: auto-detected `expose` is stored in an unexported field; inferred OpenShift `RunAsUser` is applied to the container security context without writing back to `t.RunAsUser`
- **trait.Apply**: restored merge of executed traits into `Status.Traits`

## Scope

This PR covers the traits called out in #6663 (`container`, `service`). Similar auto-writeback patterns exist in `knative-service`, `knative`, `cron`, and `master` traits and can be addressed in follow-up PRs.

## Testing

- `TestAutoInferredServiceTraitsDoNotLeakIntoStatus` — HTTP integration creates a Service but `Status.Traits` stays empty
- `TestUserSpecifiedTraitValuesStillAppearInStatus` — user-set `container.port` is still recorded in status
- Updated existing tests that previously expected auto-inferred `RunAsUser` / `service.enabled` in serialized traits
- `go test ./pkg/trait/...` and `make lint` pass