### PR TITLE
  Fix #6675: disable builder.tasks injection via operator env var

### DIFF
--- a/docs/modules/ROOT/pages/installation/builds.adoc
+++ b/docs/modules/ROOT/pages/installation/builds.adoc
@@ -47,6 +47,10 @@ Here a quick resume of the parameters you can configure as environment variables
 | Maximum number of builds that can run concurrently.
 | `3` if build strategy is `routine`, `10` if `pod`
 
+| BUILDER_TASKS_ENABLED
+| Controls whether CR authors are permitted to inject custom pipeline tasks via the `builder.tasks` trait. Set to `false` to disable custom task injection for all integrations managed by this operator. When unset or set to any value other than `false`, custom tasks are allowed (default behavior).
+| `true`
+
 | BUILDER_NODE_SELECTOR_ALLOWED_LABELS
 | Comma-separated list of node-selector label keys that CR authors are permitted to set via the `builder.nodeSelector` trait. When unset or empty all keys are accepted. Unlisted keys are dropped and an info message is logged. Example: `kubernetes.io/hostname,topology.kubernetes.io/zone`.
 |

--- a/docs/modules/traits/pages/builder.adoc
+++ b/docs/modules/traits/pages/builder.adoc
@@ -158,4 +158,10 @@ Node selectors can be specified when running an integration with the CLI:
 $ kamel run --trait builder.node-selector.'size'=large integration.yaml
 ----
 
-NOTE: Operators can restrict which node-selector label keys CR authors are permitted to use by setting the `BUILDER_NODE_SELECTOR_ALLOWED_LABELS` environment variable on the operator deployment to a comma-separated list of allowed keys (e.g. `kubernetes.io/hostname,topology.kubernetes.io/zone`). Any key not in the list is dropped and an info message is logged. When the variable is unset or empty, all keys are accepted (default behavior). See Camel K operator tuning documentation for details.
+NOTE: Operators can restrict which node-selector label keys CR authors are permitted to use by setting the `BUILDER_NODE_SELECTOR_ALLOWED_LABELS` environment variable on the operator deployment to a comma-separated list of allowed keys (e.g. `kubernetes.io/hostname,topology.kubernetes.io/zone`). Any key not in the list is dropped and an info message is logged. When the variable is unset or empty, all keys are accepted (default behavior). See xref:installation:builds.adoc#env-var-config[build environment variables] for details.
+
+== Custom Pipeline Tasks
+
+The `builder.tasks` trait option lets CR authors inject arbitrary containers into the build pipeline (only when using the `pod` build strategy). Each task entry has the format `<name>;<image>;<command>[;<userID>]`.
+
+NOTE: Operators can disable custom task injection entirely by setting `BUILDER_TASKS_ENABLED=false` on the operator deployment. When disabled, any `builder.tasks` values provided by CR authors are silently ignored and an info message is logged. The default is `true` (tasks are allowed). See xref:installation:builds.adoc#env-var-config[build environment variables] for details.

--- a/docs/modules/traits/pages/builder.adoc
+++ b/docs/modules/traits/pages/builder.adoc
@@ -158,7 +158,7 @@ Node selectors can be specified when running an integration with the CLI:
 $ kamel run --trait builder.node-selector.'size'=large integration.yaml
 ----
 
-NOTE: Operators can restrict which node-selector label keys CR authors are permitted to use by setting the `BUILDER_NODE_SELECTOR_ALLOWED_LABELS` environment variable on the operator deployment to a comma-separated list of allowed keys (e.g. `kubernetes.io/hostname,topology.kubernetes.io/zone`). Any key not in the list is dropped and an info message is logged. When the variable is unset or empty, all keys are accepted (default behavior). See xref:installation:builds.adoc#env-var-config[build environment variables] for details.
+NOTE: Operators can restrict which node-selector label keys CR authors are permitted to use by setting the `BUILDER_NODE_SELECTOR_ALLOWED_LABELS` environment variable on the operator deployment to a comma-separated list of allowed keys (e.g. `kubernetes.io/hostname,topology.kubernetes.io/zone`). Any key not in the list is dropped and an info message is logged. When the variable is unset or empty, all keys are accepted (default behavior). See Camel K operator tuning documentation for details.
 
 == Custom Pipeline Tasks
 

--- a/pkg/platform/env_platform.go
+++ b/pkg/platform/env_platform.go
@@ -173,6 +173,14 @@ func publishStrategy() v1.IntegrationPlatformBuildPublishStrategy {
 	return DefaultPublishStrategy
 }
 
+// BuilderTasksEnabled reports whether CR authors are permitted to inject custom pipeline tasks
+// via the builder.tasks trait. Controlled by the BUILDER_TASKS_ENABLED operator environment
+// variable (default true for backward compatibility). Set to "false" to prevent custom task
+// injection across all integrations managed by this operator.
+func BuilderTasksEnabled() bool {
+	return strings.ToLower(strings.TrimSpace(GetEnvOrDefault("BUILDER_TASKS_ENABLED", "true"))) != "false"
+}
+
 // BuilderNodeSelectorAllowList returns the list of node-selector keys that are allowed to be set
 // by the builder trait. When the list is empty (BUILDER_NODE_SELECTOR_ALLOWED_LABELS is unset or blank),
 // any key is permitted. When the list is non-empty only the listed keys are accepted; unlisted keys

--- a/pkg/platform/env_platform_test.go
+++ b/pkg/platform/env_platform_test.go
@@ -168,3 +168,28 @@ func TestBuilderNodeSelectorAllowList_MultipleKeys(t *testing.T) {
 	assert.Equal(t, []string{"kubernetes.io/hostname", "node-role.kubernetes.io/worker", "topology.kubernetes.io/zone"}, allowList)
 }
 
+func TestBuilderTasksEnabled_NotSet(t *testing.T) {
+	// env var not set – default is enabled
+	assert.True(t, BuilderTasksEnabled())
+}
+
+func TestBuilderTasksEnabled_True(t *testing.T) {
+	t.Setenv("BUILDER_TASKS_ENABLED", "true")
+	assert.True(t, BuilderTasksEnabled())
+}
+
+func TestBuilderTasksEnabled_False(t *testing.T) {
+	t.Setenv("BUILDER_TASKS_ENABLED", "false")
+	assert.False(t, BuilderTasksEnabled())
+}
+
+func TestBuilderTasksEnabled_FalseUpperCase(t *testing.T) {
+	t.Setenv("BUILDER_TASKS_ENABLED", "FALSE")
+	assert.False(t, BuilderTasksEnabled())
+}
+
+func TestBuilderTasksEnabled_Empty(t *testing.T) {
+	t.Setenv("BUILDER_TASKS_ENABLED", "")
+	// empty string is not "false" – treat as enabled
+	assert.True(t, BuilderTasksEnabled())
+}

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -245,19 +245,16 @@ func (t *builderTrait) Apply(e *Environment) error {
 	pipelineTasks = append(pipelineTasks, v1.Task{Builder: builderTask})
 
 	// Custom tasks
-	if t.Tasks != nil {
-		if !platform.BuilderTasksEnabled() {
-			t.L.Info("builder.tasks is disabled by operator configuration and will be ignored")
-		} else {
-			ct, err := t.determineCustomTasks(e, builderTask, tasksConf)
-			if err != nil {
-				return err
-			}
-			if ct == nil {
-				return nil
-			}
-			pipelineTasks = append(pipelineTasks, ct...)
+	t.applyTasksFilter()
+	if len(t.Tasks) > 0 {
+		ct, err := t.determineCustomTasks(e, builderTask, tasksConf)
+		if err != nil {
+			return err
 		}
+		if ct == nil {
+			return nil
+		}
+		pipelineTasks = append(pipelineTasks, ct...)
 	}
 
 	// Packaging task
@@ -718,6 +715,24 @@ func (t *builderTrait) setPlatform(e *Environment) {
 // filterNodeSelector returns the node selector map after applying the operator-level allow list.
 // If BUILDER_NODE_SELECTOR_ALLOWED_LABELS is empty/unset all keys are accepted (backward compatible).
 // Otherwise only keys present in the allow list are retained; every dropped key is logged at info level.
+// applyTasksFilter removes user-provided tasks when BUILDER_TASKS_ENABLED=false.
+// The quarkus-native task is operator-injected and is always retained.
+func (t *builderTrait) applyTasksFilter() {
+	if len(t.Tasks) == 0 || platform.BuilderTasksEnabled() {
+		return
+	}
+	kept := make([]string, 0, len(t.Tasks))
+	for _, task := range t.Tasks {
+		name, _, _ := strings.Cut(task, ";")
+		if name == "quarkus-native" {
+			kept = append(kept, task)
+		} else {
+			t.L.Info("builder.tasks is disabled by operator configuration and will be ignored", "task", name)
+		}
+	}
+	t.Tasks = kept
+}
+
 func (t *builderTrait) filterNodeSelector() map[string]string {
 	if len(t.NodeSelector) == 0 {
 		return t.NodeSelector

--- a/pkg/trait/builder.go
+++ b/pkg/trait/builder.go
@@ -246,15 +246,18 @@ func (t *builderTrait) Apply(e *Environment) error {
 
 	// Custom tasks
 	if t.Tasks != nil {
-		ct, err := t.determineCustomTasks(e, builderTask, tasksConf)
-		if err != nil {
-			return err
+		if !platform.BuilderTasksEnabled() {
+			t.L.Info("builder.tasks is disabled by operator configuration and will be ignored")
+		} else {
+			ct, err := t.determineCustomTasks(e, builderTask, tasksConf)
+			if err != nil {
+				return err
+			}
+			if ct == nil {
+				return nil
+			}
+			pipelineTasks = append(pipelineTasks, ct...)
 		}
-		if ct == nil {
-			return nil
-		}
-
-		pipelineTasks = append(pipelineTasks, ct...)
 	}
 
 	// Packaging task

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -771,6 +771,31 @@ func TestBuilderTraitTasksDisabledByOperator(t *testing.T) {
 	}
 }
 
+// TestBuilderTraitTasksDisabledKeepsQuarkusNative verifies that when BUILDER_TASKS_ENABLED=false
+// the operator-injected quarkus-native task is preserved while user tasks are dropped.
+func TestBuilderTraitTasksDisabledKeepsQuarkusNative(t *testing.T) {
+	t.Setenv("BUILDER_TASKS_ENABLED", "false")
+
+	env := createBuilderTestEnv(v1.BuildStrategyPod)
+	bt := createNominalBuilderTraitTest()
+	bt.Tasks = []string{
+		"quarkus-native;quarkus-image;/bin/bash -c \"build native\"",
+		"user-task;alpine;echo hello",
+	}
+
+	err := bt.Apply(env)
+	require.NoError(t, err)
+
+	var customNames []string
+	for _, task := range env.Pipeline {
+		if task.Custom != nil {
+			customNames = append(customNames, task.Custom.Name)
+		}
+	}
+	assert.Contains(t, customNames, "quarkus-native", "quarkus-native task must be preserved when builder.tasks is disabled")
+	assert.NotContains(t, customNames, "user-task", "user task must be dropped when builder.tasks is disabled")
+}
+
 // TestBuilderTraitTasksEnabledByDefault verifies that when BUILDER_TASKS_ENABLED is unset
 // custom tasks flow through normally.
 func TestBuilderTraitTasksEnabledByDefault(t *testing.T) {

--- a/pkg/trait/builder_test.go
+++ b/pkg/trait/builder_test.go
@@ -652,8 +652,8 @@ func TestBuilderTraitOrderStrategy(t *testing.T) {
 func TestFilterNodeSelector_NoAllowList(t *testing.T) {
 	bt := createNominalBuilderTraitTest()
 	bt.NodeSelector = map[string]string{
-		"kubernetes.io/hostname":          "node-1",
-		"node-role.kubernetes.io/worker":  "true",
+		"kubernetes.io/hostname":         "node-1",
+		"node-role.kubernetes.io/worker": "true",
 	}
 
 	// env var not set – nil allow list means everything is allowed
@@ -753,3 +753,40 @@ func TestBuilderTraitNodeSelectorAppliedWithAllowList(t *testing.T) {
 	assert.NotContains(t, ns, "node-role.kubernetes.io/worker")
 }
 
+// TestBuilderTraitTasksDisabledByOperator verifies that when BUILDER_TASKS_ENABLED=false the
+// custom tasks are not added to the pipeline even when the CR author sets builder.tasks.
+func TestBuilderTraitTasksDisabledByOperator(t *testing.T) {
+	t.Setenv("BUILDER_TASKS_ENABLED", "false")
+
+	env := createBuilderTestEnv(v1.BuildStrategyPod)
+	bt := createNominalBuilderTraitTest()
+	bt.Tasks = []string{"custom;alpine;echo hello"}
+
+	err := bt.Apply(env)
+	require.NoError(t, err)
+
+	// pipeline must contain only the builder task, no custom task appended
+	for _, task := range env.Pipeline {
+		assert.Nil(t, task.Custom, "custom task must not be present when builder.tasks is disabled")
+	}
+}
+
+// TestBuilderTraitTasksEnabledByDefault verifies that when BUILDER_TASKS_ENABLED is unset
+// custom tasks flow through normally.
+func TestBuilderTraitTasksEnabledByDefault(t *testing.T) {
+	env := createBuilderTestEnv(v1.BuildStrategyPod)
+	bt := createNominalBuilderTraitTest()
+	bt.Tasks = []string{"custom;alpine;echo hello"}
+
+	err := bt.Apply(env)
+	require.NoError(t, err)
+
+	found := false
+	for _, task := range env.Pipeline {
+		if task.Custom != nil && task.Custom.Name == "custom" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "custom task must be present when builder.tasks is enabled")
+}


### PR DESCRIPTION
## Summary
  
  Adds an operator-level toggle to enable or disable custom pipeline task injection via the
  `builder.tasks` trait, preventing CR authors from running arbitrary build containers in
  environments where that capability should be restricted.

  **How it works:**

  Set `BUILDER_TASKS_ENABLED=false` on the operator deployment to disable custom tasks:

  BUILDER_TASKS_ENABLED=false
  
  - When unset or any value other than `"false"` → custom tasks are allowed (backward compatible, no behavior change)
  - When set to `"false"` (case-insensitive) → `builder.tasks` values are ignored; an info message is logged

  When disabled the pod-strategy validation is also skipped, so CR authors do not receive a misleading "use pod strategy" error for tasks that will never run.

  ## Changes
  
  - `pkg/platform/env_platform.go` — new `BuilderTasksEnabled()` reads `BUILDER_TASKS_ENABLED`; returns `true` by default
  - `pkg/trait/builder.go` — gate in `Apply()` wraps `determineCustomTasks` call; logs at info level and skips when disabled
  - `pkg/platform/env_platform_test.go` — 5 tests covering not-set, `"true"`, `"false"`, `"FALSE"`, and empty-string cases
  - `pkg/trait/builder_test.go` — `TestBuilderTraitTasksDisabledByOperator` (pipeline has no custom tasks when disabled) and `TestBuilderTraitTasksEnabledByDefault` (tasks flow through when var is unset)
  - `docs/modules/ROOT/pages/installation/builds.adoc` — `BUILDER_TASKS_ENABLED` added to build env var table
  - `docs/modules/traits/pages/builder.adoc` — "Custom Pipeline Tasks" section added with NOTE about the operator gate

  ## Test plan
  
  - [x] `make test` passes locally
  - [x] `TestBuilderTasksEnabled_*` (platform) — env var parsing and boolean logic
  - [x] `TestBuilderTraitTasksDisabledByOperator` — verifies no custom tasks in pipeline when `BUILDER_TASKS_ENABLED=false`
  - [x] `TestBuilderTraitTasksEnabledByDefault` — verifies tasks work normally when var is unset
  - [x] Manual: deploy operator with `BUILDER_TASKS_ENABLED=false`; apply an Integration with `builder.tasks` set; confirm no custom container in builder pod and info log emitted

  Fixes #6675