### PR TITLE
ci: fix sbom generator install in workflow

### DIFF
--- a/.github/actions/release-nightly/action.yml
+++ b/.github/actions/release-nightly/action.yml
@@ -112,7 +112,9 @@ runs:
 
     - name: Install SBOM generator
       shell: bash
-      run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+      run: |
+        go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Generate SBOM
       shell: bash


### PR DESCRIPTION
Fixes #6746 

I think the path needs to be updated because the code is in an action.
Tested the fix in a workflow on my fork, it worked.
<!-- Description -->




<!--
Please, describe the PR intent carefully, linking it to the github issue that it wants to address.
-->

