### PR TITLE
Fix #6657: Use default catalog controller worker count

### DIFF
--- a/pkg/controller/catalog/catalog_controller.go
+++ b/pkg/controller/catalog/catalog_controller.go
@@ -19,7 +19,6 @@ package catalog
 
 import (
 	"context"
-	goruntime "runtime"
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +28,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -96,9 +94,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 					return !e.DeleteStateUnknown
 				},
 			})).
-		WithOptions(controller.Options{
-			MaxConcurrentReconciles: goruntime.GOMAXPROCS(0),
-		}).
 		Complete(r)
 }
 


### PR DESCRIPTION
<!-- Description -->

This PR removes the explicit `MaxConcurrentReconciles: runtime.GOMAXPROCS(0)` override from the `catalog-controller`.

With the operator default CPU limit, `GOMAXPROCS` is commonly `2`, so the catalog controller starts with `worker count: 2` while the other controllers use controller-runtime's default of `1`. Removing the override lets `catalog-controller` use the same default worker count as the other controllers.

Fixes #6657

## Test Plan

- `go test ./pkg/controller/catalog`
- `make lint`

