### PR TITLE
feat(trait): Add metricType support to the KEDA trait triggers

### DIFF
--- a/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
+++ b/docs/modules/ROOT/partials/apis/camel-k-crds.adoc
@@ -8362,6 +8362,14 @@ string
 
 The autoscaler type.
 
+|`metricType` +
+string
+|
+*(Optional)*
+
+The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+(`Utilization`, `AverageValue` or `Value`).
+
 |`metadata` +
 map[string]string
 |

--- a/helm/camel-k/crds/camel-k-crds.yaml
+++ b/helm/camel-k/crds/camel-k-crds.yaml
@@ -5015,6 +5015,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -7559,6 +7568,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -9997,6 +10015,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -12421,6 +12448,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -21707,6 +21743,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -24092,6 +24137,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -34744,6 +34798,15 @@ spec:
                                   description: The trigger metadata (see Keda documentation
                                     to learn how to fill for each type).
                                   type: object
+                                metricType:
+                                  description: |-
+                                    The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                    (`Utilization`, `AverageValue` or `Value`).
+                                  enum:
+                                  - Utilization
+                                  - AverageValue
+                                  - Value
+                                  type: string
                                 secrets:
                                   description: The secrets mapping to use. Keda allows
                                     the possibility to use values coming from different
@@ -37048,6 +37111,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different

--- a/pkg/apis/camel/v1/trait/keda.go
+++ b/pkg/apis/camel/v1/trait/keda.go
@@ -51,6 +51,11 @@ type KedaTrait struct {
 type KedaTrigger struct {
 	// The autoscaler type.
 	Type string `json:"type,omitempty" property:"type"`
+	// The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+	// (`Utilization`, `AverageValue` or `Value`).
+	// +kubebuilder:validation:Enum=Utilization;AverageValue;Value
+	// +optional
+	MetricType string `json:"metricType,omitempty" property:"metric-type"`
 	// The trigger metadata (see Keda documentation to learn how to fill for each type).
 	Metadata map[string]string `json:"metadata,omitempty" property:"metadata"`
 	// The secrets mapping to use. Keda allows the possibility to use values coming from different secrets.

--- a/pkg/apis/duck/keda/v1alpha1/duck_types.go
+++ b/pkg/apis/duck/keda/v1alpha1/duck_types.go
@@ -56,8 +56,10 @@ type ScaledObjectSpec struct {
 type ScaleTriggers struct {
 	Type string `json:"type"`
 	// +optional
-	Name     string            `json:"name,omitempty"`
-	Metadata map[string]string `json:"metadata"`
+	Name string `json:"name,omitempty"`
+	// +optional
+	MetricType string            `json:"metricType,omitempty"`
+	Metadata   map[string]string `json:"metadata"`
 	// +optional
 	AuthenticationRef *ScaledObjectAuthRef `json:"authenticationRef,omitempty"`
 	// +optional

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationplatforms.yaml
@@ -1709,6 +1709,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -4253,6 +4262,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrationprofiles.yaml
@@ -1567,6 +1567,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -3991,6 +4000,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different

--- a/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_integrations.yaml
@@ -8418,6 +8418,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different
@@ -10803,6 +10812,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different

--- a/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
+++ b/pkg/resources/config/crd/bases/camel.apache.org_pipes.yaml
@@ -8476,6 +8476,15 @@ spec:
                                   description: The trigger metadata (see Keda documentation
                                     to learn how to fill for each type).
                                   type: object
+                                metricType:
+                                  description: |-
+                                    The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                    (`Utilization`, `AverageValue` or `Value`).
+                                  enum:
+                                  - Utilization
+                                  - AverageValue
+                                  - Value
+                                  type: string
                                 secrets:
                                   description: The secrets mapping to use. Keda allows
                                     the possibility to use values coming from different
@@ -10780,6 +10789,15 @@ spec:
                               description: The trigger metadata (see Keda documentation
                                 to learn how to fill for each type).
                               type: object
+                            metricType:
+                              description: |-
+                                The metric type for this trigger, mapping to KEDA's trigger-level `metricType`
+                                (`Utilization`, `AverageValue` or `Value`).
+                              enum:
+                              - Utilization
+                              - AverageValue
+                              - Value
+                              type: string
                             secrets:
                               description: The secrets mapping to use. Keda allows
                                 the possibility to use values coming from different

--- a/pkg/trait/keda.go
+++ b/pkg/trait/keda.go
@@ -97,8 +97,9 @@ func (t *kedaTrait) populateTriggers(itName, itNamespace string) ([]v1alpha1.Sca
 	triggers := make([]v1alpha1.ScaleTriggers, 0, len(t.Triggers))
 	for _, trigger := range t.Triggers {
 		scaleTrigger := v1alpha1.ScaleTriggers{
-			Type:     trigger.Type,
-			Metadata: trigger.Metadata,
+			Type:       trigger.Type,
+			MetricType: trigger.MetricType,
+			Metadata:   trigger.Metadata,
 		}
 		if trigger.Secrets != nil {
 			triggerAuth := populateTriggerAuth(trigger.Secrets, itName, itNamespace, trigger.Type)

--- a/pkg/trait/keda_test.go
+++ b/pkg/trait/keda_test.go
@@ -57,6 +57,35 @@ func TestKeda(t *testing.T) {
 	assert.Equal(t, "10", scaledObject.Spec.Triggers[0].Metadata["lagThreshold"])
 }
 
+func TestKedaMetricType(t *testing.T) {
+	environment := nominalEnv(t)
+	// A cpu trigger with a trigger-level metricType: KEDA v2.18+ requires this for
+	// the cpu/memory scalers (the deprecated metadata.type was removed).
+	environment.Integration.Spec.Traits.Keda.Triggers = []traitv1.KedaTrigger{
+		{
+			Type:       "cpu",
+			MetricType: "Utilization",
+			Metadata: map[string]string{
+				"value": "70",
+			},
+		},
+	}
+	traitCatalog := environment.Catalog
+
+	_, _, err := traitCatalog.apply(&environment)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, environment.ExecutedTraits)
+	assert.NotNil(t, environment.GetTrait("keda"))
+
+	scaledObject := getKedaScaledObject(environment.Resources)
+	require.NotNil(t, scaledObject)
+	require.Len(t, scaledObject.Spec.Triggers, 1)
+	assert.Equal(t, "cpu", scaledObject.Spec.Triggers[0].Type)
+	assert.Equal(t, "Utilization", scaledObject.Spec.Triggers[0].MetricType)
+	assert.Equal(t, "70", scaledObject.Spec.Triggers[0].Metadata["value"])
+}
+
 func TestKedaAutoDiscovery(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
This PR adds support for specifying a trigger-level `metricType` in the KEDA trait, mapping to KEDA's `ScaleTriggers.metricType` field (`Utilization`, `AverageValue` or `Value`).

This is required for compatibility with **KEDA v2.18+**, which removed the deprecated `metadata.type` field for the `cpu` and `memory` scalers. Without a way to set the trigger-level `metricType`, those scalers can no longer be configured through the KEDA trait on recent KEDA versions.

### Changes

- Added the `MetricType` field to `KedaTrigger` (`pkg/apis/camel/v1/trait/keda.go`), exposed as the `metric-type` trait property and validated against the enum `Utilization`/`AverageValue`/`Value`.
- Added the `MetricType` field to the KEDA duck type `ScaleTriggers` (`pkg/apis/duck/keda/v1alpha1/duck_types.go`).
- Propagated `MetricType` from the trait trigger to the generated `ScaledObject` triggers (`pkg/trait/keda.go`).
- Regenerated CRDs and API docs.
- Added `TestKedaMetricType` covering a `cpu` trigger with `metricType: Utilization`.

### Example

```yaml
traits:
  keda:
    triggers:
      - type: cpu
        metricType: Utilization
        metadata:
          value: "70"
```

## Release Note

```
Add metricType support to the KEDA trait triggers (required for cpu/memory scalers on KEDA v2.18+).
```
