### PR TITLE
Fix #6780: Document NetworkPolicy for operator metrics

### DIFF
--- a/docs/modules/ROOT/pages/observability/monitoring/operator.adoc
+++ b/docs/modules/ROOT/pages/observability/monitoring/operator.adoc
@@ -19,6 +19,8 @@ kubectl apply -k github.com/apache/camel-k/install/base/config/prometheus?ref=v{
 
 NOTE: change the ref value with the installation version tag you want to install.
 
+IMPORTANT: The provided Prometheus configuration does not create a `NetworkPolicy`. As a post-installation step, cluster administrators should https://kubernetes.io/docs/concepts/services-networking/network-policies/[configure a network policy] that only allows the Prometheus scraper to access the operator metrics port. Adapt the namespace and pod selectors to your Prometheus deployment, and verify that the cluster networking solution supports `NetworkPolicy` resources.
+
 However, most of the time you want to probably configure and add different thresholds and KPIs in order to monitor in a properly manner your installation.
 
 [[metrics]]


### PR DESCRIPTION
<!-- Description -->

Adds a post-installation note to the operator monitoring documentation explaining that the provided Prometheus configuration does not create a `NetworkPolicy`.

The note recommends restricting access to the operator metrics port to the Prometheus scraper, adapting selectors to the Prometheus deployment, and verifying that the cluster networking solution supports `NetworkPolicy` resources.

Fixes #6780.

Validation:
- `git diff --check`
- `corepack yarn build:antora-local-quick`

_This pull request was generated with Codex on behalf of @jjj-n._