### PR TITLE
Fix #6724: Allow setting enableServiceLinks on the Integration pod template

### DIFF
--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -15093,6 +15093,12 @@ spec:
                       dnsPolicy:
                         description: DNSPolicy
                         type: string
+                      enableServiceLinks:
+                        description: EnableServiceLinks indicates whether information
+                          about services should be injected into the Pod's environment
+                          variables, matching the syntax of Docker links. Defaults
+                          to true.
+                        type: boolean
                       ephemeralContainers:
                         description: EphemeralContainers
                         items:
@@ -28057,6 +28063,12 @@ spec:
                           dnsPolicy:
                             description: DNSPolicy
                             type: string
+                          enableServiceLinks:
+                            description: EnableServiceLinks indicates whether information
+                              about services should be injected into the Pod's environment
+                              variables, matching the syntax of Docker links. Defaults
+                              to true.
+                            type: boolean
                           ephemeralContainers:
                             description: EphemeralContainers
                             items:

--- a/pkg/apis/camel/v1/integration_types.go
+++ b/pkg/apis/camel/v1/integration_types.go
@@ -327,6 +327,8 @@ type PodSpecTemplate struct {
 type PodSpec struct {
 	// AutomountServiceAccountToken
 	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty" protobuf:"varint,21,opt,name=automountServiceAccountToken"`
+	// EnableServiceLinks indicates whether information about services should be injected into the Pod's environment variables, matching the syntax of Docker links. Defaults to true.
+	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty" protobuf:"varint,30,opt,name=enableServiceLinks"`
 	// Volumes
 	Volumes []corev1.Volume `json:"volumes,omitempty" patchMergeKey:"name" patchStrategy:"merge,retainKeys" protobuf:"bytes,1,rep,name=volumes"`
 	// InitContainers

--- a/pkg/apis/camel/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/camel/v1/zz_generated.deepcopy.go
@@ -2749,6 +2749,11 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableServiceLinks != nil {
+		in, out := &in.EnableServiceLinks, &out.EnableServiceLinks
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]corev1.Volume, len(*in))

--- a/pkg/client/camel/applyconfiguration/camel/v1/podspec.go
+++ b/pkg/client/camel/applyconfiguration/camel/v1/podspec.go
@@ -32,6 +32,8 @@ import (
 type PodSpecApplyConfiguration struct {
 	// AutomountServiceAccountToken
 	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty"`
+	// EnableServiceLinks indicates whether information about services should be injected into the Pod's environment variables, matching the syntax of Docker links. Defaults to true.
+	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
 	// Volumes
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 	// InitContainers
@@ -67,6 +69,14 @@ func PodSpec() *PodSpecApplyConfiguration {
 // If called multiple times, the AutomountServiceAccountToken field is set to the value of the last call.
 func (b *PodSpecApplyConfiguration) WithAutomountServiceAccountToken(value bool) *PodSpecApplyConfiguration {
 	b.AutomountServiceAccountToken = &value
+	return b
+}
+
+// WithEnableServiceLinks sets the EnableServiceLinks field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnableServiceLinks field is set to the value of the last call.
+func (b *PodSpecApplyConfiguration) WithEnableServiceLinks(value bool) *PodSpecApplyConfiguration {
+	b.EnableServiceLinks = &value
 	return b
 }
 

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -1836,6 +1836,12 @@ spec:
                       dnsPolicy:
                         description: DNSPolicy
                         type: string
+                      enableServiceLinks:
+                        description: EnableServiceLinks indicates whether information
+                          about services should be injected into the Pod's environment
+                          variables, matching the syntax of Docker links. Defaults
+                          to true.
+                        type: boolean
                       ephemeralContainers:
                         description: EphemeralContainers
                         items:

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -1843,6 +1843,12 @@ spec:
                           dnsPolicy:
                             description: DNSPolicy
                             type: string
+                          enableServiceLinks:
+                            description: EnableServiceLinks indicates whether information
+                              about services should be injected into the Pod's environment
+                              variables, matching the syntax of Docker links. Defaults
+                              to true.
+                            type: boolean
                           ephemeralContainers:
                             description: EphemeralContainers
                             items:

--- a/pkg/trait/pod_test.go
+++ b/pkg/trait/pod_test.go
@@ -112,6 +112,14 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 	assert.False(t, *templateSpec.Spec.AutomountServiceAccountToken)
 }
 
+func TestEnableServiceLinks(t *testing.T) {
+	templateString := `enableServiceLinks: false`
+	templateSpec := testPodTemplateSpec(t, templateString)
+
+	assert.NotNil(t, templateSpec.Spec.EnableServiceLinks)
+	assert.False(t, *templateSpec.Spec.EnableServiceLinks)
+}
+
 // nolint: unparam
 func createPodTest(podSpecTemplate string) (*podTrait, *Environment, *appsv1.Deployment) {
 	trait, _ := newPodTrait().(*podTrait)


### PR DESCRIPTION
### Motivation

Fixes #6724

Users need to control the Kubernetes pod-level `enableServiceLinks` flag on an
Integration. When many Services exist in a namespace, Kubernetes injects a
`{SVC}_SERVICE_HOST` / `{SVC}_SERVICE_PORT` env var per Service into every
container (the Docker-links compatibility feature). This bloats the environment
and can slow pod startup, so operators commonly want to set
`enableServiceLinks: false`. There was previously no way to express this on an
Integration.

### What this does

Adds an `EnableServiceLinks *bool` field to the curated `v1.PodSpec` used by
`spec.template.spec`, mirroring the upstream Kubernetes `PodSpec` field
(json `enableServiceLinks`, defaults to `true`).

```yaml
apiVersion: camel.apache.org/v1
kind: Integration
spec:
  template:
    spec:
      enableServiceLinks: false
```

The `pod` trait marshals `spec.template.spec` and applies it as a
**strategic merge patch** onto the workload pod spec, so the new field
propagates to Deployment, CronJob and Knative Service pods with no additional
trait logic.

### Generated artifacts

Regenerated and committed:
- CRDs: `camel.apache.org_integrations.yaml`, `camel.apache.org_pipes.yaml`
- Helm CRD bundle: `helm/camel-k/crds/camel-k-crds.yaml`
- `zz_generated.deepcopy.go`
- apply-configuration client `podspec.go`

### Note on deprecation

`PodSpecTemplate` / `v1.PodSpec` and the `pod` trait are marked
`Deprecated: to be removed in future versions` ("use container, init-containers
or owner traits instead"). I placed the field here because `enableServiceLinks`
is a **pod-level** toggle that no current non-deprecated trait can set — the
pod template is genuinely the only mechanism available today. Happy to move it
to a different home (e.g. a dedicated trait) if the maintainers prefer that over
extending the deprecated surface.

### Testing

- New unit test `TestEnableServiceLinks` in `pkg/trait/pod_test.go` verifies
  `enableServiceLinks: false` propagates to the deployment pod spec.
- `go build`, `go vet`, `gofmt`, and `golangci-lint` (v2.12.2) pass on the
  affected packages; full `pkg/trait` suite is green.

### Suggested reviewers

- @squakez (Pasquale Congiusti) — most active on the pod trait / API and author
  of the Pod-trait deprecation; best placed to weigh in on the deprecation note.
- Pranjul Kalsi — recent contributor to this area.

---

_This change was prepared by Claude Code on behalf of Luis Sergio Carneiro (@lsergio)._
