### PR TITLE
feat(operator): secure operator metrics by default

### DIFF
--- a/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
+++ b/docs/modules/ROOT/pages/installation/advanced/advanced.adoc
@@ -25,7 +25,9 @@ Camel K Operator provides certain parameters that would let you enable monitorin
 
 There is a default liveness service that is available at the operator Pod _/healtz_ endpoint on port _8081_. You can change the port parameter if you need to expose under a different port making sure to start the operator with the _--health-port_ to the same value. You also need to change the Deployment template spec to reflect the change on the operator container liveness check.
 
-There is a default metrics service as well available at the operator Pod _/metrics_ endpoint on port _8080_. The port can be also changed. In this case you only need to change the Deployment container operator, changing the _--monitoring-port_ value to the port you want the operator to expose.
+There is a default metrics service as well available at the operator Pod _/metrics_ endpoint on port _8080_. The endpoint uses HTTPS by default. The port can be also changed. In this case you only need to change the Deployment container operator, changing the _--monitoring-port_ value to the port you want the operator to expose.
+
+You can restore the previous HTTP behavior by setting `KAMEL_OPERATOR_METRICS_SECURE=false`. Kubernetes authentication and authorization can be enabled with `KAMEL_OPERATOR_METRICS_AUTH=true`; this requires HTTPS. To use a mounted certificate instead of the generated self-signed certificate, set `KAMEL_OPERATOR_METRICS_CERT_DIR` to a directory containing `tls.crt` and `tls.key`.
 
 The service exposed on the _/metrics_ endpoint is compatible with Prometheus. You can learn more about xref:observability/monitoring/operator.adoc[how to monitor Camel K Operator].
 
@@ -64,6 +66,18 @@ The following environment variables can be configured on the operator Deployment
 |`CAMEL_K_SYNTHETIC_INTEGRATIONS`
 |`false`
 |When set to `true`, enables synthetic Integration support for managing external workloads.
+
+|`KAMEL_OPERATOR_METRICS_SECURE`
+|`true`
+|When set to `true`, serves the operator metrics endpoint over HTTPS.
+
+|`KAMEL_OPERATOR_METRICS_AUTH`
+|`false`
+|When set to `true`, requires Kubernetes authentication and authorization for the operator metrics endpoint. Requires secure metrics serving.
+
+|`KAMEL_OPERATOR_METRICS_CERT_DIR`
+|_empty_
+|Directory containing `tls.crt` and `tls.key` for the metrics endpoint. A self-signed certificate is generated when empty.
 
 |`CAMEL_MONITOR_OPERATOR_LABEL`
 |`camel.apache.org/monitor`

--- a/docs/modules/ROOT/pages/observability/monitoring/operator.adoc
+++ b/docs/modules/ROOT/pages/observability/monitoring/operator.adoc
@@ -19,7 +19,53 @@ kubectl apply -k github.com/apache/camel-k/install/base/config/prometheus?ref=v{
 
 NOTE: change the ref value with the installation version tag you want to install.
 
+The operator metrics endpoint uses HTTPS by default. The example `PodMonitor` is configured to scrape HTTPS and to accept the self-signed certificate that controller-runtime generates when no certificate is configured.
+
+For production, mount a TLS Secret containing `tls.crt` and `tls.key` into the operator Pod and set `KAMEL_OPERATOR_METRICS_CERT_DIR` to the mount directory. Update the `PodMonitor` `tlsConfig` to trust that certificate instead of skipping certificate verification.
+
 IMPORTANT: The provided Prometheus configuration does not create a `NetworkPolicy`. As a post-installation step, cluster administrators should https://kubernetes.io/docs/concepts/services-networking/network-policies/[configure a network policy] that only allows the Prometheus scraper to access the operator metrics port. Adapt the namespace and pod selectors to your Prometheus deployment, and verify that the cluster networking solution supports `NetworkPolicy` resources.
+
+[[security-configuration]]
+== Security configuration
+
+The metrics endpoint can be configured with the following operator environment variables. The equivalent command-line flags are shown in parentheses.
+
+[cols="2,1,3"]
+|===
+|Variable |Default |Description
+
+|`KAMEL_OPERATOR_METRICS_SECURE` (`--metrics-secure`)
+|`true`
+|Serve metrics over HTTPS. Set to `false` to restore the previous HTTP behavior.
+
+|`KAMEL_OPERATOR_METRICS_AUTH` (`--metrics-auth`)
+|`false`
+|Require Kubernetes bearer-token authentication and authorization for the `/metrics` endpoint. This option requires secure metrics serving.
+
+|`KAMEL_OPERATOR_METRICS_CERT_DIR` (`--metrics-cert-dir`)
+|_empty_
+|Directory containing `tls.crt` and `tls.key`. When empty, controller-runtime generates a self-signed certificate.
+|===
+
+When metrics authentication is enabled, the operator performs Kubernetes `TokenReview` and `SubjectAccessReview` requests. The standard Camel K installation grants these permissions to the operator and installs an unbound `camel-k-metrics-reader` `ClusterRole`. Bind this role to the service account used by your scraper, for example:
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: camel-k-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: camel-k-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: monitoring
+----
+
+Adapt the service-account name and namespace to your Prometheus installation, and configure the scraper to send that service account's bearer token. A request without a valid token, or from an identity that is not allowed to `GET` `/metrics`, is rejected.
 
 However, most of the time you want to probably configure and add different thresholds and KPIs in order to monitor in a properly manner your installation.
 
@@ -87,9 +133,13 @@ spec:
       camel.apache.org/component: operator
   podMetricsEndpoints:
     - port: metrics
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true # <3>
 ----
 <1> The labels must match the `podMonitorSelector` field from the `Prometheus` resource
 <2> This label selector matches the Camel K operator Deployment labels
+<3> The example accepts controller-runtime's generated self-signed certificate. Configure certificate verification for production.
 
 The Prometheus Operator https://prometheus-operator.dev/docs/user-guides/getting-started/[getting started] guide documents the discovery mechanism, as well as the relationship between the operator resources.
 

--- a/go.mod
+++ b/go.mod
@@ -56,13 +56,16 @@ require (
 )
 
 require (
+	cel.dev/expr v0.25.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudevents/sdk-go/sql/v2 v2.15.2 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.16.1 // indirect
@@ -94,11 +97,13 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/google/cel-go v0.29.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -132,24 +137,35 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/apiextensions-apiserver v0.36.3 // indirect
+	k8s.io/apiserver v0.36.3 // indirect
+	k8s.io/component-base v0.36.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect
 	k8s.io/streaming v0.36.3 // indirect
 	knative.dev/networking v0.0.0-20260727162500-c7a7b772cac9 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
@@ -15,6 +17,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -35,6 +39,7 @@ github.com/cloudevents/sdk-go/v2 v2.16.1 h1:G91iUdqvl88BZ1GYYr9vScTj5zzXSyEuqbfE
 github.com/cloudevents/sdk-go/v2 v2.16.1/go.mod h1:v/kVOaWjNfbvc6tkhhlkhvLapj8Aa8kvXiH5GiOHCKI=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+github.com/coreos/go-oidc v2.5.0+incompatible h1:6W0vGJR3Tu0r0PwfmjOrRZSlfxeEln8dsejt3ZWIvwo=
 github.com/coreos/go-oidc/v3 v3.9.0 h1:0J/ogVOd4y8P0f0xUh8l9t07xRP/d8tccvjHl2dcsSo=
 github.com/coreos/go-oidc/v3 v3.9.0/go.mod h1:rTKz2PYwftcrtoCzV5g5kvfJoWcm0Mk8AF8y1iAQro4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -136,6 +141,10 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/cel-go v0.29.2 h1:ZtDxkeiMmz0mxbKDYiNkE5Lk7V5edMRcaaDf2jX002k=
+github.com/google/cel-go v0.29.2/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=
 github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -370,6 +379,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
@@ -432,6 +443,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0=
 gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
+gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:Kjn0N0tCrDgiAFW+lGO4JZ3ck44CehvJQMAwj9QF0G8=
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
@@ -478,6 +491,8 @@ k8s.io/cli-runtime v0.36.0 h1:HNxciQpQMMOKS0/GiUXcKDyA6J2FDILJj9NmP2BZrTg=
 k8s.io/cli-runtime v0.36.0/go.mod h1:KObkknK9Ro5LYX+1RdiKc7C8CvGg4aX+V/Zv+E8WPHA=
 k8s.io/client-go v0.36.3 h1:M4JdVzXxYcZk4fGpfDdYnxSwhLKWCFoQsHW6t+z8Hfg=
 k8s.io/client-go v0.36.3/go.mod h1:gcPwr0c87vjjG6HB6pWEqOeuYVoXSsREjzux2j6GF30=
+k8s.io/component-base v0.36.3 h1:vc/UFvPCkW0irPz84LAodAL1j3f4xktPM6dDJIEheAY=
+k8s.io/component-base v0.36.3/go.mod h1:hZbNFG+gCMl9EbykDGEu73feKP9/Cq6JsV4pTo9GTO8=
 k8s.io/gengo v0.0.0-20251215205346-5ee0d033ba5b h1:X0Afwan8Q1l7bMcNgh6DAah2jKCQ2irT7EoAXIChFqk=
 k8s.io/gengo v0.0.0-20251215205346-5ee0d033ba5b/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
@@ -497,6 +512,8 @@ knative.dev/pkg v0.0.0-20260727151759-521cb33b33dd h1:Tpo7m+KdcccVGygF/fr0af9Qv4
 knative.dev/pkg v0.0.0-20260727151759-521cb33b33dd/go.mod h1:H+Z0Cy8MsihAolnB4luN7/7RV96ed8VzLvf4jzE8OP4=
 knative.dev/serving v0.50.0 h1:9XUQq2yqUPN1YZUuGH6nF8IMvuumNvGXzCrSTYu44bA=
 knative.dev/serving v0.50.0/go.mod h1:MP+yKsx/gLczU+agah1HgRrpU6KT0SV96a7bD+v5PKo=
+sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=
+sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/gateway-api v1.6.1 h1:mock6phZbI6rvZerwrVNk7hVNymQgHo+6sJ81Ia7ftY=

--- a/helm/camel-k/templates/rbacs-common.yaml
+++ b/helm/camel-k/templates/rbacs-common.yaml
@@ -116,6 +116,18 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: camel-k
+  name: {{ include "camel-k.fullname" . }}-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/helm/camel-k/templates/rbacs-descoped.yaml
+++ b/helm/camel-k/templates/rbacs-descoped.yaml
@@ -214,6 +214,12 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/camel-k/templates/rbacs-namespaced.yaml
+++ b/helm/camel-k/templates/rbacs-namespaced.yaml
@@ -452,6 +452,26 @@ rules:
   - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: camel-k
+  name: {{ include "camel-k.fullname" . }}-operator-metrics-auth
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -562,4 +582,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "camel-k.fullname" . }}-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: camel-k
+  name: {{ include "camel-k.fullname" . }}-operator-metrics-auth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "camel-k.fullname" . }}-operator-metrics-auth
+subjects:
+- kind: ServiceAccount
+  name: {{ include "camel-k.fullname" . }}-operator
+  namespace: '{{ .Release.Namespace }}'
 {{- end }}

--- a/pkg/cmd/operator.go
+++ b/pkg/cmd/operator.go
@@ -18,6 +18,8 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
+
 	"github.com/apache/camel-k/v2/pkg/cmd/operator"
 	"github.com/apache/camel-k/v2/pkg/platform"
 	"github.com/apache/camel-k/v2/pkg/util/defaults"
@@ -32,18 +34,27 @@ const (
 
 func newCmdOperator(rootCmdOptions *RootCmdOptions) (*cobra.Command, *operatorCmdOptions) {
 	options := operatorCmdOptions{}
+	decodeOptions := decode(&options, rootCmdOptions.Flags)
 
 	cmd := cobra.Command{
-		Use:     "operator",
-		Short:   "Run the Camel K operator",
-		Long:    `Run the Camel K operator`,
-		Hidden:  true,
-		PreRunE: decode(&options, rootCmdOptions.Flags),
-		Run:     options.run,
+		Use:    "operator",
+		Short:  "Run the Camel K operator",
+		Long:   `Run the Camel K operator`,
+		Hidden: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := decodeOptions(cmd, args); err != nil {
+				return err
+			}
+			return options.validate()
+		},
+		Run: options.run,
 	}
 
 	cmd.Flags().Int32("health-port", defaultHealthPort, "The port of the health endpoint")
 	cmd.Flags().Int32("monitoring-port", defaultMonitoringPort, "The port of the metrics endpoint")
+	cmd.Flags().Bool("metrics-secure", true, "Serve the metrics endpoint over HTTPS")
+	cmd.Flags().Bool("metrics-auth", false, "Require Kubernetes authentication and authorization for the metrics endpoint")
+	cmd.Flags().String("metrics-cert-dir", "", "The directory containing tls.crt and tls.key for the metrics endpoint")
 	cmd.Flags().Bool("leader-election", true, "Use leader election")
 	cmd.Flags().String("leader-election-id", "", "Use the given ID as the leader election Lease name")
 
@@ -53,8 +64,18 @@ func newCmdOperator(rootCmdOptions *RootCmdOptions) (*cobra.Command, *operatorCm
 type operatorCmdOptions struct {
 	HealthPort       int32  `mapstructure:"health-port"`
 	MonitoringPort   int32  `mapstructure:"monitoring-port"`
+	MetricsSecure    bool   `mapstructure:"metrics-secure"`
+	MetricsAuth      bool   `mapstructure:"metrics-auth"`
+	MetricsCertDir   string `mapstructure:"metrics-cert-dir"`
 	LeaderElection   bool   `mapstructure:"leader-election"`
 	LeaderElectionID string `mapstructure:"leader-election-id"`
+}
+
+func (o *operatorCmdOptions) validate() error {
+	if o.MetricsAuth && !o.MetricsSecure {
+		return errors.New("metrics authentication requires secure metrics serving")
+	}
+	return nil
 }
 
 func (o *operatorCmdOptions) run(_ *cobra.Command, _ []string) {
@@ -67,5 +88,5 @@ func (o *operatorCmdOptions) run(_ *cobra.Command, _ []string) {
 		}
 	}
 
-	operator.Run(o.HealthPort, o.MonitoringPort, o.LeaderElection, leaderElectionID)
+	operator.Run(o.HealthPort, o.MonitoringPort, o.MetricsSecure, o.MetricsAuth, o.MetricsCertDir, o.LeaderElection, leaderElectionID)
 }

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -50,6 +50,7 @@ import (
 	zapctrl "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -83,7 +84,7 @@ func printVersion() {
 }
 
 // Run starts the Camel K operator.
-func Run(healthPort, monitoringPort int32, leaderElection bool, leaderElectionID string) {
+func Run(healthPort, monitoringPort int32, metricsSecure, metricsAuth bool, metricsCertDir string, leaderElection bool, leaderElectionID string) {
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger
@@ -217,7 +218,7 @@ func Run(healthPort, monitoringPort int32, leaderElection bool, leaderElectionID
 		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
 		LeaderElectionReleaseOnCancel: true,
 		HealthProbeBindAddress:        ":" + strconv.Itoa(int(healthPort)),
-		Metrics:                       metricsserver.Options{BindAddress: ":" + strconv.Itoa(int(monitoringPort))},
+		Metrics:                       newMetricsServerOptions(monitoringPort, metricsSecure, metricsAuth, metricsCertDir),
 		Cache:                         options,
 	})
 	exitOnError(err, "")
@@ -244,6 +245,18 @@ func Run(healthPort, monitoringPort int32, leaderElection bool, leaderElectionID
 	}
 	log.Info("Starting the manager")
 	exitOnError(mgr.Start(ctx), "manager exited non-zero")
+}
+
+func newMetricsServerOptions(monitoringPort int32, secureServing, authEnabled bool, certDir string) metricsserver.Options {
+	options := metricsserver.Options{
+		BindAddress:   ":" + strconv.Itoa(int(monitoringPort)),
+		SecureServing: secureServing,
+		CertDir:       certDir,
+	}
+	if authEnabled {
+		options.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+	return options
 }
 
 func getNamespacesSelector(operatorNamespace string, watchNamespace string) map[string]cache.Config {

--- a/pkg/cmd/operator/operator_test.go
+++ b/pkg/cmd/operator/operator_test.go
@@ -31,6 +31,34 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
+func TestNewMetricsServerOptions(t *testing.T) {
+	t.Run("HTTPS without authentication", func(t *testing.T) {
+		options := newMetricsServerOptions(8080, true, false, "")
+
+		assert.Equal(t, ":8080", options.BindAddress)
+		assert.True(t, options.SecureServing)
+		assert.Nil(t, options.FilterProvider)
+		assert.Empty(t, options.CertDir)
+	})
+
+	t.Run("HTTPS with authentication", func(t *testing.T) {
+		options := newMetricsServerOptions(9090, true, true, "/etc/camel-k/metrics-certs")
+
+		assert.Equal(t, ":9090", options.BindAddress)
+		assert.True(t, options.SecureServing)
+		assert.NotNil(t, options.FilterProvider)
+		assert.Equal(t, "/etc/camel-k/metrics-certs", options.CertDir)
+	})
+
+	t.Run("legacy HTTP", func(t *testing.T) {
+		options := newMetricsServerOptions(7070, false, false, "")
+
+		assert.Equal(t, ":7070", options.BindAddress)
+		assert.False(t, options.SecureServing)
+		assert.Nil(t, options.FilterProvider)
+	})
+}
+
 func TestGetNamespacesSelector(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/cmd/operator_test.go
+++ b/pkg/cmd/operator_test.go
@@ -59,6 +59,9 @@ func TestOperatorNoFlag(t *testing.T) {
 	// Check default expected values
 	assert.Equal(t, int32(8081), operatorCmdOptions.HealthPort)
 	assert.Equal(t, int32(8080), operatorCmdOptions.MonitoringPort)
+	assert.True(t, operatorCmdOptions.MetricsSecure)
+	assert.False(t, operatorCmdOptions.MetricsAuth)
+	assert.Empty(t, operatorCmdOptions.MetricsCertDir)
 }
 
 func TestOperatorNonExistingFlag(t *testing.T) {
@@ -79,4 +82,39 @@ func TestOperatorMonitoringPortFlag(t *testing.T) {
 	_, err := ExecuteCommand(rootCmd, cmdOperator, "--monitoring-port", "7172")
 	require.NoError(t, err)
 	assert.Equal(t, int32(7172), operatorCmdOptions.MonitoringPort)
+}
+
+func TestOperatorMetricsFlags(t *testing.T) {
+	operatorCmdOptions, rootCmd, _ := initializeOperatorCmdOptions(t)
+	_, err := ExecuteCommand(rootCmd, cmdOperator, "--metrics-secure=true", "--metrics-auth=true", "--metrics-cert-dir", "/etc/camel-k/metrics-certs")
+	require.NoError(t, err)
+	assert.True(t, operatorCmdOptions.MetricsSecure)
+	assert.True(t, operatorCmdOptions.MetricsAuth)
+	assert.Equal(t, "/etc/camel-k/metrics-certs", operatorCmdOptions.MetricsCertDir)
+}
+
+func TestOperatorMetricsEnvironmentVariables(t *testing.T) {
+	t.Setenv("KAMEL_OPERATOR_METRICS_SECURE", "true")
+	t.Setenv("KAMEL_OPERATOR_METRICS_AUTH", "true")
+	t.Setenv("KAMEL_OPERATOR_METRICS_CERT_DIR", "/etc/camel-k/metrics-certs")
+	operatorCmdOptions, rootCmd, _ := initializeOperatorCmdOptions(t)
+	_, err := ExecuteCommand(rootCmd, cmdOperator)
+	require.NoError(t, err)
+	assert.True(t, operatorCmdOptions.MetricsSecure)
+	assert.True(t, operatorCmdOptions.MetricsAuth)
+	assert.Equal(t, "/etc/camel-k/metrics-certs", operatorCmdOptions.MetricsCertDir)
+}
+
+func TestOperatorMetricsSecureEnvironmentVariable(t *testing.T) {
+	t.Setenv("KAMEL_OPERATOR_METRICS_SECURE", "false")
+	operatorCmdOptions, rootCmd, _ := initializeOperatorCmdOptions(t)
+	_, err := ExecuteCommand(rootCmd, cmdOperator)
+	require.NoError(t, err)
+	assert.False(t, operatorCmdOptions.MetricsSecure)
+}
+
+func TestOperatorRejectsMetricsAuthOverHTTP(t *testing.T) {
+	_, rootCmd, _ := initializeOperatorCmdOptions(t)
+	_, err := ExecuteCommand(rootCmd, cmdOperator, "--metrics-secure=false", "--metrics-auth=true")
+	require.ErrorContains(t, err, "metrics authentication requires secure metrics serving")
 }

--- a/pkg/resources/config/helm/namespaced/kustomization.yaml
+++ b/pkg/resources/config/helm/namespaced/kustomization.yaml
@@ -23,3 +23,11 @@ commonLabels:
 
 resources:
 - ../../rbac/namespaced
+
+patches:
+ - target:
+      kind: ClusterRoleBinding
+   patch: |-
+     - op: add
+       path: /subjects/0/namespace
+       value: "{{ .Release.Namespace }}"

--- a/pkg/resources/config/rbac/descoped/operator-cluster-role.yaml
+++ b/pkg/resources/config/rbac/descoped/operator-cluster-role.yaml
@@ -224,3 +224,10 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+# Required by metrics authentication
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create

--- a/pkg/resources/config/rbac/kustomization.yaml
+++ b/pkg/resources/config/rbac/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
 - builder-role.yaml
 - builder-role-openshift.yaml
 - kamelets-viewer-role.yaml
+- metrics-reader-role.yaml
 - builder-role-binding.yaml
 - builder-role-binding-openshift.yaml
 - kamelets-viewer-role-binding.yaml

--- a/pkg/resources/config/rbac/metrics-reader-role.yaml
+++ b/pkg/resources/config/rbac/metrics-reader-role.yaml
@@ -15,21 +15,14 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: camel-k-operator
+  name: camel-k-metrics-reader
   labels:
     app: "camel-k"
-    camel.apache.org/component: operator
-spec:
-  selector:
-    matchLabels:
-      app: "camel-k"
-      camel.apache.org/component: operator
-  podMetricsEndpoints:
-    - port: metrics
-      scheme: https
-      tlsConfig:
-        # The operator generates a self-signed certificate when no certificate is configured.
-        insecureSkipVerify: true
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/pkg/resources/config/rbac/namespaced/kustomization.yaml
+++ b/pkg/resources/config/rbac/namespaced/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
 - operator-role-openshift.yaml
 - operator-role-podmonitors.yaml
 - operator-role-strimzi.yaml
+- operator-cluster-role-metrics-auth.yaml
 - operator-role-binding.yaml
 - operator-role-binding-events.yaml
 - operator-role-binding-keda.yaml
@@ -38,3 +39,4 @@ resources:
 - operator-role-binding-openshift.yaml
 - operator-role-binding-podmonitors.yaml
 - operator-role-binding-strimzi.yaml
+- operator-cluster-role-binding-metrics-auth.yaml

--- a/pkg/resources/config/rbac/namespaced/operator-cluster-role-binding-metrics-auth.yaml
+++ b/pkg/resources/config/rbac/namespaced/operator-cluster-role-binding-metrics-auth.yaml
@@ -15,21 +15,16 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  name: camel-k-operator
+  name: camel-k-operator-metrics-auth
   labels:
     app: "camel-k"
-    camel.apache.org/component: operator
-spec:
-  selector:
-    matchLabels:
-      app: "camel-k"
-      camel.apache.org/component: operator
-  podMetricsEndpoints:
-    - port: metrics
-      scheme: https
-      tlsConfig:
-        # The operator generates a self-signed certificate when no certificate is configured.
-        insecureSkipVerify: true
+subjects:
+- kind: ServiceAccount
+  name: camel-k-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: camel-k-operator-metrics-auth

--- a/pkg/resources/config/rbac/namespaced/operator-cluster-role-metrics-auth.yaml
+++ b/pkg/resources/config/rbac/namespaced/operator-cluster-role-metrics-auth.yaml
@@ -15,21 +15,22 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: camel-k-operator
+  name: camel-k-operator-metrics-auth
   labels:
     app: "camel-k"
-    camel.apache.org/component: operator
-spec:
-  selector:
-    matchLabels:
-      app: "camel-k"
-      camel.apache.org/component: operator
-  podMetricsEndpoints:
-    - port: metrics
-      scheme: https
-      tlsConfig:
-        # The operator generates a self-signed certificate when no certificate is configured.
-        insecureSkipVerify: true
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create


### PR DESCRIPTION
## Summary

- serve the operator metrics endpoint over HTTPS by default, with an explicit HTTP compatibility opt-out
- add optional Kubernetes bearer-token authentication and authorization, including the required TokenReview, SubjectAccessReview, and metrics-reader RBAC
- update the example PodMonitor, generated Helm RBAC, documentation, and tests for the new configuration

## Configuration

| Environment variable | Default | Purpose |
| --- | --- | --- |
| `KAMEL_OPERATOR_METRICS_SECURE` | `true` | Enable HTTPS metrics; set to `false` for the previous HTTP behavior |
| `KAMEL_OPERATOR_METRICS_AUTH` | `false` | Enable Kubernetes authentication and authorization; requires HTTPS |
| `KAMEL_OPERATOR_METRICS_CERT_DIR` | empty | Directory containing `tls.crt` and `tls.key`; controller-runtime generates a self-signed certificate when empty |

## Compatibility and security

HTTPS is the secure default while authentication remains independently opt-in because it requires scraper credentials and RBAC configuration. The provided PodMonitor now scrapes HTTPS and accepts controller-runtime's generated self-signed certificate. The documentation recommends mounting a trusted certificate and enabling verification for production.

When authentication is enabled, the operator can create TokenReview and SubjectAccessReview requests. An unbound `camel-k-metrics-reader` ClusterRole is installed so administrators can explicitly grant `GET /metrics` to the scraper service account.



A final combined test rerun after formatting reached the linker but could not complete because the local disk was full (`errno=28`); the same focused packages passed immediately before formatting. CI should provide the clean-environment verification.

Fixes #6779

