### PR TITLE
ci: Replace non maintained gh-go-mod-generate-sbom action by custom install

### DIFF
--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -110,11 +110,13 @@ runs:
       run: |
         NOTEST=1 make VERSION=${{ env.VERSION }} IMAGE_NAME=${{ env.IMAGE_NAME }} BUNDLE_IMAGE_NAME=docker.io/testcamelk/camel-k-bundle bundle-push
 
+    - name: Install SBOM generator
+      shell: bash
+      run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+
     - name: Generate SBOM
-      uses: ./.github/actions/gh-go-mod-generate-sbom
-      with:
-        version: v1
-        args: mod -licenses -json -output sbom.json
+      shell: bash
+      run: cyclonedx-gomod mod -licenses -json -output sbom.json
 
     - name: Commit and push nightly branch
       shell: bash

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".github/actions/gh-go-mod-generate-sbom"]
-	path = .github/actions/gh-go-mod-generate-sbom
-	url = https://github.com/CycloneDX/gh-gomod-generate-sbom/


### PR DESCRIPTION
Closes #6746 

The old action contained mainly a Node.js wrapper. It was only needed because the action pre-dates the pattern of just using go install directly.

That is replaced by one line: go install ...@latest ad Go is already set up in the workflow. 

<!-- Description -->




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

