### PR TITLE
  Fix #6676: restrict builder.nodeSelector keys via operator allow list

### DIFF
--- a/docs/modules/ROOT/pages/installation/builds.adoc
+++ b/docs/modules/ROOT/pages/installation/builds.adoc
@@ -47,6 +47,10 @@ Here a quick resume of the parameters you can configure as environment variables
 | Maximum number of builds that can run concurrently.
 | `3` if build strategy is `routine`, `10` if `pod`
 
+| BUILDER_NODE_SELECTOR_ALLOWED_LABELS
+| Comma-separated list of node-selector label keys that CR authors are permitted to set via the `builder.nodeSelector` trait. When unset or empty all keys are accepted. Unlisted keys are dropped and an info message is logged. Example: `kubernetes.io/hostname,topology.kubernetes.io/zone`.
+|
+
 |===
 
 Certain configuration can be also specified via trait configuration on xref:traits:builder.adoc[`builder`] and xref:traits:builder.adoc[`camel`] trait. Those values have precedence over global configuration.

--- a/docs/modules/traits/pages/builder.adoc
+++ b/docs/modules/traits/pages/builder.adoc
@@ -157,3 +157,5 @@ Node selectors can be specified when running an integration with the CLI:
 ----
 $ kamel run --trait builder.node-selector.'size'=large integration.yaml
 ----
+
+NOTE: Operators can restrict which node-selector label keys CR authors are permitted to use by setting the `BUILDER_NODE_SELECTOR_ALLOWED_LABELS` environment variable on the operator deployment to a comma-separated list of allowed keys (e.g. `kubernetes.io/hostname,topology.kubernetes.io/zone`). Any key not in the list is dropped and an info message is logged. When the variable is unset or empty, all keys are accepted (default behavior). See xref:installation:builds.adoc#env-var-config[build environment variables] for details.

--- a/pkg/platform/env_platform.go
+++ b/pkg/platform/env_platform.go
@@ -173,6 +173,27 @@ func publishStrategy() v1.IntegrationPlatformBuildPublishStrategy {
 	return DefaultPublishStrategy
 }
 
+// BuilderNodeSelectorAllowList returns the list of node-selector keys that are allowed to be set
+// by the builder trait. When the list is empty (BUILDER_NODE_SELECTOR_ALLOWED_LABELS is unset or blank),
+// any key is permitted. When the list is non-empty only the listed keys are accepted; unlisted keys
+// are dropped; an info message is logged by the trait.
+func BuilderNodeSelectorAllowList() []string {
+	raw := GetEnvOrDefault("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "")
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+
+	return result
+}
+
 func imagePlatforms() []string {
 	buildImagePlatforms := GetEnvOrDefault("BUILD_IMAGE_PLATFORMS", "")
 	if buildImagePlatforms != "" {

--- a/pkg/platform/env_platform_test.go
+++ b/pkg/platform/env_platform_test.go
@@ -140,3 +140,31 @@ func TestImagePlatforms_OtherArch(t *testing.T) {
 	ips := imagePlatforms()
 	assert.Nil(t, ips)
 }
+
+func TestBuilderNodeSelectorAllowList_NotSet(t *testing.T) {
+	// env var not set – should return nil (allow everything)
+	allowList := BuilderNodeSelectorAllowList()
+	assert.Nil(t, allowList)
+}
+
+func TestBuilderNodeSelectorAllowList_Empty(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "")
+
+	allowList := BuilderNodeSelectorAllowList()
+	assert.Empty(t, allowList)
+}
+
+func TestBuilderNodeSelectorAllowList_SingleKey(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "kubernetes.io/hostname")
+
+	allowList := BuilderNodeSelectorAllowList()
+	assert.Equal(t, []string{"kubernetes.io/hostname"}, allowList)
+}
+
+func TestBuilderNodeSelectorAllowList_MultipleKeys(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "kubernetes.io/hostname,node-role.kubernetes.io/worker, topology.kubernetes.io/zone ")
+
+	allowList := BuilderNodeSelectorAllowList()
+	assert.Equal(t, []string{"kubernetes.io/hostname", "node-role.kubernetes.io/worker", "topology.kubernetes.io/zone"}, allowList)
+}
+

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -34,6 +34,7 @@ import (
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
 	"github.com/apache/camel-k/v2/pkg/builder"
+	"github.com/apache/camel-k/v2/pkg/platform"
 	mvn "github.com/apache/camel-k/v2/pkg/util/maven"
 	"github.com/apache/camel-k/v2/pkg/util/property"
 )
@@ -239,7 +240,7 @@ func (t *builderTrait) Apply(e *Environment) error {
 
 		return nil
 	}
-	builderTask.Configuration.NodeSelector = t.NodeSelector
+	builderTask.Configuration.NodeSelector = t.filterNodeSelector()
 	builderTask.Configuration.Annotations = t.Annotations
 	pipelineTasks = append(pipelineTasks, v1.Task{Builder: builderTask})
 
@@ -710,3 +711,31 @@ func (t *builderTrait) setPlatform(e *Environment) {
 		}
 	}
 }
+
+// filterNodeSelector returns the node selector map after applying the operator-level allow list.
+// If BUILDER_NODE_SELECTOR_ALLOWED_LABELS is empty/unset all keys are accepted (backward compatible).
+// Otherwise only keys present in the allow list are retained; every dropped key is logged at info level.
+func (t *builderTrait) filterNodeSelector() map[string]string {
+	if len(t.NodeSelector) == 0 {
+		return t.NodeSelector
+	}
+
+	allowList := platform.BuilderNodeSelectorAllowList()
+	if len(allowList) == 0 {
+		// no restriction configured – accept everything
+		return t.NodeSelector
+	}
+
+	filtered := make(map[string]string, len(t.NodeSelector))
+	for k, v := range t.NodeSelector {
+		if slices.Contains(allowList, k) {
+			filtered[k] = v
+		} else {
+			t.L.Info("builder.nodeSelector key is not in the allowed list and will be ignored",
+				"key", k, "allowedKeys", allowList)
+		}
+	}
+
+	return filtered
+}
+

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -738,4 +738,3 @@ func (t *builderTrait) filterNodeSelector() map[string]string {
 
 	return filtered
 }
-

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -646,3 +646,110 @@ func TestBuilderTraitOrderStrategy(t *testing.T) {
 
 	assert.Equal(t, v1.BuildOrderStrategyFIFO, env.Pipeline[0].Builder.Configuration.OrderStrategy)
 }
+
+// TestFilterNodeSelector_NoAllowList verifies that when BUILDER_NODE_SELECTOR_ALLOWED_LABELS is
+// not set, all node-selector keys pass through unchanged.
+func TestFilterNodeSelector_NoAllowList(t *testing.T) {
+	bt := createNominalBuilderTraitTest()
+	bt.NodeSelector = map[string]string{
+		"kubernetes.io/hostname":          "node-1",
+		"node-role.kubernetes.io/worker":  "true",
+	}
+
+	// env var not set – nil allow list means everything is allowed
+	result := bt.filterNodeSelector()
+	assert.Equal(t, bt.NodeSelector, result)
+}
+
+// TestFilterNodeSelector_AllowListFiltersKeys verifies that only keys present in the allow list
+// survive when BUILDER_NODE_SELECTOR_ALLOWED_LABELS is set.
+func TestFilterNodeSelector_AllowListFiltersKeys(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "kubernetes.io/hostname")
+
+	bt := createNominalBuilderTraitTest()
+	bt.NodeSelector = map[string]string{
+		"kubernetes.io/hostname":         "node-1",
+		"node-role.kubernetes.io/worker": "true", // not in allow list – must be dropped
+	}
+
+	result := bt.filterNodeSelector()
+	assert.Len(t, result, 1)
+	assert.Equal(t, "node-1", result["kubernetes.io/hostname"])
+	assert.NotContains(t, result, "node-role.kubernetes.io/worker")
+}
+
+// TestFilterNodeSelector_AllowListAllKeysAllowed verifies that when every key is in the allow list
+// the map is returned intact.
+func TestFilterNodeSelector_AllowListAllKeysAllowed(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "kubernetes.io/hostname,node-role.kubernetes.io/worker")
+
+	bt := createNominalBuilderTraitTest()
+	bt.NodeSelector = map[string]string{
+		"kubernetes.io/hostname":         "node-1",
+		"node-role.kubernetes.io/worker": "true",
+	}
+
+	result := bt.filterNodeSelector()
+	assert.Equal(t, bt.NodeSelector, result)
+}
+
+// TestFilterNodeSelector_NilNodeSelector verifies that a nil NodeSelector is returned as-is.
+func TestFilterNodeSelector_NilNodeSelector(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "kubernetes.io/hostname")
+
+	bt := createNominalBuilderTraitTest()
+	bt.NodeSelector = nil
+
+	result := bt.filterNodeSelector()
+	assert.Nil(t, result)
+}
+
+// TestFilterNodeSelector_EmptyNodeSelector verifies that an empty NodeSelector is returned as-is.
+func TestFilterNodeSelector_EmptyNodeSelector(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "kubernetes.io/hostname")
+
+	bt := createNominalBuilderTraitTest()
+	bt.NodeSelector = map[string]string{}
+
+	result := bt.filterNodeSelector()
+	assert.Empty(t, result)
+}
+
+// TestFilterNodeSelector_AllKeysDropped verifies that when no key matches the allow list the
+// result is an empty map (not nil).
+func TestFilterNodeSelector_AllKeysDropped(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "kubernetes.io/hostname")
+
+	bt := createNominalBuilderTraitTest()
+	bt.NodeSelector = map[string]string{
+		"node-role.kubernetes.io/worker": "true",
+		"topology.kubernetes.io/zone":    "us-east-1a",
+	}
+
+	result := bt.filterNodeSelector()
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+// TestBuilderTraitNodeSelectorAppliedWithAllowList is an end-to-end test that verifies the
+// pipeline builder task only contains allowed node-selector keys after Apply().
+func TestBuilderTraitNodeSelectorAppliedWithAllowList(t *testing.T) {
+	t.Setenv("BUILDER_NODE_SELECTOR_ALLOWED_LABELS", "kubernetes.io/hostname")
+
+	env := createBuilderTestEnv(platform.DefaultBuildStrategy)
+	bt := createNominalBuilderTraitTest()
+	bt.NodeSelector = map[string]string{
+		"kubernetes.io/hostname":         "node-42",
+		"node-role.kubernetes.io/worker": "true",
+	}
+
+	err := bt.Apply(env)
+	require.NoError(t, err)
+	require.NotNil(t, env.Pipeline[0].Builder)
+
+	ns := env.Pipeline[0].Builder.Configuration.NodeSelector
+	assert.Len(t, ns, 1)
+	assert.Equal(t, "node-42", ns["kubernetes.io/hostname"])
+	assert.NotContains(t, ns, "node-role.kubernetes.io/worker")
+}
+


### PR DESCRIPTION
  Fixes #6676

## Summary
  
  Adds an operator-level allow list to restrict which node-selector label keys CR authors can
  set via the `builder.nodeSelector` trait, preventing unauthorized node targeting in shared
  clusters.

  **How it works:**
  
  Set `BUILDER_NODE_SELECTOR_ALLOWED_LABELS` on the operator deployment to a comma-separated
  list of permitted label keys:

  BUILDER_NODE_SELECTOR_ALLOWED_LABELS=kubernetes.io/hostname,topology.kubernetes.io/zone

  - When unset or empty → all keys accepted (backward compatible, no behavior change)
  - When set → only listed keys pass through; unlisted keys are dropped and logged at info level

  ## Changes

  - `pkg/platform/env_platform.go` — new `BuilderNodeSelectorAllowList()` reads and parses the env var
  - `pkg/trait/builder.go` — `filterNodeSelector()` applies the allow list in `Apply()` instead of assigning `t.NodeSelector` directly
  - `pkg/platform/env_platform_test.go` / `pkg/trait/builder_test.go` — unit tests including nil, empty, partial, full-match, and all-keys-dropped cases
  - `docs/modules/ROOT/pages/installation/builds.adoc` — `BUILDER_NODE_SELECTOR_ALLOWED_LABELS` added to build env var table
  - `docs/modules/traits/pages/builder.adoc` — NOTE block added to Node Selectors section with xref to builds config docs