### PR TITLE
Move from panic to error in doc-gen main.go

### DIFF
--- a/cmd/util/doc-gen/main.go
+++ b/cmd/util/doc-gen/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/apache/camel-k/v2/cmd/util/doc-gen/generators"
 	"github.com/spf13/pflag"
 	"k8s.io/gengo/args"
+	"os"
+
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -44,6 +46,7 @@ func main() {
 		generators.DefaultNameSystem(),
 		generators.Packages,
 	); err != nil {
-		panic(err)
+		log.Log.Error(err, "failed to execute doc generator")
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

Security: Use of panic in doc-gen main.go

## Problem

**Severity**: `Low` | **File**: `cmd/util/doc-gen/main.go:L42`

The `main.go` in `cmd/util/doc-gen` uses `panic(err)` for error handling, which can cause abrupt program termination and may leak sensitive information in stack traces if the error contains internal paths or configuration details.

## Solution

Replace `panic(err)` with proper error handling that logs the error and exits gracefully with a non-zero status code, avoiding stack trace exposure.

## Changes

- `cmd/util/doc-gen/main.go` (modified)