### PR TITLE
Fix #6797: Disable enableServiceLinks on operator and builder pods

### DIFF
--- a/helm/camel-k/templates/operator-deployment.yaml
+++ b/helm/camel-k/templates/operator-deployment.yaml
@@ -45,6 +45,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.operator.imagePullSecrets | indent 8 }}
     {{- end }}
+      enableServiceLinks: false
 
       containers:
         - command:

--- a/pkg/controller/build/build_pod.go
+++ b/pkg/controller/build/build_pod.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -76,6 +77,7 @@ func newBuildPod(ctx context.Context, client client.Client, build *v1.Build) *co
 			RestartPolicy:      corev1.RestartPolicyNever,
 			SecurityContext:    podSecurityContext,
 			NodeSelector:       build.BuilderConfiguration().NodeSelector,
+			EnableServiceLinks: ptr.To(false),
 		},
 	}
 

--- a/pkg/controller/build/build_pod.go
+++ b/pkg/controller/build/build_pod.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/apache/camel-k/v2/pkg/apis/camel/v1"
@@ -77,7 +76,7 @@ func newBuildPod(ctx context.Context, client client.Client, build *v1.Build) *co
 			RestartPolicy:      corev1.RestartPolicyNever,
 			SecurityContext:    podSecurityContext,
 			NodeSelector:       build.BuilderConfiguration().NodeSelector,
-			EnableServiceLinks: ptr.To(false),
+			EnableServiceLinks: new(bool),
 		},
 	}
 

--- a/pkg/controller/build/build_pod_test.go
+++ b/pkg/controller/build/build_pod_test.go
@@ -65,4 +65,6 @@ func TestNewBuildPodConfiguration(t *testing.T) {
 	}, pod.Labels)
 	assert.Equal(t, map[string]string{"node": "selector"}, pod.Spec.NodeSelector)
 	assert.Equal(t, map[string]string{"annotation": "value"}, pod.Annotations)
+	require.NotNil(t, pod.Spec.EnableServiceLinks)
+	assert.False(t, *pod.Spec.EnableServiceLinks)
 }

--- a/pkg/resources/config/manager/operator-deployment.yaml
+++ b/pkg/resources/config/manager/operator-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         app.kubernetes.io/version: "2.12.0-SNAPSHOT"
     spec:
       serviceAccountName: camel-k-operator
+      enableServiceLinks: false
       containers:
         - name: camel-k-operator
           image: docker.io/apache/camel-k:2.12.0-SNAPSHOT


### PR DESCRIPTION
### Motivation

Fixes #6797

The camel-k-operator pod and the builder Pods created by the `pod` build
strategy have no use for Kubernetes' Docker-links-style service env
injection (`{SVC}_SERVICE_HOST` / `{SVC}_SERVICE_PORT` per Service in
the namespace). In a namespace with a high Service count, this env
injection can push a container's combined args+env past the kernel's
`ARG_MAX` / `MAX_ARG_STRLEN`, causing it to fail to even start with
`exec ...: argument list too long`.

This is the same E2BIG failure mode that #6724 / #6725 addressed for
user Integrations, by adding an opt-in `enableServiceLinks` field to the
(deprecated) Integration pod template. Integration pods are user-facing,
so that fix made the behavior configurable rather than changing the
default.

The operator pod and builder pods are purely internal to camel-k and
never rely on service-link env injection, so there's no tradeoff in
setting `enableServiceLinks: false` unconditionally for both, rather
than requiring an operator-deployer to opt in.

### What this does

- Sets `enableServiceLinks: false` on the operator Deployment's pod spec
  in `pkg/resources/config/manager/operator-deployment.yaml` (the
  canonical manifest; `install/base/config` is a symlink to
  `pkg/resources/config`, so the Kustomize install picks this up too)
  and in the Helm chart's own copy,
  `helm/camel-k/templates/operator-deployment.yaml`.
- Sets `EnableServiceLinks: new(bool)` on the builder Pod's
  `corev1.PodSpec` built in `newBuildPod`
  (`pkg/controller/build/build_pod.go`).

### Testing

- Extended `TestNewBuildPodConfiguration` in `build_pod_test.go` to
  assert `pod.Spec.EnableServiceLinks` is non-nil and `false`.
- `go build ./pkg/controller/build/...` and the extended unit test pass.
- No test added for the two YAML manifests themselves — the repo has no
  existing test harness parsing/asserting fields on the operator
  Deployment manifest (no Helm unittest setup, no Go test loading
  `operator-deployment.yaml`), so adding one felt disproportionate for a
  single field.
- Addressed a `golangci-lint` `modernize` finding from review
  (`ptr.To(false)` → `new(bool)`, dropping the now-unused `k8s.io/utils/ptr`
  import); `go build`, `go vet`, `gofmt`, and the unit test above still
  pass clean.

### Suggested reviewers

- @squakez (Pasquale Congiusti) — by far the most active recent
  committer across all three touched files/areas (operator manifest,
  Helm chart, builder pod).
- @oscerd (Andrea Cosentino) — authored the project's threat model and
  SECURITY.md; this change follows the threat model's operator
  hardening guidance (reducing the operator/builder pod's default
  attack surface), so flagging for input on that framing.

---

_This change was prepared by Claude Code on behalf of Luis Sergio Carneiro (@lsergio)._

