### PR TITLE
Fix #6677: restrict affinity.nodeAffinityLabels keys via operator allow list

### DIFF
--- a/docs/modules/ROOT/pages/installation/builds.adoc
+++ b/docs/modules/ROOT/pages/installation/builds.adoc
@@ -47,6 +47,10 @@ Here a quick resume of the parameters you can configure as environment variables
 | Maximum number of builds that can run concurrently.
 | `3` if build strategy is `routine`, `10` if `pod`
 
+| AFFINITY_NODE_LABELS_ALLOWED_KEYS
+| Comma-separated list of label keys that CR authors are permitted to use in `affinity.nodeAffinityLabels`. When unset or empty all keys are accepted. Expressions whose key is not in the list are dropped and an info message is logged. Example: `kubernetes.io/hostname,topology.kubernetes.io/zone`.
+|
+
 | BUILDER_TASKS_ENABLED
 | Controls whether CR authors are permitted to inject custom pipeline tasks via the `builder.tasks` trait. Set to `false` to disable custom task injection for all integrations managed by this operator. When unset or set to any value other than `false`, custom tasks are allowed (default behavior).
 | `true`

--- a/docs/modules/traits/pages/affinity.adoc
+++ b/docs/modules/traits/pages/affinity.adoc
@@ -85,3 +85,5 @@ $ kamel run -t affinity.pod-anti-affinity-labels="camel.apache.org/integration" 
 ----
 
 More information can be found in the official Kubernetes documentation about https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes].
+
+NOTE: Operators can restrict which label keys CR authors are permitted to use in `affinity.nodeAffinityLabels` by setting the `AFFINITY_NODE_LABELS_ALLOWED_KEYS` environment variable on the operator deployment to a comma-separated list of allowed keys (e.g. `kubernetes.io/hostname,topology.kubernetes.io/zone`). Expressions whose key is not in the list are dropped and an info message is logged. When the variable is unset or empty, all keys are accepted (default behavior). See build environment variables documentation for details.

--- a/pkg/platform/env_platform.go
+++ b/pkg/platform/env_platform.go
@@ -173,6 +173,27 @@ func publishStrategy() v1.IntegrationPlatformBuildPublishStrategy {
 	return DefaultPublishStrategy
 }
 
+// AffinityNodeLabelsAllowList returns the list of label keys that are allowed to be used in
+// affinity.nodeAffinityLabels. When the list is empty (AFFINITY_NODE_LABELS_ALLOWED_KEYS is
+// unset or blank), any key is permitted. When the list is non-empty only expressions whose
+// keys are in the list are accepted; others are dropped and an info message is logged by the trait.
+func AffinityNodeLabelsAllowList() []string {
+	raw := GetEnvOrDefault("AFFINITY_NODE_LABELS_ALLOWED_KEYS", "")
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+
+	return result
+}
+
 // BuilderTasksEnabled reports whether CR authors are permitted to inject custom pipeline tasks
 // via the builder.tasks trait. Controlled by the BUILDER_TASKS_ENABLED operator environment
 // variable (default true for backward compatibility). Set to "false" to prevent custom task

--- a/pkg/platform/env_platform_test.go
+++ b/pkg/platform/env_platform_test.go
@@ -168,6 +168,32 @@ func TestBuilderNodeSelectorAllowList_MultipleKeys(t *testing.T) {
 	assert.Equal(t, []string{"kubernetes.io/hostname", "node-role.kubernetes.io/worker", "topology.kubernetes.io/zone"}, allowList)
 }
 
+func TestAffinityNodeLabelsAllowList_NotSet(t *testing.T) {
+	allowList := AffinityNodeLabelsAllowList()
+	assert.Nil(t, allowList)
+}
+
+func TestAffinityNodeLabelsAllowList_Empty(t *testing.T) {
+	t.Setenv("AFFINITY_NODE_LABELS_ALLOWED_KEYS", "")
+
+	allowList := AffinityNodeLabelsAllowList()
+	assert.Empty(t, allowList)
+}
+
+func TestAffinityNodeLabelsAllowList_SingleKey(t *testing.T) {
+	t.Setenv("AFFINITY_NODE_LABELS_ALLOWED_KEYS", "kubernetes.io/hostname")
+
+	allowList := AffinityNodeLabelsAllowList()
+	assert.Equal(t, []string{"kubernetes.io/hostname"}, allowList)
+}
+
+func TestAffinityNodeLabelsAllowList_MultipleKeys(t *testing.T) {
+	t.Setenv("AFFINITY_NODE_LABELS_ALLOWED_KEYS", "kubernetes.io/hostname, topology.kubernetes.io/zone ")
+
+	allowList := AffinityNodeLabelsAllowList()
+	assert.Equal(t, []string{"kubernetes.io/hostname", "topology.kubernetes.io/zone"}, allowList)
+}
+
 func TestBuilderTasksEnabled_NotSet(t *testing.T) {
 	// env var not set – default is enabled
 	assert.True(t, BuilderTasksEnabled())

--- a/pkg/trait/affinity.go
+++ b/pkg/trait/affinity.go
@@ -20,6 +20,7 @@ package trait
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
 	traitv1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1/trait"
+	"github.com/apache/camel-k/v2/pkg/platform"
 )
 
 const (
@@ -83,6 +85,7 @@ func (t *affinityTrait) Apply(e *Environment) error {
 }
 
 func (t *affinityTrait) addNodeAffinity(_ *Environment, podSpec *corev1.PodSpec) error {
+	t.filterNodeAffinityLabels()
 	if len(t.NodeAffinityLabels) == 0 {
 		return nil
 	}
@@ -259,4 +262,40 @@ func operatorToLabelSelectorOperator(operator selection.Operator) (metav1.LabelS
 	}
 
 	return "", fmt.Errorf("unsupported label selector operator: %s", operator)
+}
+
+// filterNodeAffinityLabels removes expressions whose label key is not in the operator-configured
+// allow list. When AFFINITY_NODE_LABELS_ALLOWED_KEYS is unset or empty all expressions are kept.
+func (t *affinityTrait) filterNodeAffinityLabels() {
+	allowList := platform.AffinityNodeLabelsAllowList()
+	if len(allowList) == 0 || len(t.NodeAffinityLabels) == 0 {
+		return
+	}
+	kept := make([]string, 0, len(t.NodeAffinityLabels))
+	for _, expr := range t.NodeAffinityLabels {
+		if t.nodeAffinityLabelAllowed(expr, allowList) {
+			kept = append(kept, expr)
+		}
+	}
+	t.NodeAffinityLabels = kept
+}
+
+// nodeAffinityLabelAllowed returns true when every label key in the expression is in allowList.
+// Malformed expressions are kept so existing error handling in addNodeAffinity fires as before.
+func (t *affinityTrait) nodeAffinityLabelAllowed(expr string, allowList []string) bool {
+	sel, err := labels.Parse(expr)
+	if err != nil {
+		return true
+	}
+	reqs, _ := sel.Requirements()
+	for _, r := range reqs {
+		if !slices.Contains(allowList, r.Key()) {
+			t.L.Info("affinity.nodeAffinityLabels key is not in the allowed list and will be ignored",
+				"key", r.Key(), "allowedKeys", allowList)
+
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/trait/affinity_test.go
+++ b/pkg/trait/affinity_test.go
@@ -198,3 +198,62 @@ func createNominalAffinityTest() *affinityTrait {
 
 	return trait
 }
+
+func TestFilterNodeAffinityLabels_NoAllowList(t *testing.T) {
+	trait := createNominalAffinityTest()
+	trait.NodeAffinityLabels = []string{"kubernetes.io/hostname = node-1", "topology.kubernetes.io/zone = us-east-1a"}
+
+	trait.filterNodeAffinityLabels()
+	assert.Equal(t, []string{"kubernetes.io/hostname = node-1", "topology.kubernetes.io/zone = us-east-1a"}, trait.NodeAffinityLabels)
+}
+
+func TestFilterNodeAffinityLabels_AllowListFilters(t *testing.T) {
+	t.Setenv("AFFINITY_NODE_LABELS_ALLOWED_KEYS", "kubernetes.io/hostname")
+
+	trait := createNominalAffinityTest()
+	trait.NodeAffinityLabels = []string{"kubernetes.io/hostname = node-1", "topology.kubernetes.io/zone = us-east-1a"}
+
+	trait.filterNodeAffinityLabels()
+	assert.Equal(t, []string{"kubernetes.io/hostname = node-1"}, trait.NodeAffinityLabels)
+	assert.NotContains(t, trait.NodeAffinityLabels, "topology.kubernetes.io/zone = us-east-1a")
+}
+
+func TestFilterNodeAffinityLabels_AllAllowed(t *testing.T) {
+	t.Setenv("AFFINITY_NODE_LABELS_ALLOWED_KEYS", "kubernetes.io/hostname,topology.kubernetes.io/zone")
+
+	trait := createNominalAffinityTest()
+	trait.NodeAffinityLabels = []string{"kubernetes.io/hostname = node-1", "topology.kubernetes.io/zone = us-east-1a"}
+
+	trait.filterNodeAffinityLabels()
+	assert.Len(t, trait.NodeAffinityLabels, 2)
+}
+
+func TestFilterNodeAffinityLabels_AllDropped(t *testing.T) {
+	t.Setenv("AFFINITY_NODE_LABELS_ALLOWED_KEYS", "kubernetes.io/hostname")
+
+	trait := createNominalAffinityTest()
+	trait.NodeAffinityLabels = []string{"topology.kubernetes.io/zone = us-east-1a"}
+
+	trait.filterNodeAffinityLabels()
+	assert.Empty(t, trait.NodeAffinityLabels)
+}
+
+func TestApplyNodeAffinityLabelsWithAllowList(t *testing.T) {
+	t.Setenv("AFFINITY_NODE_LABELS_ALLOWED_KEYS", "kubernetes.io/hostname")
+
+	affinityTrait := createNominalAffinityTest()
+	affinityTrait.NodeAffinityLabels = []string{
+		"kubernetes.io/hostname = node-1",
+		"topology.kubernetes.io/zone = us-east-1a",
+	}
+
+	environment, deployment := createNominalDeploymentTraitTest()
+	err := affinityTrait.Apply(environment)
+
+	require.NoError(t, err)
+	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+	require.NotNil(t, nodeAffinity)
+	terms := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
+	assert.Len(t, terms, 1)
+	assert.Equal(t, "kubernetes.io/hostname", terms[0].Key)
+}


### PR DESCRIPTION
## Summary

  Adds an operator-level allow list to restrict which label keys CR authors can use in
  `affinity.nodeAffinityLabels`, preventing unauthorized node targeting in shared clusters.

  **How it works:**

  Set `AFFINITY_NODE_LABELS_ALLOWED_KEYS` on the operator deployment to a comma-separated
  list of permitted label keys:

  AFFINITY_NODE_LABELS_ALLOWED_KEYS=kubernetes.io/hostname,topology.kubernetes.io/zone

  - When unset or empty → all keys accepted (backward compatible, no behavior change)
  - When set → each `nodeAffinityLabels` expression is parsed; any expression whose label key
    is not in the list is dropped and logged at info level; the rest proceed as normal

  Malformed expressions are kept as-is so existing error handling in `addNodeAffinity` fires
  as before.

  ## Changes

  - `pkg/platform/env_platform.go` — new `AffinityNodeLabelsAllowList()` reads and parses `AFFINITY_NODE_LABELS_ALLOWED_KEYS` (same comma-split/trim pattern as `BuilderNodeSelectorAllowList`)
  - `pkg/trait/affinity.go` — `filterNodeAffinityLabels()` iterates expressions and delegates per-expression key checking to `nodeAffinityLabelAllowed()` (uses `labels.Parse` to extract keys); called at the
  top of `addNodeAffinity()`
  - `pkg/platform/env_platform_test.go` — 4 tests: not-set, empty, single key, multiple keys with whitespace trimming
  - `pkg/trait/affinity_test.go` — 5 tests: no allow list (pass-through), partial filter, all allowed, all dropped, end-to-end through `Apply()`
  - `docs/modules/ROOT/pages/installation/builds.adoc` — `AFFINITY_NODE_LABELS_ALLOWED_KEYS` added to build env var table
  - `docs/modules/traits/pages/affinity.adoc` — NOTE block added with xref to builds config docs

  ## Test plan

  - [x] `make test` passes locally
  - [x] `TestAffinityNodeLabelsAllowList_*` (platform) — env var parsing
  - [x] `TestFilterNodeAffinityLabels_*` (trait) — allow list filtering including all-dropped case
  - [x] `TestApplyNodeAffinityLabelsWithAllowList` — end-to-end through `Apply()`
  - [x] Manual: deploy operator with `AFFINITY_NODE_LABELS_ALLOWED_KEYS` set; apply Integration with a disallowed key in `affinity.nodeAffinityLabels`; verify expression absent from pod spec and info log
  emitted

  Fixes #6677